### PR TITLE
Apache Spark Kubernetes Operator CRD schemas

### DIFF
--- a/spark.apache.org/sparkapplication_v1.json
+++ b/spark.apache.org/sparkapplication_v1.json
@@ -1,0 +1,14574 @@
+{
+  "properties": {
+    "spec": {
+      "properties": {
+        "applicationTolerations": {
+          "properties": {
+            "applicationTimeoutConfig": {
+              "properties": {
+                "driverReadyTimeoutMillis": {
+                  "type": "integer"
+                },
+                "driverStartTimeoutMillis": {
+                  "type": "integer"
+                },
+                "executorStartTimeoutMillis": {
+                  "type": "integer"
+                },
+                "forceTerminationGracePeriodMillis": {
+                  "type": "integer"
+                },
+                "terminationRequeuePeriodMillis": {
+                  "type": "integer"
+                }
+              },
+              "type": "object"
+            },
+            "instanceConfig": {
+              "properties": {
+                "initExecutors": {
+                  "type": "integer"
+                },
+                "maxExecutors": {
+                  "type": "integer"
+                },
+                "minExecutors": {
+                  "type": "integer"
+                }
+              },
+              "type": "object"
+            },
+            "resourceRetainDurationMillis": {
+              "default": -1,
+              "type": "integer"
+            },
+            "resourceRetainPolicy": {
+              "enum": [
+                "Always",
+                "Never",
+                "OnFailure"
+              ],
+              "type": "string"
+            },
+            "restartConfig": {
+              "properties": {
+                "maxRestartAttempts": {
+                  "type": "integer"
+                },
+                "maxRestartOnFailure": {
+                  "type": "integer"
+                },
+                "maxRestartOnSchedulingFailure": {
+                  "type": "integer"
+                },
+                "restartBackoffMillis": {
+                  "type": "integer"
+                },
+                "restartBackoffMillisForFailure": {
+                  "type": "integer"
+                },
+                "restartBackoffMillisForSchedulingFailure": {
+                  "type": "integer"
+                },
+                "restartCounterResetMillis": {
+                  "default": -1,
+                  "type": "integer"
+                },
+                "restartPolicy": {
+                  "enum": [
+                    "Always",
+                    "Never",
+                    "OnFailure",
+                    "OnInfrastructureFailure"
+                  ],
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "ttlAfterStopMillis": {
+              "default": -1,
+              "type": "integer"
+            }
+          },
+          "type": "object"
+        },
+        "configMapSpecs": {
+          "items": {
+            "properties": {
+              "annotations": {
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "type": "object"
+              },
+              "data": {
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "type": "object"
+              },
+              "labels": {
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "type": "object"
+              },
+              "name": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "name"
+            ],
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "deploymentMode": {
+          "enum": [
+            "ClientMode",
+            "ClusterMode"
+          ],
+          "type": "string"
+        },
+        "driverArgs": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "driverServiceIngressList": {
+          "items": {
+            "properties": {
+              "ingressMetadata": {
+                "properties": {
+                  "annotations": {
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "type": "object"
+                  },
+                  "creationTimestamp": {
+                    "type": "string"
+                  },
+                  "deletionGracePeriodSeconds": {
+                    "type": "integer"
+                  },
+                  "deletionTimestamp": {
+                    "type": "string"
+                  },
+                  "finalizers": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "generateName": {
+                    "type": "string"
+                  },
+                  "generation": {
+                    "type": "integer"
+                  },
+                  "labels": {
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "type": "object"
+                  },
+                  "managedFields": {
+                    "items": {
+                      "properties": {
+                        "apiVersion": {
+                          "type": "string"
+                        },
+                        "fieldsType": {
+                          "type": "string"
+                        },
+                        "fieldsV1": {
+                          "type": "object"
+                        },
+                        "manager": {
+                          "type": "string"
+                        },
+                        "operation": {
+                          "type": "string"
+                        },
+                        "subresource": {
+                          "type": "string"
+                        },
+                        "time": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "namespace": {
+                    "type": "string"
+                  },
+                  "ownerReferences": {
+                    "items": {
+                      "properties": {
+                        "apiVersion": {
+                          "type": "string"
+                        },
+                        "blockOwnerDeletion": {
+                          "type": "boolean"
+                        },
+                        "controller": {
+                          "type": "boolean"
+                        },
+                        "kind": {
+                          "type": "string"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "uid": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "resourceVersion": {
+                    "type": "string"
+                  },
+                  "selfLink": {
+                    "type": "string"
+                  },
+                  "uid": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "ingressSpec": {
+                "properties": {
+                  "defaultBackend": {
+                    "properties": {
+                      "resource": {
+                        "properties": {
+                          "apiGroup": {
+                            "type": "string"
+                          },
+                          "kind": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "service": {
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          },
+                          "port": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "number": {
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object"
+                          }
+                        },
+                        "type": "object"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "ingressClassName": {
+                    "type": "string"
+                  },
+                  "rules": {
+                    "items": {
+                      "properties": {
+                        "host": {
+                          "type": "string"
+                        },
+                        "http": {
+                          "properties": {
+                            "paths": {
+                              "items": {
+                                "properties": {
+                                  "backend": {
+                                    "properties": {
+                                      "resource": {
+                                        "properties": {
+                                          "apiGroup": {
+                                            "type": "string"
+                                          },
+                                          "kind": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "service": {
+                                        "properties": {
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "properties": {
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "number": {
+                                                "type": "integer"
+                                              }
+                                            },
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "pathType": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "tls": {
+                    "items": {
+                      "properties": {
+                        "hosts": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "secretName": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "type": "array"
+                  }
+                },
+                "type": "object"
+              },
+              "serviceMetadata": {
+                "properties": {
+                  "annotations": {
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "type": "object"
+                  },
+                  "creationTimestamp": {
+                    "type": "string"
+                  },
+                  "deletionGracePeriodSeconds": {
+                    "type": "integer"
+                  },
+                  "deletionTimestamp": {
+                    "type": "string"
+                  },
+                  "finalizers": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "generateName": {
+                    "type": "string"
+                  },
+                  "generation": {
+                    "type": "integer"
+                  },
+                  "labels": {
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "type": "object"
+                  },
+                  "managedFields": {
+                    "items": {
+                      "properties": {
+                        "apiVersion": {
+                          "type": "string"
+                        },
+                        "fieldsType": {
+                          "type": "string"
+                        },
+                        "fieldsV1": {
+                          "type": "object"
+                        },
+                        "manager": {
+                          "type": "string"
+                        },
+                        "operation": {
+                          "type": "string"
+                        },
+                        "subresource": {
+                          "type": "string"
+                        },
+                        "time": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "namespace": {
+                    "type": "string"
+                  },
+                  "ownerReferences": {
+                    "items": {
+                      "properties": {
+                        "apiVersion": {
+                          "type": "string"
+                        },
+                        "blockOwnerDeletion": {
+                          "type": "boolean"
+                        },
+                        "controller": {
+                          "type": "boolean"
+                        },
+                        "kind": {
+                          "type": "string"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "uid": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "resourceVersion": {
+                    "type": "string"
+                  },
+                  "selfLink": {
+                    "type": "string"
+                  },
+                  "uid": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "serviceSpec": {
+                "properties": {
+                  "allocateLoadBalancerNodePorts": {
+                    "type": "boolean"
+                  },
+                  "clusterIP": {
+                    "type": "string"
+                  },
+                  "clusterIPs": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "externalIPs": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "externalName": {
+                    "type": "string"
+                  },
+                  "externalTrafficPolicy": {
+                    "type": "string"
+                  },
+                  "healthCheckNodePort": {
+                    "type": "integer"
+                  },
+                  "internalTrafficPolicy": {
+                    "type": "string"
+                  },
+                  "ipFamilies": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "ipFamilyPolicy": {
+                    "type": "string"
+                  },
+                  "loadBalancerClass": {
+                    "type": "string"
+                  },
+                  "loadBalancerIP": {
+                    "type": "string"
+                  },
+                  "loadBalancerSourceRanges": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "ports": {
+                    "items": {
+                      "properties": {
+                        "appProtocol": {
+                          "type": "string"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "nodePort": {
+                          "type": "integer"
+                        },
+                        "port": {
+                          "type": "integer"
+                        },
+                        "protocol": {
+                          "type": "string"
+                        },
+                        "targetPort": {
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "string"
+                            }
+                          ],
+                          "x-kubernetes-int-or-string": true
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "publishNotReadyAddresses": {
+                    "type": "boolean"
+                  },
+                  "selector": {
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "type": "object"
+                  },
+                  "sessionAffinity": {
+                    "type": "string"
+                  },
+                  "sessionAffinityConfig": {
+                    "properties": {
+                      "clientIP": {
+                        "properties": {
+                          "timeoutSeconds": {
+                            "type": "integer"
+                          }
+                        },
+                        "type": "object"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "trafficDistribution": {
+                    "type": "string"
+                  },
+                  "type": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              }
+            },
+            "required": [
+              "ingressMetadata",
+              "serviceMetadata",
+              "serviceSpec"
+            ],
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "driverSpec": {
+          "properties": {
+            "podTemplateSpec": {
+              "properties": {
+                "metadata": {
+                  "properties": {
+                    "annotations": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "type": "object"
+                    },
+                    "creationTimestamp": {
+                      "type": "string"
+                    },
+                    "deletionGracePeriodSeconds": {
+                      "type": "integer"
+                    },
+                    "deletionTimestamp": {
+                      "type": "string"
+                    },
+                    "finalizers": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "generateName": {
+                      "type": "string"
+                    },
+                    "generation": {
+                      "type": "integer"
+                    },
+                    "labels": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "type": "object"
+                    },
+                    "managedFields": {
+                      "items": {
+                        "properties": {
+                          "apiVersion": {
+                            "type": "string"
+                          },
+                          "fieldsType": {
+                            "type": "string"
+                          },
+                          "fieldsV1": {
+                            "type": "object"
+                          },
+                          "manager": {
+                            "type": "string"
+                          },
+                          "operation": {
+                            "type": "string"
+                          },
+                          "subresource": {
+                            "type": "string"
+                          },
+                          "time": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "namespace": {
+                      "type": "string"
+                    },
+                    "ownerReferences": {
+                      "items": {
+                        "properties": {
+                          "apiVersion": {
+                            "type": "string"
+                          },
+                          "blockOwnerDeletion": {
+                            "type": "boolean"
+                          },
+                          "controller": {
+                            "type": "boolean"
+                          },
+                          "kind": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "uid": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "resourceVersion": {
+                      "type": "string"
+                    },
+                    "selfLink": {
+                      "type": "string"
+                    },
+                    "uid": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "spec": {
+                  "properties": {
+                    "activeDeadlineSeconds": {
+                      "type": "integer"
+                    },
+                    "affinity": {
+                      "properties": {
+                        "nodeAffinity": {
+                          "properties": {
+                            "preferredDuringSchedulingIgnoredDuringExecution": {
+                              "items": {
+                                "properties": {
+                                  "preference": {
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "matchFields": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "weight": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "requiredDuringSchedulingIgnoredDuringExecution": {
+                              "properties": {
+                                "nodeSelectorTerms": {
+                                  "items": {
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "matchFields": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "type": "object"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "podAffinity": {
+                          "properties": {
+                            "preferredDuringSchedulingIgnoredDuringExecution": {
+                              "items": {
+                                "properties": {
+                                  "podAffinityTerm": {
+                                    "properties": {
+                                      "labelSelector": {
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "matchLabels": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "matchLabelKeys": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "mismatchLabelKeys": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "namespaceSelector": {
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "matchLabels": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "namespaces": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "topologyKey": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "weight": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "requiredDuringSchedulingIgnoredDuringExecution": {
+                              "items": {
+                                "properties": {
+                                  "labelSelector": {
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "matchLabels": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "matchLabelKeys": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "mismatchLabelKeys": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "namespaceSelector": {
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "matchLabels": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "namespaces": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "topologyKey": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "podAntiAffinity": {
+                          "properties": {
+                            "preferredDuringSchedulingIgnoredDuringExecution": {
+                              "items": {
+                                "properties": {
+                                  "podAffinityTerm": {
+                                    "properties": {
+                                      "labelSelector": {
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "matchLabels": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "matchLabelKeys": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "mismatchLabelKeys": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "namespaceSelector": {
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "matchLabels": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "namespaces": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "topologyKey": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "weight": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "requiredDuringSchedulingIgnoredDuringExecution": {
+                              "items": {
+                                "properties": {
+                                  "labelSelector": {
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "matchLabels": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "matchLabelKeys": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "mismatchLabelKeys": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "namespaceSelector": {
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "matchLabels": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "namespaces": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "topologyKey": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "automountServiceAccountToken": {
+                      "type": "boolean"
+                    },
+                    "containers": {
+                      "items": {
+                        "properties": {
+                          "args": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "command": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "env": {
+                            "items": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "value": {
+                                  "type": "string"
+                                },
+                                "valueFrom": {
+                                  "properties": {
+                                    "configMapKeyRef": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "fieldRef": {
+                                      "properties": {
+                                        "apiVersion": {
+                                          "type": "string"
+                                        },
+                                        "fieldPath": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "fileKeyRef": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        },
+                                        "path": {
+                                          "type": "string"
+                                        },
+                                        "volumeName": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "resourceFieldRef": {
+                                      "properties": {
+                                        "containerName": {
+                                          "type": "string"
+                                        },
+                                        "divisor": {
+                                          "anyOf": [
+                                            {
+                                              "type": "integer"
+                                            },
+                                            {
+                                              "type": "string"
+                                            }
+                                          ],
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "resource": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "secretKeyRef": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "envFrom": {
+                            "items": {
+                              "properties": {
+                                "configMapRef": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "prefix": {
+                                  "type": "string"
+                                },
+                                "secretRef": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "image": {
+                            "type": "string"
+                          },
+                          "imagePullPolicy": {
+                            "type": "string"
+                          },
+                          "lifecycle": {
+                            "properties": {
+                              "postStart": {
+                                "properties": {
+                                  "exec": {
+                                    "properties": {
+                                      "command": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "httpGet": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "sleep": {
+                                    "properties": {
+                                      "seconds": {
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "tcpSocket": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "preStop": {
+                                "properties": {
+                                  "exec": {
+                                    "properties": {
+                                      "command": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "httpGet": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "sleep": {
+                                    "properties": {
+                                      "seconds": {
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "tcpSocket": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "stopSignal": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "livenessProbe": {
+                            "properties": {
+                              "exec": {
+                                "properties": {
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "failureThreshold": {
+                                "type": "integer"
+                              },
+                              "grpc": {
+                                "properties": {
+                                  "port": {
+                                    "type": "integer"
+                                  },
+                                  "service": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "httpGet": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "initialDelaySeconds": {
+                                "type": "integer"
+                              },
+                              "periodSeconds": {
+                                "type": "integer"
+                              },
+                              "successThreshold": {
+                                "type": "integer"
+                              },
+                              "tcpSocket": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "terminationGracePeriodSeconds": {
+                                "type": "integer"
+                              },
+                              "timeoutSeconds": {
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "ports": {
+                            "items": {
+                              "properties": {
+                                "containerPort": {
+                                  "type": "integer"
+                                },
+                                "hostIP": {
+                                  "type": "string"
+                                },
+                                "hostPort": {
+                                  "type": "integer"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "protocol": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "readinessProbe": {
+                            "properties": {
+                              "exec": {
+                                "properties": {
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "failureThreshold": {
+                                "type": "integer"
+                              },
+                              "grpc": {
+                                "properties": {
+                                  "port": {
+                                    "type": "integer"
+                                  },
+                                  "service": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "httpGet": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "initialDelaySeconds": {
+                                "type": "integer"
+                              },
+                              "periodSeconds": {
+                                "type": "integer"
+                              },
+                              "successThreshold": {
+                                "type": "integer"
+                              },
+                              "tcpSocket": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "terminationGracePeriodSeconds": {
+                                "type": "integer"
+                              },
+                              "timeoutSeconds": {
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "resizePolicy": {
+                            "items": {
+                              "properties": {
+                                "resourceName": {
+                                  "type": "string"
+                                },
+                                "restartPolicy": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "resources": {
+                            "properties": {
+                              "claims": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "request": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "limits": {
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "type": "object"
+                              },
+                              "requests": {
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "restartPolicy": {
+                            "type": "string"
+                          },
+                          "restartPolicyRules": {
+                            "items": {
+                              "properties": {
+                                "action": {
+                                  "type": "string"
+                                },
+                                "exitCodes": {
+                                  "properties": {
+                                    "operator": {
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "items": {
+                                        "type": "integer"
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "securityContext": {
+                            "properties": {
+                              "allowPrivilegeEscalation": {
+                                "type": "boolean"
+                              },
+                              "appArmorProfile": {
+                                "properties": {
+                                  "localhostProfile": {
+                                    "type": "string"
+                                  },
+                                  "type": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "capabilities": {
+                                "properties": {
+                                  "add": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "drop": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "privileged": {
+                                "type": "boolean"
+                              },
+                              "procMount": {
+                                "type": "string"
+                              },
+                              "readOnlyRootFilesystem": {
+                                "type": "boolean"
+                              },
+                              "runAsGroup": {
+                                "type": "integer"
+                              },
+                              "runAsNonRoot": {
+                                "type": "boolean"
+                              },
+                              "runAsUser": {
+                                "type": "integer"
+                              },
+                              "seLinuxOptions": {
+                                "properties": {
+                                  "level": {
+                                    "type": "string"
+                                  },
+                                  "role": {
+                                    "type": "string"
+                                  },
+                                  "type": {
+                                    "type": "string"
+                                  },
+                                  "user": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "seccompProfile": {
+                                "properties": {
+                                  "localhostProfile": {
+                                    "type": "string"
+                                  },
+                                  "type": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "windowsOptions": {
+                                "properties": {
+                                  "gmsaCredentialSpec": {
+                                    "type": "string"
+                                  },
+                                  "gmsaCredentialSpecName": {
+                                    "type": "string"
+                                  },
+                                  "hostProcess": {
+                                    "type": "boolean"
+                                  },
+                                  "runAsUserName": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "startupProbe": {
+                            "properties": {
+                              "exec": {
+                                "properties": {
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "failureThreshold": {
+                                "type": "integer"
+                              },
+                              "grpc": {
+                                "properties": {
+                                  "port": {
+                                    "type": "integer"
+                                  },
+                                  "service": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "httpGet": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "initialDelaySeconds": {
+                                "type": "integer"
+                              },
+                              "periodSeconds": {
+                                "type": "integer"
+                              },
+                              "successThreshold": {
+                                "type": "integer"
+                              },
+                              "tcpSocket": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "terminationGracePeriodSeconds": {
+                                "type": "integer"
+                              },
+                              "timeoutSeconds": {
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "stdin": {
+                            "type": "boolean"
+                          },
+                          "stdinOnce": {
+                            "type": "boolean"
+                          },
+                          "terminationMessagePath": {
+                            "type": "string"
+                          },
+                          "terminationMessagePolicy": {
+                            "type": "string"
+                          },
+                          "tty": {
+                            "type": "boolean"
+                          },
+                          "volumeDevices": {
+                            "items": {
+                              "properties": {
+                                "devicePath": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "volumeMounts": {
+                            "items": {
+                              "properties": {
+                                "mountPath": {
+                                  "type": "string"
+                                },
+                                "mountPropagation": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "readOnly": {
+                                  "type": "boolean"
+                                },
+                                "recursiveReadOnly": {
+                                  "type": "string"
+                                },
+                                "subPath": {
+                                  "type": "string"
+                                },
+                                "subPathExpr": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "workingDir": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "dnsConfig": {
+                      "properties": {
+                        "nameservers": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "options": {
+                          "items": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "value": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "searches": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "dnsPolicy": {
+                      "type": "string"
+                    },
+                    "enableServiceLinks": {
+                      "type": "boolean"
+                    },
+                    "ephemeralContainers": {
+                      "items": {
+                        "properties": {
+                          "args": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "command": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "env": {
+                            "items": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "value": {
+                                  "type": "string"
+                                },
+                                "valueFrom": {
+                                  "properties": {
+                                    "configMapKeyRef": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "fieldRef": {
+                                      "properties": {
+                                        "apiVersion": {
+                                          "type": "string"
+                                        },
+                                        "fieldPath": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "fileKeyRef": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        },
+                                        "path": {
+                                          "type": "string"
+                                        },
+                                        "volumeName": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "resourceFieldRef": {
+                                      "properties": {
+                                        "containerName": {
+                                          "type": "string"
+                                        },
+                                        "divisor": {
+                                          "anyOf": [
+                                            {
+                                              "type": "integer"
+                                            },
+                                            {
+                                              "type": "string"
+                                            }
+                                          ],
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "resource": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "secretKeyRef": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "envFrom": {
+                            "items": {
+                              "properties": {
+                                "configMapRef": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "prefix": {
+                                  "type": "string"
+                                },
+                                "secretRef": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "image": {
+                            "type": "string"
+                          },
+                          "imagePullPolicy": {
+                            "type": "string"
+                          },
+                          "lifecycle": {
+                            "properties": {
+                              "postStart": {
+                                "properties": {
+                                  "exec": {
+                                    "properties": {
+                                      "command": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "httpGet": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "sleep": {
+                                    "properties": {
+                                      "seconds": {
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "tcpSocket": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "preStop": {
+                                "properties": {
+                                  "exec": {
+                                    "properties": {
+                                      "command": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "httpGet": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "sleep": {
+                                    "properties": {
+                                      "seconds": {
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "tcpSocket": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "stopSignal": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "livenessProbe": {
+                            "properties": {
+                              "exec": {
+                                "properties": {
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "failureThreshold": {
+                                "type": "integer"
+                              },
+                              "grpc": {
+                                "properties": {
+                                  "port": {
+                                    "type": "integer"
+                                  },
+                                  "service": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "httpGet": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "initialDelaySeconds": {
+                                "type": "integer"
+                              },
+                              "periodSeconds": {
+                                "type": "integer"
+                              },
+                              "successThreshold": {
+                                "type": "integer"
+                              },
+                              "tcpSocket": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "terminationGracePeriodSeconds": {
+                                "type": "integer"
+                              },
+                              "timeoutSeconds": {
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "ports": {
+                            "items": {
+                              "properties": {
+                                "containerPort": {
+                                  "type": "integer"
+                                },
+                                "hostIP": {
+                                  "type": "string"
+                                },
+                                "hostPort": {
+                                  "type": "integer"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "protocol": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "readinessProbe": {
+                            "properties": {
+                              "exec": {
+                                "properties": {
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "failureThreshold": {
+                                "type": "integer"
+                              },
+                              "grpc": {
+                                "properties": {
+                                  "port": {
+                                    "type": "integer"
+                                  },
+                                  "service": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "httpGet": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "initialDelaySeconds": {
+                                "type": "integer"
+                              },
+                              "periodSeconds": {
+                                "type": "integer"
+                              },
+                              "successThreshold": {
+                                "type": "integer"
+                              },
+                              "tcpSocket": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "terminationGracePeriodSeconds": {
+                                "type": "integer"
+                              },
+                              "timeoutSeconds": {
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "resizePolicy": {
+                            "items": {
+                              "properties": {
+                                "resourceName": {
+                                  "type": "string"
+                                },
+                                "restartPolicy": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "resources": {
+                            "properties": {
+                              "claims": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "request": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "limits": {
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "type": "object"
+                              },
+                              "requests": {
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "restartPolicy": {
+                            "type": "string"
+                          },
+                          "restartPolicyRules": {
+                            "items": {
+                              "properties": {
+                                "action": {
+                                  "type": "string"
+                                },
+                                "exitCodes": {
+                                  "properties": {
+                                    "operator": {
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "items": {
+                                        "type": "integer"
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "securityContext": {
+                            "properties": {
+                              "allowPrivilegeEscalation": {
+                                "type": "boolean"
+                              },
+                              "appArmorProfile": {
+                                "properties": {
+                                  "localhostProfile": {
+                                    "type": "string"
+                                  },
+                                  "type": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "capabilities": {
+                                "properties": {
+                                  "add": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "drop": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "privileged": {
+                                "type": "boolean"
+                              },
+                              "procMount": {
+                                "type": "string"
+                              },
+                              "readOnlyRootFilesystem": {
+                                "type": "boolean"
+                              },
+                              "runAsGroup": {
+                                "type": "integer"
+                              },
+                              "runAsNonRoot": {
+                                "type": "boolean"
+                              },
+                              "runAsUser": {
+                                "type": "integer"
+                              },
+                              "seLinuxOptions": {
+                                "properties": {
+                                  "level": {
+                                    "type": "string"
+                                  },
+                                  "role": {
+                                    "type": "string"
+                                  },
+                                  "type": {
+                                    "type": "string"
+                                  },
+                                  "user": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "seccompProfile": {
+                                "properties": {
+                                  "localhostProfile": {
+                                    "type": "string"
+                                  },
+                                  "type": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "windowsOptions": {
+                                "properties": {
+                                  "gmsaCredentialSpec": {
+                                    "type": "string"
+                                  },
+                                  "gmsaCredentialSpecName": {
+                                    "type": "string"
+                                  },
+                                  "hostProcess": {
+                                    "type": "boolean"
+                                  },
+                                  "runAsUserName": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "startupProbe": {
+                            "properties": {
+                              "exec": {
+                                "properties": {
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "failureThreshold": {
+                                "type": "integer"
+                              },
+                              "grpc": {
+                                "properties": {
+                                  "port": {
+                                    "type": "integer"
+                                  },
+                                  "service": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "httpGet": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "initialDelaySeconds": {
+                                "type": "integer"
+                              },
+                              "periodSeconds": {
+                                "type": "integer"
+                              },
+                              "successThreshold": {
+                                "type": "integer"
+                              },
+                              "tcpSocket": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "terminationGracePeriodSeconds": {
+                                "type": "integer"
+                              },
+                              "timeoutSeconds": {
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "stdin": {
+                            "type": "boolean"
+                          },
+                          "stdinOnce": {
+                            "type": "boolean"
+                          },
+                          "targetContainerName": {
+                            "type": "string"
+                          },
+                          "terminationMessagePath": {
+                            "type": "string"
+                          },
+                          "terminationMessagePolicy": {
+                            "type": "string"
+                          },
+                          "tty": {
+                            "type": "boolean"
+                          },
+                          "volumeDevices": {
+                            "items": {
+                              "properties": {
+                                "devicePath": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "volumeMounts": {
+                            "items": {
+                              "properties": {
+                                "mountPath": {
+                                  "type": "string"
+                                },
+                                "mountPropagation": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "readOnly": {
+                                  "type": "boolean"
+                                },
+                                "recursiveReadOnly": {
+                                  "type": "string"
+                                },
+                                "subPath": {
+                                  "type": "string"
+                                },
+                                "subPathExpr": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "workingDir": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "hostAliases": {
+                      "items": {
+                        "properties": {
+                          "hostnames": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "ip": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "hostIPC": {
+                      "type": "boolean"
+                    },
+                    "hostNetwork": {
+                      "type": "boolean"
+                    },
+                    "hostPID": {
+                      "type": "boolean"
+                    },
+                    "hostUsers": {
+                      "type": "boolean"
+                    },
+                    "hostname": {
+                      "type": "string"
+                    },
+                    "hostnameOverride": {
+                      "type": "string"
+                    },
+                    "imagePullSecrets": {
+                      "items": {
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "initContainers": {
+                      "items": {
+                        "properties": {
+                          "args": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "command": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "env": {
+                            "items": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "value": {
+                                  "type": "string"
+                                },
+                                "valueFrom": {
+                                  "properties": {
+                                    "configMapKeyRef": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "fieldRef": {
+                                      "properties": {
+                                        "apiVersion": {
+                                          "type": "string"
+                                        },
+                                        "fieldPath": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "fileKeyRef": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        },
+                                        "path": {
+                                          "type": "string"
+                                        },
+                                        "volumeName": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "resourceFieldRef": {
+                                      "properties": {
+                                        "containerName": {
+                                          "type": "string"
+                                        },
+                                        "divisor": {
+                                          "anyOf": [
+                                            {
+                                              "type": "integer"
+                                            },
+                                            {
+                                              "type": "string"
+                                            }
+                                          ],
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "resource": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "secretKeyRef": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "envFrom": {
+                            "items": {
+                              "properties": {
+                                "configMapRef": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "prefix": {
+                                  "type": "string"
+                                },
+                                "secretRef": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "image": {
+                            "type": "string"
+                          },
+                          "imagePullPolicy": {
+                            "type": "string"
+                          },
+                          "lifecycle": {
+                            "properties": {
+                              "postStart": {
+                                "properties": {
+                                  "exec": {
+                                    "properties": {
+                                      "command": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "httpGet": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "sleep": {
+                                    "properties": {
+                                      "seconds": {
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "tcpSocket": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "preStop": {
+                                "properties": {
+                                  "exec": {
+                                    "properties": {
+                                      "command": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "httpGet": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "sleep": {
+                                    "properties": {
+                                      "seconds": {
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "tcpSocket": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "stopSignal": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "livenessProbe": {
+                            "properties": {
+                              "exec": {
+                                "properties": {
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "failureThreshold": {
+                                "type": "integer"
+                              },
+                              "grpc": {
+                                "properties": {
+                                  "port": {
+                                    "type": "integer"
+                                  },
+                                  "service": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "httpGet": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "initialDelaySeconds": {
+                                "type": "integer"
+                              },
+                              "periodSeconds": {
+                                "type": "integer"
+                              },
+                              "successThreshold": {
+                                "type": "integer"
+                              },
+                              "tcpSocket": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "terminationGracePeriodSeconds": {
+                                "type": "integer"
+                              },
+                              "timeoutSeconds": {
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "ports": {
+                            "items": {
+                              "properties": {
+                                "containerPort": {
+                                  "type": "integer"
+                                },
+                                "hostIP": {
+                                  "type": "string"
+                                },
+                                "hostPort": {
+                                  "type": "integer"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "protocol": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "readinessProbe": {
+                            "properties": {
+                              "exec": {
+                                "properties": {
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "failureThreshold": {
+                                "type": "integer"
+                              },
+                              "grpc": {
+                                "properties": {
+                                  "port": {
+                                    "type": "integer"
+                                  },
+                                  "service": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "httpGet": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "initialDelaySeconds": {
+                                "type": "integer"
+                              },
+                              "periodSeconds": {
+                                "type": "integer"
+                              },
+                              "successThreshold": {
+                                "type": "integer"
+                              },
+                              "tcpSocket": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "terminationGracePeriodSeconds": {
+                                "type": "integer"
+                              },
+                              "timeoutSeconds": {
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "resizePolicy": {
+                            "items": {
+                              "properties": {
+                                "resourceName": {
+                                  "type": "string"
+                                },
+                                "restartPolicy": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "resources": {
+                            "properties": {
+                              "claims": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "request": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "limits": {
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "type": "object"
+                              },
+                              "requests": {
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "restartPolicy": {
+                            "type": "string"
+                          },
+                          "restartPolicyRules": {
+                            "items": {
+                              "properties": {
+                                "action": {
+                                  "type": "string"
+                                },
+                                "exitCodes": {
+                                  "properties": {
+                                    "operator": {
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "items": {
+                                        "type": "integer"
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "securityContext": {
+                            "properties": {
+                              "allowPrivilegeEscalation": {
+                                "type": "boolean"
+                              },
+                              "appArmorProfile": {
+                                "properties": {
+                                  "localhostProfile": {
+                                    "type": "string"
+                                  },
+                                  "type": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "capabilities": {
+                                "properties": {
+                                  "add": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "drop": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "privileged": {
+                                "type": "boolean"
+                              },
+                              "procMount": {
+                                "type": "string"
+                              },
+                              "readOnlyRootFilesystem": {
+                                "type": "boolean"
+                              },
+                              "runAsGroup": {
+                                "type": "integer"
+                              },
+                              "runAsNonRoot": {
+                                "type": "boolean"
+                              },
+                              "runAsUser": {
+                                "type": "integer"
+                              },
+                              "seLinuxOptions": {
+                                "properties": {
+                                  "level": {
+                                    "type": "string"
+                                  },
+                                  "role": {
+                                    "type": "string"
+                                  },
+                                  "type": {
+                                    "type": "string"
+                                  },
+                                  "user": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "seccompProfile": {
+                                "properties": {
+                                  "localhostProfile": {
+                                    "type": "string"
+                                  },
+                                  "type": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "windowsOptions": {
+                                "properties": {
+                                  "gmsaCredentialSpec": {
+                                    "type": "string"
+                                  },
+                                  "gmsaCredentialSpecName": {
+                                    "type": "string"
+                                  },
+                                  "hostProcess": {
+                                    "type": "boolean"
+                                  },
+                                  "runAsUserName": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "startupProbe": {
+                            "properties": {
+                              "exec": {
+                                "properties": {
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "failureThreshold": {
+                                "type": "integer"
+                              },
+                              "grpc": {
+                                "properties": {
+                                  "port": {
+                                    "type": "integer"
+                                  },
+                                  "service": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "httpGet": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "initialDelaySeconds": {
+                                "type": "integer"
+                              },
+                              "periodSeconds": {
+                                "type": "integer"
+                              },
+                              "successThreshold": {
+                                "type": "integer"
+                              },
+                              "tcpSocket": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "terminationGracePeriodSeconds": {
+                                "type": "integer"
+                              },
+                              "timeoutSeconds": {
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "stdin": {
+                            "type": "boolean"
+                          },
+                          "stdinOnce": {
+                            "type": "boolean"
+                          },
+                          "terminationMessagePath": {
+                            "type": "string"
+                          },
+                          "terminationMessagePolicy": {
+                            "type": "string"
+                          },
+                          "tty": {
+                            "type": "boolean"
+                          },
+                          "volumeDevices": {
+                            "items": {
+                              "properties": {
+                                "devicePath": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "volumeMounts": {
+                            "items": {
+                              "properties": {
+                                "mountPath": {
+                                  "type": "string"
+                                },
+                                "mountPropagation": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "readOnly": {
+                                  "type": "boolean"
+                                },
+                                "recursiveReadOnly": {
+                                  "type": "string"
+                                },
+                                "subPath": {
+                                  "type": "string"
+                                },
+                                "subPathExpr": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "workingDir": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "nodeName": {
+                      "type": "string"
+                    },
+                    "nodeSelector": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "type": "object"
+                    },
+                    "os": {
+                      "properties": {
+                        "name": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "overhead": {
+                      "additionalProperties": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "x-kubernetes-int-or-string": true
+                      },
+                      "type": "object"
+                    },
+                    "preemptionPolicy": {
+                      "type": "string"
+                    },
+                    "priority": {
+                      "type": "integer"
+                    },
+                    "priorityClassName": {
+                      "type": "string"
+                    },
+                    "readinessGates": {
+                      "items": {
+                        "properties": {
+                          "conditionType": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "resourceClaims": {
+                      "items": {
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          },
+                          "resourceClaimName": {
+                            "type": "string"
+                          },
+                          "resourceClaimTemplateName": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "resources": {
+                      "properties": {
+                        "claims": {
+                          "items": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "request": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "limits": {
+                          "additionalProperties": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "x-kubernetes-int-or-string": true
+                          },
+                          "type": "object"
+                        },
+                        "requests": {
+                          "additionalProperties": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "x-kubernetes-int-or-string": true
+                          },
+                          "type": "object"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "restartPolicy": {
+                      "type": "string"
+                    },
+                    "runtimeClassName": {
+                      "type": "string"
+                    },
+                    "schedulerName": {
+                      "type": "string"
+                    },
+                    "schedulingGates": {
+                      "items": {
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "securityContext": {
+                      "properties": {
+                        "appArmorProfile": {
+                          "properties": {
+                            "localhostProfile": {
+                              "type": "string"
+                            },
+                            "type": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "fsGroup": {
+                          "type": "integer"
+                        },
+                        "fsGroupChangePolicy": {
+                          "type": "string"
+                        },
+                        "runAsGroup": {
+                          "type": "integer"
+                        },
+                        "runAsNonRoot": {
+                          "type": "boolean"
+                        },
+                        "runAsUser": {
+                          "type": "integer"
+                        },
+                        "seLinuxChangePolicy": {
+                          "type": "string"
+                        },
+                        "seLinuxOptions": {
+                          "properties": {
+                            "level": {
+                              "type": "string"
+                            },
+                            "role": {
+                              "type": "string"
+                            },
+                            "type": {
+                              "type": "string"
+                            },
+                            "user": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "seccompProfile": {
+                          "properties": {
+                            "localhostProfile": {
+                              "type": "string"
+                            },
+                            "type": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "supplementalGroups": {
+                          "items": {
+                            "type": "integer"
+                          },
+                          "type": "array"
+                        },
+                        "supplementalGroupsPolicy": {
+                          "type": "string"
+                        },
+                        "sysctls": {
+                          "items": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "value": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "windowsOptions": {
+                          "properties": {
+                            "gmsaCredentialSpec": {
+                              "type": "string"
+                            },
+                            "gmsaCredentialSpecName": {
+                              "type": "string"
+                            },
+                            "hostProcess": {
+                              "type": "boolean"
+                            },
+                            "runAsUserName": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "serviceAccount": {
+                      "type": "string"
+                    },
+                    "serviceAccountName": {
+                      "type": "string"
+                    },
+                    "setHostnameAsFQDN": {
+                      "type": "boolean"
+                    },
+                    "shareProcessNamespace": {
+                      "type": "boolean"
+                    },
+                    "subdomain": {
+                      "type": "string"
+                    },
+                    "terminationGracePeriodSeconds": {
+                      "type": "integer"
+                    },
+                    "tolerations": {
+                      "items": {
+                        "properties": {
+                          "effect": {
+                            "type": "string"
+                          },
+                          "key": {
+                            "type": "string"
+                          },
+                          "operator": {
+                            "type": "string"
+                          },
+                          "tolerationSeconds": {
+                            "type": "integer"
+                          },
+                          "value": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "topologySpreadConstraints": {
+                      "items": {
+                        "properties": {
+                          "labelSelector": {
+                            "properties": {
+                              "matchExpressions": {
+                                "items": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "matchLabels": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "matchLabelKeys": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "maxSkew": {
+                            "type": "integer"
+                          },
+                          "minDomains": {
+                            "type": "integer"
+                          },
+                          "nodeAffinityPolicy": {
+                            "type": "string"
+                          },
+                          "nodeTaintsPolicy": {
+                            "type": "string"
+                          },
+                          "topologyKey": {
+                            "type": "string"
+                          },
+                          "whenUnsatisfiable": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "volumes": {
+                      "items": {
+                        "properties": {
+                          "awsElasticBlockStore": {
+                            "properties": {
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "partition": {
+                                "type": "integer"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "volumeID": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "azureDisk": {
+                            "properties": {
+                              "cachingMode": {
+                                "type": "string"
+                              },
+                              "diskName": {
+                                "type": "string"
+                              },
+                              "diskURI": {
+                                "type": "string"
+                              },
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "kind": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "azureFile": {
+                            "properties": {
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "secretName": {
+                                "type": "string"
+                              },
+                              "shareName": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "cephfs": {
+                            "properties": {
+                              "monitors": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "path": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "secretFile": {
+                                "type": "string"
+                              },
+                              "secretRef": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "user": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "cinder": {
+                            "properties": {
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "secretRef": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "volumeID": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "configMap": {
+                            "properties": {
+                              "defaultMode": {
+                                "type": "integer"
+                              },
+                              "items": {
+                                "items": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "mode": {
+                                      "type": "integer"
+                                    },
+                                    "path": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "optional": {
+                                "type": "boolean"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "csi": {
+                            "properties": {
+                              "driver": {
+                                "type": "string"
+                              },
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "nodePublishSecretRef": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "volumeAttributes": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "downwardAPI": {
+                            "properties": {
+                              "defaultMode": {
+                                "type": "integer"
+                              },
+                              "items": {
+                                "items": {
+                                  "properties": {
+                                    "fieldRef": {
+                                      "properties": {
+                                        "apiVersion": {
+                                          "type": "string"
+                                        },
+                                        "fieldPath": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "mode": {
+                                      "type": "integer"
+                                    },
+                                    "path": {
+                                      "type": "string"
+                                    },
+                                    "resourceFieldRef": {
+                                      "properties": {
+                                        "containerName": {
+                                          "type": "string"
+                                        },
+                                        "divisor": {
+                                          "anyOf": [
+                                            {
+                                              "type": "integer"
+                                            },
+                                            {
+                                              "type": "string"
+                                            }
+                                          ],
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "resource": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "emptyDir": {
+                            "properties": {
+                              "medium": {
+                                "type": "string"
+                              },
+                              "sizeLimit": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "ephemeral": {
+                            "properties": {
+                              "volumeClaimTemplate": {
+                                "properties": {
+                                  "metadata": {
+                                    "properties": {
+                                      "annotations": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
+                                      },
+                                      "creationTimestamp": {
+                                        "type": "string"
+                                      },
+                                      "deletionGracePeriodSeconds": {
+                                        "type": "integer"
+                                      },
+                                      "deletionTimestamp": {
+                                        "type": "string"
+                                      },
+                                      "finalizers": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "generateName": {
+                                        "type": "string"
+                                      },
+                                      "generation": {
+                                        "type": "integer"
+                                      },
+                                      "labels": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
+                                      },
+                                      "managedFields": {
+                                        "items": {
+                                          "properties": {
+                                            "apiVersion": {
+                                              "type": "string"
+                                            },
+                                            "fieldsType": {
+                                              "type": "string"
+                                            },
+                                            "fieldsV1": {
+                                              "type": "object"
+                                            },
+                                            "manager": {
+                                              "type": "string"
+                                            },
+                                            "operation": {
+                                              "type": "string"
+                                            },
+                                            "subresource": {
+                                              "type": "string"
+                                            },
+                                            "time": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "namespace": {
+                                        "type": "string"
+                                      },
+                                      "ownerReferences": {
+                                        "items": {
+                                          "properties": {
+                                            "apiVersion": {
+                                              "type": "string"
+                                            },
+                                            "blockOwnerDeletion": {
+                                              "type": "boolean"
+                                            },
+                                            "controller": {
+                                              "type": "boolean"
+                                            },
+                                            "kind": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "uid": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "resourceVersion": {
+                                        "type": "string"
+                                      },
+                                      "selfLink": {
+                                        "type": "string"
+                                      },
+                                      "uid": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "spec": {
+                                    "properties": {
+                                      "accessModes": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "dataSource": {
+                                        "properties": {
+                                          "apiGroup": {
+                                            "type": "string"
+                                          },
+                                          "kind": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "dataSourceRef": {
+                                        "properties": {
+                                          "apiGroup": {
+                                            "type": "string"
+                                          },
+                                          "kind": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "namespace": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "resources": {
+                                        "properties": {
+                                          "limits": {
+                                            "additionalProperties": {
+                                              "anyOf": [
+                                                {
+                                                  "type": "integer"
+                                                },
+                                                {
+                                                  "type": "string"
+                                                }
+                                              ],
+                                              "x-kubernetes-int-or-string": true
+                                            },
+                                            "type": "object"
+                                          },
+                                          "requests": {
+                                            "additionalProperties": {
+                                              "anyOf": [
+                                                {
+                                                  "type": "integer"
+                                                },
+                                                {
+                                                  "type": "string"
+                                                }
+                                              ],
+                                              "x-kubernetes-int-or-string": true
+                                            },
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "selector": {
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "matchLabels": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "storageClassName": {
+                                        "type": "string"
+                                      },
+                                      "volumeAttributesClassName": {
+                                        "type": "string"
+                                      },
+                                      "volumeMode": {
+                                        "type": "string"
+                                      },
+                                      "volumeName": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "fc": {
+                            "properties": {
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "lun": {
+                                "type": "integer"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "targetWWNs": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "wwids": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "flexVolume": {
+                            "properties": {
+                              "driver": {
+                                "type": "string"
+                              },
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "options": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "type": "object"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "secretRef": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "flocker": {
+                            "properties": {
+                              "datasetName": {
+                                "type": "string"
+                              },
+                              "datasetUUID": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "gcePersistentDisk": {
+                            "properties": {
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "partition": {
+                                "type": "integer"
+                              },
+                              "pdName": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "gitRepo": {
+                            "properties": {
+                              "directory": {
+                                "type": "string"
+                              },
+                              "repository": {
+                                "type": "string"
+                              },
+                              "revision": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "glusterfs": {
+                            "properties": {
+                              "endpoints": {
+                                "type": "string"
+                              },
+                              "path": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "hostPath": {
+                            "properties": {
+                              "path": {
+                                "type": "string"
+                              },
+                              "type": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "image": {
+                            "properties": {
+                              "pullPolicy": {
+                                "type": "string"
+                              },
+                              "reference": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "iscsi": {
+                            "properties": {
+                              "chapAuthDiscovery": {
+                                "type": "boolean"
+                              },
+                              "chapAuthSession": {
+                                "type": "boolean"
+                              },
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "initiatorName": {
+                                "type": "string"
+                              },
+                              "iqn": {
+                                "type": "string"
+                              },
+                              "iscsiInterface": {
+                                "type": "string"
+                              },
+                              "lun": {
+                                "type": "integer"
+                              },
+                              "portals": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "secretRef": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "targetPortal": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "nfs": {
+                            "properties": {
+                              "path": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "server": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "persistentVolumeClaim": {
+                            "properties": {
+                              "claimName": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "photonPersistentDisk": {
+                            "properties": {
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "pdID": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "portworxVolume": {
+                            "properties": {
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "volumeID": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "projected": {
+                            "properties": {
+                              "defaultMode": {
+                                "type": "integer"
+                              },
+                              "sources": {
+                                "items": {
+                                  "properties": {
+                                    "clusterTrustBundle": {
+                                      "properties": {
+                                        "labelSelector": {
+                                          "properties": {
+                                            "matchExpressions": {
+                                              "items": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "operator": {
+                                                    "type": "string"
+                                                  },
+                                                  "values": {
+                                                    "items": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "array"
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              "type": "array"
+                                            },
+                                            "matchLabels": {
+                                              "additionalProperties": {
+                                                "type": "string"
+                                              },
+                                              "type": "object"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        },
+                                        "path": {
+                                          "type": "string"
+                                        },
+                                        "signerName": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "configMap": {
+                                      "properties": {
+                                        "items": {
+                                          "items": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "mode": {
+                                                "type": "integer"
+                                              },
+                                              "path": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          "type": "array"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "downwardAPI": {
+                                      "properties": {
+                                        "items": {
+                                          "items": {
+                                            "properties": {
+                                              "fieldRef": {
+                                                "properties": {
+                                                  "apiVersion": {
+                                                    "type": "string"
+                                                  },
+                                                  "fieldPath": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              "mode": {
+                                                "type": "integer"
+                                              },
+                                              "path": {
+                                                "type": "string"
+                                              },
+                                              "resourceFieldRef": {
+                                                "properties": {
+                                                  "containerName": {
+                                                    "type": "string"
+                                                  },
+                                                  "divisor": {
+                                                    "anyOf": [
+                                                      {
+                                                        "type": "integer"
+                                                      },
+                                                      {
+                                                        "type": "string"
+                                                      }
+                                                    ],
+                                                    "x-kubernetes-int-or-string": true
+                                                  },
+                                                  "resource": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object"
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "podCertificate": {
+                                      "properties": {
+                                        "certificateChainPath": {
+                                          "type": "string"
+                                        },
+                                        "credentialBundlePath": {
+                                          "type": "string"
+                                        },
+                                        "keyPath": {
+                                          "type": "string"
+                                        },
+                                        "keyType": {
+                                          "type": "string"
+                                        },
+                                        "maxExpirationSeconds": {
+                                          "type": "integer"
+                                        },
+                                        "signerName": {
+                                          "type": "string"
+                                        },
+                                        "userAnnotations": {
+                                          "additionalProperties": {
+                                            "type": "string"
+                                          },
+                                          "type": "object"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "secret": {
+                                      "properties": {
+                                        "items": {
+                                          "items": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "mode": {
+                                                "type": "integer"
+                                              },
+                                              "path": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          "type": "array"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "serviceAccountToken": {
+                                      "properties": {
+                                        "audience": {
+                                          "type": "string"
+                                        },
+                                        "expirationSeconds": {
+                                          "type": "integer"
+                                        },
+                                        "path": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "quobyte": {
+                            "properties": {
+                              "group": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "registry": {
+                                "type": "string"
+                              },
+                              "tenant": {
+                                "type": "string"
+                              },
+                              "user": {
+                                "type": "string"
+                              },
+                              "volume": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "rbd": {
+                            "properties": {
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "image": {
+                                "type": "string"
+                              },
+                              "keyring": {
+                                "type": "string"
+                              },
+                              "monitors": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "pool": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "secretRef": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "user": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "scaleIO": {
+                            "properties": {
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "gateway": {
+                                "type": "string"
+                              },
+                              "protectionDomain": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "secretRef": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "sslEnabled": {
+                                "type": "boolean"
+                              },
+                              "storageMode": {
+                                "type": "string"
+                              },
+                              "storagePool": {
+                                "type": "string"
+                              },
+                              "system": {
+                                "type": "string"
+                              },
+                              "volumeName": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "secret": {
+                            "properties": {
+                              "defaultMode": {
+                                "type": "integer"
+                              },
+                              "items": {
+                                "items": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "mode": {
+                                      "type": "integer"
+                                    },
+                                    "path": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "optional": {
+                                "type": "boolean"
+                              },
+                              "secretName": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "storageos": {
+                            "properties": {
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "secretRef": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "volumeName": {
+                                "type": "string"
+                              },
+                              "volumeNamespace": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "vsphereVolume": {
+                            "properties": {
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "storagePolicyID": {
+                                "type": "string"
+                              },
+                              "storagePolicyName": {
+                                "type": "string"
+                              },
+                              "volumePath": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "workloadRef": {
+                      "properties": {
+                        "name": {
+                          "type": "string"
+                        },
+                        "podGroup": {
+                          "type": "string"
+                        },
+                        "podGroupReplicaKey": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "type": "object"
+        },
+        "executorSpec": {
+          "properties": {
+            "podTemplateSpec": {
+              "properties": {
+                "metadata": {
+                  "properties": {
+                    "annotations": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "type": "object"
+                    },
+                    "creationTimestamp": {
+                      "type": "string"
+                    },
+                    "deletionGracePeriodSeconds": {
+                      "type": "integer"
+                    },
+                    "deletionTimestamp": {
+                      "type": "string"
+                    },
+                    "finalizers": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "generateName": {
+                      "type": "string"
+                    },
+                    "generation": {
+                      "type": "integer"
+                    },
+                    "labels": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "type": "object"
+                    },
+                    "managedFields": {
+                      "items": {
+                        "properties": {
+                          "apiVersion": {
+                            "type": "string"
+                          },
+                          "fieldsType": {
+                            "type": "string"
+                          },
+                          "fieldsV1": {
+                            "type": "object"
+                          },
+                          "manager": {
+                            "type": "string"
+                          },
+                          "operation": {
+                            "type": "string"
+                          },
+                          "subresource": {
+                            "type": "string"
+                          },
+                          "time": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "namespace": {
+                      "type": "string"
+                    },
+                    "ownerReferences": {
+                      "items": {
+                        "properties": {
+                          "apiVersion": {
+                            "type": "string"
+                          },
+                          "blockOwnerDeletion": {
+                            "type": "boolean"
+                          },
+                          "controller": {
+                            "type": "boolean"
+                          },
+                          "kind": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "uid": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "resourceVersion": {
+                      "type": "string"
+                    },
+                    "selfLink": {
+                      "type": "string"
+                    },
+                    "uid": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "spec": {
+                  "properties": {
+                    "activeDeadlineSeconds": {
+                      "type": "integer"
+                    },
+                    "affinity": {
+                      "properties": {
+                        "nodeAffinity": {
+                          "properties": {
+                            "preferredDuringSchedulingIgnoredDuringExecution": {
+                              "items": {
+                                "properties": {
+                                  "preference": {
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "matchFields": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "weight": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "requiredDuringSchedulingIgnoredDuringExecution": {
+                              "properties": {
+                                "nodeSelectorTerms": {
+                                  "items": {
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "matchFields": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "type": "object"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "podAffinity": {
+                          "properties": {
+                            "preferredDuringSchedulingIgnoredDuringExecution": {
+                              "items": {
+                                "properties": {
+                                  "podAffinityTerm": {
+                                    "properties": {
+                                      "labelSelector": {
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "matchLabels": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "matchLabelKeys": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "mismatchLabelKeys": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "namespaceSelector": {
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "matchLabels": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "namespaces": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "topologyKey": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "weight": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "requiredDuringSchedulingIgnoredDuringExecution": {
+                              "items": {
+                                "properties": {
+                                  "labelSelector": {
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "matchLabels": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "matchLabelKeys": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "mismatchLabelKeys": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "namespaceSelector": {
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "matchLabels": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "namespaces": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "topologyKey": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "podAntiAffinity": {
+                          "properties": {
+                            "preferredDuringSchedulingIgnoredDuringExecution": {
+                              "items": {
+                                "properties": {
+                                  "podAffinityTerm": {
+                                    "properties": {
+                                      "labelSelector": {
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "matchLabels": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "matchLabelKeys": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "mismatchLabelKeys": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "namespaceSelector": {
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "matchLabels": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "namespaces": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "topologyKey": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "weight": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "requiredDuringSchedulingIgnoredDuringExecution": {
+                              "items": {
+                                "properties": {
+                                  "labelSelector": {
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "matchLabels": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "matchLabelKeys": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "mismatchLabelKeys": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "namespaceSelector": {
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "matchLabels": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "namespaces": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "topologyKey": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "automountServiceAccountToken": {
+                      "type": "boolean"
+                    },
+                    "containers": {
+                      "items": {
+                        "properties": {
+                          "args": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "command": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "env": {
+                            "items": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "value": {
+                                  "type": "string"
+                                },
+                                "valueFrom": {
+                                  "properties": {
+                                    "configMapKeyRef": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "fieldRef": {
+                                      "properties": {
+                                        "apiVersion": {
+                                          "type": "string"
+                                        },
+                                        "fieldPath": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "fileKeyRef": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        },
+                                        "path": {
+                                          "type": "string"
+                                        },
+                                        "volumeName": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "resourceFieldRef": {
+                                      "properties": {
+                                        "containerName": {
+                                          "type": "string"
+                                        },
+                                        "divisor": {
+                                          "anyOf": [
+                                            {
+                                              "type": "integer"
+                                            },
+                                            {
+                                              "type": "string"
+                                            }
+                                          ],
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "resource": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "secretKeyRef": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "envFrom": {
+                            "items": {
+                              "properties": {
+                                "configMapRef": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "prefix": {
+                                  "type": "string"
+                                },
+                                "secretRef": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "image": {
+                            "type": "string"
+                          },
+                          "imagePullPolicy": {
+                            "type": "string"
+                          },
+                          "lifecycle": {
+                            "properties": {
+                              "postStart": {
+                                "properties": {
+                                  "exec": {
+                                    "properties": {
+                                      "command": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "httpGet": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "sleep": {
+                                    "properties": {
+                                      "seconds": {
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "tcpSocket": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "preStop": {
+                                "properties": {
+                                  "exec": {
+                                    "properties": {
+                                      "command": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "httpGet": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "sleep": {
+                                    "properties": {
+                                      "seconds": {
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "tcpSocket": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "stopSignal": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "livenessProbe": {
+                            "properties": {
+                              "exec": {
+                                "properties": {
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "failureThreshold": {
+                                "type": "integer"
+                              },
+                              "grpc": {
+                                "properties": {
+                                  "port": {
+                                    "type": "integer"
+                                  },
+                                  "service": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "httpGet": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "initialDelaySeconds": {
+                                "type": "integer"
+                              },
+                              "periodSeconds": {
+                                "type": "integer"
+                              },
+                              "successThreshold": {
+                                "type": "integer"
+                              },
+                              "tcpSocket": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "terminationGracePeriodSeconds": {
+                                "type": "integer"
+                              },
+                              "timeoutSeconds": {
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "ports": {
+                            "items": {
+                              "properties": {
+                                "containerPort": {
+                                  "type": "integer"
+                                },
+                                "hostIP": {
+                                  "type": "string"
+                                },
+                                "hostPort": {
+                                  "type": "integer"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "protocol": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "readinessProbe": {
+                            "properties": {
+                              "exec": {
+                                "properties": {
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "failureThreshold": {
+                                "type": "integer"
+                              },
+                              "grpc": {
+                                "properties": {
+                                  "port": {
+                                    "type": "integer"
+                                  },
+                                  "service": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "httpGet": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "initialDelaySeconds": {
+                                "type": "integer"
+                              },
+                              "periodSeconds": {
+                                "type": "integer"
+                              },
+                              "successThreshold": {
+                                "type": "integer"
+                              },
+                              "tcpSocket": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "terminationGracePeriodSeconds": {
+                                "type": "integer"
+                              },
+                              "timeoutSeconds": {
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "resizePolicy": {
+                            "items": {
+                              "properties": {
+                                "resourceName": {
+                                  "type": "string"
+                                },
+                                "restartPolicy": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "resources": {
+                            "properties": {
+                              "claims": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "request": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "limits": {
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "type": "object"
+                              },
+                              "requests": {
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "restartPolicy": {
+                            "type": "string"
+                          },
+                          "restartPolicyRules": {
+                            "items": {
+                              "properties": {
+                                "action": {
+                                  "type": "string"
+                                },
+                                "exitCodes": {
+                                  "properties": {
+                                    "operator": {
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "items": {
+                                        "type": "integer"
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "securityContext": {
+                            "properties": {
+                              "allowPrivilegeEscalation": {
+                                "type": "boolean"
+                              },
+                              "appArmorProfile": {
+                                "properties": {
+                                  "localhostProfile": {
+                                    "type": "string"
+                                  },
+                                  "type": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "capabilities": {
+                                "properties": {
+                                  "add": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "drop": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "privileged": {
+                                "type": "boolean"
+                              },
+                              "procMount": {
+                                "type": "string"
+                              },
+                              "readOnlyRootFilesystem": {
+                                "type": "boolean"
+                              },
+                              "runAsGroup": {
+                                "type": "integer"
+                              },
+                              "runAsNonRoot": {
+                                "type": "boolean"
+                              },
+                              "runAsUser": {
+                                "type": "integer"
+                              },
+                              "seLinuxOptions": {
+                                "properties": {
+                                  "level": {
+                                    "type": "string"
+                                  },
+                                  "role": {
+                                    "type": "string"
+                                  },
+                                  "type": {
+                                    "type": "string"
+                                  },
+                                  "user": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "seccompProfile": {
+                                "properties": {
+                                  "localhostProfile": {
+                                    "type": "string"
+                                  },
+                                  "type": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "windowsOptions": {
+                                "properties": {
+                                  "gmsaCredentialSpec": {
+                                    "type": "string"
+                                  },
+                                  "gmsaCredentialSpecName": {
+                                    "type": "string"
+                                  },
+                                  "hostProcess": {
+                                    "type": "boolean"
+                                  },
+                                  "runAsUserName": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "startupProbe": {
+                            "properties": {
+                              "exec": {
+                                "properties": {
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "failureThreshold": {
+                                "type": "integer"
+                              },
+                              "grpc": {
+                                "properties": {
+                                  "port": {
+                                    "type": "integer"
+                                  },
+                                  "service": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "httpGet": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "initialDelaySeconds": {
+                                "type": "integer"
+                              },
+                              "periodSeconds": {
+                                "type": "integer"
+                              },
+                              "successThreshold": {
+                                "type": "integer"
+                              },
+                              "tcpSocket": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "terminationGracePeriodSeconds": {
+                                "type": "integer"
+                              },
+                              "timeoutSeconds": {
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "stdin": {
+                            "type": "boolean"
+                          },
+                          "stdinOnce": {
+                            "type": "boolean"
+                          },
+                          "terminationMessagePath": {
+                            "type": "string"
+                          },
+                          "terminationMessagePolicy": {
+                            "type": "string"
+                          },
+                          "tty": {
+                            "type": "boolean"
+                          },
+                          "volumeDevices": {
+                            "items": {
+                              "properties": {
+                                "devicePath": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "volumeMounts": {
+                            "items": {
+                              "properties": {
+                                "mountPath": {
+                                  "type": "string"
+                                },
+                                "mountPropagation": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "readOnly": {
+                                  "type": "boolean"
+                                },
+                                "recursiveReadOnly": {
+                                  "type": "string"
+                                },
+                                "subPath": {
+                                  "type": "string"
+                                },
+                                "subPathExpr": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "workingDir": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "dnsConfig": {
+                      "properties": {
+                        "nameservers": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "options": {
+                          "items": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "value": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "searches": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "dnsPolicy": {
+                      "type": "string"
+                    },
+                    "enableServiceLinks": {
+                      "type": "boolean"
+                    },
+                    "ephemeralContainers": {
+                      "items": {
+                        "properties": {
+                          "args": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "command": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "env": {
+                            "items": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "value": {
+                                  "type": "string"
+                                },
+                                "valueFrom": {
+                                  "properties": {
+                                    "configMapKeyRef": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "fieldRef": {
+                                      "properties": {
+                                        "apiVersion": {
+                                          "type": "string"
+                                        },
+                                        "fieldPath": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "fileKeyRef": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        },
+                                        "path": {
+                                          "type": "string"
+                                        },
+                                        "volumeName": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "resourceFieldRef": {
+                                      "properties": {
+                                        "containerName": {
+                                          "type": "string"
+                                        },
+                                        "divisor": {
+                                          "anyOf": [
+                                            {
+                                              "type": "integer"
+                                            },
+                                            {
+                                              "type": "string"
+                                            }
+                                          ],
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "resource": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "secretKeyRef": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "envFrom": {
+                            "items": {
+                              "properties": {
+                                "configMapRef": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "prefix": {
+                                  "type": "string"
+                                },
+                                "secretRef": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "image": {
+                            "type": "string"
+                          },
+                          "imagePullPolicy": {
+                            "type": "string"
+                          },
+                          "lifecycle": {
+                            "properties": {
+                              "postStart": {
+                                "properties": {
+                                  "exec": {
+                                    "properties": {
+                                      "command": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "httpGet": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "sleep": {
+                                    "properties": {
+                                      "seconds": {
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "tcpSocket": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "preStop": {
+                                "properties": {
+                                  "exec": {
+                                    "properties": {
+                                      "command": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "httpGet": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "sleep": {
+                                    "properties": {
+                                      "seconds": {
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "tcpSocket": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "stopSignal": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "livenessProbe": {
+                            "properties": {
+                              "exec": {
+                                "properties": {
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "failureThreshold": {
+                                "type": "integer"
+                              },
+                              "grpc": {
+                                "properties": {
+                                  "port": {
+                                    "type": "integer"
+                                  },
+                                  "service": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "httpGet": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "initialDelaySeconds": {
+                                "type": "integer"
+                              },
+                              "periodSeconds": {
+                                "type": "integer"
+                              },
+                              "successThreshold": {
+                                "type": "integer"
+                              },
+                              "tcpSocket": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "terminationGracePeriodSeconds": {
+                                "type": "integer"
+                              },
+                              "timeoutSeconds": {
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "ports": {
+                            "items": {
+                              "properties": {
+                                "containerPort": {
+                                  "type": "integer"
+                                },
+                                "hostIP": {
+                                  "type": "string"
+                                },
+                                "hostPort": {
+                                  "type": "integer"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "protocol": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "readinessProbe": {
+                            "properties": {
+                              "exec": {
+                                "properties": {
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "failureThreshold": {
+                                "type": "integer"
+                              },
+                              "grpc": {
+                                "properties": {
+                                  "port": {
+                                    "type": "integer"
+                                  },
+                                  "service": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "httpGet": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "initialDelaySeconds": {
+                                "type": "integer"
+                              },
+                              "periodSeconds": {
+                                "type": "integer"
+                              },
+                              "successThreshold": {
+                                "type": "integer"
+                              },
+                              "tcpSocket": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "terminationGracePeriodSeconds": {
+                                "type": "integer"
+                              },
+                              "timeoutSeconds": {
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "resizePolicy": {
+                            "items": {
+                              "properties": {
+                                "resourceName": {
+                                  "type": "string"
+                                },
+                                "restartPolicy": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "resources": {
+                            "properties": {
+                              "claims": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "request": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "limits": {
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "type": "object"
+                              },
+                              "requests": {
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "restartPolicy": {
+                            "type": "string"
+                          },
+                          "restartPolicyRules": {
+                            "items": {
+                              "properties": {
+                                "action": {
+                                  "type": "string"
+                                },
+                                "exitCodes": {
+                                  "properties": {
+                                    "operator": {
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "items": {
+                                        "type": "integer"
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "securityContext": {
+                            "properties": {
+                              "allowPrivilegeEscalation": {
+                                "type": "boolean"
+                              },
+                              "appArmorProfile": {
+                                "properties": {
+                                  "localhostProfile": {
+                                    "type": "string"
+                                  },
+                                  "type": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "capabilities": {
+                                "properties": {
+                                  "add": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "drop": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "privileged": {
+                                "type": "boolean"
+                              },
+                              "procMount": {
+                                "type": "string"
+                              },
+                              "readOnlyRootFilesystem": {
+                                "type": "boolean"
+                              },
+                              "runAsGroup": {
+                                "type": "integer"
+                              },
+                              "runAsNonRoot": {
+                                "type": "boolean"
+                              },
+                              "runAsUser": {
+                                "type": "integer"
+                              },
+                              "seLinuxOptions": {
+                                "properties": {
+                                  "level": {
+                                    "type": "string"
+                                  },
+                                  "role": {
+                                    "type": "string"
+                                  },
+                                  "type": {
+                                    "type": "string"
+                                  },
+                                  "user": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "seccompProfile": {
+                                "properties": {
+                                  "localhostProfile": {
+                                    "type": "string"
+                                  },
+                                  "type": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "windowsOptions": {
+                                "properties": {
+                                  "gmsaCredentialSpec": {
+                                    "type": "string"
+                                  },
+                                  "gmsaCredentialSpecName": {
+                                    "type": "string"
+                                  },
+                                  "hostProcess": {
+                                    "type": "boolean"
+                                  },
+                                  "runAsUserName": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "startupProbe": {
+                            "properties": {
+                              "exec": {
+                                "properties": {
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "failureThreshold": {
+                                "type": "integer"
+                              },
+                              "grpc": {
+                                "properties": {
+                                  "port": {
+                                    "type": "integer"
+                                  },
+                                  "service": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "httpGet": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "initialDelaySeconds": {
+                                "type": "integer"
+                              },
+                              "periodSeconds": {
+                                "type": "integer"
+                              },
+                              "successThreshold": {
+                                "type": "integer"
+                              },
+                              "tcpSocket": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "terminationGracePeriodSeconds": {
+                                "type": "integer"
+                              },
+                              "timeoutSeconds": {
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "stdin": {
+                            "type": "boolean"
+                          },
+                          "stdinOnce": {
+                            "type": "boolean"
+                          },
+                          "targetContainerName": {
+                            "type": "string"
+                          },
+                          "terminationMessagePath": {
+                            "type": "string"
+                          },
+                          "terminationMessagePolicy": {
+                            "type": "string"
+                          },
+                          "tty": {
+                            "type": "boolean"
+                          },
+                          "volumeDevices": {
+                            "items": {
+                              "properties": {
+                                "devicePath": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "volumeMounts": {
+                            "items": {
+                              "properties": {
+                                "mountPath": {
+                                  "type": "string"
+                                },
+                                "mountPropagation": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "readOnly": {
+                                  "type": "boolean"
+                                },
+                                "recursiveReadOnly": {
+                                  "type": "string"
+                                },
+                                "subPath": {
+                                  "type": "string"
+                                },
+                                "subPathExpr": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "workingDir": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "hostAliases": {
+                      "items": {
+                        "properties": {
+                          "hostnames": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "ip": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "hostIPC": {
+                      "type": "boolean"
+                    },
+                    "hostNetwork": {
+                      "type": "boolean"
+                    },
+                    "hostPID": {
+                      "type": "boolean"
+                    },
+                    "hostUsers": {
+                      "type": "boolean"
+                    },
+                    "hostname": {
+                      "type": "string"
+                    },
+                    "hostnameOverride": {
+                      "type": "string"
+                    },
+                    "imagePullSecrets": {
+                      "items": {
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "initContainers": {
+                      "items": {
+                        "properties": {
+                          "args": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "command": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "env": {
+                            "items": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "value": {
+                                  "type": "string"
+                                },
+                                "valueFrom": {
+                                  "properties": {
+                                    "configMapKeyRef": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "fieldRef": {
+                                      "properties": {
+                                        "apiVersion": {
+                                          "type": "string"
+                                        },
+                                        "fieldPath": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "fileKeyRef": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        },
+                                        "path": {
+                                          "type": "string"
+                                        },
+                                        "volumeName": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "resourceFieldRef": {
+                                      "properties": {
+                                        "containerName": {
+                                          "type": "string"
+                                        },
+                                        "divisor": {
+                                          "anyOf": [
+                                            {
+                                              "type": "integer"
+                                            },
+                                            {
+                                              "type": "string"
+                                            }
+                                          ],
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "resource": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "secretKeyRef": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "envFrom": {
+                            "items": {
+                              "properties": {
+                                "configMapRef": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "prefix": {
+                                  "type": "string"
+                                },
+                                "secretRef": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "image": {
+                            "type": "string"
+                          },
+                          "imagePullPolicy": {
+                            "type": "string"
+                          },
+                          "lifecycle": {
+                            "properties": {
+                              "postStart": {
+                                "properties": {
+                                  "exec": {
+                                    "properties": {
+                                      "command": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "httpGet": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "sleep": {
+                                    "properties": {
+                                      "seconds": {
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "tcpSocket": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "preStop": {
+                                "properties": {
+                                  "exec": {
+                                    "properties": {
+                                      "command": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "httpGet": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "sleep": {
+                                    "properties": {
+                                      "seconds": {
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "tcpSocket": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "stopSignal": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "livenessProbe": {
+                            "properties": {
+                              "exec": {
+                                "properties": {
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "failureThreshold": {
+                                "type": "integer"
+                              },
+                              "grpc": {
+                                "properties": {
+                                  "port": {
+                                    "type": "integer"
+                                  },
+                                  "service": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "httpGet": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "initialDelaySeconds": {
+                                "type": "integer"
+                              },
+                              "periodSeconds": {
+                                "type": "integer"
+                              },
+                              "successThreshold": {
+                                "type": "integer"
+                              },
+                              "tcpSocket": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "terminationGracePeriodSeconds": {
+                                "type": "integer"
+                              },
+                              "timeoutSeconds": {
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "ports": {
+                            "items": {
+                              "properties": {
+                                "containerPort": {
+                                  "type": "integer"
+                                },
+                                "hostIP": {
+                                  "type": "string"
+                                },
+                                "hostPort": {
+                                  "type": "integer"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "protocol": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "readinessProbe": {
+                            "properties": {
+                              "exec": {
+                                "properties": {
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "failureThreshold": {
+                                "type": "integer"
+                              },
+                              "grpc": {
+                                "properties": {
+                                  "port": {
+                                    "type": "integer"
+                                  },
+                                  "service": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "httpGet": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "initialDelaySeconds": {
+                                "type": "integer"
+                              },
+                              "periodSeconds": {
+                                "type": "integer"
+                              },
+                              "successThreshold": {
+                                "type": "integer"
+                              },
+                              "tcpSocket": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "terminationGracePeriodSeconds": {
+                                "type": "integer"
+                              },
+                              "timeoutSeconds": {
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "resizePolicy": {
+                            "items": {
+                              "properties": {
+                                "resourceName": {
+                                  "type": "string"
+                                },
+                                "restartPolicy": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "resources": {
+                            "properties": {
+                              "claims": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "request": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "limits": {
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "type": "object"
+                              },
+                              "requests": {
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "restartPolicy": {
+                            "type": "string"
+                          },
+                          "restartPolicyRules": {
+                            "items": {
+                              "properties": {
+                                "action": {
+                                  "type": "string"
+                                },
+                                "exitCodes": {
+                                  "properties": {
+                                    "operator": {
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "items": {
+                                        "type": "integer"
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "securityContext": {
+                            "properties": {
+                              "allowPrivilegeEscalation": {
+                                "type": "boolean"
+                              },
+                              "appArmorProfile": {
+                                "properties": {
+                                  "localhostProfile": {
+                                    "type": "string"
+                                  },
+                                  "type": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "capabilities": {
+                                "properties": {
+                                  "add": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "drop": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "privileged": {
+                                "type": "boolean"
+                              },
+                              "procMount": {
+                                "type": "string"
+                              },
+                              "readOnlyRootFilesystem": {
+                                "type": "boolean"
+                              },
+                              "runAsGroup": {
+                                "type": "integer"
+                              },
+                              "runAsNonRoot": {
+                                "type": "boolean"
+                              },
+                              "runAsUser": {
+                                "type": "integer"
+                              },
+                              "seLinuxOptions": {
+                                "properties": {
+                                  "level": {
+                                    "type": "string"
+                                  },
+                                  "role": {
+                                    "type": "string"
+                                  },
+                                  "type": {
+                                    "type": "string"
+                                  },
+                                  "user": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "seccompProfile": {
+                                "properties": {
+                                  "localhostProfile": {
+                                    "type": "string"
+                                  },
+                                  "type": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "windowsOptions": {
+                                "properties": {
+                                  "gmsaCredentialSpec": {
+                                    "type": "string"
+                                  },
+                                  "gmsaCredentialSpecName": {
+                                    "type": "string"
+                                  },
+                                  "hostProcess": {
+                                    "type": "boolean"
+                                  },
+                                  "runAsUserName": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "startupProbe": {
+                            "properties": {
+                              "exec": {
+                                "properties": {
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "failureThreshold": {
+                                "type": "integer"
+                              },
+                              "grpc": {
+                                "properties": {
+                                  "port": {
+                                    "type": "integer"
+                                  },
+                                  "service": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "httpGet": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "initialDelaySeconds": {
+                                "type": "integer"
+                              },
+                              "periodSeconds": {
+                                "type": "integer"
+                              },
+                              "successThreshold": {
+                                "type": "integer"
+                              },
+                              "tcpSocket": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "terminationGracePeriodSeconds": {
+                                "type": "integer"
+                              },
+                              "timeoutSeconds": {
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "stdin": {
+                            "type": "boolean"
+                          },
+                          "stdinOnce": {
+                            "type": "boolean"
+                          },
+                          "terminationMessagePath": {
+                            "type": "string"
+                          },
+                          "terminationMessagePolicy": {
+                            "type": "string"
+                          },
+                          "tty": {
+                            "type": "boolean"
+                          },
+                          "volumeDevices": {
+                            "items": {
+                              "properties": {
+                                "devicePath": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "volumeMounts": {
+                            "items": {
+                              "properties": {
+                                "mountPath": {
+                                  "type": "string"
+                                },
+                                "mountPropagation": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "readOnly": {
+                                  "type": "boolean"
+                                },
+                                "recursiveReadOnly": {
+                                  "type": "string"
+                                },
+                                "subPath": {
+                                  "type": "string"
+                                },
+                                "subPathExpr": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "workingDir": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "nodeName": {
+                      "type": "string"
+                    },
+                    "nodeSelector": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "type": "object"
+                    },
+                    "os": {
+                      "properties": {
+                        "name": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "overhead": {
+                      "additionalProperties": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "x-kubernetes-int-or-string": true
+                      },
+                      "type": "object"
+                    },
+                    "preemptionPolicy": {
+                      "type": "string"
+                    },
+                    "priority": {
+                      "type": "integer"
+                    },
+                    "priorityClassName": {
+                      "type": "string"
+                    },
+                    "readinessGates": {
+                      "items": {
+                        "properties": {
+                          "conditionType": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "resourceClaims": {
+                      "items": {
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          },
+                          "resourceClaimName": {
+                            "type": "string"
+                          },
+                          "resourceClaimTemplateName": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "resources": {
+                      "properties": {
+                        "claims": {
+                          "items": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "request": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "limits": {
+                          "additionalProperties": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "x-kubernetes-int-or-string": true
+                          },
+                          "type": "object"
+                        },
+                        "requests": {
+                          "additionalProperties": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "x-kubernetes-int-or-string": true
+                          },
+                          "type": "object"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "restartPolicy": {
+                      "type": "string"
+                    },
+                    "runtimeClassName": {
+                      "type": "string"
+                    },
+                    "schedulerName": {
+                      "type": "string"
+                    },
+                    "schedulingGates": {
+                      "items": {
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "securityContext": {
+                      "properties": {
+                        "appArmorProfile": {
+                          "properties": {
+                            "localhostProfile": {
+                              "type": "string"
+                            },
+                            "type": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "fsGroup": {
+                          "type": "integer"
+                        },
+                        "fsGroupChangePolicy": {
+                          "type": "string"
+                        },
+                        "runAsGroup": {
+                          "type": "integer"
+                        },
+                        "runAsNonRoot": {
+                          "type": "boolean"
+                        },
+                        "runAsUser": {
+                          "type": "integer"
+                        },
+                        "seLinuxChangePolicy": {
+                          "type": "string"
+                        },
+                        "seLinuxOptions": {
+                          "properties": {
+                            "level": {
+                              "type": "string"
+                            },
+                            "role": {
+                              "type": "string"
+                            },
+                            "type": {
+                              "type": "string"
+                            },
+                            "user": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "seccompProfile": {
+                          "properties": {
+                            "localhostProfile": {
+                              "type": "string"
+                            },
+                            "type": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "supplementalGroups": {
+                          "items": {
+                            "type": "integer"
+                          },
+                          "type": "array"
+                        },
+                        "supplementalGroupsPolicy": {
+                          "type": "string"
+                        },
+                        "sysctls": {
+                          "items": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "value": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "windowsOptions": {
+                          "properties": {
+                            "gmsaCredentialSpec": {
+                              "type": "string"
+                            },
+                            "gmsaCredentialSpecName": {
+                              "type": "string"
+                            },
+                            "hostProcess": {
+                              "type": "boolean"
+                            },
+                            "runAsUserName": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "serviceAccount": {
+                      "type": "string"
+                    },
+                    "serviceAccountName": {
+                      "type": "string"
+                    },
+                    "setHostnameAsFQDN": {
+                      "type": "boolean"
+                    },
+                    "shareProcessNamespace": {
+                      "type": "boolean"
+                    },
+                    "subdomain": {
+                      "type": "string"
+                    },
+                    "terminationGracePeriodSeconds": {
+                      "type": "integer"
+                    },
+                    "tolerations": {
+                      "items": {
+                        "properties": {
+                          "effect": {
+                            "type": "string"
+                          },
+                          "key": {
+                            "type": "string"
+                          },
+                          "operator": {
+                            "type": "string"
+                          },
+                          "tolerationSeconds": {
+                            "type": "integer"
+                          },
+                          "value": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "topologySpreadConstraints": {
+                      "items": {
+                        "properties": {
+                          "labelSelector": {
+                            "properties": {
+                              "matchExpressions": {
+                                "items": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "matchLabels": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "matchLabelKeys": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "maxSkew": {
+                            "type": "integer"
+                          },
+                          "minDomains": {
+                            "type": "integer"
+                          },
+                          "nodeAffinityPolicy": {
+                            "type": "string"
+                          },
+                          "nodeTaintsPolicy": {
+                            "type": "string"
+                          },
+                          "topologyKey": {
+                            "type": "string"
+                          },
+                          "whenUnsatisfiable": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "volumes": {
+                      "items": {
+                        "properties": {
+                          "awsElasticBlockStore": {
+                            "properties": {
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "partition": {
+                                "type": "integer"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "volumeID": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "azureDisk": {
+                            "properties": {
+                              "cachingMode": {
+                                "type": "string"
+                              },
+                              "diskName": {
+                                "type": "string"
+                              },
+                              "diskURI": {
+                                "type": "string"
+                              },
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "kind": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "azureFile": {
+                            "properties": {
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "secretName": {
+                                "type": "string"
+                              },
+                              "shareName": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "cephfs": {
+                            "properties": {
+                              "monitors": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "path": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "secretFile": {
+                                "type": "string"
+                              },
+                              "secretRef": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "user": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "cinder": {
+                            "properties": {
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "secretRef": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "volumeID": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "configMap": {
+                            "properties": {
+                              "defaultMode": {
+                                "type": "integer"
+                              },
+                              "items": {
+                                "items": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "mode": {
+                                      "type": "integer"
+                                    },
+                                    "path": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "optional": {
+                                "type": "boolean"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "csi": {
+                            "properties": {
+                              "driver": {
+                                "type": "string"
+                              },
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "nodePublishSecretRef": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "volumeAttributes": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "downwardAPI": {
+                            "properties": {
+                              "defaultMode": {
+                                "type": "integer"
+                              },
+                              "items": {
+                                "items": {
+                                  "properties": {
+                                    "fieldRef": {
+                                      "properties": {
+                                        "apiVersion": {
+                                          "type": "string"
+                                        },
+                                        "fieldPath": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "mode": {
+                                      "type": "integer"
+                                    },
+                                    "path": {
+                                      "type": "string"
+                                    },
+                                    "resourceFieldRef": {
+                                      "properties": {
+                                        "containerName": {
+                                          "type": "string"
+                                        },
+                                        "divisor": {
+                                          "anyOf": [
+                                            {
+                                              "type": "integer"
+                                            },
+                                            {
+                                              "type": "string"
+                                            }
+                                          ],
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "resource": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "emptyDir": {
+                            "properties": {
+                              "medium": {
+                                "type": "string"
+                              },
+                              "sizeLimit": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "ephemeral": {
+                            "properties": {
+                              "volumeClaimTemplate": {
+                                "properties": {
+                                  "metadata": {
+                                    "properties": {
+                                      "annotations": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
+                                      },
+                                      "creationTimestamp": {
+                                        "type": "string"
+                                      },
+                                      "deletionGracePeriodSeconds": {
+                                        "type": "integer"
+                                      },
+                                      "deletionTimestamp": {
+                                        "type": "string"
+                                      },
+                                      "finalizers": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "generateName": {
+                                        "type": "string"
+                                      },
+                                      "generation": {
+                                        "type": "integer"
+                                      },
+                                      "labels": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
+                                      },
+                                      "managedFields": {
+                                        "items": {
+                                          "properties": {
+                                            "apiVersion": {
+                                              "type": "string"
+                                            },
+                                            "fieldsType": {
+                                              "type": "string"
+                                            },
+                                            "fieldsV1": {
+                                              "type": "object"
+                                            },
+                                            "manager": {
+                                              "type": "string"
+                                            },
+                                            "operation": {
+                                              "type": "string"
+                                            },
+                                            "subresource": {
+                                              "type": "string"
+                                            },
+                                            "time": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "namespace": {
+                                        "type": "string"
+                                      },
+                                      "ownerReferences": {
+                                        "items": {
+                                          "properties": {
+                                            "apiVersion": {
+                                              "type": "string"
+                                            },
+                                            "blockOwnerDeletion": {
+                                              "type": "boolean"
+                                            },
+                                            "controller": {
+                                              "type": "boolean"
+                                            },
+                                            "kind": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "uid": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "resourceVersion": {
+                                        "type": "string"
+                                      },
+                                      "selfLink": {
+                                        "type": "string"
+                                      },
+                                      "uid": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "spec": {
+                                    "properties": {
+                                      "accessModes": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "dataSource": {
+                                        "properties": {
+                                          "apiGroup": {
+                                            "type": "string"
+                                          },
+                                          "kind": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "dataSourceRef": {
+                                        "properties": {
+                                          "apiGroup": {
+                                            "type": "string"
+                                          },
+                                          "kind": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "namespace": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "resources": {
+                                        "properties": {
+                                          "limits": {
+                                            "additionalProperties": {
+                                              "anyOf": [
+                                                {
+                                                  "type": "integer"
+                                                },
+                                                {
+                                                  "type": "string"
+                                                }
+                                              ],
+                                              "x-kubernetes-int-or-string": true
+                                            },
+                                            "type": "object"
+                                          },
+                                          "requests": {
+                                            "additionalProperties": {
+                                              "anyOf": [
+                                                {
+                                                  "type": "integer"
+                                                },
+                                                {
+                                                  "type": "string"
+                                                }
+                                              ],
+                                              "x-kubernetes-int-or-string": true
+                                            },
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "selector": {
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "matchLabels": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "storageClassName": {
+                                        "type": "string"
+                                      },
+                                      "volumeAttributesClassName": {
+                                        "type": "string"
+                                      },
+                                      "volumeMode": {
+                                        "type": "string"
+                                      },
+                                      "volumeName": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "fc": {
+                            "properties": {
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "lun": {
+                                "type": "integer"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "targetWWNs": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "wwids": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "flexVolume": {
+                            "properties": {
+                              "driver": {
+                                "type": "string"
+                              },
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "options": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "type": "object"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "secretRef": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "flocker": {
+                            "properties": {
+                              "datasetName": {
+                                "type": "string"
+                              },
+                              "datasetUUID": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "gcePersistentDisk": {
+                            "properties": {
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "partition": {
+                                "type": "integer"
+                              },
+                              "pdName": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "gitRepo": {
+                            "properties": {
+                              "directory": {
+                                "type": "string"
+                              },
+                              "repository": {
+                                "type": "string"
+                              },
+                              "revision": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "glusterfs": {
+                            "properties": {
+                              "endpoints": {
+                                "type": "string"
+                              },
+                              "path": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "hostPath": {
+                            "properties": {
+                              "path": {
+                                "type": "string"
+                              },
+                              "type": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "image": {
+                            "properties": {
+                              "pullPolicy": {
+                                "type": "string"
+                              },
+                              "reference": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "iscsi": {
+                            "properties": {
+                              "chapAuthDiscovery": {
+                                "type": "boolean"
+                              },
+                              "chapAuthSession": {
+                                "type": "boolean"
+                              },
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "initiatorName": {
+                                "type": "string"
+                              },
+                              "iqn": {
+                                "type": "string"
+                              },
+                              "iscsiInterface": {
+                                "type": "string"
+                              },
+                              "lun": {
+                                "type": "integer"
+                              },
+                              "portals": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "secretRef": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "targetPortal": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "nfs": {
+                            "properties": {
+                              "path": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "server": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "persistentVolumeClaim": {
+                            "properties": {
+                              "claimName": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "photonPersistentDisk": {
+                            "properties": {
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "pdID": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "portworxVolume": {
+                            "properties": {
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "volumeID": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "projected": {
+                            "properties": {
+                              "defaultMode": {
+                                "type": "integer"
+                              },
+                              "sources": {
+                                "items": {
+                                  "properties": {
+                                    "clusterTrustBundle": {
+                                      "properties": {
+                                        "labelSelector": {
+                                          "properties": {
+                                            "matchExpressions": {
+                                              "items": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "operator": {
+                                                    "type": "string"
+                                                  },
+                                                  "values": {
+                                                    "items": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "array"
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              "type": "array"
+                                            },
+                                            "matchLabels": {
+                                              "additionalProperties": {
+                                                "type": "string"
+                                              },
+                                              "type": "object"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        },
+                                        "path": {
+                                          "type": "string"
+                                        },
+                                        "signerName": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "configMap": {
+                                      "properties": {
+                                        "items": {
+                                          "items": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "mode": {
+                                                "type": "integer"
+                                              },
+                                              "path": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          "type": "array"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "downwardAPI": {
+                                      "properties": {
+                                        "items": {
+                                          "items": {
+                                            "properties": {
+                                              "fieldRef": {
+                                                "properties": {
+                                                  "apiVersion": {
+                                                    "type": "string"
+                                                  },
+                                                  "fieldPath": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              "mode": {
+                                                "type": "integer"
+                                              },
+                                              "path": {
+                                                "type": "string"
+                                              },
+                                              "resourceFieldRef": {
+                                                "properties": {
+                                                  "containerName": {
+                                                    "type": "string"
+                                                  },
+                                                  "divisor": {
+                                                    "anyOf": [
+                                                      {
+                                                        "type": "integer"
+                                                      },
+                                                      {
+                                                        "type": "string"
+                                                      }
+                                                    ],
+                                                    "x-kubernetes-int-or-string": true
+                                                  },
+                                                  "resource": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object"
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "podCertificate": {
+                                      "properties": {
+                                        "certificateChainPath": {
+                                          "type": "string"
+                                        },
+                                        "credentialBundlePath": {
+                                          "type": "string"
+                                        },
+                                        "keyPath": {
+                                          "type": "string"
+                                        },
+                                        "keyType": {
+                                          "type": "string"
+                                        },
+                                        "maxExpirationSeconds": {
+                                          "type": "integer"
+                                        },
+                                        "signerName": {
+                                          "type": "string"
+                                        },
+                                        "userAnnotations": {
+                                          "additionalProperties": {
+                                            "type": "string"
+                                          },
+                                          "type": "object"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "secret": {
+                                      "properties": {
+                                        "items": {
+                                          "items": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "mode": {
+                                                "type": "integer"
+                                              },
+                                              "path": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          "type": "array"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "serviceAccountToken": {
+                                      "properties": {
+                                        "audience": {
+                                          "type": "string"
+                                        },
+                                        "expirationSeconds": {
+                                          "type": "integer"
+                                        },
+                                        "path": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "quobyte": {
+                            "properties": {
+                              "group": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "registry": {
+                                "type": "string"
+                              },
+                              "tenant": {
+                                "type": "string"
+                              },
+                              "user": {
+                                "type": "string"
+                              },
+                              "volume": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "rbd": {
+                            "properties": {
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "image": {
+                                "type": "string"
+                              },
+                              "keyring": {
+                                "type": "string"
+                              },
+                              "monitors": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "pool": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "secretRef": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "user": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "scaleIO": {
+                            "properties": {
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "gateway": {
+                                "type": "string"
+                              },
+                              "protectionDomain": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "secretRef": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "sslEnabled": {
+                                "type": "boolean"
+                              },
+                              "storageMode": {
+                                "type": "string"
+                              },
+                              "storagePool": {
+                                "type": "string"
+                              },
+                              "system": {
+                                "type": "string"
+                              },
+                              "volumeName": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "secret": {
+                            "properties": {
+                              "defaultMode": {
+                                "type": "integer"
+                              },
+                              "items": {
+                                "items": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "mode": {
+                                      "type": "integer"
+                                    },
+                                    "path": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "optional": {
+                                "type": "boolean"
+                              },
+                              "secretName": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "storageos": {
+                            "properties": {
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "secretRef": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "volumeName": {
+                                "type": "string"
+                              },
+                              "volumeNamespace": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "vsphereVolume": {
+                            "properties": {
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "storagePolicyID": {
+                                "type": "string"
+                              },
+                              "storagePolicyName": {
+                                "type": "string"
+                              },
+                              "volumePath": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "workloadRef": {
+                      "properties": {
+                        "name": {
+                          "type": "string"
+                        },
+                        "podGroup": {
+                          "type": "string"
+                        },
+                        "podGroupReplicaKey": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "type": "object"
+        },
+        "files": {
+          "type": "string"
+        },
+        "jars": {
+          "type": "string"
+        },
+        "mainClass": {
+          "type": "string"
+        },
+        "proxyUser": {
+          "type": "string"
+        },
+        "pyFiles": {
+          "type": "string"
+        },
+        "runtimeVersions": {
+          "properties": {
+            "jdkVersion": {
+              "type": "string"
+            },
+            "scalaVersion": {
+              "type": "string"
+            },
+            "sparkVersion": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "sparkVersion"
+          ],
+          "type": "object"
+        },
+        "sparkConf": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "sparkRFiles": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "runtimeVersions"
+      ],
+      "type": "object"
+    },
+    "status": {
+      "properties": {
+        "currentAttemptSummary": {
+          "properties": {
+            "attemptInfo": {
+              "properties": {
+                "failureRestartCounter": {
+                  "type": "integer"
+                },
+                "id": {
+                  "type": "integer"
+                },
+                "restartCounter": {
+                  "type": "integer"
+                },
+                "schedulingFailureRestartCounter": {
+                  "type": "integer"
+                }
+              },
+              "type": "object"
+            },
+            "stateTransitionHistory": {
+              "additionalProperties": {
+                "properties": {
+                  "currentStateSummary": {
+                    "enum": [
+                      "DriverEvicted",
+                      "DriverReady",
+                      "DriverReadyTimedOut",
+                      "DriverRequested",
+                      "DriverStartTimedOut",
+                      "DriverStarted",
+                      "ExecutorsStartTimedOut",
+                      "Failed",
+                      "InitializedBelowThresholdExecutors",
+                      "ResourceReleased",
+                      "RunningHealthy",
+                      "RunningWithBelowThresholdExecutors",
+                      "RunningWithPartialCapacity",
+                      "ScheduledToRestart",
+                      "SchedulingFailure",
+                      "Submitted",
+                      "Succeeded",
+                      "TerminatedWithoutReleaseResources"
+                    ],
+                    "type": "string"
+                  },
+                  "lastObservedDriverStatus": {
+                    "properties": {
+                      "allocatedResources": {
+                        "additionalProperties": {
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "string"
+                            }
+                          ],
+                          "x-kubernetes-int-or-string": true
+                        },
+                        "type": "object"
+                      },
+                      "conditions": {
+                        "items": {
+                          "properties": {
+                            "lastProbeTime": {
+                              "type": "string"
+                            },
+                            "lastTransitionTime": {
+                              "type": "string"
+                            },
+                            "message": {
+                              "type": "string"
+                            },
+                            "observedGeneration": {
+                              "type": "integer"
+                            },
+                            "reason": {
+                              "type": "string"
+                            },
+                            "status": {
+                              "type": "string"
+                            },
+                            "type": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "type": "array"
+                      },
+                      "containerStatuses": {
+                        "items": {
+                          "properties": {
+                            "allocatedResources": {
+                              "additionalProperties": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "type": "object"
+                            },
+                            "allocatedResourcesStatus": {
+                              "items": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "resources": {
+                                    "items": {
+                                      "properties": {
+                                        "health": {
+                                          "type": "string"
+                                        },
+                                        "resourceID": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "containerID": {
+                              "type": "string"
+                            },
+                            "image": {
+                              "type": "string"
+                            },
+                            "imageID": {
+                              "type": "string"
+                            },
+                            "lastState": {
+                              "properties": {
+                                "running": {
+                                  "properties": {
+                                    "startedAt": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "terminated": {
+                                  "properties": {
+                                    "containerID": {
+                                      "type": "string"
+                                    },
+                                    "exitCode": {
+                                      "type": "integer"
+                                    },
+                                    "finishedAt": {
+                                      "type": "string"
+                                    },
+                                    "message": {
+                                      "type": "string"
+                                    },
+                                    "reason": {
+                                      "type": "string"
+                                    },
+                                    "signal": {
+                                      "type": "integer"
+                                    },
+                                    "startedAt": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "waiting": {
+                                  "properties": {
+                                    "message": {
+                                      "type": "string"
+                                    },
+                                    "reason": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "ready": {
+                              "type": "boolean"
+                            },
+                            "resources": {
+                              "properties": {
+                                "claims": {
+                                  "items": {
+                                    "properties": {
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "request": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "type": "array"
+                                },
+                                "limits": {
+                                  "additionalProperties": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "type": "object"
+                                },
+                                "requests": {
+                                  "additionalProperties": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "restartCount": {
+                              "type": "integer"
+                            },
+                            "started": {
+                              "type": "boolean"
+                            },
+                            "state": {
+                              "properties": {
+                                "running": {
+                                  "properties": {
+                                    "startedAt": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "terminated": {
+                                  "properties": {
+                                    "containerID": {
+                                      "type": "string"
+                                    },
+                                    "exitCode": {
+                                      "type": "integer"
+                                    },
+                                    "finishedAt": {
+                                      "type": "string"
+                                    },
+                                    "message": {
+                                      "type": "string"
+                                    },
+                                    "reason": {
+                                      "type": "string"
+                                    },
+                                    "signal": {
+                                      "type": "integer"
+                                    },
+                                    "startedAt": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "waiting": {
+                                  "properties": {
+                                    "message": {
+                                      "type": "string"
+                                    },
+                                    "reason": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "stopSignal": {
+                              "type": "string"
+                            },
+                            "user": {
+                              "properties": {
+                                "linux": {
+                                  "properties": {
+                                    "gid": {
+                                      "type": "integer"
+                                    },
+                                    "supplementalGroups": {
+                                      "items": {
+                                        "type": "integer"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "uid": {
+                                      "type": "integer"
+                                    }
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "volumeMounts": {
+                              "items": {
+                                "properties": {
+                                  "mountPath": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  },
+                                  "recursiveReadOnly": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "type": "array"
+                      },
+                      "ephemeralContainerStatuses": {
+                        "items": {
+                          "properties": {
+                            "allocatedResources": {
+                              "additionalProperties": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "type": "object"
+                            },
+                            "allocatedResourcesStatus": {
+                              "items": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "resources": {
+                                    "items": {
+                                      "properties": {
+                                        "health": {
+                                          "type": "string"
+                                        },
+                                        "resourceID": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "containerID": {
+                              "type": "string"
+                            },
+                            "image": {
+                              "type": "string"
+                            },
+                            "imageID": {
+                              "type": "string"
+                            },
+                            "lastState": {
+                              "properties": {
+                                "running": {
+                                  "properties": {
+                                    "startedAt": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "terminated": {
+                                  "properties": {
+                                    "containerID": {
+                                      "type": "string"
+                                    },
+                                    "exitCode": {
+                                      "type": "integer"
+                                    },
+                                    "finishedAt": {
+                                      "type": "string"
+                                    },
+                                    "message": {
+                                      "type": "string"
+                                    },
+                                    "reason": {
+                                      "type": "string"
+                                    },
+                                    "signal": {
+                                      "type": "integer"
+                                    },
+                                    "startedAt": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "waiting": {
+                                  "properties": {
+                                    "message": {
+                                      "type": "string"
+                                    },
+                                    "reason": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "ready": {
+                              "type": "boolean"
+                            },
+                            "resources": {
+                              "properties": {
+                                "claims": {
+                                  "items": {
+                                    "properties": {
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "request": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "type": "array"
+                                },
+                                "limits": {
+                                  "additionalProperties": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "type": "object"
+                                },
+                                "requests": {
+                                  "additionalProperties": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "restartCount": {
+                              "type": "integer"
+                            },
+                            "started": {
+                              "type": "boolean"
+                            },
+                            "state": {
+                              "properties": {
+                                "running": {
+                                  "properties": {
+                                    "startedAt": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "terminated": {
+                                  "properties": {
+                                    "containerID": {
+                                      "type": "string"
+                                    },
+                                    "exitCode": {
+                                      "type": "integer"
+                                    },
+                                    "finishedAt": {
+                                      "type": "string"
+                                    },
+                                    "message": {
+                                      "type": "string"
+                                    },
+                                    "reason": {
+                                      "type": "string"
+                                    },
+                                    "signal": {
+                                      "type": "integer"
+                                    },
+                                    "startedAt": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "waiting": {
+                                  "properties": {
+                                    "message": {
+                                      "type": "string"
+                                    },
+                                    "reason": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "stopSignal": {
+                              "type": "string"
+                            },
+                            "user": {
+                              "properties": {
+                                "linux": {
+                                  "properties": {
+                                    "gid": {
+                                      "type": "integer"
+                                    },
+                                    "supplementalGroups": {
+                                      "items": {
+                                        "type": "integer"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "uid": {
+                                      "type": "integer"
+                                    }
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "volumeMounts": {
+                              "items": {
+                                "properties": {
+                                  "mountPath": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  },
+                                  "recursiveReadOnly": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "type": "array"
+                      },
+                      "extendedResourceClaimStatus": {
+                        "properties": {
+                          "requestMappings": {
+                            "items": {
+                              "properties": {
+                                "containerName": {
+                                  "type": "string"
+                                },
+                                "requestName": {
+                                  "type": "string"
+                                },
+                                "resourceName": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "resourceClaimName": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "hostIP": {
+                        "type": "string"
+                      },
+                      "hostIPs": {
+                        "items": {
+                          "properties": {
+                            "ip": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "type": "array"
+                      },
+                      "initContainerStatuses": {
+                        "items": {
+                          "properties": {
+                            "allocatedResources": {
+                              "additionalProperties": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "type": "object"
+                            },
+                            "allocatedResourcesStatus": {
+                              "items": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "resources": {
+                                    "items": {
+                                      "properties": {
+                                        "health": {
+                                          "type": "string"
+                                        },
+                                        "resourceID": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "containerID": {
+                              "type": "string"
+                            },
+                            "image": {
+                              "type": "string"
+                            },
+                            "imageID": {
+                              "type": "string"
+                            },
+                            "lastState": {
+                              "properties": {
+                                "running": {
+                                  "properties": {
+                                    "startedAt": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "terminated": {
+                                  "properties": {
+                                    "containerID": {
+                                      "type": "string"
+                                    },
+                                    "exitCode": {
+                                      "type": "integer"
+                                    },
+                                    "finishedAt": {
+                                      "type": "string"
+                                    },
+                                    "message": {
+                                      "type": "string"
+                                    },
+                                    "reason": {
+                                      "type": "string"
+                                    },
+                                    "signal": {
+                                      "type": "integer"
+                                    },
+                                    "startedAt": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "waiting": {
+                                  "properties": {
+                                    "message": {
+                                      "type": "string"
+                                    },
+                                    "reason": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "ready": {
+                              "type": "boolean"
+                            },
+                            "resources": {
+                              "properties": {
+                                "claims": {
+                                  "items": {
+                                    "properties": {
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "request": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "type": "array"
+                                },
+                                "limits": {
+                                  "additionalProperties": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "type": "object"
+                                },
+                                "requests": {
+                                  "additionalProperties": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "restartCount": {
+                              "type": "integer"
+                            },
+                            "started": {
+                              "type": "boolean"
+                            },
+                            "state": {
+                              "properties": {
+                                "running": {
+                                  "properties": {
+                                    "startedAt": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "terminated": {
+                                  "properties": {
+                                    "containerID": {
+                                      "type": "string"
+                                    },
+                                    "exitCode": {
+                                      "type": "integer"
+                                    },
+                                    "finishedAt": {
+                                      "type": "string"
+                                    },
+                                    "message": {
+                                      "type": "string"
+                                    },
+                                    "reason": {
+                                      "type": "string"
+                                    },
+                                    "signal": {
+                                      "type": "integer"
+                                    },
+                                    "startedAt": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "waiting": {
+                                  "properties": {
+                                    "message": {
+                                      "type": "string"
+                                    },
+                                    "reason": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "stopSignal": {
+                              "type": "string"
+                            },
+                            "user": {
+                              "properties": {
+                                "linux": {
+                                  "properties": {
+                                    "gid": {
+                                      "type": "integer"
+                                    },
+                                    "supplementalGroups": {
+                                      "items": {
+                                        "type": "integer"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "uid": {
+                                      "type": "integer"
+                                    }
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "volumeMounts": {
+                              "items": {
+                                "properties": {
+                                  "mountPath": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  },
+                                  "recursiveReadOnly": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "type": "array"
+                      },
+                      "message": {
+                        "type": "string"
+                      },
+                      "nominatedNodeName": {
+                        "type": "string"
+                      },
+                      "observedGeneration": {
+                        "type": "integer"
+                      },
+                      "phase": {
+                        "type": "string"
+                      },
+                      "podIP": {
+                        "type": "string"
+                      },
+                      "podIPs": {
+                        "items": {
+                          "properties": {
+                            "ip": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "type": "array"
+                      },
+                      "qosClass": {
+                        "type": "string"
+                      },
+                      "reason": {
+                        "type": "string"
+                      },
+                      "resize": {
+                        "type": "string"
+                      },
+                      "resourceClaimStatuses": {
+                        "items": {
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            },
+                            "resourceClaimName": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "type": "array"
+                      },
+                      "resources": {
+                        "properties": {
+                          "claims": {
+                            "items": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "request": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "limits": {
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "type": "object"
+                          },
+                          "requests": {
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "type": "object"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "startTime": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "lastTransitionTime": {
+                    "type": "string"
+                  },
+                  "message": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "type": "object"
+            }
+          },
+          "type": "object"
+        },
+        "currentState": {
+          "properties": {
+            "currentStateSummary": {
+              "enum": [
+                "DriverEvicted",
+                "DriverReady",
+                "DriverReadyTimedOut",
+                "DriverRequested",
+                "DriverStartTimedOut",
+                "DriverStarted",
+                "ExecutorsStartTimedOut",
+                "Failed",
+                "InitializedBelowThresholdExecutors",
+                "ResourceReleased",
+                "RunningHealthy",
+                "RunningWithBelowThresholdExecutors",
+                "RunningWithPartialCapacity",
+                "ScheduledToRestart",
+                "SchedulingFailure",
+                "Submitted",
+                "Succeeded",
+                "TerminatedWithoutReleaseResources"
+              ],
+              "type": "string"
+            },
+            "lastObservedDriverStatus": {
+              "properties": {
+                "allocatedResources": {
+                  "additionalProperties": {
+                    "anyOf": [
+                      {
+                        "type": "integer"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ],
+                    "x-kubernetes-int-or-string": true
+                  },
+                  "type": "object"
+                },
+                "conditions": {
+                  "items": {
+                    "properties": {
+                      "lastProbeTime": {
+                        "type": "string"
+                      },
+                      "lastTransitionTime": {
+                        "type": "string"
+                      },
+                      "message": {
+                        "type": "string"
+                      },
+                      "observedGeneration": {
+                        "type": "integer"
+                      },
+                      "reason": {
+                        "type": "string"
+                      },
+                      "status": {
+                        "type": "string"
+                      },
+                      "type": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "containerStatuses": {
+                  "items": {
+                    "properties": {
+                      "allocatedResources": {
+                        "additionalProperties": {
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "string"
+                            }
+                          ],
+                          "x-kubernetes-int-or-string": true
+                        },
+                        "type": "object"
+                      },
+                      "allocatedResourcesStatus": {
+                        "items": {
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            },
+                            "resources": {
+                              "items": {
+                                "properties": {
+                                  "health": {
+                                    "type": "string"
+                                  },
+                                  "resourceID": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "type": "array"
+                      },
+                      "containerID": {
+                        "type": "string"
+                      },
+                      "image": {
+                        "type": "string"
+                      },
+                      "imageID": {
+                        "type": "string"
+                      },
+                      "lastState": {
+                        "properties": {
+                          "running": {
+                            "properties": {
+                              "startedAt": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "terminated": {
+                            "properties": {
+                              "containerID": {
+                                "type": "string"
+                              },
+                              "exitCode": {
+                                "type": "integer"
+                              },
+                              "finishedAt": {
+                                "type": "string"
+                              },
+                              "message": {
+                                "type": "string"
+                              },
+                              "reason": {
+                                "type": "string"
+                              },
+                              "signal": {
+                                "type": "integer"
+                              },
+                              "startedAt": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "waiting": {
+                            "properties": {
+                              "message": {
+                                "type": "string"
+                              },
+                              "reason": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "ready": {
+                        "type": "boolean"
+                      },
+                      "resources": {
+                        "properties": {
+                          "claims": {
+                            "items": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "request": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "limits": {
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "type": "object"
+                          },
+                          "requests": {
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "type": "object"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "restartCount": {
+                        "type": "integer"
+                      },
+                      "started": {
+                        "type": "boolean"
+                      },
+                      "state": {
+                        "properties": {
+                          "running": {
+                            "properties": {
+                              "startedAt": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "terminated": {
+                            "properties": {
+                              "containerID": {
+                                "type": "string"
+                              },
+                              "exitCode": {
+                                "type": "integer"
+                              },
+                              "finishedAt": {
+                                "type": "string"
+                              },
+                              "message": {
+                                "type": "string"
+                              },
+                              "reason": {
+                                "type": "string"
+                              },
+                              "signal": {
+                                "type": "integer"
+                              },
+                              "startedAt": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "waiting": {
+                            "properties": {
+                              "message": {
+                                "type": "string"
+                              },
+                              "reason": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "stopSignal": {
+                        "type": "string"
+                      },
+                      "user": {
+                        "properties": {
+                          "linux": {
+                            "properties": {
+                              "gid": {
+                                "type": "integer"
+                              },
+                              "supplementalGroups": {
+                                "items": {
+                                  "type": "integer"
+                                },
+                                "type": "array"
+                              },
+                              "uid": {
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "volumeMounts": {
+                        "items": {
+                          "properties": {
+                            "mountPath": {
+                              "type": "string"
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "readOnly": {
+                              "type": "boolean"
+                            },
+                            "recursiveReadOnly": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "ephemeralContainerStatuses": {
+                  "items": {
+                    "properties": {
+                      "allocatedResources": {
+                        "additionalProperties": {
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "string"
+                            }
+                          ],
+                          "x-kubernetes-int-or-string": true
+                        },
+                        "type": "object"
+                      },
+                      "allocatedResourcesStatus": {
+                        "items": {
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            },
+                            "resources": {
+                              "items": {
+                                "properties": {
+                                  "health": {
+                                    "type": "string"
+                                  },
+                                  "resourceID": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "type": "array"
+                      },
+                      "containerID": {
+                        "type": "string"
+                      },
+                      "image": {
+                        "type": "string"
+                      },
+                      "imageID": {
+                        "type": "string"
+                      },
+                      "lastState": {
+                        "properties": {
+                          "running": {
+                            "properties": {
+                              "startedAt": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "terminated": {
+                            "properties": {
+                              "containerID": {
+                                "type": "string"
+                              },
+                              "exitCode": {
+                                "type": "integer"
+                              },
+                              "finishedAt": {
+                                "type": "string"
+                              },
+                              "message": {
+                                "type": "string"
+                              },
+                              "reason": {
+                                "type": "string"
+                              },
+                              "signal": {
+                                "type": "integer"
+                              },
+                              "startedAt": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "waiting": {
+                            "properties": {
+                              "message": {
+                                "type": "string"
+                              },
+                              "reason": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "ready": {
+                        "type": "boolean"
+                      },
+                      "resources": {
+                        "properties": {
+                          "claims": {
+                            "items": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "request": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "limits": {
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "type": "object"
+                          },
+                          "requests": {
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "type": "object"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "restartCount": {
+                        "type": "integer"
+                      },
+                      "started": {
+                        "type": "boolean"
+                      },
+                      "state": {
+                        "properties": {
+                          "running": {
+                            "properties": {
+                              "startedAt": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "terminated": {
+                            "properties": {
+                              "containerID": {
+                                "type": "string"
+                              },
+                              "exitCode": {
+                                "type": "integer"
+                              },
+                              "finishedAt": {
+                                "type": "string"
+                              },
+                              "message": {
+                                "type": "string"
+                              },
+                              "reason": {
+                                "type": "string"
+                              },
+                              "signal": {
+                                "type": "integer"
+                              },
+                              "startedAt": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "waiting": {
+                            "properties": {
+                              "message": {
+                                "type": "string"
+                              },
+                              "reason": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "stopSignal": {
+                        "type": "string"
+                      },
+                      "user": {
+                        "properties": {
+                          "linux": {
+                            "properties": {
+                              "gid": {
+                                "type": "integer"
+                              },
+                              "supplementalGroups": {
+                                "items": {
+                                  "type": "integer"
+                                },
+                                "type": "array"
+                              },
+                              "uid": {
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "volumeMounts": {
+                        "items": {
+                          "properties": {
+                            "mountPath": {
+                              "type": "string"
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "readOnly": {
+                              "type": "boolean"
+                            },
+                            "recursiveReadOnly": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "extendedResourceClaimStatus": {
+                  "properties": {
+                    "requestMappings": {
+                      "items": {
+                        "properties": {
+                          "containerName": {
+                            "type": "string"
+                          },
+                          "requestName": {
+                            "type": "string"
+                          },
+                          "resourceName": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "resourceClaimName": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "hostIP": {
+                  "type": "string"
+                },
+                "hostIPs": {
+                  "items": {
+                    "properties": {
+                      "ip": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "initContainerStatuses": {
+                  "items": {
+                    "properties": {
+                      "allocatedResources": {
+                        "additionalProperties": {
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "string"
+                            }
+                          ],
+                          "x-kubernetes-int-or-string": true
+                        },
+                        "type": "object"
+                      },
+                      "allocatedResourcesStatus": {
+                        "items": {
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            },
+                            "resources": {
+                              "items": {
+                                "properties": {
+                                  "health": {
+                                    "type": "string"
+                                  },
+                                  "resourceID": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "type": "array"
+                      },
+                      "containerID": {
+                        "type": "string"
+                      },
+                      "image": {
+                        "type": "string"
+                      },
+                      "imageID": {
+                        "type": "string"
+                      },
+                      "lastState": {
+                        "properties": {
+                          "running": {
+                            "properties": {
+                              "startedAt": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "terminated": {
+                            "properties": {
+                              "containerID": {
+                                "type": "string"
+                              },
+                              "exitCode": {
+                                "type": "integer"
+                              },
+                              "finishedAt": {
+                                "type": "string"
+                              },
+                              "message": {
+                                "type": "string"
+                              },
+                              "reason": {
+                                "type": "string"
+                              },
+                              "signal": {
+                                "type": "integer"
+                              },
+                              "startedAt": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "waiting": {
+                            "properties": {
+                              "message": {
+                                "type": "string"
+                              },
+                              "reason": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "ready": {
+                        "type": "boolean"
+                      },
+                      "resources": {
+                        "properties": {
+                          "claims": {
+                            "items": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "request": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "limits": {
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "type": "object"
+                          },
+                          "requests": {
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "type": "object"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "restartCount": {
+                        "type": "integer"
+                      },
+                      "started": {
+                        "type": "boolean"
+                      },
+                      "state": {
+                        "properties": {
+                          "running": {
+                            "properties": {
+                              "startedAt": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "terminated": {
+                            "properties": {
+                              "containerID": {
+                                "type": "string"
+                              },
+                              "exitCode": {
+                                "type": "integer"
+                              },
+                              "finishedAt": {
+                                "type": "string"
+                              },
+                              "message": {
+                                "type": "string"
+                              },
+                              "reason": {
+                                "type": "string"
+                              },
+                              "signal": {
+                                "type": "integer"
+                              },
+                              "startedAt": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "waiting": {
+                            "properties": {
+                              "message": {
+                                "type": "string"
+                              },
+                              "reason": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "stopSignal": {
+                        "type": "string"
+                      },
+                      "user": {
+                        "properties": {
+                          "linux": {
+                            "properties": {
+                              "gid": {
+                                "type": "integer"
+                              },
+                              "supplementalGroups": {
+                                "items": {
+                                  "type": "integer"
+                                },
+                                "type": "array"
+                              },
+                              "uid": {
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "volumeMounts": {
+                        "items": {
+                          "properties": {
+                            "mountPath": {
+                              "type": "string"
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "readOnly": {
+                              "type": "boolean"
+                            },
+                            "recursiveReadOnly": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "message": {
+                  "type": "string"
+                },
+                "nominatedNodeName": {
+                  "type": "string"
+                },
+                "observedGeneration": {
+                  "type": "integer"
+                },
+                "phase": {
+                  "type": "string"
+                },
+                "podIP": {
+                  "type": "string"
+                },
+                "podIPs": {
+                  "items": {
+                    "properties": {
+                      "ip": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "qosClass": {
+                  "type": "string"
+                },
+                "reason": {
+                  "type": "string"
+                },
+                "resize": {
+                  "type": "string"
+                },
+                "resourceClaimStatuses": {
+                  "items": {
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      },
+                      "resourceClaimName": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "resources": {
+                  "properties": {
+                    "claims": {
+                      "items": {
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          },
+                          "request": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "limits": {
+                      "additionalProperties": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "x-kubernetes-int-or-string": true
+                      },
+                      "type": "object"
+                    },
+                    "requests": {
+                      "additionalProperties": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "x-kubernetes-int-or-string": true
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "type": "object"
+                },
+                "startTime": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "lastTransitionTime": {
+              "type": "string"
+            },
+            "message": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "previousAttemptSummary": {
+          "properties": {
+            "attemptInfo": {
+              "properties": {
+                "failureRestartCounter": {
+                  "type": "integer"
+                },
+                "id": {
+                  "type": "integer"
+                },
+                "restartCounter": {
+                  "type": "integer"
+                },
+                "schedulingFailureRestartCounter": {
+                  "type": "integer"
+                }
+              },
+              "type": "object"
+            },
+            "stateTransitionHistory": {
+              "additionalProperties": {
+                "properties": {
+                  "currentStateSummary": {
+                    "enum": [
+                      "DriverEvicted",
+                      "DriverReady",
+                      "DriverReadyTimedOut",
+                      "DriverRequested",
+                      "DriverStartTimedOut",
+                      "DriverStarted",
+                      "ExecutorsStartTimedOut",
+                      "Failed",
+                      "InitializedBelowThresholdExecutors",
+                      "ResourceReleased",
+                      "RunningHealthy",
+                      "RunningWithBelowThresholdExecutors",
+                      "RunningWithPartialCapacity",
+                      "ScheduledToRestart",
+                      "SchedulingFailure",
+                      "Submitted",
+                      "Succeeded",
+                      "TerminatedWithoutReleaseResources"
+                    ],
+                    "type": "string"
+                  },
+                  "lastObservedDriverStatus": {
+                    "properties": {
+                      "allocatedResources": {
+                        "additionalProperties": {
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "string"
+                            }
+                          ],
+                          "x-kubernetes-int-or-string": true
+                        },
+                        "type": "object"
+                      },
+                      "conditions": {
+                        "items": {
+                          "properties": {
+                            "lastProbeTime": {
+                              "type": "string"
+                            },
+                            "lastTransitionTime": {
+                              "type": "string"
+                            },
+                            "message": {
+                              "type": "string"
+                            },
+                            "observedGeneration": {
+                              "type": "integer"
+                            },
+                            "reason": {
+                              "type": "string"
+                            },
+                            "status": {
+                              "type": "string"
+                            },
+                            "type": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "type": "array"
+                      },
+                      "containerStatuses": {
+                        "items": {
+                          "properties": {
+                            "allocatedResources": {
+                              "additionalProperties": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "type": "object"
+                            },
+                            "allocatedResourcesStatus": {
+                              "items": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "resources": {
+                                    "items": {
+                                      "properties": {
+                                        "health": {
+                                          "type": "string"
+                                        },
+                                        "resourceID": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "containerID": {
+                              "type": "string"
+                            },
+                            "image": {
+                              "type": "string"
+                            },
+                            "imageID": {
+                              "type": "string"
+                            },
+                            "lastState": {
+                              "properties": {
+                                "running": {
+                                  "properties": {
+                                    "startedAt": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "terminated": {
+                                  "properties": {
+                                    "containerID": {
+                                      "type": "string"
+                                    },
+                                    "exitCode": {
+                                      "type": "integer"
+                                    },
+                                    "finishedAt": {
+                                      "type": "string"
+                                    },
+                                    "message": {
+                                      "type": "string"
+                                    },
+                                    "reason": {
+                                      "type": "string"
+                                    },
+                                    "signal": {
+                                      "type": "integer"
+                                    },
+                                    "startedAt": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "waiting": {
+                                  "properties": {
+                                    "message": {
+                                      "type": "string"
+                                    },
+                                    "reason": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "ready": {
+                              "type": "boolean"
+                            },
+                            "resources": {
+                              "properties": {
+                                "claims": {
+                                  "items": {
+                                    "properties": {
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "request": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "type": "array"
+                                },
+                                "limits": {
+                                  "additionalProperties": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "type": "object"
+                                },
+                                "requests": {
+                                  "additionalProperties": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "restartCount": {
+                              "type": "integer"
+                            },
+                            "started": {
+                              "type": "boolean"
+                            },
+                            "state": {
+                              "properties": {
+                                "running": {
+                                  "properties": {
+                                    "startedAt": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "terminated": {
+                                  "properties": {
+                                    "containerID": {
+                                      "type": "string"
+                                    },
+                                    "exitCode": {
+                                      "type": "integer"
+                                    },
+                                    "finishedAt": {
+                                      "type": "string"
+                                    },
+                                    "message": {
+                                      "type": "string"
+                                    },
+                                    "reason": {
+                                      "type": "string"
+                                    },
+                                    "signal": {
+                                      "type": "integer"
+                                    },
+                                    "startedAt": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "waiting": {
+                                  "properties": {
+                                    "message": {
+                                      "type": "string"
+                                    },
+                                    "reason": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "stopSignal": {
+                              "type": "string"
+                            },
+                            "user": {
+                              "properties": {
+                                "linux": {
+                                  "properties": {
+                                    "gid": {
+                                      "type": "integer"
+                                    },
+                                    "supplementalGroups": {
+                                      "items": {
+                                        "type": "integer"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "uid": {
+                                      "type": "integer"
+                                    }
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "volumeMounts": {
+                              "items": {
+                                "properties": {
+                                  "mountPath": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  },
+                                  "recursiveReadOnly": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "type": "array"
+                      },
+                      "ephemeralContainerStatuses": {
+                        "items": {
+                          "properties": {
+                            "allocatedResources": {
+                              "additionalProperties": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "type": "object"
+                            },
+                            "allocatedResourcesStatus": {
+                              "items": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "resources": {
+                                    "items": {
+                                      "properties": {
+                                        "health": {
+                                          "type": "string"
+                                        },
+                                        "resourceID": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "containerID": {
+                              "type": "string"
+                            },
+                            "image": {
+                              "type": "string"
+                            },
+                            "imageID": {
+                              "type": "string"
+                            },
+                            "lastState": {
+                              "properties": {
+                                "running": {
+                                  "properties": {
+                                    "startedAt": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "terminated": {
+                                  "properties": {
+                                    "containerID": {
+                                      "type": "string"
+                                    },
+                                    "exitCode": {
+                                      "type": "integer"
+                                    },
+                                    "finishedAt": {
+                                      "type": "string"
+                                    },
+                                    "message": {
+                                      "type": "string"
+                                    },
+                                    "reason": {
+                                      "type": "string"
+                                    },
+                                    "signal": {
+                                      "type": "integer"
+                                    },
+                                    "startedAt": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "waiting": {
+                                  "properties": {
+                                    "message": {
+                                      "type": "string"
+                                    },
+                                    "reason": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "ready": {
+                              "type": "boolean"
+                            },
+                            "resources": {
+                              "properties": {
+                                "claims": {
+                                  "items": {
+                                    "properties": {
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "request": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "type": "array"
+                                },
+                                "limits": {
+                                  "additionalProperties": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "type": "object"
+                                },
+                                "requests": {
+                                  "additionalProperties": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "restartCount": {
+                              "type": "integer"
+                            },
+                            "started": {
+                              "type": "boolean"
+                            },
+                            "state": {
+                              "properties": {
+                                "running": {
+                                  "properties": {
+                                    "startedAt": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "terminated": {
+                                  "properties": {
+                                    "containerID": {
+                                      "type": "string"
+                                    },
+                                    "exitCode": {
+                                      "type": "integer"
+                                    },
+                                    "finishedAt": {
+                                      "type": "string"
+                                    },
+                                    "message": {
+                                      "type": "string"
+                                    },
+                                    "reason": {
+                                      "type": "string"
+                                    },
+                                    "signal": {
+                                      "type": "integer"
+                                    },
+                                    "startedAt": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "waiting": {
+                                  "properties": {
+                                    "message": {
+                                      "type": "string"
+                                    },
+                                    "reason": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "stopSignal": {
+                              "type": "string"
+                            },
+                            "user": {
+                              "properties": {
+                                "linux": {
+                                  "properties": {
+                                    "gid": {
+                                      "type": "integer"
+                                    },
+                                    "supplementalGroups": {
+                                      "items": {
+                                        "type": "integer"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "uid": {
+                                      "type": "integer"
+                                    }
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "volumeMounts": {
+                              "items": {
+                                "properties": {
+                                  "mountPath": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  },
+                                  "recursiveReadOnly": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "type": "array"
+                      },
+                      "extendedResourceClaimStatus": {
+                        "properties": {
+                          "requestMappings": {
+                            "items": {
+                              "properties": {
+                                "containerName": {
+                                  "type": "string"
+                                },
+                                "requestName": {
+                                  "type": "string"
+                                },
+                                "resourceName": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "resourceClaimName": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "hostIP": {
+                        "type": "string"
+                      },
+                      "hostIPs": {
+                        "items": {
+                          "properties": {
+                            "ip": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "type": "array"
+                      },
+                      "initContainerStatuses": {
+                        "items": {
+                          "properties": {
+                            "allocatedResources": {
+                              "additionalProperties": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "type": "object"
+                            },
+                            "allocatedResourcesStatus": {
+                              "items": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "resources": {
+                                    "items": {
+                                      "properties": {
+                                        "health": {
+                                          "type": "string"
+                                        },
+                                        "resourceID": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "containerID": {
+                              "type": "string"
+                            },
+                            "image": {
+                              "type": "string"
+                            },
+                            "imageID": {
+                              "type": "string"
+                            },
+                            "lastState": {
+                              "properties": {
+                                "running": {
+                                  "properties": {
+                                    "startedAt": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "terminated": {
+                                  "properties": {
+                                    "containerID": {
+                                      "type": "string"
+                                    },
+                                    "exitCode": {
+                                      "type": "integer"
+                                    },
+                                    "finishedAt": {
+                                      "type": "string"
+                                    },
+                                    "message": {
+                                      "type": "string"
+                                    },
+                                    "reason": {
+                                      "type": "string"
+                                    },
+                                    "signal": {
+                                      "type": "integer"
+                                    },
+                                    "startedAt": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "waiting": {
+                                  "properties": {
+                                    "message": {
+                                      "type": "string"
+                                    },
+                                    "reason": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "ready": {
+                              "type": "boolean"
+                            },
+                            "resources": {
+                              "properties": {
+                                "claims": {
+                                  "items": {
+                                    "properties": {
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "request": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "type": "array"
+                                },
+                                "limits": {
+                                  "additionalProperties": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "type": "object"
+                                },
+                                "requests": {
+                                  "additionalProperties": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "restartCount": {
+                              "type": "integer"
+                            },
+                            "started": {
+                              "type": "boolean"
+                            },
+                            "state": {
+                              "properties": {
+                                "running": {
+                                  "properties": {
+                                    "startedAt": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "terminated": {
+                                  "properties": {
+                                    "containerID": {
+                                      "type": "string"
+                                    },
+                                    "exitCode": {
+                                      "type": "integer"
+                                    },
+                                    "finishedAt": {
+                                      "type": "string"
+                                    },
+                                    "message": {
+                                      "type": "string"
+                                    },
+                                    "reason": {
+                                      "type": "string"
+                                    },
+                                    "signal": {
+                                      "type": "integer"
+                                    },
+                                    "startedAt": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "waiting": {
+                                  "properties": {
+                                    "message": {
+                                      "type": "string"
+                                    },
+                                    "reason": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "stopSignal": {
+                              "type": "string"
+                            },
+                            "user": {
+                              "properties": {
+                                "linux": {
+                                  "properties": {
+                                    "gid": {
+                                      "type": "integer"
+                                    },
+                                    "supplementalGroups": {
+                                      "items": {
+                                        "type": "integer"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "uid": {
+                                      "type": "integer"
+                                    }
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "volumeMounts": {
+                              "items": {
+                                "properties": {
+                                  "mountPath": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  },
+                                  "recursiveReadOnly": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "type": "array"
+                      },
+                      "message": {
+                        "type": "string"
+                      },
+                      "nominatedNodeName": {
+                        "type": "string"
+                      },
+                      "observedGeneration": {
+                        "type": "integer"
+                      },
+                      "phase": {
+                        "type": "string"
+                      },
+                      "podIP": {
+                        "type": "string"
+                      },
+                      "podIPs": {
+                        "items": {
+                          "properties": {
+                            "ip": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "type": "array"
+                      },
+                      "qosClass": {
+                        "type": "string"
+                      },
+                      "reason": {
+                        "type": "string"
+                      },
+                      "resize": {
+                        "type": "string"
+                      },
+                      "resourceClaimStatuses": {
+                        "items": {
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            },
+                            "resourceClaimName": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "type": "array"
+                      },
+                      "resources": {
+                        "properties": {
+                          "claims": {
+                            "items": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "request": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "limits": {
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "type": "object"
+                          },
+                          "requests": {
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "type": "object"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "startTime": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "lastTransitionTime": {
+                    "type": "string"
+                  },
+                  "message": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "type": "object"
+            }
+          },
+          "type": "object"
+        },
+        "stateTransitionHistory": {
+          "additionalProperties": {
+            "properties": {
+              "currentStateSummary": {
+                "enum": [
+                  "DriverEvicted",
+                  "DriverReady",
+                  "DriverReadyTimedOut",
+                  "DriverRequested",
+                  "DriverStartTimedOut",
+                  "DriverStarted",
+                  "ExecutorsStartTimedOut",
+                  "Failed",
+                  "InitializedBelowThresholdExecutors",
+                  "ResourceReleased",
+                  "RunningHealthy",
+                  "RunningWithBelowThresholdExecutors",
+                  "RunningWithPartialCapacity",
+                  "ScheduledToRestart",
+                  "SchedulingFailure",
+                  "Submitted",
+                  "Succeeded",
+                  "TerminatedWithoutReleaseResources"
+                ],
+                "type": "string"
+              },
+              "lastObservedDriverStatus": {
+                "properties": {
+                  "allocatedResources": {
+                    "additionalProperties": {
+                      "anyOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ],
+                      "x-kubernetes-int-or-string": true
+                    },
+                    "type": "object"
+                  },
+                  "conditions": {
+                    "items": {
+                      "properties": {
+                        "lastProbeTime": {
+                          "type": "string"
+                        },
+                        "lastTransitionTime": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "observedGeneration": {
+                          "type": "integer"
+                        },
+                        "reason": {
+                          "type": "string"
+                        },
+                        "status": {
+                          "type": "string"
+                        },
+                        "type": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "containerStatuses": {
+                    "items": {
+                      "properties": {
+                        "allocatedResources": {
+                          "additionalProperties": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "x-kubernetes-int-or-string": true
+                          },
+                          "type": "object"
+                        },
+                        "allocatedResourcesStatus": {
+                          "items": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "resources": {
+                                "items": {
+                                  "properties": {
+                                    "health": {
+                                      "type": "string"
+                                    },
+                                    "resourceID": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "containerID": {
+                          "type": "string"
+                        },
+                        "image": {
+                          "type": "string"
+                        },
+                        "imageID": {
+                          "type": "string"
+                        },
+                        "lastState": {
+                          "properties": {
+                            "running": {
+                              "properties": {
+                                "startedAt": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "terminated": {
+                              "properties": {
+                                "containerID": {
+                                  "type": "string"
+                                },
+                                "exitCode": {
+                                  "type": "integer"
+                                },
+                                "finishedAt": {
+                                  "type": "string"
+                                },
+                                "message": {
+                                  "type": "string"
+                                },
+                                "reason": {
+                                  "type": "string"
+                                },
+                                "signal": {
+                                  "type": "integer"
+                                },
+                                "startedAt": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "waiting": {
+                              "properties": {
+                                "message": {
+                                  "type": "string"
+                                },
+                                "reason": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "ready": {
+                          "type": "boolean"
+                        },
+                        "resources": {
+                          "properties": {
+                            "claims": {
+                              "items": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "request": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "limits": {
+                              "additionalProperties": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "type": "object"
+                            },
+                            "requests": {
+                              "additionalProperties": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "type": "object"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "restartCount": {
+                          "type": "integer"
+                        },
+                        "started": {
+                          "type": "boolean"
+                        },
+                        "state": {
+                          "properties": {
+                            "running": {
+                              "properties": {
+                                "startedAt": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "terminated": {
+                              "properties": {
+                                "containerID": {
+                                  "type": "string"
+                                },
+                                "exitCode": {
+                                  "type": "integer"
+                                },
+                                "finishedAt": {
+                                  "type": "string"
+                                },
+                                "message": {
+                                  "type": "string"
+                                },
+                                "reason": {
+                                  "type": "string"
+                                },
+                                "signal": {
+                                  "type": "integer"
+                                },
+                                "startedAt": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "waiting": {
+                              "properties": {
+                                "message": {
+                                  "type": "string"
+                                },
+                                "reason": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "stopSignal": {
+                          "type": "string"
+                        },
+                        "user": {
+                          "properties": {
+                            "linux": {
+                              "properties": {
+                                "gid": {
+                                  "type": "integer"
+                                },
+                                "supplementalGroups": {
+                                  "items": {
+                                    "type": "integer"
+                                  },
+                                  "type": "array"
+                                },
+                                "uid": {
+                                  "type": "integer"
+                                }
+                              },
+                              "type": "object"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "volumeMounts": {
+                          "items": {
+                            "properties": {
+                              "mountPath": {
+                                "type": "string"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "recursiveReadOnly": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "ephemeralContainerStatuses": {
+                    "items": {
+                      "properties": {
+                        "allocatedResources": {
+                          "additionalProperties": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "x-kubernetes-int-or-string": true
+                          },
+                          "type": "object"
+                        },
+                        "allocatedResourcesStatus": {
+                          "items": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "resources": {
+                                "items": {
+                                  "properties": {
+                                    "health": {
+                                      "type": "string"
+                                    },
+                                    "resourceID": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "containerID": {
+                          "type": "string"
+                        },
+                        "image": {
+                          "type": "string"
+                        },
+                        "imageID": {
+                          "type": "string"
+                        },
+                        "lastState": {
+                          "properties": {
+                            "running": {
+                              "properties": {
+                                "startedAt": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "terminated": {
+                              "properties": {
+                                "containerID": {
+                                  "type": "string"
+                                },
+                                "exitCode": {
+                                  "type": "integer"
+                                },
+                                "finishedAt": {
+                                  "type": "string"
+                                },
+                                "message": {
+                                  "type": "string"
+                                },
+                                "reason": {
+                                  "type": "string"
+                                },
+                                "signal": {
+                                  "type": "integer"
+                                },
+                                "startedAt": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "waiting": {
+                              "properties": {
+                                "message": {
+                                  "type": "string"
+                                },
+                                "reason": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "ready": {
+                          "type": "boolean"
+                        },
+                        "resources": {
+                          "properties": {
+                            "claims": {
+                              "items": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "request": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "limits": {
+                              "additionalProperties": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "type": "object"
+                            },
+                            "requests": {
+                              "additionalProperties": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "type": "object"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "restartCount": {
+                          "type": "integer"
+                        },
+                        "started": {
+                          "type": "boolean"
+                        },
+                        "state": {
+                          "properties": {
+                            "running": {
+                              "properties": {
+                                "startedAt": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "terminated": {
+                              "properties": {
+                                "containerID": {
+                                  "type": "string"
+                                },
+                                "exitCode": {
+                                  "type": "integer"
+                                },
+                                "finishedAt": {
+                                  "type": "string"
+                                },
+                                "message": {
+                                  "type": "string"
+                                },
+                                "reason": {
+                                  "type": "string"
+                                },
+                                "signal": {
+                                  "type": "integer"
+                                },
+                                "startedAt": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "waiting": {
+                              "properties": {
+                                "message": {
+                                  "type": "string"
+                                },
+                                "reason": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "stopSignal": {
+                          "type": "string"
+                        },
+                        "user": {
+                          "properties": {
+                            "linux": {
+                              "properties": {
+                                "gid": {
+                                  "type": "integer"
+                                },
+                                "supplementalGroups": {
+                                  "items": {
+                                    "type": "integer"
+                                  },
+                                  "type": "array"
+                                },
+                                "uid": {
+                                  "type": "integer"
+                                }
+                              },
+                              "type": "object"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "volumeMounts": {
+                          "items": {
+                            "properties": {
+                              "mountPath": {
+                                "type": "string"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "recursiveReadOnly": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "extendedResourceClaimStatus": {
+                    "properties": {
+                      "requestMappings": {
+                        "items": {
+                          "properties": {
+                            "containerName": {
+                              "type": "string"
+                            },
+                            "requestName": {
+                              "type": "string"
+                            },
+                            "resourceName": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "type": "array"
+                      },
+                      "resourceClaimName": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "hostIP": {
+                    "type": "string"
+                  },
+                  "hostIPs": {
+                    "items": {
+                      "properties": {
+                        "ip": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "initContainerStatuses": {
+                    "items": {
+                      "properties": {
+                        "allocatedResources": {
+                          "additionalProperties": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "x-kubernetes-int-or-string": true
+                          },
+                          "type": "object"
+                        },
+                        "allocatedResourcesStatus": {
+                          "items": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "resources": {
+                                "items": {
+                                  "properties": {
+                                    "health": {
+                                      "type": "string"
+                                    },
+                                    "resourceID": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "containerID": {
+                          "type": "string"
+                        },
+                        "image": {
+                          "type": "string"
+                        },
+                        "imageID": {
+                          "type": "string"
+                        },
+                        "lastState": {
+                          "properties": {
+                            "running": {
+                              "properties": {
+                                "startedAt": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "terminated": {
+                              "properties": {
+                                "containerID": {
+                                  "type": "string"
+                                },
+                                "exitCode": {
+                                  "type": "integer"
+                                },
+                                "finishedAt": {
+                                  "type": "string"
+                                },
+                                "message": {
+                                  "type": "string"
+                                },
+                                "reason": {
+                                  "type": "string"
+                                },
+                                "signal": {
+                                  "type": "integer"
+                                },
+                                "startedAt": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "waiting": {
+                              "properties": {
+                                "message": {
+                                  "type": "string"
+                                },
+                                "reason": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "ready": {
+                          "type": "boolean"
+                        },
+                        "resources": {
+                          "properties": {
+                            "claims": {
+                              "items": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "request": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "limits": {
+                              "additionalProperties": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "type": "object"
+                            },
+                            "requests": {
+                              "additionalProperties": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "type": "object"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "restartCount": {
+                          "type": "integer"
+                        },
+                        "started": {
+                          "type": "boolean"
+                        },
+                        "state": {
+                          "properties": {
+                            "running": {
+                              "properties": {
+                                "startedAt": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "terminated": {
+                              "properties": {
+                                "containerID": {
+                                  "type": "string"
+                                },
+                                "exitCode": {
+                                  "type": "integer"
+                                },
+                                "finishedAt": {
+                                  "type": "string"
+                                },
+                                "message": {
+                                  "type": "string"
+                                },
+                                "reason": {
+                                  "type": "string"
+                                },
+                                "signal": {
+                                  "type": "integer"
+                                },
+                                "startedAt": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "waiting": {
+                              "properties": {
+                                "message": {
+                                  "type": "string"
+                                },
+                                "reason": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "stopSignal": {
+                          "type": "string"
+                        },
+                        "user": {
+                          "properties": {
+                            "linux": {
+                              "properties": {
+                                "gid": {
+                                  "type": "integer"
+                                },
+                                "supplementalGroups": {
+                                  "items": {
+                                    "type": "integer"
+                                  },
+                                  "type": "array"
+                                },
+                                "uid": {
+                                  "type": "integer"
+                                }
+                              },
+                              "type": "object"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "volumeMounts": {
+                          "items": {
+                            "properties": {
+                              "mountPath": {
+                                "type": "string"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "recursiveReadOnly": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "message": {
+                    "type": "string"
+                  },
+                  "nominatedNodeName": {
+                    "type": "string"
+                  },
+                  "observedGeneration": {
+                    "type": "integer"
+                  },
+                  "phase": {
+                    "type": "string"
+                  },
+                  "podIP": {
+                    "type": "string"
+                  },
+                  "podIPs": {
+                    "items": {
+                      "properties": {
+                        "ip": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "qosClass": {
+                    "type": "string"
+                  },
+                  "reason": {
+                    "type": "string"
+                  },
+                  "resize": {
+                    "type": "string"
+                  },
+                  "resourceClaimStatuses": {
+                    "items": {
+                      "properties": {
+                        "name": {
+                          "type": "string"
+                        },
+                        "resourceClaimName": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "resources": {
+                    "properties": {
+                      "claims": {
+                        "items": {
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            },
+                            "request": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "type": "array"
+                      },
+                      "limits": {
+                        "additionalProperties": {
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "string"
+                            }
+                          ],
+                          "x-kubernetes-int-or-string": true
+                        },
+                        "type": "object"
+                      },
+                      "requests": {
+                        "additionalProperties": {
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "string"
+                            }
+                          ],
+                          "x-kubernetes-int-or-string": true
+                        },
+                        "type": "object"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "startTime": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "lastTransitionTime": {
+                "type": "string"
+              },
+              "message": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "type": "object"
+        }
+      },
+      "type": "object"
+    },
+    "apiVersion": {
+      "type": "string"
+    },
+    "kind": {
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    }
+  },
+  "type": "object"
+}

--- a/spark.apache.org/sparkapplication_v1alpha1.json
+++ b/spark.apache.org/sparkapplication_v1alpha1.json
@@ -1,0 +1,13840 @@
+{
+  "properties": {
+    "spec": {
+      "properties": {
+        "applicationTolerations": {
+          "properties": {
+            "applicationTimeoutConfig": {
+              "properties": {
+                "driverReadyTimeoutMillis": {
+                  "type": "integer"
+                },
+                "driverStartTimeoutMillis": {
+                  "type": "integer"
+                },
+                "executorStartTimeoutMillis": {
+                  "type": "integer"
+                },
+                "forceTerminationGracePeriodMillis": {
+                  "type": "integer"
+                },
+                "terminationRequeuePeriodMillis": {
+                  "type": "integer"
+                }
+              },
+              "type": "object"
+            },
+            "instanceConfig": {
+              "properties": {
+                "initExecutors": {
+                  "type": "integer"
+                },
+                "maxExecutors": {
+                  "type": "integer"
+                },
+                "minExecutors": {
+                  "type": "integer"
+                }
+              },
+              "type": "object"
+            },
+            "resourceRetainPolicy": {
+              "enum": [
+                "Always",
+                "Never",
+                "OnFailure"
+              ],
+              "type": "string"
+            },
+            "restartConfig": {
+              "properties": {
+                "maxRestartAttempts": {
+                  "type": "integer"
+                },
+                "restartBackoffMillis": {
+                  "type": "integer"
+                },
+                "restartPolicy": {
+                  "enum": [
+                    "Always",
+                    "Never",
+                    "OnFailure",
+                    "OnInfrastructureFailure"
+                  ],
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "type": "object"
+        },
+        "configMapSpecs": {
+          "items": {
+            "properties": {
+              "annotations": {
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "type": "object"
+              },
+              "data": {
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "type": "object"
+              },
+              "labels": {
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "type": "object"
+              },
+              "name": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "name"
+            ],
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "deploymentMode": {
+          "enum": [
+            "ClientMode",
+            "ClusterMode"
+          ],
+          "type": "string"
+        },
+        "driverArgs": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "driverServiceIngressList": {
+          "items": {
+            "properties": {
+              "ingressMetadata": {
+                "properties": {
+                  "annotations": {
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "type": "object"
+                  },
+                  "creationTimestamp": {
+                    "type": "string"
+                  },
+                  "deletionGracePeriodSeconds": {
+                    "type": "integer"
+                  },
+                  "deletionTimestamp": {
+                    "type": "string"
+                  },
+                  "finalizers": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "generateName": {
+                    "type": "string"
+                  },
+                  "generation": {
+                    "type": "integer"
+                  },
+                  "labels": {
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "type": "object"
+                  },
+                  "managedFields": {
+                    "items": {
+                      "properties": {
+                        "apiVersion": {
+                          "type": "string"
+                        },
+                        "fieldsType": {
+                          "type": "string"
+                        },
+                        "fieldsV1": {
+                          "type": "object"
+                        },
+                        "manager": {
+                          "type": "string"
+                        },
+                        "operation": {
+                          "type": "string"
+                        },
+                        "subresource": {
+                          "type": "string"
+                        },
+                        "time": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "namespace": {
+                    "type": "string"
+                  },
+                  "ownerReferences": {
+                    "items": {
+                      "properties": {
+                        "apiVersion": {
+                          "type": "string"
+                        },
+                        "blockOwnerDeletion": {
+                          "type": "boolean"
+                        },
+                        "controller": {
+                          "type": "boolean"
+                        },
+                        "kind": {
+                          "type": "string"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "uid": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "resourceVersion": {
+                    "type": "string"
+                  },
+                  "selfLink": {
+                    "type": "string"
+                  },
+                  "uid": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "ingressSpec": {
+                "properties": {
+                  "defaultBackend": {
+                    "properties": {
+                      "resource": {
+                        "properties": {
+                          "apiGroup": {
+                            "type": "string"
+                          },
+                          "kind": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "service": {
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          },
+                          "port": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "number": {
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object"
+                          }
+                        },
+                        "type": "object"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "ingressClassName": {
+                    "type": "string"
+                  },
+                  "rules": {
+                    "items": {
+                      "properties": {
+                        "host": {
+                          "type": "string"
+                        },
+                        "http": {
+                          "properties": {
+                            "paths": {
+                              "items": {
+                                "properties": {
+                                  "backend": {
+                                    "properties": {
+                                      "resource": {
+                                        "properties": {
+                                          "apiGroup": {
+                                            "type": "string"
+                                          },
+                                          "kind": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "service": {
+                                        "properties": {
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "properties": {
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "number": {
+                                                "type": "integer"
+                                              }
+                                            },
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "pathType": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "tls": {
+                    "items": {
+                      "properties": {
+                        "hosts": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "secretName": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "type": "array"
+                  }
+                },
+                "type": "object"
+              },
+              "serviceMetadata": {
+                "properties": {
+                  "annotations": {
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "type": "object"
+                  },
+                  "creationTimestamp": {
+                    "type": "string"
+                  },
+                  "deletionGracePeriodSeconds": {
+                    "type": "integer"
+                  },
+                  "deletionTimestamp": {
+                    "type": "string"
+                  },
+                  "finalizers": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "generateName": {
+                    "type": "string"
+                  },
+                  "generation": {
+                    "type": "integer"
+                  },
+                  "labels": {
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "type": "object"
+                  },
+                  "managedFields": {
+                    "items": {
+                      "properties": {
+                        "apiVersion": {
+                          "type": "string"
+                        },
+                        "fieldsType": {
+                          "type": "string"
+                        },
+                        "fieldsV1": {
+                          "type": "object"
+                        },
+                        "manager": {
+                          "type": "string"
+                        },
+                        "operation": {
+                          "type": "string"
+                        },
+                        "subresource": {
+                          "type": "string"
+                        },
+                        "time": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "namespace": {
+                    "type": "string"
+                  },
+                  "ownerReferences": {
+                    "items": {
+                      "properties": {
+                        "apiVersion": {
+                          "type": "string"
+                        },
+                        "blockOwnerDeletion": {
+                          "type": "boolean"
+                        },
+                        "controller": {
+                          "type": "boolean"
+                        },
+                        "kind": {
+                          "type": "string"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "uid": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "resourceVersion": {
+                    "type": "string"
+                  },
+                  "selfLink": {
+                    "type": "string"
+                  },
+                  "uid": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "serviceSpec": {
+                "properties": {
+                  "allocateLoadBalancerNodePorts": {
+                    "type": "boolean"
+                  },
+                  "clusterIP": {
+                    "type": "string"
+                  },
+                  "clusterIPs": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "externalIPs": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "externalName": {
+                    "type": "string"
+                  },
+                  "externalTrafficPolicy": {
+                    "type": "string"
+                  },
+                  "healthCheckNodePort": {
+                    "type": "integer"
+                  },
+                  "internalTrafficPolicy": {
+                    "type": "string"
+                  },
+                  "ipFamilies": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "ipFamilyPolicy": {
+                    "type": "string"
+                  },
+                  "loadBalancerClass": {
+                    "type": "string"
+                  },
+                  "loadBalancerIP": {
+                    "type": "string"
+                  },
+                  "loadBalancerSourceRanges": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "ports": {
+                    "items": {
+                      "properties": {
+                        "appProtocol": {
+                          "type": "string"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "nodePort": {
+                          "type": "integer"
+                        },
+                        "port": {
+                          "type": "integer"
+                        },
+                        "protocol": {
+                          "type": "string"
+                        },
+                        "targetPort": {
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "string"
+                            }
+                          ],
+                          "x-kubernetes-int-or-string": true
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "publishNotReadyAddresses": {
+                    "type": "boolean"
+                  },
+                  "selector": {
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "type": "object"
+                  },
+                  "sessionAffinity": {
+                    "type": "string"
+                  },
+                  "sessionAffinityConfig": {
+                    "properties": {
+                      "clientIP": {
+                        "properties": {
+                          "timeoutSeconds": {
+                            "type": "integer"
+                          }
+                        },
+                        "type": "object"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "trafficDistribution": {
+                    "type": "string"
+                  },
+                  "type": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              }
+            },
+            "required": [
+              "ingressMetadata",
+              "serviceMetadata",
+              "serviceSpec"
+            ],
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "driverSpec": {
+          "properties": {
+            "podTemplateSpec": {
+              "properties": {
+                "metadata": {
+                  "properties": {
+                    "annotations": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "type": "object"
+                    },
+                    "creationTimestamp": {
+                      "type": "string"
+                    },
+                    "deletionGracePeriodSeconds": {
+                      "type": "integer"
+                    },
+                    "deletionTimestamp": {
+                      "type": "string"
+                    },
+                    "finalizers": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "generateName": {
+                      "type": "string"
+                    },
+                    "generation": {
+                      "type": "integer"
+                    },
+                    "labels": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "type": "object"
+                    },
+                    "managedFields": {
+                      "items": {
+                        "properties": {
+                          "apiVersion": {
+                            "type": "string"
+                          },
+                          "fieldsType": {
+                            "type": "string"
+                          },
+                          "fieldsV1": {
+                            "type": "object"
+                          },
+                          "manager": {
+                            "type": "string"
+                          },
+                          "operation": {
+                            "type": "string"
+                          },
+                          "subresource": {
+                            "type": "string"
+                          },
+                          "time": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "namespace": {
+                      "type": "string"
+                    },
+                    "ownerReferences": {
+                      "items": {
+                        "properties": {
+                          "apiVersion": {
+                            "type": "string"
+                          },
+                          "blockOwnerDeletion": {
+                            "type": "boolean"
+                          },
+                          "controller": {
+                            "type": "boolean"
+                          },
+                          "kind": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "uid": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "resourceVersion": {
+                      "type": "string"
+                    },
+                    "selfLink": {
+                      "type": "string"
+                    },
+                    "uid": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "spec": {
+                  "properties": {
+                    "activeDeadlineSeconds": {
+                      "type": "integer"
+                    },
+                    "affinity": {
+                      "properties": {
+                        "nodeAffinity": {
+                          "properties": {
+                            "preferredDuringSchedulingIgnoredDuringExecution": {
+                              "items": {
+                                "properties": {
+                                  "preference": {
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "matchFields": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "weight": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "requiredDuringSchedulingIgnoredDuringExecution": {
+                              "properties": {
+                                "nodeSelectorTerms": {
+                                  "items": {
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "matchFields": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "type": "object"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "podAffinity": {
+                          "properties": {
+                            "preferredDuringSchedulingIgnoredDuringExecution": {
+                              "items": {
+                                "properties": {
+                                  "podAffinityTerm": {
+                                    "properties": {
+                                      "labelSelector": {
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "matchLabels": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "matchLabelKeys": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "mismatchLabelKeys": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "namespaceSelector": {
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "matchLabels": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "namespaces": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "topologyKey": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "weight": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "requiredDuringSchedulingIgnoredDuringExecution": {
+                              "items": {
+                                "properties": {
+                                  "labelSelector": {
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "matchLabels": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "matchLabelKeys": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "mismatchLabelKeys": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "namespaceSelector": {
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "matchLabels": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "namespaces": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "topologyKey": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "podAntiAffinity": {
+                          "properties": {
+                            "preferredDuringSchedulingIgnoredDuringExecution": {
+                              "items": {
+                                "properties": {
+                                  "podAffinityTerm": {
+                                    "properties": {
+                                      "labelSelector": {
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "matchLabels": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "matchLabelKeys": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "mismatchLabelKeys": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "namespaceSelector": {
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "matchLabels": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "namespaces": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "topologyKey": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "weight": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "requiredDuringSchedulingIgnoredDuringExecution": {
+                              "items": {
+                                "properties": {
+                                  "labelSelector": {
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "matchLabels": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "matchLabelKeys": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "mismatchLabelKeys": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "namespaceSelector": {
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "matchLabels": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "namespaces": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "topologyKey": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "automountServiceAccountToken": {
+                      "type": "boolean"
+                    },
+                    "containers": {
+                      "items": {
+                        "properties": {
+                          "args": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "command": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "env": {
+                            "items": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "value": {
+                                  "type": "string"
+                                },
+                                "valueFrom": {
+                                  "properties": {
+                                    "configMapKeyRef": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "fieldRef": {
+                                      "properties": {
+                                        "apiVersion": {
+                                          "type": "string"
+                                        },
+                                        "fieldPath": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "resourceFieldRef": {
+                                      "properties": {
+                                        "containerName": {
+                                          "type": "string"
+                                        },
+                                        "divisor": {
+                                          "anyOf": [
+                                            {
+                                              "type": "integer"
+                                            },
+                                            {
+                                              "type": "string"
+                                            }
+                                          ],
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "resource": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "secretKeyRef": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "envFrom": {
+                            "items": {
+                              "properties": {
+                                "configMapRef": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "prefix": {
+                                  "type": "string"
+                                },
+                                "secretRef": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "image": {
+                            "type": "string"
+                          },
+                          "imagePullPolicy": {
+                            "type": "string"
+                          },
+                          "lifecycle": {
+                            "properties": {
+                              "postStart": {
+                                "properties": {
+                                  "exec": {
+                                    "properties": {
+                                      "command": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "httpGet": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "sleep": {
+                                    "properties": {
+                                      "seconds": {
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "tcpSocket": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "preStop": {
+                                "properties": {
+                                  "exec": {
+                                    "properties": {
+                                      "command": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "httpGet": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "sleep": {
+                                    "properties": {
+                                      "seconds": {
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "tcpSocket": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "stopSignal": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "livenessProbe": {
+                            "properties": {
+                              "exec": {
+                                "properties": {
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "failureThreshold": {
+                                "type": "integer"
+                              },
+                              "grpc": {
+                                "properties": {
+                                  "port": {
+                                    "type": "integer"
+                                  },
+                                  "service": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "httpGet": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "initialDelaySeconds": {
+                                "type": "integer"
+                              },
+                              "periodSeconds": {
+                                "type": "integer"
+                              },
+                              "successThreshold": {
+                                "type": "integer"
+                              },
+                              "tcpSocket": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "terminationGracePeriodSeconds": {
+                                "type": "integer"
+                              },
+                              "timeoutSeconds": {
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "ports": {
+                            "items": {
+                              "properties": {
+                                "containerPort": {
+                                  "type": "integer"
+                                },
+                                "hostIP": {
+                                  "type": "string"
+                                },
+                                "hostPort": {
+                                  "type": "integer"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "protocol": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "readinessProbe": {
+                            "properties": {
+                              "exec": {
+                                "properties": {
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "failureThreshold": {
+                                "type": "integer"
+                              },
+                              "grpc": {
+                                "properties": {
+                                  "port": {
+                                    "type": "integer"
+                                  },
+                                  "service": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "httpGet": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "initialDelaySeconds": {
+                                "type": "integer"
+                              },
+                              "periodSeconds": {
+                                "type": "integer"
+                              },
+                              "successThreshold": {
+                                "type": "integer"
+                              },
+                              "tcpSocket": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "terminationGracePeriodSeconds": {
+                                "type": "integer"
+                              },
+                              "timeoutSeconds": {
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "resizePolicy": {
+                            "items": {
+                              "properties": {
+                                "resourceName": {
+                                  "type": "string"
+                                },
+                                "restartPolicy": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "resources": {
+                            "properties": {
+                              "claims": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "request": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "limits": {
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "type": "object"
+                              },
+                              "requests": {
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "restartPolicy": {
+                            "type": "string"
+                          },
+                          "securityContext": {
+                            "properties": {
+                              "allowPrivilegeEscalation": {
+                                "type": "boolean"
+                              },
+                              "appArmorProfile": {
+                                "properties": {
+                                  "localhostProfile": {
+                                    "type": "string"
+                                  },
+                                  "type": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "capabilities": {
+                                "properties": {
+                                  "add": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "drop": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "privileged": {
+                                "type": "boolean"
+                              },
+                              "procMount": {
+                                "type": "string"
+                              },
+                              "readOnlyRootFilesystem": {
+                                "type": "boolean"
+                              },
+                              "runAsGroup": {
+                                "type": "integer"
+                              },
+                              "runAsNonRoot": {
+                                "type": "boolean"
+                              },
+                              "runAsUser": {
+                                "type": "integer"
+                              },
+                              "seLinuxOptions": {
+                                "properties": {
+                                  "level": {
+                                    "type": "string"
+                                  },
+                                  "role": {
+                                    "type": "string"
+                                  },
+                                  "type": {
+                                    "type": "string"
+                                  },
+                                  "user": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "seccompProfile": {
+                                "properties": {
+                                  "localhostProfile": {
+                                    "type": "string"
+                                  },
+                                  "type": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "windowsOptions": {
+                                "properties": {
+                                  "gmsaCredentialSpec": {
+                                    "type": "string"
+                                  },
+                                  "gmsaCredentialSpecName": {
+                                    "type": "string"
+                                  },
+                                  "hostProcess": {
+                                    "type": "boolean"
+                                  },
+                                  "runAsUserName": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "startupProbe": {
+                            "properties": {
+                              "exec": {
+                                "properties": {
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "failureThreshold": {
+                                "type": "integer"
+                              },
+                              "grpc": {
+                                "properties": {
+                                  "port": {
+                                    "type": "integer"
+                                  },
+                                  "service": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "httpGet": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "initialDelaySeconds": {
+                                "type": "integer"
+                              },
+                              "periodSeconds": {
+                                "type": "integer"
+                              },
+                              "successThreshold": {
+                                "type": "integer"
+                              },
+                              "tcpSocket": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "terminationGracePeriodSeconds": {
+                                "type": "integer"
+                              },
+                              "timeoutSeconds": {
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "stdin": {
+                            "type": "boolean"
+                          },
+                          "stdinOnce": {
+                            "type": "boolean"
+                          },
+                          "terminationMessagePath": {
+                            "type": "string"
+                          },
+                          "terminationMessagePolicy": {
+                            "type": "string"
+                          },
+                          "tty": {
+                            "type": "boolean"
+                          },
+                          "volumeDevices": {
+                            "items": {
+                              "properties": {
+                                "devicePath": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "volumeMounts": {
+                            "items": {
+                              "properties": {
+                                "mountPath": {
+                                  "type": "string"
+                                },
+                                "mountPropagation": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "readOnly": {
+                                  "type": "boolean"
+                                },
+                                "recursiveReadOnly": {
+                                  "type": "string"
+                                },
+                                "subPath": {
+                                  "type": "string"
+                                },
+                                "subPathExpr": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "workingDir": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "dnsConfig": {
+                      "properties": {
+                        "nameservers": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "options": {
+                          "items": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "value": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "searches": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "dnsPolicy": {
+                      "type": "string"
+                    },
+                    "enableServiceLinks": {
+                      "type": "boolean"
+                    },
+                    "ephemeralContainers": {
+                      "items": {
+                        "properties": {
+                          "args": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "command": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "env": {
+                            "items": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "value": {
+                                  "type": "string"
+                                },
+                                "valueFrom": {
+                                  "properties": {
+                                    "configMapKeyRef": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "fieldRef": {
+                                      "properties": {
+                                        "apiVersion": {
+                                          "type": "string"
+                                        },
+                                        "fieldPath": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "resourceFieldRef": {
+                                      "properties": {
+                                        "containerName": {
+                                          "type": "string"
+                                        },
+                                        "divisor": {
+                                          "anyOf": [
+                                            {
+                                              "type": "integer"
+                                            },
+                                            {
+                                              "type": "string"
+                                            }
+                                          ],
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "resource": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "secretKeyRef": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "envFrom": {
+                            "items": {
+                              "properties": {
+                                "configMapRef": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "prefix": {
+                                  "type": "string"
+                                },
+                                "secretRef": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "image": {
+                            "type": "string"
+                          },
+                          "imagePullPolicy": {
+                            "type": "string"
+                          },
+                          "lifecycle": {
+                            "properties": {
+                              "postStart": {
+                                "properties": {
+                                  "exec": {
+                                    "properties": {
+                                      "command": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "httpGet": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "sleep": {
+                                    "properties": {
+                                      "seconds": {
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "tcpSocket": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "preStop": {
+                                "properties": {
+                                  "exec": {
+                                    "properties": {
+                                      "command": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "httpGet": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "sleep": {
+                                    "properties": {
+                                      "seconds": {
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "tcpSocket": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "stopSignal": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "livenessProbe": {
+                            "properties": {
+                              "exec": {
+                                "properties": {
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "failureThreshold": {
+                                "type": "integer"
+                              },
+                              "grpc": {
+                                "properties": {
+                                  "port": {
+                                    "type": "integer"
+                                  },
+                                  "service": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "httpGet": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "initialDelaySeconds": {
+                                "type": "integer"
+                              },
+                              "periodSeconds": {
+                                "type": "integer"
+                              },
+                              "successThreshold": {
+                                "type": "integer"
+                              },
+                              "tcpSocket": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "terminationGracePeriodSeconds": {
+                                "type": "integer"
+                              },
+                              "timeoutSeconds": {
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "ports": {
+                            "items": {
+                              "properties": {
+                                "containerPort": {
+                                  "type": "integer"
+                                },
+                                "hostIP": {
+                                  "type": "string"
+                                },
+                                "hostPort": {
+                                  "type": "integer"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "protocol": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "readinessProbe": {
+                            "properties": {
+                              "exec": {
+                                "properties": {
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "failureThreshold": {
+                                "type": "integer"
+                              },
+                              "grpc": {
+                                "properties": {
+                                  "port": {
+                                    "type": "integer"
+                                  },
+                                  "service": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "httpGet": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "initialDelaySeconds": {
+                                "type": "integer"
+                              },
+                              "periodSeconds": {
+                                "type": "integer"
+                              },
+                              "successThreshold": {
+                                "type": "integer"
+                              },
+                              "tcpSocket": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "terminationGracePeriodSeconds": {
+                                "type": "integer"
+                              },
+                              "timeoutSeconds": {
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "resizePolicy": {
+                            "items": {
+                              "properties": {
+                                "resourceName": {
+                                  "type": "string"
+                                },
+                                "restartPolicy": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "resources": {
+                            "properties": {
+                              "claims": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "request": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "limits": {
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "type": "object"
+                              },
+                              "requests": {
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "restartPolicy": {
+                            "type": "string"
+                          },
+                          "securityContext": {
+                            "properties": {
+                              "allowPrivilegeEscalation": {
+                                "type": "boolean"
+                              },
+                              "appArmorProfile": {
+                                "properties": {
+                                  "localhostProfile": {
+                                    "type": "string"
+                                  },
+                                  "type": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "capabilities": {
+                                "properties": {
+                                  "add": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "drop": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "privileged": {
+                                "type": "boolean"
+                              },
+                              "procMount": {
+                                "type": "string"
+                              },
+                              "readOnlyRootFilesystem": {
+                                "type": "boolean"
+                              },
+                              "runAsGroup": {
+                                "type": "integer"
+                              },
+                              "runAsNonRoot": {
+                                "type": "boolean"
+                              },
+                              "runAsUser": {
+                                "type": "integer"
+                              },
+                              "seLinuxOptions": {
+                                "properties": {
+                                  "level": {
+                                    "type": "string"
+                                  },
+                                  "role": {
+                                    "type": "string"
+                                  },
+                                  "type": {
+                                    "type": "string"
+                                  },
+                                  "user": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "seccompProfile": {
+                                "properties": {
+                                  "localhostProfile": {
+                                    "type": "string"
+                                  },
+                                  "type": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "windowsOptions": {
+                                "properties": {
+                                  "gmsaCredentialSpec": {
+                                    "type": "string"
+                                  },
+                                  "gmsaCredentialSpecName": {
+                                    "type": "string"
+                                  },
+                                  "hostProcess": {
+                                    "type": "boolean"
+                                  },
+                                  "runAsUserName": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "startupProbe": {
+                            "properties": {
+                              "exec": {
+                                "properties": {
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "failureThreshold": {
+                                "type": "integer"
+                              },
+                              "grpc": {
+                                "properties": {
+                                  "port": {
+                                    "type": "integer"
+                                  },
+                                  "service": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "httpGet": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "initialDelaySeconds": {
+                                "type": "integer"
+                              },
+                              "periodSeconds": {
+                                "type": "integer"
+                              },
+                              "successThreshold": {
+                                "type": "integer"
+                              },
+                              "tcpSocket": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "terminationGracePeriodSeconds": {
+                                "type": "integer"
+                              },
+                              "timeoutSeconds": {
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "stdin": {
+                            "type": "boolean"
+                          },
+                          "stdinOnce": {
+                            "type": "boolean"
+                          },
+                          "targetContainerName": {
+                            "type": "string"
+                          },
+                          "terminationMessagePath": {
+                            "type": "string"
+                          },
+                          "terminationMessagePolicy": {
+                            "type": "string"
+                          },
+                          "tty": {
+                            "type": "boolean"
+                          },
+                          "volumeDevices": {
+                            "items": {
+                              "properties": {
+                                "devicePath": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "volumeMounts": {
+                            "items": {
+                              "properties": {
+                                "mountPath": {
+                                  "type": "string"
+                                },
+                                "mountPropagation": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "readOnly": {
+                                  "type": "boolean"
+                                },
+                                "recursiveReadOnly": {
+                                  "type": "string"
+                                },
+                                "subPath": {
+                                  "type": "string"
+                                },
+                                "subPathExpr": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "workingDir": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "hostAliases": {
+                      "items": {
+                        "properties": {
+                          "hostnames": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "ip": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "hostIPC": {
+                      "type": "boolean"
+                    },
+                    "hostNetwork": {
+                      "type": "boolean"
+                    },
+                    "hostPID": {
+                      "type": "boolean"
+                    },
+                    "hostUsers": {
+                      "type": "boolean"
+                    },
+                    "hostname": {
+                      "type": "string"
+                    },
+                    "imagePullSecrets": {
+                      "items": {
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "initContainers": {
+                      "items": {
+                        "properties": {
+                          "args": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "command": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "env": {
+                            "items": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "value": {
+                                  "type": "string"
+                                },
+                                "valueFrom": {
+                                  "properties": {
+                                    "configMapKeyRef": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "fieldRef": {
+                                      "properties": {
+                                        "apiVersion": {
+                                          "type": "string"
+                                        },
+                                        "fieldPath": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "resourceFieldRef": {
+                                      "properties": {
+                                        "containerName": {
+                                          "type": "string"
+                                        },
+                                        "divisor": {
+                                          "anyOf": [
+                                            {
+                                              "type": "integer"
+                                            },
+                                            {
+                                              "type": "string"
+                                            }
+                                          ],
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "resource": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "secretKeyRef": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "envFrom": {
+                            "items": {
+                              "properties": {
+                                "configMapRef": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "prefix": {
+                                  "type": "string"
+                                },
+                                "secretRef": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "image": {
+                            "type": "string"
+                          },
+                          "imagePullPolicy": {
+                            "type": "string"
+                          },
+                          "lifecycle": {
+                            "properties": {
+                              "postStart": {
+                                "properties": {
+                                  "exec": {
+                                    "properties": {
+                                      "command": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "httpGet": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "sleep": {
+                                    "properties": {
+                                      "seconds": {
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "tcpSocket": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "preStop": {
+                                "properties": {
+                                  "exec": {
+                                    "properties": {
+                                      "command": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "httpGet": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "sleep": {
+                                    "properties": {
+                                      "seconds": {
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "tcpSocket": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "stopSignal": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "livenessProbe": {
+                            "properties": {
+                              "exec": {
+                                "properties": {
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "failureThreshold": {
+                                "type": "integer"
+                              },
+                              "grpc": {
+                                "properties": {
+                                  "port": {
+                                    "type": "integer"
+                                  },
+                                  "service": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "httpGet": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "initialDelaySeconds": {
+                                "type": "integer"
+                              },
+                              "periodSeconds": {
+                                "type": "integer"
+                              },
+                              "successThreshold": {
+                                "type": "integer"
+                              },
+                              "tcpSocket": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "terminationGracePeriodSeconds": {
+                                "type": "integer"
+                              },
+                              "timeoutSeconds": {
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "ports": {
+                            "items": {
+                              "properties": {
+                                "containerPort": {
+                                  "type": "integer"
+                                },
+                                "hostIP": {
+                                  "type": "string"
+                                },
+                                "hostPort": {
+                                  "type": "integer"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "protocol": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "readinessProbe": {
+                            "properties": {
+                              "exec": {
+                                "properties": {
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "failureThreshold": {
+                                "type": "integer"
+                              },
+                              "grpc": {
+                                "properties": {
+                                  "port": {
+                                    "type": "integer"
+                                  },
+                                  "service": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "httpGet": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "initialDelaySeconds": {
+                                "type": "integer"
+                              },
+                              "periodSeconds": {
+                                "type": "integer"
+                              },
+                              "successThreshold": {
+                                "type": "integer"
+                              },
+                              "tcpSocket": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "terminationGracePeriodSeconds": {
+                                "type": "integer"
+                              },
+                              "timeoutSeconds": {
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "resizePolicy": {
+                            "items": {
+                              "properties": {
+                                "resourceName": {
+                                  "type": "string"
+                                },
+                                "restartPolicy": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "resources": {
+                            "properties": {
+                              "claims": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "request": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "limits": {
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "type": "object"
+                              },
+                              "requests": {
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "restartPolicy": {
+                            "type": "string"
+                          },
+                          "securityContext": {
+                            "properties": {
+                              "allowPrivilegeEscalation": {
+                                "type": "boolean"
+                              },
+                              "appArmorProfile": {
+                                "properties": {
+                                  "localhostProfile": {
+                                    "type": "string"
+                                  },
+                                  "type": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "capabilities": {
+                                "properties": {
+                                  "add": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "drop": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "privileged": {
+                                "type": "boolean"
+                              },
+                              "procMount": {
+                                "type": "string"
+                              },
+                              "readOnlyRootFilesystem": {
+                                "type": "boolean"
+                              },
+                              "runAsGroup": {
+                                "type": "integer"
+                              },
+                              "runAsNonRoot": {
+                                "type": "boolean"
+                              },
+                              "runAsUser": {
+                                "type": "integer"
+                              },
+                              "seLinuxOptions": {
+                                "properties": {
+                                  "level": {
+                                    "type": "string"
+                                  },
+                                  "role": {
+                                    "type": "string"
+                                  },
+                                  "type": {
+                                    "type": "string"
+                                  },
+                                  "user": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "seccompProfile": {
+                                "properties": {
+                                  "localhostProfile": {
+                                    "type": "string"
+                                  },
+                                  "type": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "windowsOptions": {
+                                "properties": {
+                                  "gmsaCredentialSpec": {
+                                    "type": "string"
+                                  },
+                                  "gmsaCredentialSpecName": {
+                                    "type": "string"
+                                  },
+                                  "hostProcess": {
+                                    "type": "boolean"
+                                  },
+                                  "runAsUserName": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "startupProbe": {
+                            "properties": {
+                              "exec": {
+                                "properties": {
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "failureThreshold": {
+                                "type": "integer"
+                              },
+                              "grpc": {
+                                "properties": {
+                                  "port": {
+                                    "type": "integer"
+                                  },
+                                  "service": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "httpGet": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "initialDelaySeconds": {
+                                "type": "integer"
+                              },
+                              "periodSeconds": {
+                                "type": "integer"
+                              },
+                              "successThreshold": {
+                                "type": "integer"
+                              },
+                              "tcpSocket": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "terminationGracePeriodSeconds": {
+                                "type": "integer"
+                              },
+                              "timeoutSeconds": {
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "stdin": {
+                            "type": "boolean"
+                          },
+                          "stdinOnce": {
+                            "type": "boolean"
+                          },
+                          "terminationMessagePath": {
+                            "type": "string"
+                          },
+                          "terminationMessagePolicy": {
+                            "type": "string"
+                          },
+                          "tty": {
+                            "type": "boolean"
+                          },
+                          "volumeDevices": {
+                            "items": {
+                              "properties": {
+                                "devicePath": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "volumeMounts": {
+                            "items": {
+                              "properties": {
+                                "mountPath": {
+                                  "type": "string"
+                                },
+                                "mountPropagation": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "readOnly": {
+                                  "type": "boolean"
+                                },
+                                "recursiveReadOnly": {
+                                  "type": "string"
+                                },
+                                "subPath": {
+                                  "type": "string"
+                                },
+                                "subPathExpr": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "workingDir": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "nodeName": {
+                      "type": "string"
+                    },
+                    "nodeSelector": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "type": "object"
+                    },
+                    "os": {
+                      "properties": {
+                        "name": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "overhead": {
+                      "additionalProperties": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "x-kubernetes-int-or-string": true
+                      },
+                      "type": "object"
+                    },
+                    "preemptionPolicy": {
+                      "type": "string"
+                    },
+                    "priority": {
+                      "type": "integer"
+                    },
+                    "priorityClassName": {
+                      "type": "string"
+                    },
+                    "readinessGates": {
+                      "items": {
+                        "properties": {
+                          "conditionType": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "resourceClaims": {
+                      "items": {
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          },
+                          "resourceClaimName": {
+                            "type": "string"
+                          },
+                          "resourceClaimTemplateName": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "resources": {
+                      "properties": {
+                        "claims": {
+                          "items": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "request": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "limits": {
+                          "additionalProperties": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "x-kubernetes-int-or-string": true
+                          },
+                          "type": "object"
+                        },
+                        "requests": {
+                          "additionalProperties": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "x-kubernetes-int-or-string": true
+                          },
+                          "type": "object"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "restartPolicy": {
+                      "type": "string"
+                    },
+                    "runtimeClassName": {
+                      "type": "string"
+                    },
+                    "schedulerName": {
+                      "type": "string"
+                    },
+                    "schedulingGates": {
+                      "items": {
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "securityContext": {
+                      "properties": {
+                        "appArmorProfile": {
+                          "properties": {
+                            "localhostProfile": {
+                              "type": "string"
+                            },
+                            "type": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "fsGroup": {
+                          "type": "integer"
+                        },
+                        "fsGroupChangePolicy": {
+                          "type": "string"
+                        },
+                        "runAsGroup": {
+                          "type": "integer"
+                        },
+                        "runAsNonRoot": {
+                          "type": "boolean"
+                        },
+                        "runAsUser": {
+                          "type": "integer"
+                        },
+                        "seLinuxChangePolicy": {
+                          "type": "string"
+                        },
+                        "seLinuxOptions": {
+                          "properties": {
+                            "level": {
+                              "type": "string"
+                            },
+                            "role": {
+                              "type": "string"
+                            },
+                            "type": {
+                              "type": "string"
+                            },
+                            "user": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "seccompProfile": {
+                          "properties": {
+                            "localhostProfile": {
+                              "type": "string"
+                            },
+                            "type": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "supplementalGroups": {
+                          "items": {
+                            "type": "integer"
+                          },
+                          "type": "array"
+                        },
+                        "supplementalGroupsPolicy": {
+                          "type": "string"
+                        },
+                        "sysctls": {
+                          "items": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "value": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "windowsOptions": {
+                          "properties": {
+                            "gmsaCredentialSpec": {
+                              "type": "string"
+                            },
+                            "gmsaCredentialSpecName": {
+                              "type": "string"
+                            },
+                            "hostProcess": {
+                              "type": "boolean"
+                            },
+                            "runAsUserName": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "serviceAccount": {
+                      "type": "string"
+                    },
+                    "serviceAccountName": {
+                      "type": "string"
+                    },
+                    "setHostnameAsFQDN": {
+                      "type": "boolean"
+                    },
+                    "shareProcessNamespace": {
+                      "type": "boolean"
+                    },
+                    "subdomain": {
+                      "type": "string"
+                    },
+                    "terminationGracePeriodSeconds": {
+                      "type": "integer"
+                    },
+                    "tolerations": {
+                      "items": {
+                        "properties": {
+                          "effect": {
+                            "type": "string"
+                          },
+                          "key": {
+                            "type": "string"
+                          },
+                          "operator": {
+                            "type": "string"
+                          },
+                          "tolerationSeconds": {
+                            "type": "integer"
+                          },
+                          "value": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "topologySpreadConstraints": {
+                      "items": {
+                        "properties": {
+                          "labelSelector": {
+                            "properties": {
+                              "matchExpressions": {
+                                "items": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "matchLabels": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "matchLabelKeys": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "maxSkew": {
+                            "type": "integer"
+                          },
+                          "minDomains": {
+                            "type": "integer"
+                          },
+                          "nodeAffinityPolicy": {
+                            "type": "string"
+                          },
+                          "nodeTaintsPolicy": {
+                            "type": "string"
+                          },
+                          "topologyKey": {
+                            "type": "string"
+                          },
+                          "whenUnsatisfiable": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "volumes": {
+                      "items": {
+                        "properties": {
+                          "awsElasticBlockStore": {
+                            "properties": {
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "partition": {
+                                "type": "integer"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "volumeID": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "azureDisk": {
+                            "properties": {
+                              "cachingMode": {
+                                "type": "string"
+                              },
+                              "diskName": {
+                                "type": "string"
+                              },
+                              "diskURI": {
+                                "type": "string"
+                              },
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "kind": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "azureFile": {
+                            "properties": {
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "secretName": {
+                                "type": "string"
+                              },
+                              "shareName": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "cephfs": {
+                            "properties": {
+                              "monitors": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "path": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "secretFile": {
+                                "type": "string"
+                              },
+                              "secretRef": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "user": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "cinder": {
+                            "properties": {
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "secretRef": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "volumeID": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "configMap": {
+                            "properties": {
+                              "defaultMode": {
+                                "type": "integer"
+                              },
+                              "items": {
+                                "items": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "mode": {
+                                      "type": "integer"
+                                    },
+                                    "path": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "optional": {
+                                "type": "boolean"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "csi": {
+                            "properties": {
+                              "driver": {
+                                "type": "string"
+                              },
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "nodePublishSecretRef": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "volumeAttributes": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "downwardAPI": {
+                            "properties": {
+                              "defaultMode": {
+                                "type": "integer"
+                              },
+                              "items": {
+                                "items": {
+                                  "properties": {
+                                    "fieldRef": {
+                                      "properties": {
+                                        "apiVersion": {
+                                          "type": "string"
+                                        },
+                                        "fieldPath": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "mode": {
+                                      "type": "integer"
+                                    },
+                                    "path": {
+                                      "type": "string"
+                                    },
+                                    "resourceFieldRef": {
+                                      "properties": {
+                                        "containerName": {
+                                          "type": "string"
+                                        },
+                                        "divisor": {
+                                          "anyOf": [
+                                            {
+                                              "type": "integer"
+                                            },
+                                            {
+                                              "type": "string"
+                                            }
+                                          ],
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "resource": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "emptyDir": {
+                            "properties": {
+                              "medium": {
+                                "type": "string"
+                              },
+                              "sizeLimit": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "ephemeral": {
+                            "properties": {
+                              "volumeClaimTemplate": {
+                                "properties": {
+                                  "metadata": {
+                                    "properties": {
+                                      "annotations": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
+                                      },
+                                      "creationTimestamp": {
+                                        "type": "string"
+                                      },
+                                      "deletionGracePeriodSeconds": {
+                                        "type": "integer"
+                                      },
+                                      "deletionTimestamp": {
+                                        "type": "string"
+                                      },
+                                      "finalizers": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "generateName": {
+                                        "type": "string"
+                                      },
+                                      "generation": {
+                                        "type": "integer"
+                                      },
+                                      "labels": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
+                                      },
+                                      "managedFields": {
+                                        "items": {
+                                          "properties": {
+                                            "apiVersion": {
+                                              "type": "string"
+                                            },
+                                            "fieldsType": {
+                                              "type": "string"
+                                            },
+                                            "fieldsV1": {
+                                              "type": "object"
+                                            },
+                                            "manager": {
+                                              "type": "string"
+                                            },
+                                            "operation": {
+                                              "type": "string"
+                                            },
+                                            "subresource": {
+                                              "type": "string"
+                                            },
+                                            "time": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "namespace": {
+                                        "type": "string"
+                                      },
+                                      "ownerReferences": {
+                                        "items": {
+                                          "properties": {
+                                            "apiVersion": {
+                                              "type": "string"
+                                            },
+                                            "blockOwnerDeletion": {
+                                              "type": "boolean"
+                                            },
+                                            "controller": {
+                                              "type": "boolean"
+                                            },
+                                            "kind": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "uid": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "resourceVersion": {
+                                        "type": "string"
+                                      },
+                                      "selfLink": {
+                                        "type": "string"
+                                      },
+                                      "uid": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "spec": {
+                                    "properties": {
+                                      "accessModes": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "dataSource": {
+                                        "properties": {
+                                          "apiGroup": {
+                                            "type": "string"
+                                          },
+                                          "kind": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "dataSourceRef": {
+                                        "properties": {
+                                          "apiGroup": {
+                                            "type": "string"
+                                          },
+                                          "kind": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "namespace": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "resources": {
+                                        "properties": {
+                                          "limits": {
+                                            "additionalProperties": {
+                                              "anyOf": [
+                                                {
+                                                  "type": "integer"
+                                                },
+                                                {
+                                                  "type": "string"
+                                                }
+                                              ],
+                                              "x-kubernetes-int-or-string": true
+                                            },
+                                            "type": "object"
+                                          },
+                                          "requests": {
+                                            "additionalProperties": {
+                                              "anyOf": [
+                                                {
+                                                  "type": "integer"
+                                                },
+                                                {
+                                                  "type": "string"
+                                                }
+                                              ],
+                                              "x-kubernetes-int-or-string": true
+                                            },
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "selector": {
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "matchLabels": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "storageClassName": {
+                                        "type": "string"
+                                      },
+                                      "volumeAttributesClassName": {
+                                        "type": "string"
+                                      },
+                                      "volumeMode": {
+                                        "type": "string"
+                                      },
+                                      "volumeName": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "fc": {
+                            "properties": {
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "lun": {
+                                "type": "integer"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "targetWWNs": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "wwids": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "flexVolume": {
+                            "properties": {
+                              "driver": {
+                                "type": "string"
+                              },
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "options": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "type": "object"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "secretRef": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "flocker": {
+                            "properties": {
+                              "datasetName": {
+                                "type": "string"
+                              },
+                              "datasetUUID": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "gcePersistentDisk": {
+                            "properties": {
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "partition": {
+                                "type": "integer"
+                              },
+                              "pdName": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "gitRepo": {
+                            "properties": {
+                              "directory": {
+                                "type": "string"
+                              },
+                              "repository": {
+                                "type": "string"
+                              },
+                              "revision": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "glusterfs": {
+                            "properties": {
+                              "endpoints": {
+                                "type": "string"
+                              },
+                              "path": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "hostPath": {
+                            "properties": {
+                              "path": {
+                                "type": "string"
+                              },
+                              "type": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "image": {
+                            "properties": {
+                              "pullPolicy": {
+                                "type": "string"
+                              },
+                              "reference": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "iscsi": {
+                            "properties": {
+                              "chapAuthDiscovery": {
+                                "type": "boolean"
+                              },
+                              "chapAuthSession": {
+                                "type": "boolean"
+                              },
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "initiatorName": {
+                                "type": "string"
+                              },
+                              "iqn": {
+                                "type": "string"
+                              },
+                              "iscsiInterface": {
+                                "type": "string"
+                              },
+                              "lun": {
+                                "type": "integer"
+                              },
+                              "portals": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "secretRef": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "targetPortal": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "nfs": {
+                            "properties": {
+                              "path": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "server": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "persistentVolumeClaim": {
+                            "properties": {
+                              "claimName": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "photonPersistentDisk": {
+                            "properties": {
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "pdID": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "portworxVolume": {
+                            "properties": {
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "volumeID": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "projected": {
+                            "properties": {
+                              "defaultMode": {
+                                "type": "integer"
+                              },
+                              "sources": {
+                                "items": {
+                                  "properties": {
+                                    "clusterTrustBundle": {
+                                      "properties": {
+                                        "labelSelector": {
+                                          "properties": {
+                                            "matchExpressions": {
+                                              "items": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "operator": {
+                                                    "type": "string"
+                                                  },
+                                                  "values": {
+                                                    "items": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "array"
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              "type": "array"
+                                            },
+                                            "matchLabels": {
+                                              "additionalProperties": {
+                                                "type": "string"
+                                              },
+                                              "type": "object"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        },
+                                        "path": {
+                                          "type": "string"
+                                        },
+                                        "signerName": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "configMap": {
+                                      "properties": {
+                                        "items": {
+                                          "items": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "mode": {
+                                                "type": "integer"
+                                              },
+                                              "path": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          "type": "array"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "downwardAPI": {
+                                      "properties": {
+                                        "items": {
+                                          "items": {
+                                            "properties": {
+                                              "fieldRef": {
+                                                "properties": {
+                                                  "apiVersion": {
+                                                    "type": "string"
+                                                  },
+                                                  "fieldPath": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              "mode": {
+                                                "type": "integer"
+                                              },
+                                              "path": {
+                                                "type": "string"
+                                              },
+                                              "resourceFieldRef": {
+                                                "properties": {
+                                                  "containerName": {
+                                                    "type": "string"
+                                                  },
+                                                  "divisor": {
+                                                    "anyOf": [
+                                                      {
+                                                        "type": "integer"
+                                                      },
+                                                      {
+                                                        "type": "string"
+                                                      }
+                                                    ],
+                                                    "x-kubernetes-int-or-string": true
+                                                  },
+                                                  "resource": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object"
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "secret": {
+                                      "properties": {
+                                        "items": {
+                                          "items": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "mode": {
+                                                "type": "integer"
+                                              },
+                                              "path": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          "type": "array"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "serviceAccountToken": {
+                                      "properties": {
+                                        "audience": {
+                                          "type": "string"
+                                        },
+                                        "expirationSeconds": {
+                                          "type": "integer"
+                                        },
+                                        "path": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "quobyte": {
+                            "properties": {
+                              "group": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "registry": {
+                                "type": "string"
+                              },
+                              "tenant": {
+                                "type": "string"
+                              },
+                              "user": {
+                                "type": "string"
+                              },
+                              "volume": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "rbd": {
+                            "properties": {
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "image": {
+                                "type": "string"
+                              },
+                              "keyring": {
+                                "type": "string"
+                              },
+                              "monitors": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "pool": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "secretRef": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "user": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "scaleIO": {
+                            "properties": {
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "gateway": {
+                                "type": "string"
+                              },
+                              "protectionDomain": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "secretRef": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "sslEnabled": {
+                                "type": "boolean"
+                              },
+                              "storageMode": {
+                                "type": "string"
+                              },
+                              "storagePool": {
+                                "type": "string"
+                              },
+                              "system": {
+                                "type": "string"
+                              },
+                              "volumeName": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "secret": {
+                            "properties": {
+                              "defaultMode": {
+                                "type": "integer"
+                              },
+                              "items": {
+                                "items": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "mode": {
+                                      "type": "integer"
+                                    },
+                                    "path": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "optional": {
+                                "type": "boolean"
+                              },
+                              "secretName": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "storageos": {
+                            "properties": {
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "secretRef": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "volumeName": {
+                                "type": "string"
+                              },
+                              "volumeNamespace": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "vsphereVolume": {
+                            "properties": {
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "storagePolicyID": {
+                                "type": "string"
+                              },
+                              "storagePolicyName": {
+                                "type": "string"
+                              },
+                              "volumePath": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "type": "object"
+        },
+        "executorSpec": {
+          "properties": {
+            "podTemplateSpec": {
+              "properties": {
+                "metadata": {
+                  "properties": {
+                    "annotations": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "type": "object"
+                    },
+                    "creationTimestamp": {
+                      "type": "string"
+                    },
+                    "deletionGracePeriodSeconds": {
+                      "type": "integer"
+                    },
+                    "deletionTimestamp": {
+                      "type": "string"
+                    },
+                    "finalizers": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "generateName": {
+                      "type": "string"
+                    },
+                    "generation": {
+                      "type": "integer"
+                    },
+                    "labels": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "type": "object"
+                    },
+                    "managedFields": {
+                      "items": {
+                        "properties": {
+                          "apiVersion": {
+                            "type": "string"
+                          },
+                          "fieldsType": {
+                            "type": "string"
+                          },
+                          "fieldsV1": {
+                            "type": "object"
+                          },
+                          "manager": {
+                            "type": "string"
+                          },
+                          "operation": {
+                            "type": "string"
+                          },
+                          "subresource": {
+                            "type": "string"
+                          },
+                          "time": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "namespace": {
+                      "type": "string"
+                    },
+                    "ownerReferences": {
+                      "items": {
+                        "properties": {
+                          "apiVersion": {
+                            "type": "string"
+                          },
+                          "blockOwnerDeletion": {
+                            "type": "boolean"
+                          },
+                          "controller": {
+                            "type": "boolean"
+                          },
+                          "kind": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "uid": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "resourceVersion": {
+                      "type": "string"
+                    },
+                    "selfLink": {
+                      "type": "string"
+                    },
+                    "uid": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "spec": {
+                  "properties": {
+                    "activeDeadlineSeconds": {
+                      "type": "integer"
+                    },
+                    "affinity": {
+                      "properties": {
+                        "nodeAffinity": {
+                          "properties": {
+                            "preferredDuringSchedulingIgnoredDuringExecution": {
+                              "items": {
+                                "properties": {
+                                  "preference": {
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "matchFields": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "weight": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "requiredDuringSchedulingIgnoredDuringExecution": {
+                              "properties": {
+                                "nodeSelectorTerms": {
+                                  "items": {
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "matchFields": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "type": "object"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "podAffinity": {
+                          "properties": {
+                            "preferredDuringSchedulingIgnoredDuringExecution": {
+                              "items": {
+                                "properties": {
+                                  "podAffinityTerm": {
+                                    "properties": {
+                                      "labelSelector": {
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "matchLabels": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "matchLabelKeys": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "mismatchLabelKeys": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "namespaceSelector": {
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "matchLabels": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "namespaces": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "topologyKey": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "weight": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "requiredDuringSchedulingIgnoredDuringExecution": {
+                              "items": {
+                                "properties": {
+                                  "labelSelector": {
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "matchLabels": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "matchLabelKeys": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "mismatchLabelKeys": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "namespaceSelector": {
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "matchLabels": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "namespaces": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "topologyKey": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "podAntiAffinity": {
+                          "properties": {
+                            "preferredDuringSchedulingIgnoredDuringExecution": {
+                              "items": {
+                                "properties": {
+                                  "podAffinityTerm": {
+                                    "properties": {
+                                      "labelSelector": {
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "matchLabels": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "matchLabelKeys": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "mismatchLabelKeys": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "namespaceSelector": {
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "matchLabels": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "namespaces": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "topologyKey": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "weight": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "requiredDuringSchedulingIgnoredDuringExecution": {
+                              "items": {
+                                "properties": {
+                                  "labelSelector": {
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "matchLabels": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "matchLabelKeys": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "mismatchLabelKeys": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "namespaceSelector": {
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "matchLabels": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "namespaces": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "topologyKey": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "automountServiceAccountToken": {
+                      "type": "boolean"
+                    },
+                    "containers": {
+                      "items": {
+                        "properties": {
+                          "args": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "command": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "env": {
+                            "items": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "value": {
+                                  "type": "string"
+                                },
+                                "valueFrom": {
+                                  "properties": {
+                                    "configMapKeyRef": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "fieldRef": {
+                                      "properties": {
+                                        "apiVersion": {
+                                          "type": "string"
+                                        },
+                                        "fieldPath": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "resourceFieldRef": {
+                                      "properties": {
+                                        "containerName": {
+                                          "type": "string"
+                                        },
+                                        "divisor": {
+                                          "anyOf": [
+                                            {
+                                              "type": "integer"
+                                            },
+                                            {
+                                              "type": "string"
+                                            }
+                                          ],
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "resource": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "secretKeyRef": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "envFrom": {
+                            "items": {
+                              "properties": {
+                                "configMapRef": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "prefix": {
+                                  "type": "string"
+                                },
+                                "secretRef": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "image": {
+                            "type": "string"
+                          },
+                          "imagePullPolicy": {
+                            "type": "string"
+                          },
+                          "lifecycle": {
+                            "properties": {
+                              "postStart": {
+                                "properties": {
+                                  "exec": {
+                                    "properties": {
+                                      "command": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "httpGet": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "sleep": {
+                                    "properties": {
+                                      "seconds": {
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "tcpSocket": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "preStop": {
+                                "properties": {
+                                  "exec": {
+                                    "properties": {
+                                      "command": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "httpGet": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "sleep": {
+                                    "properties": {
+                                      "seconds": {
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "tcpSocket": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "stopSignal": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "livenessProbe": {
+                            "properties": {
+                              "exec": {
+                                "properties": {
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "failureThreshold": {
+                                "type": "integer"
+                              },
+                              "grpc": {
+                                "properties": {
+                                  "port": {
+                                    "type": "integer"
+                                  },
+                                  "service": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "httpGet": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "initialDelaySeconds": {
+                                "type": "integer"
+                              },
+                              "periodSeconds": {
+                                "type": "integer"
+                              },
+                              "successThreshold": {
+                                "type": "integer"
+                              },
+                              "tcpSocket": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "terminationGracePeriodSeconds": {
+                                "type": "integer"
+                              },
+                              "timeoutSeconds": {
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "ports": {
+                            "items": {
+                              "properties": {
+                                "containerPort": {
+                                  "type": "integer"
+                                },
+                                "hostIP": {
+                                  "type": "string"
+                                },
+                                "hostPort": {
+                                  "type": "integer"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "protocol": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "readinessProbe": {
+                            "properties": {
+                              "exec": {
+                                "properties": {
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "failureThreshold": {
+                                "type": "integer"
+                              },
+                              "grpc": {
+                                "properties": {
+                                  "port": {
+                                    "type": "integer"
+                                  },
+                                  "service": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "httpGet": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "initialDelaySeconds": {
+                                "type": "integer"
+                              },
+                              "periodSeconds": {
+                                "type": "integer"
+                              },
+                              "successThreshold": {
+                                "type": "integer"
+                              },
+                              "tcpSocket": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "terminationGracePeriodSeconds": {
+                                "type": "integer"
+                              },
+                              "timeoutSeconds": {
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "resizePolicy": {
+                            "items": {
+                              "properties": {
+                                "resourceName": {
+                                  "type": "string"
+                                },
+                                "restartPolicy": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "resources": {
+                            "properties": {
+                              "claims": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "request": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "limits": {
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "type": "object"
+                              },
+                              "requests": {
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "restartPolicy": {
+                            "type": "string"
+                          },
+                          "securityContext": {
+                            "properties": {
+                              "allowPrivilegeEscalation": {
+                                "type": "boolean"
+                              },
+                              "appArmorProfile": {
+                                "properties": {
+                                  "localhostProfile": {
+                                    "type": "string"
+                                  },
+                                  "type": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "capabilities": {
+                                "properties": {
+                                  "add": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "drop": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "privileged": {
+                                "type": "boolean"
+                              },
+                              "procMount": {
+                                "type": "string"
+                              },
+                              "readOnlyRootFilesystem": {
+                                "type": "boolean"
+                              },
+                              "runAsGroup": {
+                                "type": "integer"
+                              },
+                              "runAsNonRoot": {
+                                "type": "boolean"
+                              },
+                              "runAsUser": {
+                                "type": "integer"
+                              },
+                              "seLinuxOptions": {
+                                "properties": {
+                                  "level": {
+                                    "type": "string"
+                                  },
+                                  "role": {
+                                    "type": "string"
+                                  },
+                                  "type": {
+                                    "type": "string"
+                                  },
+                                  "user": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "seccompProfile": {
+                                "properties": {
+                                  "localhostProfile": {
+                                    "type": "string"
+                                  },
+                                  "type": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "windowsOptions": {
+                                "properties": {
+                                  "gmsaCredentialSpec": {
+                                    "type": "string"
+                                  },
+                                  "gmsaCredentialSpecName": {
+                                    "type": "string"
+                                  },
+                                  "hostProcess": {
+                                    "type": "boolean"
+                                  },
+                                  "runAsUserName": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "startupProbe": {
+                            "properties": {
+                              "exec": {
+                                "properties": {
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "failureThreshold": {
+                                "type": "integer"
+                              },
+                              "grpc": {
+                                "properties": {
+                                  "port": {
+                                    "type": "integer"
+                                  },
+                                  "service": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "httpGet": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "initialDelaySeconds": {
+                                "type": "integer"
+                              },
+                              "periodSeconds": {
+                                "type": "integer"
+                              },
+                              "successThreshold": {
+                                "type": "integer"
+                              },
+                              "tcpSocket": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "terminationGracePeriodSeconds": {
+                                "type": "integer"
+                              },
+                              "timeoutSeconds": {
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "stdin": {
+                            "type": "boolean"
+                          },
+                          "stdinOnce": {
+                            "type": "boolean"
+                          },
+                          "terminationMessagePath": {
+                            "type": "string"
+                          },
+                          "terminationMessagePolicy": {
+                            "type": "string"
+                          },
+                          "tty": {
+                            "type": "boolean"
+                          },
+                          "volumeDevices": {
+                            "items": {
+                              "properties": {
+                                "devicePath": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "volumeMounts": {
+                            "items": {
+                              "properties": {
+                                "mountPath": {
+                                  "type": "string"
+                                },
+                                "mountPropagation": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "readOnly": {
+                                  "type": "boolean"
+                                },
+                                "recursiveReadOnly": {
+                                  "type": "string"
+                                },
+                                "subPath": {
+                                  "type": "string"
+                                },
+                                "subPathExpr": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "workingDir": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "dnsConfig": {
+                      "properties": {
+                        "nameservers": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "options": {
+                          "items": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "value": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "searches": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "dnsPolicy": {
+                      "type": "string"
+                    },
+                    "enableServiceLinks": {
+                      "type": "boolean"
+                    },
+                    "ephemeralContainers": {
+                      "items": {
+                        "properties": {
+                          "args": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "command": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "env": {
+                            "items": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "value": {
+                                  "type": "string"
+                                },
+                                "valueFrom": {
+                                  "properties": {
+                                    "configMapKeyRef": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "fieldRef": {
+                                      "properties": {
+                                        "apiVersion": {
+                                          "type": "string"
+                                        },
+                                        "fieldPath": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "resourceFieldRef": {
+                                      "properties": {
+                                        "containerName": {
+                                          "type": "string"
+                                        },
+                                        "divisor": {
+                                          "anyOf": [
+                                            {
+                                              "type": "integer"
+                                            },
+                                            {
+                                              "type": "string"
+                                            }
+                                          ],
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "resource": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "secretKeyRef": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "envFrom": {
+                            "items": {
+                              "properties": {
+                                "configMapRef": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "prefix": {
+                                  "type": "string"
+                                },
+                                "secretRef": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "image": {
+                            "type": "string"
+                          },
+                          "imagePullPolicy": {
+                            "type": "string"
+                          },
+                          "lifecycle": {
+                            "properties": {
+                              "postStart": {
+                                "properties": {
+                                  "exec": {
+                                    "properties": {
+                                      "command": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "httpGet": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "sleep": {
+                                    "properties": {
+                                      "seconds": {
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "tcpSocket": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "preStop": {
+                                "properties": {
+                                  "exec": {
+                                    "properties": {
+                                      "command": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "httpGet": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "sleep": {
+                                    "properties": {
+                                      "seconds": {
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "tcpSocket": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "stopSignal": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "livenessProbe": {
+                            "properties": {
+                              "exec": {
+                                "properties": {
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "failureThreshold": {
+                                "type": "integer"
+                              },
+                              "grpc": {
+                                "properties": {
+                                  "port": {
+                                    "type": "integer"
+                                  },
+                                  "service": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "httpGet": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "initialDelaySeconds": {
+                                "type": "integer"
+                              },
+                              "periodSeconds": {
+                                "type": "integer"
+                              },
+                              "successThreshold": {
+                                "type": "integer"
+                              },
+                              "tcpSocket": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "terminationGracePeriodSeconds": {
+                                "type": "integer"
+                              },
+                              "timeoutSeconds": {
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "ports": {
+                            "items": {
+                              "properties": {
+                                "containerPort": {
+                                  "type": "integer"
+                                },
+                                "hostIP": {
+                                  "type": "string"
+                                },
+                                "hostPort": {
+                                  "type": "integer"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "protocol": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "readinessProbe": {
+                            "properties": {
+                              "exec": {
+                                "properties": {
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "failureThreshold": {
+                                "type": "integer"
+                              },
+                              "grpc": {
+                                "properties": {
+                                  "port": {
+                                    "type": "integer"
+                                  },
+                                  "service": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "httpGet": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "initialDelaySeconds": {
+                                "type": "integer"
+                              },
+                              "periodSeconds": {
+                                "type": "integer"
+                              },
+                              "successThreshold": {
+                                "type": "integer"
+                              },
+                              "tcpSocket": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "terminationGracePeriodSeconds": {
+                                "type": "integer"
+                              },
+                              "timeoutSeconds": {
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "resizePolicy": {
+                            "items": {
+                              "properties": {
+                                "resourceName": {
+                                  "type": "string"
+                                },
+                                "restartPolicy": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "resources": {
+                            "properties": {
+                              "claims": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "request": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "limits": {
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "type": "object"
+                              },
+                              "requests": {
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "restartPolicy": {
+                            "type": "string"
+                          },
+                          "securityContext": {
+                            "properties": {
+                              "allowPrivilegeEscalation": {
+                                "type": "boolean"
+                              },
+                              "appArmorProfile": {
+                                "properties": {
+                                  "localhostProfile": {
+                                    "type": "string"
+                                  },
+                                  "type": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "capabilities": {
+                                "properties": {
+                                  "add": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "drop": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "privileged": {
+                                "type": "boolean"
+                              },
+                              "procMount": {
+                                "type": "string"
+                              },
+                              "readOnlyRootFilesystem": {
+                                "type": "boolean"
+                              },
+                              "runAsGroup": {
+                                "type": "integer"
+                              },
+                              "runAsNonRoot": {
+                                "type": "boolean"
+                              },
+                              "runAsUser": {
+                                "type": "integer"
+                              },
+                              "seLinuxOptions": {
+                                "properties": {
+                                  "level": {
+                                    "type": "string"
+                                  },
+                                  "role": {
+                                    "type": "string"
+                                  },
+                                  "type": {
+                                    "type": "string"
+                                  },
+                                  "user": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "seccompProfile": {
+                                "properties": {
+                                  "localhostProfile": {
+                                    "type": "string"
+                                  },
+                                  "type": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "windowsOptions": {
+                                "properties": {
+                                  "gmsaCredentialSpec": {
+                                    "type": "string"
+                                  },
+                                  "gmsaCredentialSpecName": {
+                                    "type": "string"
+                                  },
+                                  "hostProcess": {
+                                    "type": "boolean"
+                                  },
+                                  "runAsUserName": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "startupProbe": {
+                            "properties": {
+                              "exec": {
+                                "properties": {
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "failureThreshold": {
+                                "type": "integer"
+                              },
+                              "grpc": {
+                                "properties": {
+                                  "port": {
+                                    "type": "integer"
+                                  },
+                                  "service": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "httpGet": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "initialDelaySeconds": {
+                                "type": "integer"
+                              },
+                              "periodSeconds": {
+                                "type": "integer"
+                              },
+                              "successThreshold": {
+                                "type": "integer"
+                              },
+                              "tcpSocket": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "terminationGracePeriodSeconds": {
+                                "type": "integer"
+                              },
+                              "timeoutSeconds": {
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "stdin": {
+                            "type": "boolean"
+                          },
+                          "stdinOnce": {
+                            "type": "boolean"
+                          },
+                          "targetContainerName": {
+                            "type": "string"
+                          },
+                          "terminationMessagePath": {
+                            "type": "string"
+                          },
+                          "terminationMessagePolicy": {
+                            "type": "string"
+                          },
+                          "tty": {
+                            "type": "boolean"
+                          },
+                          "volumeDevices": {
+                            "items": {
+                              "properties": {
+                                "devicePath": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "volumeMounts": {
+                            "items": {
+                              "properties": {
+                                "mountPath": {
+                                  "type": "string"
+                                },
+                                "mountPropagation": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "readOnly": {
+                                  "type": "boolean"
+                                },
+                                "recursiveReadOnly": {
+                                  "type": "string"
+                                },
+                                "subPath": {
+                                  "type": "string"
+                                },
+                                "subPathExpr": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "workingDir": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "hostAliases": {
+                      "items": {
+                        "properties": {
+                          "hostnames": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "ip": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "hostIPC": {
+                      "type": "boolean"
+                    },
+                    "hostNetwork": {
+                      "type": "boolean"
+                    },
+                    "hostPID": {
+                      "type": "boolean"
+                    },
+                    "hostUsers": {
+                      "type": "boolean"
+                    },
+                    "hostname": {
+                      "type": "string"
+                    },
+                    "imagePullSecrets": {
+                      "items": {
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "initContainers": {
+                      "items": {
+                        "properties": {
+                          "args": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "command": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "env": {
+                            "items": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "value": {
+                                  "type": "string"
+                                },
+                                "valueFrom": {
+                                  "properties": {
+                                    "configMapKeyRef": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "fieldRef": {
+                                      "properties": {
+                                        "apiVersion": {
+                                          "type": "string"
+                                        },
+                                        "fieldPath": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "resourceFieldRef": {
+                                      "properties": {
+                                        "containerName": {
+                                          "type": "string"
+                                        },
+                                        "divisor": {
+                                          "anyOf": [
+                                            {
+                                              "type": "integer"
+                                            },
+                                            {
+                                              "type": "string"
+                                            }
+                                          ],
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "resource": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "secretKeyRef": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "envFrom": {
+                            "items": {
+                              "properties": {
+                                "configMapRef": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "prefix": {
+                                  "type": "string"
+                                },
+                                "secretRef": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "image": {
+                            "type": "string"
+                          },
+                          "imagePullPolicy": {
+                            "type": "string"
+                          },
+                          "lifecycle": {
+                            "properties": {
+                              "postStart": {
+                                "properties": {
+                                  "exec": {
+                                    "properties": {
+                                      "command": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "httpGet": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "sleep": {
+                                    "properties": {
+                                      "seconds": {
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "tcpSocket": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "preStop": {
+                                "properties": {
+                                  "exec": {
+                                    "properties": {
+                                      "command": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "httpGet": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "sleep": {
+                                    "properties": {
+                                      "seconds": {
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "tcpSocket": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "stopSignal": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "livenessProbe": {
+                            "properties": {
+                              "exec": {
+                                "properties": {
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "failureThreshold": {
+                                "type": "integer"
+                              },
+                              "grpc": {
+                                "properties": {
+                                  "port": {
+                                    "type": "integer"
+                                  },
+                                  "service": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "httpGet": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "initialDelaySeconds": {
+                                "type": "integer"
+                              },
+                              "periodSeconds": {
+                                "type": "integer"
+                              },
+                              "successThreshold": {
+                                "type": "integer"
+                              },
+                              "tcpSocket": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "terminationGracePeriodSeconds": {
+                                "type": "integer"
+                              },
+                              "timeoutSeconds": {
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "ports": {
+                            "items": {
+                              "properties": {
+                                "containerPort": {
+                                  "type": "integer"
+                                },
+                                "hostIP": {
+                                  "type": "string"
+                                },
+                                "hostPort": {
+                                  "type": "integer"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "protocol": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "readinessProbe": {
+                            "properties": {
+                              "exec": {
+                                "properties": {
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "failureThreshold": {
+                                "type": "integer"
+                              },
+                              "grpc": {
+                                "properties": {
+                                  "port": {
+                                    "type": "integer"
+                                  },
+                                  "service": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "httpGet": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "initialDelaySeconds": {
+                                "type": "integer"
+                              },
+                              "periodSeconds": {
+                                "type": "integer"
+                              },
+                              "successThreshold": {
+                                "type": "integer"
+                              },
+                              "tcpSocket": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "terminationGracePeriodSeconds": {
+                                "type": "integer"
+                              },
+                              "timeoutSeconds": {
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "resizePolicy": {
+                            "items": {
+                              "properties": {
+                                "resourceName": {
+                                  "type": "string"
+                                },
+                                "restartPolicy": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "resources": {
+                            "properties": {
+                              "claims": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "request": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "limits": {
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "type": "object"
+                              },
+                              "requests": {
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "restartPolicy": {
+                            "type": "string"
+                          },
+                          "securityContext": {
+                            "properties": {
+                              "allowPrivilegeEscalation": {
+                                "type": "boolean"
+                              },
+                              "appArmorProfile": {
+                                "properties": {
+                                  "localhostProfile": {
+                                    "type": "string"
+                                  },
+                                  "type": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "capabilities": {
+                                "properties": {
+                                  "add": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "drop": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "privileged": {
+                                "type": "boolean"
+                              },
+                              "procMount": {
+                                "type": "string"
+                              },
+                              "readOnlyRootFilesystem": {
+                                "type": "boolean"
+                              },
+                              "runAsGroup": {
+                                "type": "integer"
+                              },
+                              "runAsNonRoot": {
+                                "type": "boolean"
+                              },
+                              "runAsUser": {
+                                "type": "integer"
+                              },
+                              "seLinuxOptions": {
+                                "properties": {
+                                  "level": {
+                                    "type": "string"
+                                  },
+                                  "role": {
+                                    "type": "string"
+                                  },
+                                  "type": {
+                                    "type": "string"
+                                  },
+                                  "user": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "seccompProfile": {
+                                "properties": {
+                                  "localhostProfile": {
+                                    "type": "string"
+                                  },
+                                  "type": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "windowsOptions": {
+                                "properties": {
+                                  "gmsaCredentialSpec": {
+                                    "type": "string"
+                                  },
+                                  "gmsaCredentialSpecName": {
+                                    "type": "string"
+                                  },
+                                  "hostProcess": {
+                                    "type": "boolean"
+                                  },
+                                  "runAsUserName": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "startupProbe": {
+                            "properties": {
+                              "exec": {
+                                "properties": {
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "failureThreshold": {
+                                "type": "integer"
+                              },
+                              "grpc": {
+                                "properties": {
+                                  "port": {
+                                    "type": "integer"
+                                  },
+                                  "service": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "httpGet": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "initialDelaySeconds": {
+                                "type": "integer"
+                              },
+                              "periodSeconds": {
+                                "type": "integer"
+                              },
+                              "successThreshold": {
+                                "type": "integer"
+                              },
+                              "tcpSocket": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "terminationGracePeriodSeconds": {
+                                "type": "integer"
+                              },
+                              "timeoutSeconds": {
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "stdin": {
+                            "type": "boolean"
+                          },
+                          "stdinOnce": {
+                            "type": "boolean"
+                          },
+                          "terminationMessagePath": {
+                            "type": "string"
+                          },
+                          "terminationMessagePolicy": {
+                            "type": "string"
+                          },
+                          "tty": {
+                            "type": "boolean"
+                          },
+                          "volumeDevices": {
+                            "items": {
+                              "properties": {
+                                "devicePath": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "volumeMounts": {
+                            "items": {
+                              "properties": {
+                                "mountPath": {
+                                  "type": "string"
+                                },
+                                "mountPropagation": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "readOnly": {
+                                  "type": "boolean"
+                                },
+                                "recursiveReadOnly": {
+                                  "type": "string"
+                                },
+                                "subPath": {
+                                  "type": "string"
+                                },
+                                "subPathExpr": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "workingDir": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "nodeName": {
+                      "type": "string"
+                    },
+                    "nodeSelector": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "type": "object"
+                    },
+                    "os": {
+                      "properties": {
+                        "name": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "overhead": {
+                      "additionalProperties": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "x-kubernetes-int-or-string": true
+                      },
+                      "type": "object"
+                    },
+                    "preemptionPolicy": {
+                      "type": "string"
+                    },
+                    "priority": {
+                      "type": "integer"
+                    },
+                    "priorityClassName": {
+                      "type": "string"
+                    },
+                    "readinessGates": {
+                      "items": {
+                        "properties": {
+                          "conditionType": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "resourceClaims": {
+                      "items": {
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          },
+                          "resourceClaimName": {
+                            "type": "string"
+                          },
+                          "resourceClaimTemplateName": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "resources": {
+                      "properties": {
+                        "claims": {
+                          "items": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "request": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "limits": {
+                          "additionalProperties": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "x-kubernetes-int-or-string": true
+                          },
+                          "type": "object"
+                        },
+                        "requests": {
+                          "additionalProperties": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "x-kubernetes-int-or-string": true
+                          },
+                          "type": "object"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "restartPolicy": {
+                      "type": "string"
+                    },
+                    "runtimeClassName": {
+                      "type": "string"
+                    },
+                    "schedulerName": {
+                      "type": "string"
+                    },
+                    "schedulingGates": {
+                      "items": {
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "securityContext": {
+                      "properties": {
+                        "appArmorProfile": {
+                          "properties": {
+                            "localhostProfile": {
+                              "type": "string"
+                            },
+                            "type": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "fsGroup": {
+                          "type": "integer"
+                        },
+                        "fsGroupChangePolicy": {
+                          "type": "string"
+                        },
+                        "runAsGroup": {
+                          "type": "integer"
+                        },
+                        "runAsNonRoot": {
+                          "type": "boolean"
+                        },
+                        "runAsUser": {
+                          "type": "integer"
+                        },
+                        "seLinuxChangePolicy": {
+                          "type": "string"
+                        },
+                        "seLinuxOptions": {
+                          "properties": {
+                            "level": {
+                              "type": "string"
+                            },
+                            "role": {
+                              "type": "string"
+                            },
+                            "type": {
+                              "type": "string"
+                            },
+                            "user": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "seccompProfile": {
+                          "properties": {
+                            "localhostProfile": {
+                              "type": "string"
+                            },
+                            "type": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "supplementalGroups": {
+                          "items": {
+                            "type": "integer"
+                          },
+                          "type": "array"
+                        },
+                        "supplementalGroupsPolicy": {
+                          "type": "string"
+                        },
+                        "sysctls": {
+                          "items": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "value": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "windowsOptions": {
+                          "properties": {
+                            "gmsaCredentialSpec": {
+                              "type": "string"
+                            },
+                            "gmsaCredentialSpecName": {
+                              "type": "string"
+                            },
+                            "hostProcess": {
+                              "type": "boolean"
+                            },
+                            "runAsUserName": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "serviceAccount": {
+                      "type": "string"
+                    },
+                    "serviceAccountName": {
+                      "type": "string"
+                    },
+                    "setHostnameAsFQDN": {
+                      "type": "boolean"
+                    },
+                    "shareProcessNamespace": {
+                      "type": "boolean"
+                    },
+                    "subdomain": {
+                      "type": "string"
+                    },
+                    "terminationGracePeriodSeconds": {
+                      "type": "integer"
+                    },
+                    "tolerations": {
+                      "items": {
+                        "properties": {
+                          "effect": {
+                            "type": "string"
+                          },
+                          "key": {
+                            "type": "string"
+                          },
+                          "operator": {
+                            "type": "string"
+                          },
+                          "tolerationSeconds": {
+                            "type": "integer"
+                          },
+                          "value": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "topologySpreadConstraints": {
+                      "items": {
+                        "properties": {
+                          "labelSelector": {
+                            "properties": {
+                              "matchExpressions": {
+                                "items": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "matchLabels": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "matchLabelKeys": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "maxSkew": {
+                            "type": "integer"
+                          },
+                          "minDomains": {
+                            "type": "integer"
+                          },
+                          "nodeAffinityPolicy": {
+                            "type": "string"
+                          },
+                          "nodeTaintsPolicy": {
+                            "type": "string"
+                          },
+                          "topologyKey": {
+                            "type": "string"
+                          },
+                          "whenUnsatisfiable": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "volumes": {
+                      "items": {
+                        "properties": {
+                          "awsElasticBlockStore": {
+                            "properties": {
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "partition": {
+                                "type": "integer"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "volumeID": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "azureDisk": {
+                            "properties": {
+                              "cachingMode": {
+                                "type": "string"
+                              },
+                              "diskName": {
+                                "type": "string"
+                              },
+                              "diskURI": {
+                                "type": "string"
+                              },
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "kind": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "azureFile": {
+                            "properties": {
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "secretName": {
+                                "type": "string"
+                              },
+                              "shareName": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "cephfs": {
+                            "properties": {
+                              "monitors": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "path": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "secretFile": {
+                                "type": "string"
+                              },
+                              "secretRef": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "user": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "cinder": {
+                            "properties": {
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "secretRef": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "volumeID": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "configMap": {
+                            "properties": {
+                              "defaultMode": {
+                                "type": "integer"
+                              },
+                              "items": {
+                                "items": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "mode": {
+                                      "type": "integer"
+                                    },
+                                    "path": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "optional": {
+                                "type": "boolean"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "csi": {
+                            "properties": {
+                              "driver": {
+                                "type": "string"
+                              },
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "nodePublishSecretRef": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "volumeAttributes": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "downwardAPI": {
+                            "properties": {
+                              "defaultMode": {
+                                "type": "integer"
+                              },
+                              "items": {
+                                "items": {
+                                  "properties": {
+                                    "fieldRef": {
+                                      "properties": {
+                                        "apiVersion": {
+                                          "type": "string"
+                                        },
+                                        "fieldPath": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "mode": {
+                                      "type": "integer"
+                                    },
+                                    "path": {
+                                      "type": "string"
+                                    },
+                                    "resourceFieldRef": {
+                                      "properties": {
+                                        "containerName": {
+                                          "type": "string"
+                                        },
+                                        "divisor": {
+                                          "anyOf": [
+                                            {
+                                              "type": "integer"
+                                            },
+                                            {
+                                              "type": "string"
+                                            }
+                                          ],
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "resource": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "emptyDir": {
+                            "properties": {
+                              "medium": {
+                                "type": "string"
+                              },
+                              "sizeLimit": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "ephemeral": {
+                            "properties": {
+                              "volumeClaimTemplate": {
+                                "properties": {
+                                  "metadata": {
+                                    "properties": {
+                                      "annotations": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
+                                      },
+                                      "creationTimestamp": {
+                                        "type": "string"
+                                      },
+                                      "deletionGracePeriodSeconds": {
+                                        "type": "integer"
+                                      },
+                                      "deletionTimestamp": {
+                                        "type": "string"
+                                      },
+                                      "finalizers": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "generateName": {
+                                        "type": "string"
+                                      },
+                                      "generation": {
+                                        "type": "integer"
+                                      },
+                                      "labels": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
+                                      },
+                                      "managedFields": {
+                                        "items": {
+                                          "properties": {
+                                            "apiVersion": {
+                                              "type": "string"
+                                            },
+                                            "fieldsType": {
+                                              "type": "string"
+                                            },
+                                            "fieldsV1": {
+                                              "type": "object"
+                                            },
+                                            "manager": {
+                                              "type": "string"
+                                            },
+                                            "operation": {
+                                              "type": "string"
+                                            },
+                                            "subresource": {
+                                              "type": "string"
+                                            },
+                                            "time": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "namespace": {
+                                        "type": "string"
+                                      },
+                                      "ownerReferences": {
+                                        "items": {
+                                          "properties": {
+                                            "apiVersion": {
+                                              "type": "string"
+                                            },
+                                            "blockOwnerDeletion": {
+                                              "type": "boolean"
+                                            },
+                                            "controller": {
+                                              "type": "boolean"
+                                            },
+                                            "kind": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "uid": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "resourceVersion": {
+                                        "type": "string"
+                                      },
+                                      "selfLink": {
+                                        "type": "string"
+                                      },
+                                      "uid": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "spec": {
+                                    "properties": {
+                                      "accessModes": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "dataSource": {
+                                        "properties": {
+                                          "apiGroup": {
+                                            "type": "string"
+                                          },
+                                          "kind": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "dataSourceRef": {
+                                        "properties": {
+                                          "apiGroup": {
+                                            "type": "string"
+                                          },
+                                          "kind": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "namespace": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "resources": {
+                                        "properties": {
+                                          "limits": {
+                                            "additionalProperties": {
+                                              "anyOf": [
+                                                {
+                                                  "type": "integer"
+                                                },
+                                                {
+                                                  "type": "string"
+                                                }
+                                              ],
+                                              "x-kubernetes-int-or-string": true
+                                            },
+                                            "type": "object"
+                                          },
+                                          "requests": {
+                                            "additionalProperties": {
+                                              "anyOf": [
+                                                {
+                                                  "type": "integer"
+                                                },
+                                                {
+                                                  "type": "string"
+                                                }
+                                              ],
+                                              "x-kubernetes-int-or-string": true
+                                            },
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "selector": {
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "matchLabels": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "storageClassName": {
+                                        "type": "string"
+                                      },
+                                      "volumeAttributesClassName": {
+                                        "type": "string"
+                                      },
+                                      "volumeMode": {
+                                        "type": "string"
+                                      },
+                                      "volumeName": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "fc": {
+                            "properties": {
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "lun": {
+                                "type": "integer"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "targetWWNs": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "wwids": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "flexVolume": {
+                            "properties": {
+                              "driver": {
+                                "type": "string"
+                              },
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "options": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "type": "object"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "secretRef": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "flocker": {
+                            "properties": {
+                              "datasetName": {
+                                "type": "string"
+                              },
+                              "datasetUUID": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "gcePersistentDisk": {
+                            "properties": {
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "partition": {
+                                "type": "integer"
+                              },
+                              "pdName": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "gitRepo": {
+                            "properties": {
+                              "directory": {
+                                "type": "string"
+                              },
+                              "repository": {
+                                "type": "string"
+                              },
+                              "revision": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "glusterfs": {
+                            "properties": {
+                              "endpoints": {
+                                "type": "string"
+                              },
+                              "path": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "hostPath": {
+                            "properties": {
+                              "path": {
+                                "type": "string"
+                              },
+                              "type": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "image": {
+                            "properties": {
+                              "pullPolicy": {
+                                "type": "string"
+                              },
+                              "reference": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "iscsi": {
+                            "properties": {
+                              "chapAuthDiscovery": {
+                                "type": "boolean"
+                              },
+                              "chapAuthSession": {
+                                "type": "boolean"
+                              },
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "initiatorName": {
+                                "type": "string"
+                              },
+                              "iqn": {
+                                "type": "string"
+                              },
+                              "iscsiInterface": {
+                                "type": "string"
+                              },
+                              "lun": {
+                                "type": "integer"
+                              },
+                              "portals": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "secretRef": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "targetPortal": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "nfs": {
+                            "properties": {
+                              "path": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "server": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "persistentVolumeClaim": {
+                            "properties": {
+                              "claimName": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "photonPersistentDisk": {
+                            "properties": {
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "pdID": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "portworxVolume": {
+                            "properties": {
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "volumeID": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "projected": {
+                            "properties": {
+                              "defaultMode": {
+                                "type": "integer"
+                              },
+                              "sources": {
+                                "items": {
+                                  "properties": {
+                                    "clusterTrustBundle": {
+                                      "properties": {
+                                        "labelSelector": {
+                                          "properties": {
+                                            "matchExpressions": {
+                                              "items": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "operator": {
+                                                    "type": "string"
+                                                  },
+                                                  "values": {
+                                                    "items": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "array"
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              "type": "array"
+                                            },
+                                            "matchLabels": {
+                                              "additionalProperties": {
+                                                "type": "string"
+                                              },
+                                              "type": "object"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        },
+                                        "path": {
+                                          "type": "string"
+                                        },
+                                        "signerName": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "configMap": {
+                                      "properties": {
+                                        "items": {
+                                          "items": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "mode": {
+                                                "type": "integer"
+                                              },
+                                              "path": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          "type": "array"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "downwardAPI": {
+                                      "properties": {
+                                        "items": {
+                                          "items": {
+                                            "properties": {
+                                              "fieldRef": {
+                                                "properties": {
+                                                  "apiVersion": {
+                                                    "type": "string"
+                                                  },
+                                                  "fieldPath": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              "mode": {
+                                                "type": "integer"
+                                              },
+                                              "path": {
+                                                "type": "string"
+                                              },
+                                              "resourceFieldRef": {
+                                                "properties": {
+                                                  "containerName": {
+                                                    "type": "string"
+                                                  },
+                                                  "divisor": {
+                                                    "anyOf": [
+                                                      {
+                                                        "type": "integer"
+                                                      },
+                                                      {
+                                                        "type": "string"
+                                                      }
+                                                    ],
+                                                    "x-kubernetes-int-or-string": true
+                                                  },
+                                                  "resource": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object"
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "secret": {
+                                      "properties": {
+                                        "items": {
+                                          "items": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "mode": {
+                                                "type": "integer"
+                                              },
+                                              "path": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          "type": "array"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "serviceAccountToken": {
+                                      "properties": {
+                                        "audience": {
+                                          "type": "string"
+                                        },
+                                        "expirationSeconds": {
+                                          "type": "integer"
+                                        },
+                                        "path": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "quobyte": {
+                            "properties": {
+                              "group": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "registry": {
+                                "type": "string"
+                              },
+                              "tenant": {
+                                "type": "string"
+                              },
+                              "user": {
+                                "type": "string"
+                              },
+                              "volume": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "rbd": {
+                            "properties": {
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "image": {
+                                "type": "string"
+                              },
+                              "keyring": {
+                                "type": "string"
+                              },
+                              "monitors": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "pool": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "secretRef": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "user": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "scaleIO": {
+                            "properties": {
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "gateway": {
+                                "type": "string"
+                              },
+                              "protectionDomain": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "secretRef": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "sslEnabled": {
+                                "type": "boolean"
+                              },
+                              "storageMode": {
+                                "type": "string"
+                              },
+                              "storagePool": {
+                                "type": "string"
+                              },
+                              "system": {
+                                "type": "string"
+                              },
+                              "volumeName": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "secret": {
+                            "properties": {
+                              "defaultMode": {
+                                "type": "integer"
+                              },
+                              "items": {
+                                "items": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "mode": {
+                                      "type": "integer"
+                                    },
+                                    "path": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "optional": {
+                                "type": "boolean"
+                              },
+                              "secretName": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "storageos": {
+                            "properties": {
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "secretRef": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "volumeName": {
+                                "type": "string"
+                              },
+                              "volumeNamespace": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "vsphereVolume": {
+                            "properties": {
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "storagePolicyID": {
+                                "type": "string"
+                              },
+                              "storagePolicyName": {
+                                "type": "string"
+                              },
+                              "volumePath": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "type": "object"
+        },
+        "files": {
+          "type": "string"
+        },
+        "jars": {
+          "type": "string"
+        },
+        "mainClass": {
+          "type": "string"
+        },
+        "proxyUser": {
+          "type": "string"
+        },
+        "pyFiles": {
+          "type": "string"
+        },
+        "runtimeVersions": {
+          "properties": {
+            "jdkVersion": {
+              "type": "string"
+            },
+            "scalaVersion": {
+              "type": "string"
+            },
+            "sparkVersion": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "sparkVersion"
+          ],
+          "type": "object"
+        },
+        "sparkConf": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "sparkRFiles": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "runtimeVersions"
+      ],
+      "type": "object"
+    },
+    "status": {
+      "properties": {
+        "currentAttemptSummary": {
+          "properties": {
+            "attemptInfo": {
+              "properties": {
+                "id": {
+                  "type": "integer"
+                }
+              },
+              "type": "object"
+            },
+            "stateTransitionHistory": {
+              "additionalProperties": {
+                "properties": {
+                  "currentStateSummary": {
+                    "enum": [
+                      "DriverEvicted",
+                      "DriverReady",
+                      "DriverReadyTimedOut",
+                      "DriverRequested",
+                      "DriverStartTimedOut",
+                      "DriverStarted",
+                      "ExecutorsStartTimedOut",
+                      "Failed",
+                      "InitializedBelowThresholdExecutors",
+                      "ResourceReleased",
+                      "RunningHealthy",
+                      "RunningWithBelowThresholdExecutors",
+                      "ScheduledToRestart",
+                      "SchedulingFailure",
+                      "Submitted",
+                      "Succeeded",
+                      "TerminatedWithoutReleaseResources"
+                    ],
+                    "type": "string"
+                  },
+                  "lastObservedDriverStatus": {
+                    "properties": {
+                      "conditions": {
+                        "items": {
+                          "properties": {
+                            "lastProbeTime": {
+                              "type": "string"
+                            },
+                            "lastTransitionTime": {
+                              "type": "string"
+                            },
+                            "message": {
+                              "type": "string"
+                            },
+                            "observedGeneration": {
+                              "type": "integer"
+                            },
+                            "reason": {
+                              "type": "string"
+                            },
+                            "status": {
+                              "type": "string"
+                            },
+                            "type": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "type": "array"
+                      },
+                      "containerStatuses": {
+                        "items": {
+                          "properties": {
+                            "allocatedResources": {
+                              "additionalProperties": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "type": "object"
+                            },
+                            "allocatedResourcesStatus": {
+                              "items": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "resources": {
+                                    "items": {
+                                      "properties": {
+                                        "health": {
+                                          "type": "string"
+                                        },
+                                        "resourceID": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "containerID": {
+                              "type": "string"
+                            },
+                            "image": {
+                              "type": "string"
+                            },
+                            "imageID": {
+                              "type": "string"
+                            },
+                            "lastState": {
+                              "properties": {
+                                "running": {
+                                  "properties": {
+                                    "startedAt": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "terminated": {
+                                  "properties": {
+                                    "containerID": {
+                                      "type": "string"
+                                    },
+                                    "exitCode": {
+                                      "type": "integer"
+                                    },
+                                    "finishedAt": {
+                                      "type": "string"
+                                    },
+                                    "message": {
+                                      "type": "string"
+                                    },
+                                    "reason": {
+                                      "type": "string"
+                                    },
+                                    "signal": {
+                                      "type": "integer"
+                                    },
+                                    "startedAt": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "waiting": {
+                                  "properties": {
+                                    "message": {
+                                      "type": "string"
+                                    },
+                                    "reason": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "ready": {
+                              "type": "boolean"
+                            },
+                            "resources": {
+                              "properties": {
+                                "claims": {
+                                  "items": {
+                                    "properties": {
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "request": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "type": "array"
+                                },
+                                "limits": {
+                                  "additionalProperties": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "type": "object"
+                                },
+                                "requests": {
+                                  "additionalProperties": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "restartCount": {
+                              "type": "integer"
+                            },
+                            "started": {
+                              "type": "boolean"
+                            },
+                            "state": {
+                              "properties": {
+                                "running": {
+                                  "properties": {
+                                    "startedAt": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "terminated": {
+                                  "properties": {
+                                    "containerID": {
+                                      "type": "string"
+                                    },
+                                    "exitCode": {
+                                      "type": "integer"
+                                    },
+                                    "finishedAt": {
+                                      "type": "string"
+                                    },
+                                    "message": {
+                                      "type": "string"
+                                    },
+                                    "reason": {
+                                      "type": "string"
+                                    },
+                                    "signal": {
+                                      "type": "integer"
+                                    },
+                                    "startedAt": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "waiting": {
+                                  "properties": {
+                                    "message": {
+                                      "type": "string"
+                                    },
+                                    "reason": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "stopSignal": {
+                              "type": "string"
+                            },
+                            "user": {
+                              "properties": {
+                                "linux": {
+                                  "properties": {
+                                    "gid": {
+                                      "type": "integer"
+                                    },
+                                    "supplementalGroups": {
+                                      "items": {
+                                        "type": "integer"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "uid": {
+                                      "type": "integer"
+                                    }
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "volumeMounts": {
+                              "items": {
+                                "properties": {
+                                  "mountPath": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  },
+                                  "recursiveReadOnly": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "type": "array"
+                      },
+                      "ephemeralContainerStatuses": {
+                        "items": {
+                          "properties": {
+                            "allocatedResources": {
+                              "additionalProperties": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "type": "object"
+                            },
+                            "allocatedResourcesStatus": {
+                              "items": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "resources": {
+                                    "items": {
+                                      "properties": {
+                                        "health": {
+                                          "type": "string"
+                                        },
+                                        "resourceID": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "containerID": {
+                              "type": "string"
+                            },
+                            "image": {
+                              "type": "string"
+                            },
+                            "imageID": {
+                              "type": "string"
+                            },
+                            "lastState": {
+                              "properties": {
+                                "running": {
+                                  "properties": {
+                                    "startedAt": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "terminated": {
+                                  "properties": {
+                                    "containerID": {
+                                      "type": "string"
+                                    },
+                                    "exitCode": {
+                                      "type": "integer"
+                                    },
+                                    "finishedAt": {
+                                      "type": "string"
+                                    },
+                                    "message": {
+                                      "type": "string"
+                                    },
+                                    "reason": {
+                                      "type": "string"
+                                    },
+                                    "signal": {
+                                      "type": "integer"
+                                    },
+                                    "startedAt": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "waiting": {
+                                  "properties": {
+                                    "message": {
+                                      "type": "string"
+                                    },
+                                    "reason": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "ready": {
+                              "type": "boolean"
+                            },
+                            "resources": {
+                              "properties": {
+                                "claims": {
+                                  "items": {
+                                    "properties": {
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "request": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "type": "array"
+                                },
+                                "limits": {
+                                  "additionalProperties": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "type": "object"
+                                },
+                                "requests": {
+                                  "additionalProperties": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "restartCount": {
+                              "type": "integer"
+                            },
+                            "started": {
+                              "type": "boolean"
+                            },
+                            "state": {
+                              "properties": {
+                                "running": {
+                                  "properties": {
+                                    "startedAt": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "terminated": {
+                                  "properties": {
+                                    "containerID": {
+                                      "type": "string"
+                                    },
+                                    "exitCode": {
+                                      "type": "integer"
+                                    },
+                                    "finishedAt": {
+                                      "type": "string"
+                                    },
+                                    "message": {
+                                      "type": "string"
+                                    },
+                                    "reason": {
+                                      "type": "string"
+                                    },
+                                    "signal": {
+                                      "type": "integer"
+                                    },
+                                    "startedAt": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "waiting": {
+                                  "properties": {
+                                    "message": {
+                                      "type": "string"
+                                    },
+                                    "reason": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "stopSignal": {
+                              "type": "string"
+                            },
+                            "user": {
+                              "properties": {
+                                "linux": {
+                                  "properties": {
+                                    "gid": {
+                                      "type": "integer"
+                                    },
+                                    "supplementalGroups": {
+                                      "items": {
+                                        "type": "integer"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "uid": {
+                                      "type": "integer"
+                                    }
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "volumeMounts": {
+                              "items": {
+                                "properties": {
+                                  "mountPath": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  },
+                                  "recursiveReadOnly": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "type": "array"
+                      },
+                      "hostIP": {
+                        "type": "string"
+                      },
+                      "hostIPs": {
+                        "items": {
+                          "properties": {
+                            "ip": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "type": "array"
+                      },
+                      "initContainerStatuses": {
+                        "items": {
+                          "properties": {
+                            "allocatedResources": {
+                              "additionalProperties": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "type": "object"
+                            },
+                            "allocatedResourcesStatus": {
+                              "items": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "resources": {
+                                    "items": {
+                                      "properties": {
+                                        "health": {
+                                          "type": "string"
+                                        },
+                                        "resourceID": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "containerID": {
+                              "type": "string"
+                            },
+                            "image": {
+                              "type": "string"
+                            },
+                            "imageID": {
+                              "type": "string"
+                            },
+                            "lastState": {
+                              "properties": {
+                                "running": {
+                                  "properties": {
+                                    "startedAt": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "terminated": {
+                                  "properties": {
+                                    "containerID": {
+                                      "type": "string"
+                                    },
+                                    "exitCode": {
+                                      "type": "integer"
+                                    },
+                                    "finishedAt": {
+                                      "type": "string"
+                                    },
+                                    "message": {
+                                      "type": "string"
+                                    },
+                                    "reason": {
+                                      "type": "string"
+                                    },
+                                    "signal": {
+                                      "type": "integer"
+                                    },
+                                    "startedAt": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "waiting": {
+                                  "properties": {
+                                    "message": {
+                                      "type": "string"
+                                    },
+                                    "reason": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "ready": {
+                              "type": "boolean"
+                            },
+                            "resources": {
+                              "properties": {
+                                "claims": {
+                                  "items": {
+                                    "properties": {
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "request": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "type": "array"
+                                },
+                                "limits": {
+                                  "additionalProperties": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "type": "object"
+                                },
+                                "requests": {
+                                  "additionalProperties": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "restartCount": {
+                              "type": "integer"
+                            },
+                            "started": {
+                              "type": "boolean"
+                            },
+                            "state": {
+                              "properties": {
+                                "running": {
+                                  "properties": {
+                                    "startedAt": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "terminated": {
+                                  "properties": {
+                                    "containerID": {
+                                      "type": "string"
+                                    },
+                                    "exitCode": {
+                                      "type": "integer"
+                                    },
+                                    "finishedAt": {
+                                      "type": "string"
+                                    },
+                                    "message": {
+                                      "type": "string"
+                                    },
+                                    "reason": {
+                                      "type": "string"
+                                    },
+                                    "signal": {
+                                      "type": "integer"
+                                    },
+                                    "startedAt": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "waiting": {
+                                  "properties": {
+                                    "message": {
+                                      "type": "string"
+                                    },
+                                    "reason": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "stopSignal": {
+                              "type": "string"
+                            },
+                            "user": {
+                              "properties": {
+                                "linux": {
+                                  "properties": {
+                                    "gid": {
+                                      "type": "integer"
+                                    },
+                                    "supplementalGroups": {
+                                      "items": {
+                                        "type": "integer"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "uid": {
+                                      "type": "integer"
+                                    }
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "volumeMounts": {
+                              "items": {
+                                "properties": {
+                                  "mountPath": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  },
+                                  "recursiveReadOnly": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "type": "array"
+                      },
+                      "message": {
+                        "type": "string"
+                      },
+                      "nominatedNodeName": {
+                        "type": "string"
+                      },
+                      "observedGeneration": {
+                        "type": "integer"
+                      },
+                      "phase": {
+                        "type": "string"
+                      },
+                      "podIP": {
+                        "type": "string"
+                      },
+                      "podIPs": {
+                        "items": {
+                          "properties": {
+                            "ip": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "type": "array"
+                      },
+                      "qosClass": {
+                        "type": "string"
+                      },
+                      "reason": {
+                        "type": "string"
+                      },
+                      "resize": {
+                        "type": "string"
+                      },
+                      "resourceClaimStatuses": {
+                        "items": {
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            },
+                            "resourceClaimName": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "type": "array"
+                      },
+                      "startTime": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "lastTransitionTime": {
+                    "type": "string"
+                  },
+                  "message": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "type": "object"
+            }
+          },
+          "type": "object"
+        },
+        "currentState": {
+          "properties": {
+            "currentStateSummary": {
+              "enum": [
+                "DriverEvicted",
+                "DriverReady",
+                "DriverReadyTimedOut",
+                "DriverRequested",
+                "DriverStartTimedOut",
+                "DriverStarted",
+                "ExecutorsStartTimedOut",
+                "Failed",
+                "InitializedBelowThresholdExecutors",
+                "ResourceReleased",
+                "RunningHealthy",
+                "RunningWithBelowThresholdExecutors",
+                "ScheduledToRestart",
+                "SchedulingFailure",
+                "Submitted",
+                "Succeeded",
+                "TerminatedWithoutReleaseResources"
+              ],
+              "type": "string"
+            },
+            "lastObservedDriverStatus": {
+              "properties": {
+                "conditions": {
+                  "items": {
+                    "properties": {
+                      "lastProbeTime": {
+                        "type": "string"
+                      },
+                      "lastTransitionTime": {
+                        "type": "string"
+                      },
+                      "message": {
+                        "type": "string"
+                      },
+                      "observedGeneration": {
+                        "type": "integer"
+                      },
+                      "reason": {
+                        "type": "string"
+                      },
+                      "status": {
+                        "type": "string"
+                      },
+                      "type": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "containerStatuses": {
+                  "items": {
+                    "properties": {
+                      "allocatedResources": {
+                        "additionalProperties": {
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "string"
+                            }
+                          ],
+                          "x-kubernetes-int-or-string": true
+                        },
+                        "type": "object"
+                      },
+                      "allocatedResourcesStatus": {
+                        "items": {
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            },
+                            "resources": {
+                              "items": {
+                                "properties": {
+                                  "health": {
+                                    "type": "string"
+                                  },
+                                  "resourceID": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "type": "array"
+                      },
+                      "containerID": {
+                        "type": "string"
+                      },
+                      "image": {
+                        "type": "string"
+                      },
+                      "imageID": {
+                        "type": "string"
+                      },
+                      "lastState": {
+                        "properties": {
+                          "running": {
+                            "properties": {
+                              "startedAt": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "terminated": {
+                            "properties": {
+                              "containerID": {
+                                "type": "string"
+                              },
+                              "exitCode": {
+                                "type": "integer"
+                              },
+                              "finishedAt": {
+                                "type": "string"
+                              },
+                              "message": {
+                                "type": "string"
+                              },
+                              "reason": {
+                                "type": "string"
+                              },
+                              "signal": {
+                                "type": "integer"
+                              },
+                              "startedAt": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "waiting": {
+                            "properties": {
+                              "message": {
+                                "type": "string"
+                              },
+                              "reason": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "ready": {
+                        "type": "boolean"
+                      },
+                      "resources": {
+                        "properties": {
+                          "claims": {
+                            "items": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "request": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "limits": {
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "type": "object"
+                          },
+                          "requests": {
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "type": "object"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "restartCount": {
+                        "type": "integer"
+                      },
+                      "started": {
+                        "type": "boolean"
+                      },
+                      "state": {
+                        "properties": {
+                          "running": {
+                            "properties": {
+                              "startedAt": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "terminated": {
+                            "properties": {
+                              "containerID": {
+                                "type": "string"
+                              },
+                              "exitCode": {
+                                "type": "integer"
+                              },
+                              "finishedAt": {
+                                "type": "string"
+                              },
+                              "message": {
+                                "type": "string"
+                              },
+                              "reason": {
+                                "type": "string"
+                              },
+                              "signal": {
+                                "type": "integer"
+                              },
+                              "startedAt": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "waiting": {
+                            "properties": {
+                              "message": {
+                                "type": "string"
+                              },
+                              "reason": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "stopSignal": {
+                        "type": "string"
+                      },
+                      "user": {
+                        "properties": {
+                          "linux": {
+                            "properties": {
+                              "gid": {
+                                "type": "integer"
+                              },
+                              "supplementalGroups": {
+                                "items": {
+                                  "type": "integer"
+                                },
+                                "type": "array"
+                              },
+                              "uid": {
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "volumeMounts": {
+                        "items": {
+                          "properties": {
+                            "mountPath": {
+                              "type": "string"
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "readOnly": {
+                              "type": "boolean"
+                            },
+                            "recursiveReadOnly": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "ephemeralContainerStatuses": {
+                  "items": {
+                    "properties": {
+                      "allocatedResources": {
+                        "additionalProperties": {
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "string"
+                            }
+                          ],
+                          "x-kubernetes-int-or-string": true
+                        },
+                        "type": "object"
+                      },
+                      "allocatedResourcesStatus": {
+                        "items": {
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            },
+                            "resources": {
+                              "items": {
+                                "properties": {
+                                  "health": {
+                                    "type": "string"
+                                  },
+                                  "resourceID": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "type": "array"
+                      },
+                      "containerID": {
+                        "type": "string"
+                      },
+                      "image": {
+                        "type": "string"
+                      },
+                      "imageID": {
+                        "type": "string"
+                      },
+                      "lastState": {
+                        "properties": {
+                          "running": {
+                            "properties": {
+                              "startedAt": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "terminated": {
+                            "properties": {
+                              "containerID": {
+                                "type": "string"
+                              },
+                              "exitCode": {
+                                "type": "integer"
+                              },
+                              "finishedAt": {
+                                "type": "string"
+                              },
+                              "message": {
+                                "type": "string"
+                              },
+                              "reason": {
+                                "type": "string"
+                              },
+                              "signal": {
+                                "type": "integer"
+                              },
+                              "startedAt": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "waiting": {
+                            "properties": {
+                              "message": {
+                                "type": "string"
+                              },
+                              "reason": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "ready": {
+                        "type": "boolean"
+                      },
+                      "resources": {
+                        "properties": {
+                          "claims": {
+                            "items": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "request": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "limits": {
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "type": "object"
+                          },
+                          "requests": {
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "type": "object"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "restartCount": {
+                        "type": "integer"
+                      },
+                      "started": {
+                        "type": "boolean"
+                      },
+                      "state": {
+                        "properties": {
+                          "running": {
+                            "properties": {
+                              "startedAt": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "terminated": {
+                            "properties": {
+                              "containerID": {
+                                "type": "string"
+                              },
+                              "exitCode": {
+                                "type": "integer"
+                              },
+                              "finishedAt": {
+                                "type": "string"
+                              },
+                              "message": {
+                                "type": "string"
+                              },
+                              "reason": {
+                                "type": "string"
+                              },
+                              "signal": {
+                                "type": "integer"
+                              },
+                              "startedAt": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "waiting": {
+                            "properties": {
+                              "message": {
+                                "type": "string"
+                              },
+                              "reason": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "stopSignal": {
+                        "type": "string"
+                      },
+                      "user": {
+                        "properties": {
+                          "linux": {
+                            "properties": {
+                              "gid": {
+                                "type": "integer"
+                              },
+                              "supplementalGroups": {
+                                "items": {
+                                  "type": "integer"
+                                },
+                                "type": "array"
+                              },
+                              "uid": {
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "volumeMounts": {
+                        "items": {
+                          "properties": {
+                            "mountPath": {
+                              "type": "string"
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "readOnly": {
+                              "type": "boolean"
+                            },
+                            "recursiveReadOnly": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "hostIP": {
+                  "type": "string"
+                },
+                "hostIPs": {
+                  "items": {
+                    "properties": {
+                      "ip": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "initContainerStatuses": {
+                  "items": {
+                    "properties": {
+                      "allocatedResources": {
+                        "additionalProperties": {
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "string"
+                            }
+                          ],
+                          "x-kubernetes-int-or-string": true
+                        },
+                        "type": "object"
+                      },
+                      "allocatedResourcesStatus": {
+                        "items": {
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            },
+                            "resources": {
+                              "items": {
+                                "properties": {
+                                  "health": {
+                                    "type": "string"
+                                  },
+                                  "resourceID": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "type": "array"
+                      },
+                      "containerID": {
+                        "type": "string"
+                      },
+                      "image": {
+                        "type": "string"
+                      },
+                      "imageID": {
+                        "type": "string"
+                      },
+                      "lastState": {
+                        "properties": {
+                          "running": {
+                            "properties": {
+                              "startedAt": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "terminated": {
+                            "properties": {
+                              "containerID": {
+                                "type": "string"
+                              },
+                              "exitCode": {
+                                "type": "integer"
+                              },
+                              "finishedAt": {
+                                "type": "string"
+                              },
+                              "message": {
+                                "type": "string"
+                              },
+                              "reason": {
+                                "type": "string"
+                              },
+                              "signal": {
+                                "type": "integer"
+                              },
+                              "startedAt": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "waiting": {
+                            "properties": {
+                              "message": {
+                                "type": "string"
+                              },
+                              "reason": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "ready": {
+                        "type": "boolean"
+                      },
+                      "resources": {
+                        "properties": {
+                          "claims": {
+                            "items": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "request": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "limits": {
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "type": "object"
+                          },
+                          "requests": {
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "type": "object"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "restartCount": {
+                        "type": "integer"
+                      },
+                      "started": {
+                        "type": "boolean"
+                      },
+                      "state": {
+                        "properties": {
+                          "running": {
+                            "properties": {
+                              "startedAt": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "terminated": {
+                            "properties": {
+                              "containerID": {
+                                "type": "string"
+                              },
+                              "exitCode": {
+                                "type": "integer"
+                              },
+                              "finishedAt": {
+                                "type": "string"
+                              },
+                              "message": {
+                                "type": "string"
+                              },
+                              "reason": {
+                                "type": "string"
+                              },
+                              "signal": {
+                                "type": "integer"
+                              },
+                              "startedAt": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "waiting": {
+                            "properties": {
+                              "message": {
+                                "type": "string"
+                              },
+                              "reason": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "stopSignal": {
+                        "type": "string"
+                      },
+                      "user": {
+                        "properties": {
+                          "linux": {
+                            "properties": {
+                              "gid": {
+                                "type": "integer"
+                              },
+                              "supplementalGroups": {
+                                "items": {
+                                  "type": "integer"
+                                },
+                                "type": "array"
+                              },
+                              "uid": {
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "volumeMounts": {
+                        "items": {
+                          "properties": {
+                            "mountPath": {
+                              "type": "string"
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "readOnly": {
+                              "type": "boolean"
+                            },
+                            "recursiveReadOnly": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "message": {
+                  "type": "string"
+                },
+                "nominatedNodeName": {
+                  "type": "string"
+                },
+                "observedGeneration": {
+                  "type": "integer"
+                },
+                "phase": {
+                  "type": "string"
+                },
+                "podIP": {
+                  "type": "string"
+                },
+                "podIPs": {
+                  "items": {
+                    "properties": {
+                      "ip": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "qosClass": {
+                  "type": "string"
+                },
+                "reason": {
+                  "type": "string"
+                },
+                "resize": {
+                  "type": "string"
+                },
+                "resourceClaimStatuses": {
+                  "items": {
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      },
+                      "resourceClaimName": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "startTime": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "lastTransitionTime": {
+              "type": "string"
+            },
+            "message": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "previousAttemptSummary": {
+          "properties": {
+            "attemptInfo": {
+              "properties": {
+                "id": {
+                  "type": "integer"
+                }
+              },
+              "type": "object"
+            },
+            "stateTransitionHistory": {
+              "additionalProperties": {
+                "properties": {
+                  "currentStateSummary": {
+                    "enum": [
+                      "DriverEvicted",
+                      "DriverReady",
+                      "DriverReadyTimedOut",
+                      "DriverRequested",
+                      "DriverStartTimedOut",
+                      "DriverStarted",
+                      "ExecutorsStartTimedOut",
+                      "Failed",
+                      "InitializedBelowThresholdExecutors",
+                      "ResourceReleased",
+                      "RunningHealthy",
+                      "RunningWithBelowThresholdExecutors",
+                      "ScheduledToRestart",
+                      "SchedulingFailure",
+                      "Submitted",
+                      "Succeeded",
+                      "TerminatedWithoutReleaseResources"
+                    ],
+                    "type": "string"
+                  },
+                  "lastObservedDriverStatus": {
+                    "properties": {
+                      "conditions": {
+                        "items": {
+                          "properties": {
+                            "lastProbeTime": {
+                              "type": "string"
+                            },
+                            "lastTransitionTime": {
+                              "type": "string"
+                            },
+                            "message": {
+                              "type": "string"
+                            },
+                            "observedGeneration": {
+                              "type": "integer"
+                            },
+                            "reason": {
+                              "type": "string"
+                            },
+                            "status": {
+                              "type": "string"
+                            },
+                            "type": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "type": "array"
+                      },
+                      "containerStatuses": {
+                        "items": {
+                          "properties": {
+                            "allocatedResources": {
+                              "additionalProperties": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "type": "object"
+                            },
+                            "allocatedResourcesStatus": {
+                              "items": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "resources": {
+                                    "items": {
+                                      "properties": {
+                                        "health": {
+                                          "type": "string"
+                                        },
+                                        "resourceID": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "containerID": {
+                              "type": "string"
+                            },
+                            "image": {
+                              "type": "string"
+                            },
+                            "imageID": {
+                              "type": "string"
+                            },
+                            "lastState": {
+                              "properties": {
+                                "running": {
+                                  "properties": {
+                                    "startedAt": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "terminated": {
+                                  "properties": {
+                                    "containerID": {
+                                      "type": "string"
+                                    },
+                                    "exitCode": {
+                                      "type": "integer"
+                                    },
+                                    "finishedAt": {
+                                      "type": "string"
+                                    },
+                                    "message": {
+                                      "type": "string"
+                                    },
+                                    "reason": {
+                                      "type": "string"
+                                    },
+                                    "signal": {
+                                      "type": "integer"
+                                    },
+                                    "startedAt": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "waiting": {
+                                  "properties": {
+                                    "message": {
+                                      "type": "string"
+                                    },
+                                    "reason": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "ready": {
+                              "type": "boolean"
+                            },
+                            "resources": {
+                              "properties": {
+                                "claims": {
+                                  "items": {
+                                    "properties": {
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "request": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "type": "array"
+                                },
+                                "limits": {
+                                  "additionalProperties": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "type": "object"
+                                },
+                                "requests": {
+                                  "additionalProperties": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "restartCount": {
+                              "type": "integer"
+                            },
+                            "started": {
+                              "type": "boolean"
+                            },
+                            "state": {
+                              "properties": {
+                                "running": {
+                                  "properties": {
+                                    "startedAt": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "terminated": {
+                                  "properties": {
+                                    "containerID": {
+                                      "type": "string"
+                                    },
+                                    "exitCode": {
+                                      "type": "integer"
+                                    },
+                                    "finishedAt": {
+                                      "type": "string"
+                                    },
+                                    "message": {
+                                      "type": "string"
+                                    },
+                                    "reason": {
+                                      "type": "string"
+                                    },
+                                    "signal": {
+                                      "type": "integer"
+                                    },
+                                    "startedAt": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "waiting": {
+                                  "properties": {
+                                    "message": {
+                                      "type": "string"
+                                    },
+                                    "reason": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "stopSignal": {
+                              "type": "string"
+                            },
+                            "user": {
+                              "properties": {
+                                "linux": {
+                                  "properties": {
+                                    "gid": {
+                                      "type": "integer"
+                                    },
+                                    "supplementalGroups": {
+                                      "items": {
+                                        "type": "integer"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "uid": {
+                                      "type": "integer"
+                                    }
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "volumeMounts": {
+                              "items": {
+                                "properties": {
+                                  "mountPath": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  },
+                                  "recursiveReadOnly": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "type": "array"
+                      },
+                      "ephemeralContainerStatuses": {
+                        "items": {
+                          "properties": {
+                            "allocatedResources": {
+                              "additionalProperties": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "type": "object"
+                            },
+                            "allocatedResourcesStatus": {
+                              "items": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "resources": {
+                                    "items": {
+                                      "properties": {
+                                        "health": {
+                                          "type": "string"
+                                        },
+                                        "resourceID": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "containerID": {
+                              "type": "string"
+                            },
+                            "image": {
+                              "type": "string"
+                            },
+                            "imageID": {
+                              "type": "string"
+                            },
+                            "lastState": {
+                              "properties": {
+                                "running": {
+                                  "properties": {
+                                    "startedAt": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "terminated": {
+                                  "properties": {
+                                    "containerID": {
+                                      "type": "string"
+                                    },
+                                    "exitCode": {
+                                      "type": "integer"
+                                    },
+                                    "finishedAt": {
+                                      "type": "string"
+                                    },
+                                    "message": {
+                                      "type": "string"
+                                    },
+                                    "reason": {
+                                      "type": "string"
+                                    },
+                                    "signal": {
+                                      "type": "integer"
+                                    },
+                                    "startedAt": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "waiting": {
+                                  "properties": {
+                                    "message": {
+                                      "type": "string"
+                                    },
+                                    "reason": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "ready": {
+                              "type": "boolean"
+                            },
+                            "resources": {
+                              "properties": {
+                                "claims": {
+                                  "items": {
+                                    "properties": {
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "request": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "type": "array"
+                                },
+                                "limits": {
+                                  "additionalProperties": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "type": "object"
+                                },
+                                "requests": {
+                                  "additionalProperties": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "restartCount": {
+                              "type": "integer"
+                            },
+                            "started": {
+                              "type": "boolean"
+                            },
+                            "state": {
+                              "properties": {
+                                "running": {
+                                  "properties": {
+                                    "startedAt": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "terminated": {
+                                  "properties": {
+                                    "containerID": {
+                                      "type": "string"
+                                    },
+                                    "exitCode": {
+                                      "type": "integer"
+                                    },
+                                    "finishedAt": {
+                                      "type": "string"
+                                    },
+                                    "message": {
+                                      "type": "string"
+                                    },
+                                    "reason": {
+                                      "type": "string"
+                                    },
+                                    "signal": {
+                                      "type": "integer"
+                                    },
+                                    "startedAt": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "waiting": {
+                                  "properties": {
+                                    "message": {
+                                      "type": "string"
+                                    },
+                                    "reason": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "stopSignal": {
+                              "type": "string"
+                            },
+                            "user": {
+                              "properties": {
+                                "linux": {
+                                  "properties": {
+                                    "gid": {
+                                      "type": "integer"
+                                    },
+                                    "supplementalGroups": {
+                                      "items": {
+                                        "type": "integer"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "uid": {
+                                      "type": "integer"
+                                    }
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "volumeMounts": {
+                              "items": {
+                                "properties": {
+                                  "mountPath": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  },
+                                  "recursiveReadOnly": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "type": "array"
+                      },
+                      "hostIP": {
+                        "type": "string"
+                      },
+                      "hostIPs": {
+                        "items": {
+                          "properties": {
+                            "ip": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "type": "array"
+                      },
+                      "initContainerStatuses": {
+                        "items": {
+                          "properties": {
+                            "allocatedResources": {
+                              "additionalProperties": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "type": "object"
+                            },
+                            "allocatedResourcesStatus": {
+                              "items": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "resources": {
+                                    "items": {
+                                      "properties": {
+                                        "health": {
+                                          "type": "string"
+                                        },
+                                        "resourceID": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "containerID": {
+                              "type": "string"
+                            },
+                            "image": {
+                              "type": "string"
+                            },
+                            "imageID": {
+                              "type": "string"
+                            },
+                            "lastState": {
+                              "properties": {
+                                "running": {
+                                  "properties": {
+                                    "startedAt": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "terminated": {
+                                  "properties": {
+                                    "containerID": {
+                                      "type": "string"
+                                    },
+                                    "exitCode": {
+                                      "type": "integer"
+                                    },
+                                    "finishedAt": {
+                                      "type": "string"
+                                    },
+                                    "message": {
+                                      "type": "string"
+                                    },
+                                    "reason": {
+                                      "type": "string"
+                                    },
+                                    "signal": {
+                                      "type": "integer"
+                                    },
+                                    "startedAt": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "waiting": {
+                                  "properties": {
+                                    "message": {
+                                      "type": "string"
+                                    },
+                                    "reason": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "ready": {
+                              "type": "boolean"
+                            },
+                            "resources": {
+                              "properties": {
+                                "claims": {
+                                  "items": {
+                                    "properties": {
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "request": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "type": "array"
+                                },
+                                "limits": {
+                                  "additionalProperties": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "type": "object"
+                                },
+                                "requests": {
+                                  "additionalProperties": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "restartCount": {
+                              "type": "integer"
+                            },
+                            "started": {
+                              "type": "boolean"
+                            },
+                            "state": {
+                              "properties": {
+                                "running": {
+                                  "properties": {
+                                    "startedAt": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "terminated": {
+                                  "properties": {
+                                    "containerID": {
+                                      "type": "string"
+                                    },
+                                    "exitCode": {
+                                      "type": "integer"
+                                    },
+                                    "finishedAt": {
+                                      "type": "string"
+                                    },
+                                    "message": {
+                                      "type": "string"
+                                    },
+                                    "reason": {
+                                      "type": "string"
+                                    },
+                                    "signal": {
+                                      "type": "integer"
+                                    },
+                                    "startedAt": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "waiting": {
+                                  "properties": {
+                                    "message": {
+                                      "type": "string"
+                                    },
+                                    "reason": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "stopSignal": {
+                              "type": "string"
+                            },
+                            "user": {
+                              "properties": {
+                                "linux": {
+                                  "properties": {
+                                    "gid": {
+                                      "type": "integer"
+                                    },
+                                    "supplementalGroups": {
+                                      "items": {
+                                        "type": "integer"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "uid": {
+                                      "type": "integer"
+                                    }
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "volumeMounts": {
+                              "items": {
+                                "properties": {
+                                  "mountPath": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  },
+                                  "recursiveReadOnly": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "type": "array"
+                      },
+                      "message": {
+                        "type": "string"
+                      },
+                      "nominatedNodeName": {
+                        "type": "string"
+                      },
+                      "observedGeneration": {
+                        "type": "integer"
+                      },
+                      "phase": {
+                        "type": "string"
+                      },
+                      "podIP": {
+                        "type": "string"
+                      },
+                      "podIPs": {
+                        "items": {
+                          "properties": {
+                            "ip": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "type": "array"
+                      },
+                      "qosClass": {
+                        "type": "string"
+                      },
+                      "reason": {
+                        "type": "string"
+                      },
+                      "resize": {
+                        "type": "string"
+                      },
+                      "resourceClaimStatuses": {
+                        "items": {
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            },
+                            "resourceClaimName": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "type": "array"
+                      },
+                      "startTime": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "lastTransitionTime": {
+                    "type": "string"
+                  },
+                  "message": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "type": "object"
+            }
+          },
+          "type": "object"
+        },
+        "stateTransitionHistory": {
+          "additionalProperties": {
+            "properties": {
+              "currentStateSummary": {
+                "enum": [
+                  "DriverEvicted",
+                  "DriverReady",
+                  "DriverReadyTimedOut",
+                  "DriverRequested",
+                  "DriverStartTimedOut",
+                  "DriverStarted",
+                  "ExecutorsStartTimedOut",
+                  "Failed",
+                  "InitializedBelowThresholdExecutors",
+                  "ResourceReleased",
+                  "RunningHealthy",
+                  "RunningWithBelowThresholdExecutors",
+                  "ScheduledToRestart",
+                  "SchedulingFailure",
+                  "Submitted",
+                  "Succeeded",
+                  "TerminatedWithoutReleaseResources"
+                ],
+                "type": "string"
+              },
+              "lastObservedDriverStatus": {
+                "properties": {
+                  "conditions": {
+                    "items": {
+                      "properties": {
+                        "lastProbeTime": {
+                          "type": "string"
+                        },
+                        "lastTransitionTime": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "observedGeneration": {
+                          "type": "integer"
+                        },
+                        "reason": {
+                          "type": "string"
+                        },
+                        "status": {
+                          "type": "string"
+                        },
+                        "type": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "containerStatuses": {
+                    "items": {
+                      "properties": {
+                        "allocatedResources": {
+                          "additionalProperties": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "x-kubernetes-int-or-string": true
+                          },
+                          "type": "object"
+                        },
+                        "allocatedResourcesStatus": {
+                          "items": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "resources": {
+                                "items": {
+                                  "properties": {
+                                    "health": {
+                                      "type": "string"
+                                    },
+                                    "resourceID": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "containerID": {
+                          "type": "string"
+                        },
+                        "image": {
+                          "type": "string"
+                        },
+                        "imageID": {
+                          "type": "string"
+                        },
+                        "lastState": {
+                          "properties": {
+                            "running": {
+                              "properties": {
+                                "startedAt": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "terminated": {
+                              "properties": {
+                                "containerID": {
+                                  "type": "string"
+                                },
+                                "exitCode": {
+                                  "type": "integer"
+                                },
+                                "finishedAt": {
+                                  "type": "string"
+                                },
+                                "message": {
+                                  "type": "string"
+                                },
+                                "reason": {
+                                  "type": "string"
+                                },
+                                "signal": {
+                                  "type": "integer"
+                                },
+                                "startedAt": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "waiting": {
+                              "properties": {
+                                "message": {
+                                  "type": "string"
+                                },
+                                "reason": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "ready": {
+                          "type": "boolean"
+                        },
+                        "resources": {
+                          "properties": {
+                            "claims": {
+                              "items": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "request": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "limits": {
+                              "additionalProperties": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "type": "object"
+                            },
+                            "requests": {
+                              "additionalProperties": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "type": "object"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "restartCount": {
+                          "type": "integer"
+                        },
+                        "started": {
+                          "type": "boolean"
+                        },
+                        "state": {
+                          "properties": {
+                            "running": {
+                              "properties": {
+                                "startedAt": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "terminated": {
+                              "properties": {
+                                "containerID": {
+                                  "type": "string"
+                                },
+                                "exitCode": {
+                                  "type": "integer"
+                                },
+                                "finishedAt": {
+                                  "type": "string"
+                                },
+                                "message": {
+                                  "type": "string"
+                                },
+                                "reason": {
+                                  "type": "string"
+                                },
+                                "signal": {
+                                  "type": "integer"
+                                },
+                                "startedAt": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "waiting": {
+                              "properties": {
+                                "message": {
+                                  "type": "string"
+                                },
+                                "reason": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "stopSignal": {
+                          "type": "string"
+                        },
+                        "user": {
+                          "properties": {
+                            "linux": {
+                              "properties": {
+                                "gid": {
+                                  "type": "integer"
+                                },
+                                "supplementalGroups": {
+                                  "items": {
+                                    "type": "integer"
+                                  },
+                                  "type": "array"
+                                },
+                                "uid": {
+                                  "type": "integer"
+                                }
+                              },
+                              "type": "object"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "volumeMounts": {
+                          "items": {
+                            "properties": {
+                              "mountPath": {
+                                "type": "string"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "recursiveReadOnly": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "ephemeralContainerStatuses": {
+                    "items": {
+                      "properties": {
+                        "allocatedResources": {
+                          "additionalProperties": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "x-kubernetes-int-or-string": true
+                          },
+                          "type": "object"
+                        },
+                        "allocatedResourcesStatus": {
+                          "items": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "resources": {
+                                "items": {
+                                  "properties": {
+                                    "health": {
+                                      "type": "string"
+                                    },
+                                    "resourceID": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "containerID": {
+                          "type": "string"
+                        },
+                        "image": {
+                          "type": "string"
+                        },
+                        "imageID": {
+                          "type": "string"
+                        },
+                        "lastState": {
+                          "properties": {
+                            "running": {
+                              "properties": {
+                                "startedAt": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "terminated": {
+                              "properties": {
+                                "containerID": {
+                                  "type": "string"
+                                },
+                                "exitCode": {
+                                  "type": "integer"
+                                },
+                                "finishedAt": {
+                                  "type": "string"
+                                },
+                                "message": {
+                                  "type": "string"
+                                },
+                                "reason": {
+                                  "type": "string"
+                                },
+                                "signal": {
+                                  "type": "integer"
+                                },
+                                "startedAt": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "waiting": {
+                              "properties": {
+                                "message": {
+                                  "type": "string"
+                                },
+                                "reason": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "ready": {
+                          "type": "boolean"
+                        },
+                        "resources": {
+                          "properties": {
+                            "claims": {
+                              "items": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "request": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "limits": {
+                              "additionalProperties": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "type": "object"
+                            },
+                            "requests": {
+                              "additionalProperties": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "type": "object"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "restartCount": {
+                          "type": "integer"
+                        },
+                        "started": {
+                          "type": "boolean"
+                        },
+                        "state": {
+                          "properties": {
+                            "running": {
+                              "properties": {
+                                "startedAt": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "terminated": {
+                              "properties": {
+                                "containerID": {
+                                  "type": "string"
+                                },
+                                "exitCode": {
+                                  "type": "integer"
+                                },
+                                "finishedAt": {
+                                  "type": "string"
+                                },
+                                "message": {
+                                  "type": "string"
+                                },
+                                "reason": {
+                                  "type": "string"
+                                },
+                                "signal": {
+                                  "type": "integer"
+                                },
+                                "startedAt": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "waiting": {
+                              "properties": {
+                                "message": {
+                                  "type": "string"
+                                },
+                                "reason": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "stopSignal": {
+                          "type": "string"
+                        },
+                        "user": {
+                          "properties": {
+                            "linux": {
+                              "properties": {
+                                "gid": {
+                                  "type": "integer"
+                                },
+                                "supplementalGroups": {
+                                  "items": {
+                                    "type": "integer"
+                                  },
+                                  "type": "array"
+                                },
+                                "uid": {
+                                  "type": "integer"
+                                }
+                              },
+                              "type": "object"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "volumeMounts": {
+                          "items": {
+                            "properties": {
+                              "mountPath": {
+                                "type": "string"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "recursiveReadOnly": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "hostIP": {
+                    "type": "string"
+                  },
+                  "hostIPs": {
+                    "items": {
+                      "properties": {
+                        "ip": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "initContainerStatuses": {
+                    "items": {
+                      "properties": {
+                        "allocatedResources": {
+                          "additionalProperties": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "x-kubernetes-int-or-string": true
+                          },
+                          "type": "object"
+                        },
+                        "allocatedResourcesStatus": {
+                          "items": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "resources": {
+                                "items": {
+                                  "properties": {
+                                    "health": {
+                                      "type": "string"
+                                    },
+                                    "resourceID": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "containerID": {
+                          "type": "string"
+                        },
+                        "image": {
+                          "type": "string"
+                        },
+                        "imageID": {
+                          "type": "string"
+                        },
+                        "lastState": {
+                          "properties": {
+                            "running": {
+                              "properties": {
+                                "startedAt": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "terminated": {
+                              "properties": {
+                                "containerID": {
+                                  "type": "string"
+                                },
+                                "exitCode": {
+                                  "type": "integer"
+                                },
+                                "finishedAt": {
+                                  "type": "string"
+                                },
+                                "message": {
+                                  "type": "string"
+                                },
+                                "reason": {
+                                  "type": "string"
+                                },
+                                "signal": {
+                                  "type": "integer"
+                                },
+                                "startedAt": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "waiting": {
+                              "properties": {
+                                "message": {
+                                  "type": "string"
+                                },
+                                "reason": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "ready": {
+                          "type": "boolean"
+                        },
+                        "resources": {
+                          "properties": {
+                            "claims": {
+                              "items": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "request": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "limits": {
+                              "additionalProperties": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "type": "object"
+                            },
+                            "requests": {
+                              "additionalProperties": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "type": "object"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "restartCount": {
+                          "type": "integer"
+                        },
+                        "started": {
+                          "type": "boolean"
+                        },
+                        "state": {
+                          "properties": {
+                            "running": {
+                              "properties": {
+                                "startedAt": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "terminated": {
+                              "properties": {
+                                "containerID": {
+                                  "type": "string"
+                                },
+                                "exitCode": {
+                                  "type": "integer"
+                                },
+                                "finishedAt": {
+                                  "type": "string"
+                                },
+                                "message": {
+                                  "type": "string"
+                                },
+                                "reason": {
+                                  "type": "string"
+                                },
+                                "signal": {
+                                  "type": "integer"
+                                },
+                                "startedAt": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "waiting": {
+                              "properties": {
+                                "message": {
+                                  "type": "string"
+                                },
+                                "reason": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "stopSignal": {
+                          "type": "string"
+                        },
+                        "user": {
+                          "properties": {
+                            "linux": {
+                              "properties": {
+                                "gid": {
+                                  "type": "integer"
+                                },
+                                "supplementalGroups": {
+                                  "items": {
+                                    "type": "integer"
+                                  },
+                                  "type": "array"
+                                },
+                                "uid": {
+                                  "type": "integer"
+                                }
+                              },
+                              "type": "object"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "volumeMounts": {
+                          "items": {
+                            "properties": {
+                              "mountPath": {
+                                "type": "string"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "recursiveReadOnly": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "message": {
+                    "type": "string"
+                  },
+                  "nominatedNodeName": {
+                    "type": "string"
+                  },
+                  "observedGeneration": {
+                    "type": "integer"
+                  },
+                  "phase": {
+                    "type": "string"
+                  },
+                  "podIP": {
+                    "type": "string"
+                  },
+                  "podIPs": {
+                    "items": {
+                      "properties": {
+                        "ip": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "qosClass": {
+                    "type": "string"
+                  },
+                  "reason": {
+                    "type": "string"
+                  },
+                  "resize": {
+                    "type": "string"
+                  },
+                  "resourceClaimStatuses": {
+                    "items": {
+                      "properties": {
+                        "name": {
+                          "type": "string"
+                        },
+                        "resourceClaimName": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "startTime": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "lastTransitionTime": {
+                "type": "string"
+              },
+              "message": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "type": "object"
+        }
+      },
+      "type": "object"
+    },
+    "apiVersion": {
+      "type": "string"
+    },
+    "kind": {
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    }
+  },
+  "type": "object"
+}

--- a/spark.apache.org/sparkapplication_v1beta1.json
+++ b/spark.apache.org/sparkapplication_v1beta1.json
@@ -1,0 +1,13840 @@
+{
+  "properties": {
+    "spec": {
+      "properties": {
+        "applicationTolerations": {
+          "properties": {
+            "applicationTimeoutConfig": {
+              "properties": {
+                "driverReadyTimeoutMillis": {
+                  "type": "integer"
+                },
+                "driverStartTimeoutMillis": {
+                  "type": "integer"
+                },
+                "executorStartTimeoutMillis": {
+                  "type": "integer"
+                },
+                "forceTerminationGracePeriodMillis": {
+                  "type": "integer"
+                },
+                "terminationRequeuePeriodMillis": {
+                  "type": "integer"
+                }
+              },
+              "type": "object"
+            },
+            "instanceConfig": {
+              "properties": {
+                "initExecutors": {
+                  "type": "integer"
+                },
+                "maxExecutors": {
+                  "type": "integer"
+                },
+                "minExecutors": {
+                  "type": "integer"
+                }
+              },
+              "type": "object"
+            },
+            "resourceRetainPolicy": {
+              "enum": [
+                "Always",
+                "Never",
+                "OnFailure"
+              ],
+              "type": "string"
+            },
+            "restartConfig": {
+              "properties": {
+                "maxRestartAttempts": {
+                  "type": "integer"
+                },
+                "restartBackoffMillis": {
+                  "type": "integer"
+                },
+                "restartPolicy": {
+                  "enum": [
+                    "Always",
+                    "Never",
+                    "OnFailure",
+                    "OnInfrastructureFailure"
+                  ],
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "type": "object"
+        },
+        "configMapSpecs": {
+          "items": {
+            "properties": {
+              "annotations": {
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "type": "object"
+              },
+              "data": {
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "type": "object"
+              },
+              "labels": {
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "type": "object"
+              },
+              "name": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "name"
+            ],
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "deploymentMode": {
+          "enum": [
+            "ClientMode",
+            "ClusterMode"
+          ],
+          "type": "string"
+        },
+        "driverArgs": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "driverServiceIngressList": {
+          "items": {
+            "properties": {
+              "ingressMetadata": {
+                "properties": {
+                  "annotations": {
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "type": "object"
+                  },
+                  "creationTimestamp": {
+                    "type": "string"
+                  },
+                  "deletionGracePeriodSeconds": {
+                    "type": "integer"
+                  },
+                  "deletionTimestamp": {
+                    "type": "string"
+                  },
+                  "finalizers": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "generateName": {
+                    "type": "string"
+                  },
+                  "generation": {
+                    "type": "integer"
+                  },
+                  "labels": {
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "type": "object"
+                  },
+                  "managedFields": {
+                    "items": {
+                      "properties": {
+                        "apiVersion": {
+                          "type": "string"
+                        },
+                        "fieldsType": {
+                          "type": "string"
+                        },
+                        "fieldsV1": {
+                          "type": "object"
+                        },
+                        "manager": {
+                          "type": "string"
+                        },
+                        "operation": {
+                          "type": "string"
+                        },
+                        "subresource": {
+                          "type": "string"
+                        },
+                        "time": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "namespace": {
+                    "type": "string"
+                  },
+                  "ownerReferences": {
+                    "items": {
+                      "properties": {
+                        "apiVersion": {
+                          "type": "string"
+                        },
+                        "blockOwnerDeletion": {
+                          "type": "boolean"
+                        },
+                        "controller": {
+                          "type": "boolean"
+                        },
+                        "kind": {
+                          "type": "string"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "uid": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "resourceVersion": {
+                    "type": "string"
+                  },
+                  "selfLink": {
+                    "type": "string"
+                  },
+                  "uid": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "ingressSpec": {
+                "properties": {
+                  "defaultBackend": {
+                    "properties": {
+                      "resource": {
+                        "properties": {
+                          "apiGroup": {
+                            "type": "string"
+                          },
+                          "kind": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "service": {
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          },
+                          "port": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "number": {
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object"
+                          }
+                        },
+                        "type": "object"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "ingressClassName": {
+                    "type": "string"
+                  },
+                  "rules": {
+                    "items": {
+                      "properties": {
+                        "host": {
+                          "type": "string"
+                        },
+                        "http": {
+                          "properties": {
+                            "paths": {
+                              "items": {
+                                "properties": {
+                                  "backend": {
+                                    "properties": {
+                                      "resource": {
+                                        "properties": {
+                                          "apiGroup": {
+                                            "type": "string"
+                                          },
+                                          "kind": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "service": {
+                                        "properties": {
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "properties": {
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "number": {
+                                                "type": "integer"
+                                              }
+                                            },
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "pathType": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "tls": {
+                    "items": {
+                      "properties": {
+                        "hosts": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "secretName": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "type": "array"
+                  }
+                },
+                "type": "object"
+              },
+              "serviceMetadata": {
+                "properties": {
+                  "annotations": {
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "type": "object"
+                  },
+                  "creationTimestamp": {
+                    "type": "string"
+                  },
+                  "deletionGracePeriodSeconds": {
+                    "type": "integer"
+                  },
+                  "deletionTimestamp": {
+                    "type": "string"
+                  },
+                  "finalizers": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "generateName": {
+                    "type": "string"
+                  },
+                  "generation": {
+                    "type": "integer"
+                  },
+                  "labels": {
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "type": "object"
+                  },
+                  "managedFields": {
+                    "items": {
+                      "properties": {
+                        "apiVersion": {
+                          "type": "string"
+                        },
+                        "fieldsType": {
+                          "type": "string"
+                        },
+                        "fieldsV1": {
+                          "type": "object"
+                        },
+                        "manager": {
+                          "type": "string"
+                        },
+                        "operation": {
+                          "type": "string"
+                        },
+                        "subresource": {
+                          "type": "string"
+                        },
+                        "time": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "namespace": {
+                    "type": "string"
+                  },
+                  "ownerReferences": {
+                    "items": {
+                      "properties": {
+                        "apiVersion": {
+                          "type": "string"
+                        },
+                        "blockOwnerDeletion": {
+                          "type": "boolean"
+                        },
+                        "controller": {
+                          "type": "boolean"
+                        },
+                        "kind": {
+                          "type": "string"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "uid": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "resourceVersion": {
+                    "type": "string"
+                  },
+                  "selfLink": {
+                    "type": "string"
+                  },
+                  "uid": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "serviceSpec": {
+                "properties": {
+                  "allocateLoadBalancerNodePorts": {
+                    "type": "boolean"
+                  },
+                  "clusterIP": {
+                    "type": "string"
+                  },
+                  "clusterIPs": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "externalIPs": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "externalName": {
+                    "type": "string"
+                  },
+                  "externalTrafficPolicy": {
+                    "type": "string"
+                  },
+                  "healthCheckNodePort": {
+                    "type": "integer"
+                  },
+                  "internalTrafficPolicy": {
+                    "type": "string"
+                  },
+                  "ipFamilies": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "ipFamilyPolicy": {
+                    "type": "string"
+                  },
+                  "loadBalancerClass": {
+                    "type": "string"
+                  },
+                  "loadBalancerIP": {
+                    "type": "string"
+                  },
+                  "loadBalancerSourceRanges": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "ports": {
+                    "items": {
+                      "properties": {
+                        "appProtocol": {
+                          "type": "string"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "nodePort": {
+                          "type": "integer"
+                        },
+                        "port": {
+                          "type": "integer"
+                        },
+                        "protocol": {
+                          "type": "string"
+                        },
+                        "targetPort": {
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "string"
+                            }
+                          ],
+                          "x-kubernetes-int-or-string": true
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "publishNotReadyAddresses": {
+                    "type": "boolean"
+                  },
+                  "selector": {
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "type": "object"
+                  },
+                  "sessionAffinity": {
+                    "type": "string"
+                  },
+                  "sessionAffinityConfig": {
+                    "properties": {
+                      "clientIP": {
+                        "properties": {
+                          "timeoutSeconds": {
+                            "type": "integer"
+                          }
+                        },
+                        "type": "object"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "trafficDistribution": {
+                    "type": "string"
+                  },
+                  "type": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              }
+            },
+            "required": [
+              "ingressMetadata",
+              "serviceMetadata",
+              "serviceSpec"
+            ],
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "driverSpec": {
+          "properties": {
+            "podTemplateSpec": {
+              "properties": {
+                "metadata": {
+                  "properties": {
+                    "annotations": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "type": "object"
+                    },
+                    "creationTimestamp": {
+                      "type": "string"
+                    },
+                    "deletionGracePeriodSeconds": {
+                      "type": "integer"
+                    },
+                    "deletionTimestamp": {
+                      "type": "string"
+                    },
+                    "finalizers": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "generateName": {
+                      "type": "string"
+                    },
+                    "generation": {
+                      "type": "integer"
+                    },
+                    "labels": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "type": "object"
+                    },
+                    "managedFields": {
+                      "items": {
+                        "properties": {
+                          "apiVersion": {
+                            "type": "string"
+                          },
+                          "fieldsType": {
+                            "type": "string"
+                          },
+                          "fieldsV1": {
+                            "type": "object"
+                          },
+                          "manager": {
+                            "type": "string"
+                          },
+                          "operation": {
+                            "type": "string"
+                          },
+                          "subresource": {
+                            "type": "string"
+                          },
+                          "time": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "namespace": {
+                      "type": "string"
+                    },
+                    "ownerReferences": {
+                      "items": {
+                        "properties": {
+                          "apiVersion": {
+                            "type": "string"
+                          },
+                          "blockOwnerDeletion": {
+                            "type": "boolean"
+                          },
+                          "controller": {
+                            "type": "boolean"
+                          },
+                          "kind": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "uid": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "resourceVersion": {
+                      "type": "string"
+                    },
+                    "selfLink": {
+                      "type": "string"
+                    },
+                    "uid": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "spec": {
+                  "properties": {
+                    "activeDeadlineSeconds": {
+                      "type": "integer"
+                    },
+                    "affinity": {
+                      "properties": {
+                        "nodeAffinity": {
+                          "properties": {
+                            "preferredDuringSchedulingIgnoredDuringExecution": {
+                              "items": {
+                                "properties": {
+                                  "preference": {
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "matchFields": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "weight": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "requiredDuringSchedulingIgnoredDuringExecution": {
+                              "properties": {
+                                "nodeSelectorTerms": {
+                                  "items": {
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "matchFields": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "type": "object"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "podAffinity": {
+                          "properties": {
+                            "preferredDuringSchedulingIgnoredDuringExecution": {
+                              "items": {
+                                "properties": {
+                                  "podAffinityTerm": {
+                                    "properties": {
+                                      "labelSelector": {
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "matchLabels": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "matchLabelKeys": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "mismatchLabelKeys": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "namespaceSelector": {
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "matchLabels": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "namespaces": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "topologyKey": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "weight": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "requiredDuringSchedulingIgnoredDuringExecution": {
+                              "items": {
+                                "properties": {
+                                  "labelSelector": {
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "matchLabels": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "matchLabelKeys": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "mismatchLabelKeys": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "namespaceSelector": {
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "matchLabels": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "namespaces": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "topologyKey": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "podAntiAffinity": {
+                          "properties": {
+                            "preferredDuringSchedulingIgnoredDuringExecution": {
+                              "items": {
+                                "properties": {
+                                  "podAffinityTerm": {
+                                    "properties": {
+                                      "labelSelector": {
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "matchLabels": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "matchLabelKeys": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "mismatchLabelKeys": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "namespaceSelector": {
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "matchLabels": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "namespaces": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "topologyKey": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "weight": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "requiredDuringSchedulingIgnoredDuringExecution": {
+                              "items": {
+                                "properties": {
+                                  "labelSelector": {
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "matchLabels": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "matchLabelKeys": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "mismatchLabelKeys": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "namespaceSelector": {
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "matchLabels": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "namespaces": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "topologyKey": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "automountServiceAccountToken": {
+                      "type": "boolean"
+                    },
+                    "containers": {
+                      "items": {
+                        "properties": {
+                          "args": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "command": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "env": {
+                            "items": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "value": {
+                                  "type": "string"
+                                },
+                                "valueFrom": {
+                                  "properties": {
+                                    "configMapKeyRef": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "fieldRef": {
+                                      "properties": {
+                                        "apiVersion": {
+                                          "type": "string"
+                                        },
+                                        "fieldPath": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "resourceFieldRef": {
+                                      "properties": {
+                                        "containerName": {
+                                          "type": "string"
+                                        },
+                                        "divisor": {
+                                          "anyOf": [
+                                            {
+                                              "type": "integer"
+                                            },
+                                            {
+                                              "type": "string"
+                                            }
+                                          ],
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "resource": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "secretKeyRef": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "envFrom": {
+                            "items": {
+                              "properties": {
+                                "configMapRef": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "prefix": {
+                                  "type": "string"
+                                },
+                                "secretRef": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "image": {
+                            "type": "string"
+                          },
+                          "imagePullPolicy": {
+                            "type": "string"
+                          },
+                          "lifecycle": {
+                            "properties": {
+                              "postStart": {
+                                "properties": {
+                                  "exec": {
+                                    "properties": {
+                                      "command": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "httpGet": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "sleep": {
+                                    "properties": {
+                                      "seconds": {
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "tcpSocket": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "preStop": {
+                                "properties": {
+                                  "exec": {
+                                    "properties": {
+                                      "command": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "httpGet": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "sleep": {
+                                    "properties": {
+                                      "seconds": {
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "tcpSocket": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "stopSignal": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "livenessProbe": {
+                            "properties": {
+                              "exec": {
+                                "properties": {
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "failureThreshold": {
+                                "type": "integer"
+                              },
+                              "grpc": {
+                                "properties": {
+                                  "port": {
+                                    "type": "integer"
+                                  },
+                                  "service": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "httpGet": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "initialDelaySeconds": {
+                                "type": "integer"
+                              },
+                              "periodSeconds": {
+                                "type": "integer"
+                              },
+                              "successThreshold": {
+                                "type": "integer"
+                              },
+                              "tcpSocket": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "terminationGracePeriodSeconds": {
+                                "type": "integer"
+                              },
+                              "timeoutSeconds": {
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "ports": {
+                            "items": {
+                              "properties": {
+                                "containerPort": {
+                                  "type": "integer"
+                                },
+                                "hostIP": {
+                                  "type": "string"
+                                },
+                                "hostPort": {
+                                  "type": "integer"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "protocol": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "readinessProbe": {
+                            "properties": {
+                              "exec": {
+                                "properties": {
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "failureThreshold": {
+                                "type": "integer"
+                              },
+                              "grpc": {
+                                "properties": {
+                                  "port": {
+                                    "type": "integer"
+                                  },
+                                  "service": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "httpGet": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "initialDelaySeconds": {
+                                "type": "integer"
+                              },
+                              "periodSeconds": {
+                                "type": "integer"
+                              },
+                              "successThreshold": {
+                                "type": "integer"
+                              },
+                              "tcpSocket": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "terminationGracePeriodSeconds": {
+                                "type": "integer"
+                              },
+                              "timeoutSeconds": {
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "resizePolicy": {
+                            "items": {
+                              "properties": {
+                                "resourceName": {
+                                  "type": "string"
+                                },
+                                "restartPolicy": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "resources": {
+                            "properties": {
+                              "claims": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "request": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "limits": {
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "type": "object"
+                              },
+                              "requests": {
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "restartPolicy": {
+                            "type": "string"
+                          },
+                          "securityContext": {
+                            "properties": {
+                              "allowPrivilegeEscalation": {
+                                "type": "boolean"
+                              },
+                              "appArmorProfile": {
+                                "properties": {
+                                  "localhostProfile": {
+                                    "type": "string"
+                                  },
+                                  "type": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "capabilities": {
+                                "properties": {
+                                  "add": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "drop": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "privileged": {
+                                "type": "boolean"
+                              },
+                              "procMount": {
+                                "type": "string"
+                              },
+                              "readOnlyRootFilesystem": {
+                                "type": "boolean"
+                              },
+                              "runAsGroup": {
+                                "type": "integer"
+                              },
+                              "runAsNonRoot": {
+                                "type": "boolean"
+                              },
+                              "runAsUser": {
+                                "type": "integer"
+                              },
+                              "seLinuxOptions": {
+                                "properties": {
+                                  "level": {
+                                    "type": "string"
+                                  },
+                                  "role": {
+                                    "type": "string"
+                                  },
+                                  "type": {
+                                    "type": "string"
+                                  },
+                                  "user": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "seccompProfile": {
+                                "properties": {
+                                  "localhostProfile": {
+                                    "type": "string"
+                                  },
+                                  "type": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "windowsOptions": {
+                                "properties": {
+                                  "gmsaCredentialSpec": {
+                                    "type": "string"
+                                  },
+                                  "gmsaCredentialSpecName": {
+                                    "type": "string"
+                                  },
+                                  "hostProcess": {
+                                    "type": "boolean"
+                                  },
+                                  "runAsUserName": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "startupProbe": {
+                            "properties": {
+                              "exec": {
+                                "properties": {
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "failureThreshold": {
+                                "type": "integer"
+                              },
+                              "grpc": {
+                                "properties": {
+                                  "port": {
+                                    "type": "integer"
+                                  },
+                                  "service": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "httpGet": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "initialDelaySeconds": {
+                                "type": "integer"
+                              },
+                              "periodSeconds": {
+                                "type": "integer"
+                              },
+                              "successThreshold": {
+                                "type": "integer"
+                              },
+                              "tcpSocket": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "terminationGracePeriodSeconds": {
+                                "type": "integer"
+                              },
+                              "timeoutSeconds": {
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "stdin": {
+                            "type": "boolean"
+                          },
+                          "stdinOnce": {
+                            "type": "boolean"
+                          },
+                          "terminationMessagePath": {
+                            "type": "string"
+                          },
+                          "terminationMessagePolicy": {
+                            "type": "string"
+                          },
+                          "tty": {
+                            "type": "boolean"
+                          },
+                          "volumeDevices": {
+                            "items": {
+                              "properties": {
+                                "devicePath": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "volumeMounts": {
+                            "items": {
+                              "properties": {
+                                "mountPath": {
+                                  "type": "string"
+                                },
+                                "mountPropagation": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "readOnly": {
+                                  "type": "boolean"
+                                },
+                                "recursiveReadOnly": {
+                                  "type": "string"
+                                },
+                                "subPath": {
+                                  "type": "string"
+                                },
+                                "subPathExpr": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "workingDir": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "dnsConfig": {
+                      "properties": {
+                        "nameservers": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "options": {
+                          "items": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "value": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "searches": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "dnsPolicy": {
+                      "type": "string"
+                    },
+                    "enableServiceLinks": {
+                      "type": "boolean"
+                    },
+                    "ephemeralContainers": {
+                      "items": {
+                        "properties": {
+                          "args": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "command": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "env": {
+                            "items": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "value": {
+                                  "type": "string"
+                                },
+                                "valueFrom": {
+                                  "properties": {
+                                    "configMapKeyRef": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "fieldRef": {
+                                      "properties": {
+                                        "apiVersion": {
+                                          "type": "string"
+                                        },
+                                        "fieldPath": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "resourceFieldRef": {
+                                      "properties": {
+                                        "containerName": {
+                                          "type": "string"
+                                        },
+                                        "divisor": {
+                                          "anyOf": [
+                                            {
+                                              "type": "integer"
+                                            },
+                                            {
+                                              "type": "string"
+                                            }
+                                          ],
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "resource": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "secretKeyRef": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "envFrom": {
+                            "items": {
+                              "properties": {
+                                "configMapRef": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "prefix": {
+                                  "type": "string"
+                                },
+                                "secretRef": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "image": {
+                            "type": "string"
+                          },
+                          "imagePullPolicy": {
+                            "type": "string"
+                          },
+                          "lifecycle": {
+                            "properties": {
+                              "postStart": {
+                                "properties": {
+                                  "exec": {
+                                    "properties": {
+                                      "command": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "httpGet": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "sleep": {
+                                    "properties": {
+                                      "seconds": {
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "tcpSocket": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "preStop": {
+                                "properties": {
+                                  "exec": {
+                                    "properties": {
+                                      "command": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "httpGet": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "sleep": {
+                                    "properties": {
+                                      "seconds": {
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "tcpSocket": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "stopSignal": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "livenessProbe": {
+                            "properties": {
+                              "exec": {
+                                "properties": {
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "failureThreshold": {
+                                "type": "integer"
+                              },
+                              "grpc": {
+                                "properties": {
+                                  "port": {
+                                    "type": "integer"
+                                  },
+                                  "service": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "httpGet": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "initialDelaySeconds": {
+                                "type": "integer"
+                              },
+                              "periodSeconds": {
+                                "type": "integer"
+                              },
+                              "successThreshold": {
+                                "type": "integer"
+                              },
+                              "tcpSocket": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "terminationGracePeriodSeconds": {
+                                "type": "integer"
+                              },
+                              "timeoutSeconds": {
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "ports": {
+                            "items": {
+                              "properties": {
+                                "containerPort": {
+                                  "type": "integer"
+                                },
+                                "hostIP": {
+                                  "type": "string"
+                                },
+                                "hostPort": {
+                                  "type": "integer"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "protocol": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "readinessProbe": {
+                            "properties": {
+                              "exec": {
+                                "properties": {
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "failureThreshold": {
+                                "type": "integer"
+                              },
+                              "grpc": {
+                                "properties": {
+                                  "port": {
+                                    "type": "integer"
+                                  },
+                                  "service": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "httpGet": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "initialDelaySeconds": {
+                                "type": "integer"
+                              },
+                              "periodSeconds": {
+                                "type": "integer"
+                              },
+                              "successThreshold": {
+                                "type": "integer"
+                              },
+                              "tcpSocket": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "terminationGracePeriodSeconds": {
+                                "type": "integer"
+                              },
+                              "timeoutSeconds": {
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "resizePolicy": {
+                            "items": {
+                              "properties": {
+                                "resourceName": {
+                                  "type": "string"
+                                },
+                                "restartPolicy": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "resources": {
+                            "properties": {
+                              "claims": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "request": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "limits": {
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "type": "object"
+                              },
+                              "requests": {
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "restartPolicy": {
+                            "type": "string"
+                          },
+                          "securityContext": {
+                            "properties": {
+                              "allowPrivilegeEscalation": {
+                                "type": "boolean"
+                              },
+                              "appArmorProfile": {
+                                "properties": {
+                                  "localhostProfile": {
+                                    "type": "string"
+                                  },
+                                  "type": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "capabilities": {
+                                "properties": {
+                                  "add": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "drop": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "privileged": {
+                                "type": "boolean"
+                              },
+                              "procMount": {
+                                "type": "string"
+                              },
+                              "readOnlyRootFilesystem": {
+                                "type": "boolean"
+                              },
+                              "runAsGroup": {
+                                "type": "integer"
+                              },
+                              "runAsNonRoot": {
+                                "type": "boolean"
+                              },
+                              "runAsUser": {
+                                "type": "integer"
+                              },
+                              "seLinuxOptions": {
+                                "properties": {
+                                  "level": {
+                                    "type": "string"
+                                  },
+                                  "role": {
+                                    "type": "string"
+                                  },
+                                  "type": {
+                                    "type": "string"
+                                  },
+                                  "user": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "seccompProfile": {
+                                "properties": {
+                                  "localhostProfile": {
+                                    "type": "string"
+                                  },
+                                  "type": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "windowsOptions": {
+                                "properties": {
+                                  "gmsaCredentialSpec": {
+                                    "type": "string"
+                                  },
+                                  "gmsaCredentialSpecName": {
+                                    "type": "string"
+                                  },
+                                  "hostProcess": {
+                                    "type": "boolean"
+                                  },
+                                  "runAsUserName": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "startupProbe": {
+                            "properties": {
+                              "exec": {
+                                "properties": {
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "failureThreshold": {
+                                "type": "integer"
+                              },
+                              "grpc": {
+                                "properties": {
+                                  "port": {
+                                    "type": "integer"
+                                  },
+                                  "service": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "httpGet": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "initialDelaySeconds": {
+                                "type": "integer"
+                              },
+                              "periodSeconds": {
+                                "type": "integer"
+                              },
+                              "successThreshold": {
+                                "type": "integer"
+                              },
+                              "tcpSocket": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "terminationGracePeriodSeconds": {
+                                "type": "integer"
+                              },
+                              "timeoutSeconds": {
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "stdin": {
+                            "type": "boolean"
+                          },
+                          "stdinOnce": {
+                            "type": "boolean"
+                          },
+                          "targetContainerName": {
+                            "type": "string"
+                          },
+                          "terminationMessagePath": {
+                            "type": "string"
+                          },
+                          "terminationMessagePolicy": {
+                            "type": "string"
+                          },
+                          "tty": {
+                            "type": "boolean"
+                          },
+                          "volumeDevices": {
+                            "items": {
+                              "properties": {
+                                "devicePath": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "volumeMounts": {
+                            "items": {
+                              "properties": {
+                                "mountPath": {
+                                  "type": "string"
+                                },
+                                "mountPropagation": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "readOnly": {
+                                  "type": "boolean"
+                                },
+                                "recursiveReadOnly": {
+                                  "type": "string"
+                                },
+                                "subPath": {
+                                  "type": "string"
+                                },
+                                "subPathExpr": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "workingDir": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "hostAliases": {
+                      "items": {
+                        "properties": {
+                          "hostnames": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "ip": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "hostIPC": {
+                      "type": "boolean"
+                    },
+                    "hostNetwork": {
+                      "type": "boolean"
+                    },
+                    "hostPID": {
+                      "type": "boolean"
+                    },
+                    "hostUsers": {
+                      "type": "boolean"
+                    },
+                    "hostname": {
+                      "type": "string"
+                    },
+                    "imagePullSecrets": {
+                      "items": {
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "initContainers": {
+                      "items": {
+                        "properties": {
+                          "args": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "command": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "env": {
+                            "items": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "value": {
+                                  "type": "string"
+                                },
+                                "valueFrom": {
+                                  "properties": {
+                                    "configMapKeyRef": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "fieldRef": {
+                                      "properties": {
+                                        "apiVersion": {
+                                          "type": "string"
+                                        },
+                                        "fieldPath": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "resourceFieldRef": {
+                                      "properties": {
+                                        "containerName": {
+                                          "type": "string"
+                                        },
+                                        "divisor": {
+                                          "anyOf": [
+                                            {
+                                              "type": "integer"
+                                            },
+                                            {
+                                              "type": "string"
+                                            }
+                                          ],
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "resource": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "secretKeyRef": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "envFrom": {
+                            "items": {
+                              "properties": {
+                                "configMapRef": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "prefix": {
+                                  "type": "string"
+                                },
+                                "secretRef": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "image": {
+                            "type": "string"
+                          },
+                          "imagePullPolicy": {
+                            "type": "string"
+                          },
+                          "lifecycle": {
+                            "properties": {
+                              "postStart": {
+                                "properties": {
+                                  "exec": {
+                                    "properties": {
+                                      "command": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "httpGet": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "sleep": {
+                                    "properties": {
+                                      "seconds": {
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "tcpSocket": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "preStop": {
+                                "properties": {
+                                  "exec": {
+                                    "properties": {
+                                      "command": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "httpGet": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "sleep": {
+                                    "properties": {
+                                      "seconds": {
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "tcpSocket": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "stopSignal": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "livenessProbe": {
+                            "properties": {
+                              "exec": {
+                                "properties": {
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "failureThreshold": {
+                                "type": "integer"
+                              },
+                              "grpc": {
+                                "properties": {
+                                  "port": {
+                                    "type": "integer"
+                                  },
+                                  "service": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "httpGet": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "initialDelaySeconds": {
+                                "type": "integer"
+                              },
+                              "periodSeconds": {
+                                "type": "integer"
+                              },
+                              "successThreshold": {
+                                "type": "integer"
+                              },
+                              "tcpSocket": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "terminationGracePeriodSeconds": {
+                                "type": "integer"
+                              },
+                              "timeoutSeconds": {
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "ports": {
+                            "items": {
+                              "properties": {
+                                "containerPort": {
+                                  "type": "integer"
+                                },
+                                "hostIP": {
+                                  "type": "string"
+                                },
+                                "hostPort": {
+                                  "type": "integer"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "protocol": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "readinessProbe": {
+                            "properties": {
+                              "exec": {
+                                "properties": {
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "failureThreshold": {
+                                "type": "integer"
+                              },
+                              "grpc": {
+                                "properties": {
+                                  "port": {
+                                    "type": "integer"
+                                  },
+                                  "service": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "httpGet": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "initialDelaySeconds": {
+                                "type": "integer"
+                              },
+                              "periodSeconds": {
+                                "type": "integer"
+                              },
+                              "successThreshold": {
+                                "type": "integer"
+                              },
+                              "tcpSocket": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "terminationGracePeriodSeconds": {
+                                "type": "integer"
+                              },
+                              "timeoutSeconds": {
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "resizePolicy": {
+                            "items": {
+                              "properties": {
+                                "resourceName": {
+                                  "type": "string"
+                                },
+                                "restartPolicy": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "resources": {
+                            "properties": {
+                              "claims": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "request": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "limits": {
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "type": "object"
+                              },
+                              "requests": {
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "restartPolicy": {
+                            "type": "string"
+                          },
+                          "securityContext": {
+                            "properties": {
+                              "allowPrivilegeEscalation": {
+                                "type": "boolean"
+                              },
+                              "appArmorProfile": {
+                                "properties": {
+                                  "localhostProfile": {
+                                    "type": "string"
+                                  },
+                                  "type": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "capabilities": {
+                                "properties": {
+                                  "add": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "drop": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "privileged": {
+                                "type": "boolean"
+                              },
+                              "procMount": {
+                                "type": "string"
+                              },
+                              "readOnlyRootFilesystem": {
+                                "type": "boolean"
+                              },
+                              "runAsGroup": {
+                                "type": "integer"
+                              },
+                              "runAsNonRoot": {
+                                "type": "boolean"
+                              },
+                              "runAsUser": {
+                                "type": "integer"
+                              },
+                              "seLinuxOptions": {
+                                "properties": {
+                                  "level": {
+                                    "type": "string"
+                                  },
+                                  "role": {
+                                    "type": "string"
+                                  },
+                                  "type": {
+                                    "type": "string"
+                                  },
+                                  "user": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "seccompProfile": {
+                                "properties": {
+                                  "localhostProfile": {
+                                    "type": "string"
+                                  },
+                                  "type": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "windowsOptions": {
+                                "properties": {
+                                  "gmsaCredentialSpec": {
+                                    "type": "string"
+                                  },
+                                  "gmsaCredentialSpecName": {
+                                    "type": "string"
+                                  },
+                                  "hostProcess": {
+                                    "type": "boolean"
+                                  },
+                                  "runAsUserName": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "startupProbe": {
+                            "properties": {
+                              "exec": {
+                                "properties": {
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "failureThreshold": {
+                                "type": "integer"
+                              },
+                              "grpc": {
+                                "properties": {
+                                  "port": {
+                                    "type": "integer"
+                                  },
+                                  "service": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "httpGet": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "initialDelaySeconds": {
+                                "type": "integer"
+                              },
+                              "periodSeconds": {
+                                "type": "integer"
+                              },
+                              "successThreshold": {
+                                "type": "integer"
+                              },
+                              "tcpSocket": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "terminationGracePeriodSeconds": {
+                                "type": "integer"
+                              },
+                              "timeoutSeconds": {
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "stdin": {
+                            "type": "boolean"
+                          },
+                          "stdinOnce": {
+                            "type": "boolean"
+                          },
+                          "terminationMessagePath": {
+                            "type": "string"
+                          },
+                          "terminationMessagePolicy": {
+                            "type": "string"
+                          },
+                          "tty": {
+                            "type": "boolean"
+                          },
+                          "volumeDevices": {
+                            "items": {
+                              "properties": {
+                                "devicePath": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "volumeMounts": {
+                            "items": {
+                              "properties": {
+                                "mountPath": {
+                                  "type": "string"
+                                },
+                                "mountPropagation": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "readOnly": {
+                                  "type": "boolean"
+                                },
+                                "recursiveReadOnly": {
+                                  "type": "string"
+                                },
+                                "subPath": {
+                                  "type": "string"
+                                },
+                                "subPathExpr": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "workingDir": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "nodeName": {
+                      "type": "string"
+                    },
+                    "nodeSelector": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "type": "object"
+                    },
+                    "os": {
+                      "properties": {
+                        "name": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "overhead": {
+                      "additionalProperties": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "x-kubernetes-int-or-string": true
+                      },
+                      "type": "object"
+                    },
+                    "preemptionPolicy": {
+                      "type": "string"
+                    },
+                    "priority": {
+                      "type": "integer"
+                    },
+                    "priorityClassName": {
+                      "type": "string"
+                    },
+                    "readinessGates": {
+                      "items": {
+                        "properties": {
+                          "conditionType": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "resourceClaims": {
+                      "items": {
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          },
+                          "resourceClaimName": {
+                            "type": "string"
+                          },
+                          "resourceClaimTemplateName": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "resources": {
+                      "properties": {
+                        "claims": {
+                          "items": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "request": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "limits": {
+                          "additionalProperties": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "x-kubernetes-int-or-string": true
+                          },
+                          "type": "object"
+                        },
+                        "requests": {
+                          "additionalProperties": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "x-kubernetes-int-or-string": true
+                          },
+                          "type": "object"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "restartPolicy": {
+                      "type": "string"
+                    },
+                    "runtimeClassName": {
+                      "type": "string"
+                    },
+                    "schedulerName": {
+                      "type": "string"
+                    },
+                    "schedulingGates": {
+                      "items": {
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "securityContext": {
+                      "properties": {
+                        "appArmorProfile": {
+                          "properties": {
+                            "localhostProfile": {
+                              "type": "string"
+                            },
+                            "type": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "fsGroup": {
+                          "type": "integer"
+                        },
+                        "fsGroupChangePolicy": {
+                          "type": "string"
+                        },
+                        "runAsGroup": {
+                          "type": "integer"
+                        },
+                        "runAsNonRoot": {
+                          "type": "boolean"
+                        },
+                        "runAsUser": {
+                          "type": "integer"
+                        },
+                        "seLinuxChangePolicy": {
+                          "type": "string"
+                        },
+                        "seLinuxOptions": {
+                          "properties": {
+                            "level": {
+                              "type": "string"
+                            },
+                            "role": {
+                              "type": "string"
+                            },
+                            "type": {
+                              "type": "string"
+                            },
+                            "user": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "seccompProfile": {
+                          "properties": {
+                            "localhostProfile": {
+                              "type": "string"
+                            },
+                            "type": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "supplementalGroups": {
+                          "items": {
+                            "type": "integer"
+                          },
+                          "type": "array"
+                        },
+                        "supplementalGroupsPolicy": {
+                          "type": "string"
+                        },
+                        "sysctls": {
+                          "items": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "value": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "windowsOptions": {
+                          "properties": {
+                            "gmsaCredentialSpec": {
+                              "type": "string"
+                            },
+                            "gmsaCredentialSpecName": {
+                              "type": "string"
+                            },
+                            "hostProcess": {
+                              "type": "boolean"
+                            },
+                            "runAsUserName": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "serviceAccount": {
+                      "type": "string"
+                    },
+                    "serviceAccountName": {
+                      "type": "string"
+                    },
+                    "setHostnameAsFQDN": {
+                      "type": "boolean"
+                    },
+                    "shareProcessNamespace": {
+                      "type": "boolean"
+                    },
+                    "subdomain": {
+                      "type": "string"
+                    },
+                    "terminationGracePeriodSeconds": {
+                      "type": "integer"
+                    },
+                    "tolerations": {
+                      "items": {
+                        "properties": {
+                          "effect": {
+                            "type": "string"
+                          },
+                          "key": {
+                            "type": "string"
+                          },
+                          "operator": {
+                            "type": "string"
+                          },
+                          "tolerationSeconds": {
+                            "type": "integer"
+                          },
+                          "value": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "topologySpreadConstraints": {
+                      "items": {
+                        "properties": {
+                          "labelSelector": {
+                            "properties": {
+                              "matchExpressions": {
+                                "items": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "matchLabels": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "matchLabelKeys": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "maxSkew": {
+                            "type": "integer"
+                          },
+                          "minDomains": {
+                            "type": "integer"
+                          },
+                          "nodeAffinityPolicy": {
+                            "type": "string"
+                          },
+                          "nodeTaintsPolicy": {
+                            "type": "string"
+                          },
+                          "topologyKey": {
+                            "type": "string"
+                          },
+                          "whenUnsatisfiable": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "volumes": {
+                      "items": {
+                        "properties": {
+                          "awsElasticBlockStore": {
+                            "properties": {
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "partition": {
+                                "type": "integer"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "volumeID": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "azureDisk": {
+                            "properties": {
+                              "cachingMode": {
+                                "type": "string"
+                              },
+                              "diskName": {
+                                "type": "string"
+                              },
+                              "diskURI": {
+                                "type": "string"
+                              },
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "kind": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "azureFile": {
+                            "properties": {
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "secretName": {
+                                "type": "string"
+                              },
+                              "shareName": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "cephfs": {
+                            "properties": {
+                              "monitors": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "path": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "secretFile": {
+                                "type": "string"
+                              },
+                              "secretRef": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "user": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "cinder": {
+                            "properties": {
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "secretRef": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "volumeID": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "configMap": {
+                            "properties": {
+                              "defaultMode": {
+                                "type": "integer"
+                              },
+                              "items": {
+                                "items": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "mode": {
+                                      "type": "integer"
+                                    },
+                                    "path": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "optional": {
+                                "type": "boolean"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "csi": {
+                            "properties": {
+                              "driver": {
+                                "type": "string"
+                              },
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "nodePublishSecretRef": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "volumeAttributes": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "downwardAPI": {
+                            "properties": {
+                              "defaultMode": {
+                                "type": "integer"
+                              },
+                              "items": {
+                                "items": {
+                                  "properties": {
+                                    "fieldRef": {
+                                      "properties": {
+                                        "apiVersion": {
+                                          "type": "string"
+                                        },
+                                        "fieldPath": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "mode": {
+                                      "type": "integer"
+                                    },
+                                    "path": {
+                                      "type": "string"
+                                    },
+                                    "resourceFieldRef": {
+                                      "properties": {
+                                        "containerName": {
+                                          "type": "string"
+                                        },
+                                        "divisor": {
+                                          "anyOf": [
+                                            {
+                                              "type": "integer"
+                                            },
+                                            {
+                                              "type": "string"
+                                            }
+                                          ],
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "resource": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "emptyDir": {
+                            "properties": {
+                              "medium": {
+                                "type": "string"
+                              },
+                              "sizeLimit": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "ephemeral": {
+                            "properties": {
+                              "volumeClaimTemplate": {
+                                "properties": {
+                                  "metadata": {
+                                    "properties": {
+                                      "annotations": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
+                                      },
+                                      "creationTimestamp": {
+                                        "type": "string"
+                                      },
+                                      "deletionGracePeriodSeconds": {
+                                        "type": "integer"
+                                      },
+                                      "deletionTimestamp": {
+                                        "type": "string"
+                                      },
+                                      "finalizers": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "generateName": {
+                                        "type": "string"
+                                      },
+                                      "generation": {
+                                        "type": "integer"
+                                      },
+                                      "labels": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
+                                      },
+                                      "managedFields": {
+                                        "items": {
+                                          "properties": {
+                                            "apiVersion": {
+                                              "type": "string"
+                                            },
+                                            "fieldsType": {
+                                              "type": "string"
+                                            },
+                                            "fieldsV1": {
+                                              "type": "object"
+                                            },
+                                            "manager": {
+                                              "type": "string"
+                                            },
+                                            "operation": {
+                                              "type": "string"
+                                            },
+                                            "subresource": {
+                                              "type": "string"
+                                            },
+                                            "time": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "namespace": {
+                                        "type": "string"
+                                      },
+                                      "ownerReferences": {
+                                        "items": {
+                                          "properties": {
+                                            "apiVersion": {
+                                              "type": "string"
+                                            },
+                                            "blockOwnerDeletion": {
+                                              "type": "boolean"
+                                            },
+                                            "controller": {
+                                              "type": "boolean"
+                                            },
+                                            "kind": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "uid": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "resourceVersion": {
+                                        "type": "string"
+                                      },
+                                      "selfLink": {
+                                        "type": "string"
+                                      },
+                                      "uid": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "spec": {
+                                    "properties": {
+                                      "accessModes": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "dataSource": {
+                                        "properties": {
+                                          "apiGroup": {
+                                            "type": "string"
+                                          },
+                                          "kind": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "dataSourceRef": {
+                                        "properties": {
+                                          "apiGroup": {
+                                            "type": "string"
+                                          },
+                                          "kind": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "namespace": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "resources": {
+                                        "properties": {
+                                          "limits": {
+                                            "additionalProperties": {
+                                              "anyOf": [
+                                                {
+                                                  "type": "integer"
+                                                },
+                                                {
+                                                  "type": "string"
+                                                }
+                                              ],
+                                              "x-kubernetes-int-or-string": true
+                                            },
+                                            "type": "object"
+                                          },
+                                          "requests": {
+                                            "additionalProperties": {
+                                              "anyOf": [
+                                                {
+                                                  "type": "integer"
+                                                },
+                                                {
+                                                  "type": "string"
+                                                }
+                                              ],
+                                              "x-kubernetes-int-or-string": true
+                                            },
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "selector": {
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "matchLabels": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "storageClassName": {
+                                        "type": "string"
+                                      },
+                                      "volumeAttributesClassName": {
+                                        "type": "string"
+                                      },
+                                      "volumeMode": {
+                                        "type": "string"
+                                      },
+                                      "volumeName": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "fc": {
+                            "properties": {
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "lun": {
+                                "type": "integer"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "targetWWNs": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "wwids": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "flexVolume": {
+                            "properties": {
+                              "driver": {
+                                "type": "string"
+                              },
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "options": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "type": "object"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "secretRef": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "flocker": {
+                            "properties": {
+                              "datasetName": {
+                                "type": "string"
+                              },
+                              "datasetUUID": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "gcePersistentDisk": {
+                            "properties": {
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "partition": {
+                                "type": "integer"
+                              },
+                              "pdName": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "gitRepo": {
+                            "properties": {
+                              "directory": {
+                                "type": "string"
+                              },
+                              "repository": {
+                                "type": "string"
+                              },
+                              "revision": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "glusterfs": {
+                            "properties": {
+                              "endpoints": {
+                                "type": "string"
+                              },
+                              "path": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "hostPath": {
+                            "properties": {
+                              "path": {
+                                "type": "string"
+                              },
+                              "type": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "image": {
+                            "properties": {
+                              "pullPolicy": {
+                                "type": "string"
+                              },
+                              "reference": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "iscsi": {
+                            "properties": {
+                              "chapAuthDiscovery": {
+                                "type": "boolean"
+                              },
+                              "chapAuthSession": {
+                                "type": "boolean"
+                              },
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "initiatorName": {
+                                "type": "string"
+                              },
+                              "iqn": {
+                                "type": "string"
+                              },
+                              "iscsiInterface": {
+                                "type": "string"
+                              },
+                              "lun": {
+                                "type": "integer"
+                              },
+                              "portals": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "secretRef": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "targetPortal": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "nfs": {
+                            "properties": {
+                              "path": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "server": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "persistentVolumeClaim": {
+                            "properties": {
+                              "claimName": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "photonPersistentDisk": {
+                            "properties": {
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "pdID": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "portworxVolume": {
+                            "properties": {
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "volumeID": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "projected": {
+                            "properties": {
+                              "defaultMode": {
+                                "type": "integer"
+                              },
+                              "sources": {
+                                "items": {
+                                  "properties": {
+                                    "clusterTrustBundle": {
+                                      "properties": {
+                                        "labelSelector": {
+                                          "properties": {
+                                            "matchExpressions": {
+                                              "items": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "operator": {
+                                                    "type": "string"
+                                                  },
+                                                  "values": {
+                                                    "items": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "array"
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              "type": "array"
+                                            },
+                                            "matchLabels": {
+                                              "additionalProperties": {
+                                                "type": "string"
+                                              },
+                                              "type": "object"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        },
+                                        "path": {
+                                          "type": "string"
+                                        },
+                                        "signerName": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "configMap": {
+                                      "properties": {
+                                        "items": {
+                                          "items": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "mode": {
+                                                "type": "integer"
+                                              },
+                                              "path": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          "type": "array"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "downwardAPI": {
+                                      "properties": {
+                                        "items": {
+                                          "items": {
+                                            "properties": {
+                                              "fieldRef": {
+                                                "properties": {
+                                                  "apiVersion": {
+                                                    "type": "string"
+                                                  },
+                                                  "fieldPath": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              "mode": {
+                                                "type": "integer"
+                                              },
+                                              "path": {
+                                                "type": "string"
+                                              },
+                                              "resourceFieldRef": {
+                                                "properties": {
+                                                  "containerName": {
+                                                    "type": "string"
+                                                  },
+                                                  "divisor": {
+                                                    "anyOf": [
+                                                      {
+                                                        "type": "integer"
+                                                      },
+                                                      {
+                                                        "type": "string"
+                                                      }
+                                                    ],
+                                                    "x-kubernetes-int-or-string": true
+                                                  },
+                                                  "resource": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object"
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "secret": {
+                                      "properties": {
+                                        "items": {
+                                          "items": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "mode": {
+                                                "type": "integer"
+                                              },
+                                              "path": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          "type": "array"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "serviceAccountToken": {
+                                      "properties": {
+                                        "audience": {
+                                          "type": "string"
+                                        },
+                                        "expirationSeconds": {
+                                          "type": "integer"
+                                        },
+                                        "path": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "quobyte": {
+                            "properties": {
+                              "group": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "registry": {
+                                "type": "string"
+                              },
+                              "tenant": {
+                                "type": "string"
+                              },
+                              "user": {
+                                "type": "string"
+                              },
+                              "volume": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "rbd": {
+                            "properties": {
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "image": {
+                                "type": "string"
+                              },
+                              "keyring": {
+                                "type": "string"
+                              },
+                              "monitors": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "pool": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "secretRef": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "user": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "scaleIO": {
+                            "properties": {
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "gateway": {
+                                "type": "string"
+                              },
+                              "protectionDomain": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "secretRef": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "sslEnabled": {
+                                "type": "boolean"
+                              },
+                              "storageMode": {
+                                "type": "string"
+                              },
+                              "storagePool": {
+                                "type": "string"
+                              },
+                              "system": {
+                                "type": "string"
+                              },
+                              "volumeName": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "secret": {
+                            "properties": {
+                              "defaultMode": {
+                                "type": "integer"
+                              },
+                              "items": {
+                                "items": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "mode": {
+                                      "type": "integer"
+                                    },
+                                    "path": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "optional": {
+                                "type": "boolean"
+                              },
+                              "secretName": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "storageos": {
+                            "properties": {
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "secretRef": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "volumeName": {
+                                "type": "string"
+                              },
+                              "volumeNamespace": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "vsphereVolume": {
+                            "properties": {
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "storagePolicyID": {
+                                "type": "string"
+                              },
+                              "storagePolicyName": {
+                                "type": "string"
+                              },
+                              "volumePath": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "type": "object"
+        },
+        "executorSpec": {
+          "properties": {
+            "podTemplateSpec": {
+              "properties": {
+                "metadata": {
+                  "properties": {
+                    "annotations": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "type": "object"
+                    },
+                    "creationTimestamp": {
+                      "type": "string"
+                    },
+                    "deletionGracePeriodSeconds": {
+                      "type": "integer"
+                    },
+                    "deletionTimestamp": {
+                      "type": "string"
+                    },
+                    "finalizers": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "generateName": {
+                      "type": "string"
+                    },
+                    "generation": {
+                      "type": "integer"
+                    },
+                    "labels": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "type": "object"
+                    },
+                    "managedFields": {
+                      "items": {
+                        "properties": {
+                          "apiVersion": {
+                            "type": "string"
+                          },
+                          "fieldsType": {
+                            "type": "string"
+                          },
+                          "fieldsV1": {
+                            "type": "object"
+                          },
+                          "manager": {
+                            "type": "string"
+                          },
+                          "operation": {
+                            "type": "string"
+                          },
+                          "subresource": {
+                            "type": "string"
+                          },
+                          "time": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "namespace": {
+                      "type": "string"
+                    },
+                    "ownerReferences": {
+                      "items": {
+                        "properties": {
+                          "apiVersion": {
+                            "type": "string"
+                          },
+                          "blockOwnerDeletion": {
+                            "type": "boolean"
+                          },
+                          "controller": {
+                            "type": "boolean"
+                          },
+                          "kind": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "uid": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "resourceVersion": {
+                      "type": "string"
+                    },
+                    "selfLink": {
+                      "type": "string"
+                    },
+                    "uid": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "spec": {
+                  "properties": {
+                    "activeDeadlineSeconds": {
+                      "type": "integer"
+                    },
+                    "affinity": {
+                      "properties": {
+                        "nodeAffinity": {
+                          "properties": {
+                            "preferredDuringSchedulingIgnoredDuringExecution": {
+                              "items": {
+                                "properties": {
+                                  "preference": {
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "matchFields": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "weight": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "requiredDuringSchedulingIgnoredDuringExecution": {
+                              "properties": {
+                                "nodeSelectorTerms": {
+                                  "items": {
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "matchFields": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "type": "object"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "podAffinity": {
+                          "properties": {
+                            "preferredDuringSchedulingIgnoredDuringExecution": {
+                              "items": {
+                                "properties": {
+                                  "podAffinityTerm": {
+                                    "properties": {
+                                      "labelSelector": {
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "matchLabels": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "matchLabelKeys": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "mismatchLabelKeys": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "namespaceSelector": {
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "matchLabels": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "namespaces": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "topologyKey": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "weight": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "requiredDuringSchedulingIgnoredDuringExecution": {
+                              "items": {
+                                "properties": {
+                                  "labelSelector": {
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "matchLabels": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "matchLabelKeys": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "mismatchLabelKeys": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "namespaceSelector": {
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "matchLabels": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "namespaces": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "topologyKey": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "podAntiAffinity": {
+                          "properties": {
+                            "preferredDuringSchedulingIgnoredDuringExecution": {
+                              "items": {
+                                "properties": {
+                                  "podAffinityTerm": {
+                                    "properties": {
+                                      "labelSelector": {
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "matchLabels": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "matchLabelKeys": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "mismatchLabelKeys": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "namespaceSelector": {
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "matchLabels": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "namespaces": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "topologyKey": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "weight": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "requiredDuringSchedulingIgnoredDuringExecution": {
+                              "items": {
+                                "properties": {
+                                  "labelSelector": {
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "matchLabels": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "matchLabelKeys": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "mismatchLabelKeys": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "namespaceSelector": {
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "matchLabels": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "namespaces": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "topologyKey": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "automountServiceAccountToken": {
+                      "type": "boolean"
+                    },
+                    "containers": {
+                      "items": {
+                        "properties": {
+                          "args": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "command": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "env": {
+                            "items": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "value": {
+                                  "type": "string"
+                                },
+                                "valueFrom": {
+                                  "properties": {
+                                    "configMapKeyRef": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "fieldRef": {
+                                      "properties": {
+                                        "apiVersion": {
+                                          "type": "string"
+                                        },
+                                        "fieldPath": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "resourceFieldRef": {
+                                      "properties": {
+                                        "containerName": {
+                                          "type": "string"
+                                        },
+                                        "divisor": {
+                                          "anyOf": [
+                                            {
+                                              "type": "integer"
+                                            },
+                                            {
+                                              "type": "string"
+                                            }
+                                          ],
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "resource": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "secretKeyRef": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "envFrom": {
+                            "items": {
+                              "properties": {
+                                "configMapRef": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "prefix": {
+                                  "type": "string"
+                                },
+                                "secretRef": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "image": {
+                            "type": "string"
+                          },
+                          "imagePullPolicy": {
+                            "type": "string"
+                          },
+                          "lifecycle": {
+                            "properties": {
+                              "postStart": {
+                                "properties": {
+                                  "exec": {
+                                    "properties": {
+                                      "command": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "httpGet": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "sleep": {
+                                    "properties": {
+                                      "seconds": {
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "tcpSocket": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "preStop": {
+                                "properties": {
+                                  "exec": {
+                                    "properties": {
+                                      "command": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "httpGet": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "sleep": {
+                                    "properties": {
+                                      "seconds": {
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "tcpSocket": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "stopSignal": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "livenessProbe": {
+                            "properties": {
+                              "exec": {
+                                "properties": {
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "failureThreshold": {
+                                "type": "integer"
+                              },
+                              "grpc": {
+                                "properties": {
+                                  "port": {
+                                    "type": "integer"
+                                  },
+                                  "service": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "httpGet": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "initialDelaySeconds": {
+                                "type": "integer"
+                              },
+                              "periodSeconds": {
+                                "type": "integer"
+                              },
+                              "successThreshold": {
+                                "type": "integer"
+                              },
+                              "tcpSocket": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "terminationGracePeriodSeconds": {
+                                "type": "integer"
+                              },
+                              "timeoutSeconds": {
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "ports": {
+                            "items": {
+                              "properties": {
+                                "containerPort": {
+                                  "type": "integer"
+                                },
+                                "hostIP": {
+                                  "type": "string"
+                                },
+                                "hostPort": {
+                                  "type": "integer"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "protocol": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "readinessProbe": {
+                            "properties": {
+                              "exec": {
+                                "properties": {
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "failureThreshold": {
+                                "type": "integer"
+                              },
+                              "grpc": {
+                                "properties": {
+                                  "port": {
+                                    "type": "integer"
+                                  },
+                                  "service": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "httpGet": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "initialDelaySeconds": {
+                                "type": "integer"
+                              },
+                              "periodSeconds": {
+                                "type": "integer"
+                              },
+                              "successThreshold": {
+                                "type": "integer"
+                              },
+                              "tcpSocket": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "terminationGracePeriodSeconds": {
+                                "type": "integer"
+                              },
+                              "timeoutSeconds": {
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "resizePolicy": {
+                            "items": {
+                              "properties": {
+                                "resourceName": {
+                                  "type": "string"
+                                },
+                                "restartPolicy": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "resources": {
+                            "properties": {
+                              "claims": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "request": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "limits": {
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "type": "object"
+                              },
+                              "requests": {
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "restartPolicy": {
+                            "type": "string"
+                          },
+                          "securityContext": {
+                            "properties": {
+                              "allowPrivilegeEscalation": {
+                                "type": "boolean"
+                              },
+                              "appArmorProfile": {
+                                "properties": {
+                                  "localhostProfile": {
+                                    "type": "string"
+                                  },
+                                  "type": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "capabilities": {
+                                "properties": {
+                                  "add": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "drop": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "privileged": {
+                                "type": "boolean"
+                              },
+                              "procMount": {
+                                "type": "string"
+                              },
+                              "readOnlyRootFilesystem": {
+                                "type": "boolean"
+                              },
+                              "runAsGroup": {
+                                "type": "integer"
+                              },
+                              "runAsNonRoot": {
+                                "type": "boolean"
+                              },
+                              "runAsUser": {
+                                "type": "integer"
+                              },
+                              "seLinuxOptions": {
+                                "properties": {
+                                  "level": {
+                                    "type": "string"
+                                  },
+                                  "role": {
+                                    "type": "string"
+                                  },
+                                  "type": {
+                                    "type": "string"
+                                  },
+                                  "user": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "seccompProfile": {
+                                "properties": {
+                                  "localhostProfile": {
+                                    "type": "string"
+                                  },
+                                  "type": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "windowsOptions": {
+                                "properties": {
+                                  "gmsaCredentialSpec": {
+                                    "type": "string"
+                                  },
+                                  "gmsaCredentialSpecName": {
+                                    "type": "string"
+                                  },
+                                  "hostProcess": {
+                                    "type": "boolean"
+                                  },
+                                  "runAsUserName": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "startupProbe": {
+                            "properties": {
+                              "exec": {
+                                "properties": {
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "failureThreshold": {
+                                "type": "integer"
+                              },
+                              "grpc": {
+                                "properties": {
+                                  "port": {
+                                    "type": "integer"
+                                  },
+                                  "service": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "httpGet": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "initialDelaySeconds": {
+                                "type": "integer"
+                              },
+                              "periodSeconds": {
+                                "type": "integer"
+                              },
+                              "successThreshold": {
+                                "type": "integer"
+                              },
+                              "tcpSocket": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "terminationGracePeriodSeconds": {
+                                "type": "integer"
+                              },
+                              "timeoutSeconds": {
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "stdin": {
+                            "type": "boolean"
+                          },
+                          "stdinOnce": {
+                            "type": "boolean"
+                          },
+                          "terminationMessagePath": {
+                            "type": "string"
+                          },
+                          "terminationMessagePolicy": {
+                            "type": "string"
+                          },
+                          "tty": {
+                            "type": "boolean"
+                          },
+                          "volumeDevices": {
+                            "items": {
+                              "properties": {
+                                "devicePath": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "volumeMounts": {
+                            "items": {
+                              "properties": {
+                                "mountPath": {
+                                  "type": "string"
+                                },
+                                "mountPropagation": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "readOnly": {
+                                  "type": "boolean"
+                                },
+                                "recursiveReadOnly": {
+                                  "type": "string"
+                                },
+                                "subPath": {
+                                  "type": "string"
+                                },
+                                "subPathExpr": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "workingDir": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "dnsConfig": {
+                      "properties": {
+                        "nameservers": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "options": {
+                          "items": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "value": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "searches": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "dnsPolicy": {
+                      "type": "string"
+                    },
+                    "enableServiceLinks": {
+                      "type": "boolean"
+                    },
+                    "ephemeralContainers": {
+                      "items": {
+                        "properties": {
+                          "args": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "command": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "env": {
+                            "items": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "value": {
+                                  "type": "string"
+                                },
+                                "valueFrom": {
+                                  "properties": {
+                                    "configMapKeyRef": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "fieldRef": {
+                                      "properties": {
+                                        "apiVersion": {
+                                          "type": "string"
+                                        },
+                                        "fieldPath": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "resourceFieldRef": {
+                                      "properties": {
+                                        "containerName": {
+                                          "type": "string"
+                                        },
+                                        "divisor": {
+                                          "anyOf": [
+                                            {
+                                              "type": "integer"
+                                            },
+                                            {
+                                              "type": "string"
+                                            }
+                                          ],
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "resource": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "secretKeyRef": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "envFrom": {
+                            "items": {
+                              "properties": {
+                                "configMapRef": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "prefix": {
+                                  "type": "string"
+                                },
+                                "secretRef": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "image": {
+                            "type": "string"
+                          },
+                          "imagePullPolicy": {
+                            "type": "string"
+                          },
+                          "lifecycle": {
+                            "properties": {
+                              "postStart": {
+                                "properties": {
+                                  "exec": {
+                                    "properties": {
+                                      "command": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "httpGet": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "sleep": {
+                                    "properties": {
+                                      "seconds": {
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "tcpSocket": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "preStop": {
+                                "properties": {
+                                  "exec": {
+                                    "properties": {
+                                      "command": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "httpGet": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "sleep": {
+                                    "properties": {
+                                      "seconds": {
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "tcpSocket": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "stopSignal": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "livenessProbe": {
+                            "properties": {
+                              "exec": {
+                                "properties": {
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "failureThreshold": {
+                                "type": "integer"
+                              },
+                              "grpc": {
+                                "properties": {
+                                  "port": {
+                                    "type": "integer"
+                                  },
+                                  "service": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "httpGet": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "initialDelaySeconds": {
+                                "type": "integer"
+                              },
+                              "periodSeconds": {
+                                "type": "integer"
+                              },
+                              "successThreshold": {
+                                "type": "integer"
+                              },
+                              "tcpSocket": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "terminationGracePeriodSeconds": {
+                                "type": "integer"
+                              },
+                              "timeoutSeconds": {
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "ports": {
+                            "items": {
+                              "properties": {
+                                "containerPort": {
+                                  "type": "integer"
+                                },
+                                "hostIP": {
+                                  "type": "string"
+                                },
+                                "hostPort": {
+                                  "type": "integer"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "protocol": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "readinessProbe": {
+                            "properties": {
+                              "exec": {
+                                "properties": {
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "failureThreshold": {
+                                "type": "integer"
+                              },
+                              "grpc": {
+                                "properties": {
+                                  "port": {
+                                    "type": "integer"
+                                  },
+                                  "service": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "httpGet": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "initialDelaySeconds": {
+                                "type": "integer"
+                              },
+                              "periodSeconds": {
+                                "type": "integer"
+                              },
+                              "successThreshold": {
+                                "type": "integer"
+                              },
+                              "tcpSocket": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "terminationGracePeriodSeconds": {
+                                "type": "integer"
+                              },
+                              "timeoutSeconds": {
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "resizePolicy": {
+                            "items": {
+                              "properties": {
+                                "resourceName": {
+                                  "type": "string"
+                                },
+                                "restartPolicy": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "resources": {
+                            "properties": {
+                              "claims": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "request": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "limits": {
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "type": "object"
+                              },
+                              "requests": {
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "restartPolicy": {
+                            "type": "string"
+                          },
+                          "securityContext": {
+                            "properties": {
+                              "allowPrivilegeEscalation": {
+                                "type": "boolean"
+                              },
+                              "appArmorProfile": {
+                                "properties": {
+                                  "localhostProfile": {
+                                    "type": "string"
+                                  },
+                                  "type": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "capabilities": {
+                                "properties": {
+                                  "add": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "drop": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "privileged": {
+                                "type": "boolean"
+                              },
+                              "procMount": {
+                                "type": "string"
+                              },
+                              "readOnlyRootFilesystem": {
+                                "type": "boolean"
+                              },
+                              "runAsGroup": {
+                                "type": "integer"
+                              },
+                              "runAsNonRoot": {
+                                "type": "boolean"
+                              },
+                              "runAsUser": {
+                                "type": "integer"
+                              },
+                              "seLinuxOptions": {
+                                "properties": {
+                                  "level": {
+                                    "type": "string"
+                                  },
+                                  "role": {
+                                    "type": "string"
+                                  },
+                                  "type": {
+                                    "type": "string"
+                                  },
+                                  "user": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "seccompProfile": {
+                                "properties": {
+                                  "localhostProfile": {
+                                    "type": "string"
+                                  },
+                                  "type": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "windowsOptions": {
+                                "properties": {
+                                  "gmsaCredentialSpec": {
+                                    "type": "string"
+                                  },
+                                  "gmsaCredentialSpecName": {
+                                    "type": "string"
+                                  },
+                                  "hostProcess": {
+                                    "type": "boolean"
+                                  },
+                                  "runAsUserName": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "startupProbe": {
+                            "properties": {
+                              "exec": {
+                                "properties": {
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "failureThreshold": {
+                                "type": "integer"
+                              },
+                              "grpc": {
+                                "properties": {
+                                  "port": {
+                                    "type": "integer"
+                                  },
+                                  "service": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "httpGet": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "initialDelaySeconds": {
+                                "type": "integer"
+                              },
+                              "periodSeconds": {
+                                "type": "integer"
+                              },
+                              "successThreshold": {
+                                "type": "integer"
+                              },
+                              "tcpSocket": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "terminationGracePeriodSeconds": {
+                                "type": "integer"
+                              },
+                              "timeoutSeconds": {
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "stdin": {
+                            "type": "boolean"
+                          },
+                          "stdinOnce": {
+                            "type": "boolean"
+                          },
+                          "targetContainerName": {
+                            "type": "string"
+                          },
+                          "terminationMessagePath": {
+                            "type": "string"
+                          },
+                          "terminationMessagePolicy": {
+                            "type": "string"
+                          },
+                          "tty": {
+                            "type": "boolean"
+                          },
+                          "volumeDevices": {
+                            "items": {
+                              "properties": {
+                                "devicePath": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "volumeMounts": {
+                            "items": {
+                              "properties": {
+                                "mountPath": {
+                                  "type": "string"
+                                },
+                                "mountPropagation": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "readOnly": {
+                                  "type": "boolean"
+                                },
+                                "recursiveReadOnly": {
+                                  "type": "string"
+                                },
+                                "subPath": {
+                                  "type": "string"
+                                },
+                                "subPathExpr": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "workingDir": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "hostAliases": {
+                      "items": {
+                        "properties": {
+                          "hostnames": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "ip": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "hostIPC": {
+                      "type": "boolean"
+                    },
+                    "hostNetwork": {
+                      "type": "boolean"
+                    },
+                    "hostPID": {
+                      "type": "boolean"
+                    },
+                    "hostUsers": {
+                      "type": "boolean"
+                    },
+                    "hostname": {
+                      "type": "string"
+                    },
+                    "imagePullSecrets": {
+                      "items": {
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "initContainers": {
+                      "items": {
+                        "properties": {
+                          "args": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "command": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "env": {
+                            "items": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "value": {
+                                  "type": "string"
+                                },
+                                "valueFrom": {
+                                  "properties": {
+                                    "configMapKeyRef": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "fieldRef": {
+                                      "properties": {
+                                        "apiVersion": {
+                                          "type": "string"
+                                        },
+                                        "fieldPath": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "resourceFieldRef": {
+                                      "properties": {
+                                        "containerName": {
+                                          "type": "string"
+                                        },
+                                        "divisor": {
+                                          "anyOf": [
+                                            {
+                                              "type": "integer"
+                                            },
+                                            {
+                                              "type": "string"
+                                            }
+                                          ],
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "resource": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "secretKeyRef": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "envFrom": {
+                            "items": {
+                              "properties": {
+                                "configMapRef": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "prefix": {
+                                  "type": "string"
+                                },
+                                "secretRef": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "image": {
+                            "type": "string"
+                          },
+                          "imagePullPolicy": {
+                            "type": "string"
+                          },
+                          "lifecycle": {
+                            "properties": {
+                              "postStart": {
+                                "properties": {
+                                  "exec": {
+                                    "properties": {
+                                      "command": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "httpGet": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "sleep": {
+                                    "properties": {
+                                      "seconds": {
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "tcpSocket": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "preStop": {
+                                "properties": {
+                                  "exec": {
+                                    "properties": {
+                                      "command": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "httpGet": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "sleep": {
+                                    "properties": {
+                                      "seconds": {
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "tcpSocket": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "stopSignal": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "livenessProbe": {
+                            "properties": {
+                              "exec": {
+                                "properties": {
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "failureThreshold": {
+                                "type": "integer"
+                              },
+                              "grpc": {
+                                "properties": {
+                                  "port": {
+                                    "type": "integer"
+                                  },
+                                  "service": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "httpGet": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "initialDelaySeconds": {
+                                "type": "integer"
+                              },
+                              "periodSeconds": {
+                                "type": "integer"
+                              },
+                              "successThreshold": {
+                                "type": "integer"
+                              },
+                              "tcpSocket": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "terminationGracePeriodSeconds": {
+                                "type": "integer"
+                              },
+                              "timeoutSeconds": {
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "ports": {
+                            "items": {
+                              "properties": {
+                                "containerPort": {
+                                  "type": "integer"
+                                },
+                                "hostIP": {
+                                  "type": "string"
+                                },
+                                "hostPort": {
+                                  "type": "integer"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "protocol": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "readinessProbe": {
+                            "properties": {
+                              "exec": {
+                                "properties": {
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "failureThreshold": {
+                                "type": "integer"
+                              },
+                              "grpc": {
+                                "properties": {
+                                  "port": {
+                                    "type": "integer"
+                                  },
+                                  "service": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "httpGet": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "initialDelaySeconds": {
+                                "type": "integer"
+                              },
+                              "periodSeconds": {
+                                "type": "integer"
+                              },
+                              "successThreshold": {
+                                "type": "integer"
+                              },
+                              "tcpSocket": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "terminationGracePeriodSeconds": {
+                                "type": "integer"
+                              },
+                              "timeoutSeconds": {
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "resizePolicy": {
+                            "items": {
+                              "properties": {
+                                "resourceName": {
+                                  "type": "string"
+                                },
+                                "restartPolicy": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "resources": {
+                            "properties": {
+                              "claims": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "request": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "limits": {
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "type": "object"
+                              },
+                              "requests": {
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "restartPolicy": {
+                            "type": "string"
+                          },
+                          "securityContext": {
+                            "properties": {
+                              "allowPrivilegeEscalation": {
+                                "type": "boolean"
+                              },
+                              "appArmorProfile": {
+                                "properties": {
+                                  "localhostProfile": {
+                                    "type": "string"
+                                  },
+                                  "type": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "capabilities": {
+                                "properties": {
+                                  "add": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "drop": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "privileged": {
+                                "type": "boolean"
+                              },
+                              "procMount": {
+                                "type": "string"
+                              },
+                              "readOnlyRootFilesystem": {
+                                "type": "boolean"
+                              },
+                              "runAsGroup": {
+                                "type": "integer"
+                              },
+                              "runAsNonRoot": {
+                                "type": "boolean"
+                              },
+                              "runAsUser": {
+                                "type": "integer"
+                              },
+                              "seLinuxOptions": {
+                                "properties": {
+                                  "level": {
+                                    "type": "string"
+                                  },
+                                  "role": {
+                                    "type": "string"
+                                  },
+                                  "type": {
+                                    "type": "string"
+                                  },
+                                  "user": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "seccompProfile": {
+                                "properties": {
+                                  "localhostProfile": {
+                                    "type": "string"
+                                  },
+                                  "type": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "windowsOptions": {
+                                "properties": {
+                                  "gmsaCredentialSpec": {
+                                    "type": "string"
+                                  },
+                                  "gmsaCredentialSpecName": {
+                                    "type": "string"
+                                  },
+                                  "hostProcess": {
+                                    "type": "boolean"
+                                  },
+                                  "runAsUserName": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "startupProbe": {
+                            "properties": {
+                              "exec": {
+                                "properties": {
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "failureThreshold": {
+                                "type": "integer"
+                              },
+                              "grpc": {
+                                "properties": {
+                                  "port": {
+                                    "type": "integer"
+                                  },
+                                  "service": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "httpGet": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "initialDelaySeconds": {
+                                "type": "integer"
+                              },
+                              "periodSeconds": {
+                                "type": "integer"
+                              },
+                              "successThreshold": {
+                                "type": "integer"
+                              },
+                              "tcpSocket": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "terminationGracePeriodSeconds": {
+                                "type": "integer"
+                              },
+                              "timeoutSeconds": {
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "stdin": {
+                            "type": "boolean"
+                          },
+                          "stdinOnce": {
+                            "type": "boolean"
+                          },
+                          "terminationMessagePath": {
+                            "type": "string"
+                          },
+                          "terminationMessagePolicy": {
+                            "type": "string"
+                          },
+                          "tty": {
+                            "type": "boolean"
+                          },
+                          "volumeDevices": {
+                            "items": {
+                              "properties": {
+                                "devicePath": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "volumeMounts": {
+                            "items": {
+                              "properties": {
+                                "mountPath": {
+                                  "type": "string"
+                                },
+                                "mountPropagation": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "readOnly": {
+                                  "type": "boolean"
+                                },
+                                "recursiveReadOnly": {
+                                  "type": "string"
+                                },
+                                "subPath": {
+                                  "type": "string"
+                                },
+                                "subPathExpr": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "workingDir": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "nodeName": {
+                      "type": "string"
+                    },
+                    "nodeSelector": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "type": "object"
+                    },
+                    "os": {
+                      "properties": {
+                        "name": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "overhead": {
+                      "additionalProperties": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "x-kubernetes-int-or-string": true
+                      },
+                      "type": "object"
+                    },
+                    "preemptionPolicy": {
+                      "type": "string"
+                    },
+                    "priority": {
+                      "type": "integer"
+                    },
+                    "priorityClassName": {
+                      "type": "string"
+                    },
+                    "readinessGates": {
+                      "items": {
+                        "properties": {
+                          "conditionType": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "resourceClaims": {
+                      "items": {
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          },
+                          "resourceClaimName": {
+                            "type": "string"
+                          },
+                          "resourceClaimTemplateName": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "resources": {
+                      "properties": {
+                        "claims": {
+                          "items": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "request": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "limits": {
+                          "additionalProperties": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "x-kubernetes-int-or-string": true
+                          },
+                          "type": "object"
+                        },
+                        "requests": {
+                          "additionalProperties": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "x-kubernetes-int-or-string": true
+                          },
+                          "type": "object"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "restartPolicy": {
+                      "type": "string"
+                    },
+                    "runtimeClassName": {
+                      "type": "string"
+                    },
+                    "schedulerName": {
+                      "type": "string"
+                    },
+                    "schedulingGates": {
+                      "items": {
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "securityContext": {
+                      "properties": {
+                        "appArmorProfile": {
+                          "properties": {
+                            "localhostProfile": {
+                              "type": "string"
+                            },
+                            "type": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "fsGroup": {
+                          "type": "integer"
+                        },
+                        "fsGroupChangePolicy": {
+                          "type": "string"
+                        },
+                        "runAsGroup": {
+                          "type": "integer"
+                        },
+                        "runAsNonRoot": {
+                          "type": "boolean"
+                        },
+                        "runAsUser": {
+                          "type": "integer"
+                        },
+                        "seLinuxChangePolicy": {
+                          "type": "string"
+                        },
+                        "seLinuxOptions": {
+                          "properties": {
+                            "level": {
+                              "type": "string"
+                            },
+                            "role": {
+                              "type": "string"
+                            },
+                            "type": {
+                              "type": "string"
+                            },
+                            "user": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "seccompProfile": {
+                          "properties": {
+                            "localhostProfile": {
+                              "type": "string"
+                            },
+                            "type": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "supplementalGroups": {
+                          "items": {
+                            "type": "integer"
+                          },
+                          "type": "array"
+                        },
+                        "supplementalGroupsPolicy": {
+                          "type": "string"
+                        },
+                        "sysctls": {
+                          "items": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "value": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "windowsOptions": {
+                          "properties": {
+                            "gmsaCredentialSpec": {
+                              "type": "string"
+                            },
+                            "gmsaCredentialSpecName": {
+                              "type": "string"
+                            },
+                            "hostProcess": {
+                              "type": "boolean"
+                            },
+                            "runAsUserName": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "serviceAccount": {
+                      "type": "string"
+                    },
+                    "serviceAccountName": {
+                      "type": "string"
+                    },
+                    "setHostnameAsFQDN": {
+                      "type": "boolean"
+                    },
+                    "shareProcessNamespace": {
+                      "type": "boolean"
+                    },
+                    "subdomain": {
+                      "type": "string"
+                    },
+                    "terminationGracePeriodSeconds": {
+                      "type": "integer"
+                    },
+                    "tolerations": {
+                      "items": {
+                        "properties": {
+                          "effect": {
+                            "type": "string"
+                          },
+                          "key": {
+                            "type": "string"
+                          },
+                          "operator": {
+                            "type": "string"
+                          },
+                          "tolerationSeconds": {
+                            "type": "integer"
+                          },
+                          "value": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "topologySpreadConstraints": {
+                      "items": {
+                        "properties": {
+                          "labelSelector": {
+                            "properties": {
+                              "matchExpressions": {
+                                "items": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "matchLabels": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "matchLabelKeys": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "maxSkew": {
+                            "type": "integer"
+                          },
+                          "minDomains": {
+                            "type": "integer"
+                          },
+                          "nodeAffinityPolicy": {
+                            "type": "string"
+                          },
+                          "nodeTaintsPolicy": {
+                            "type": "string"
+                          },
+                          "topologyKey": {
+                            "type": "string"
+                          },
+                          "whenUnsatisfiable": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "volumes": {
+                      "items": {
+                        "properties": {
+                          "awsElasticBlockStore": {
+                            "properties": {
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "partition": {
+                                "type": "integer"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "volumeID": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "azureDisk": {
+                            "properties": {
+                              "cachingMode": {
+                                "type": "string"
+                              },
+                              "diskName": {
+                                "type": "string"
+                              },
+                              "diskURI": {
+                                "type": "string"
+                              },
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "kind": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "azureFile": {
+                            "properties": {
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "secretName": {
+                                "type": "string"
+                              },
+                              "shareName": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "cephfs": {
+                            "properties": {
+                              "monitors": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "path": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "secretFile": {
+                                "type": "string"
+                              },
+                              "secretRef": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "user": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "cinder": {
+                            "properties": {
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "secretRef": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "volumeID": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "configMap": {
+                            "properties": {
+                              "defaultMode": {
+                                "type": "integer"
+                              },
+                              "items": {
+                                "items": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "mode": {
+                                      "type": "integer"
+                                    },
+                                    "path": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "optional": {
+                                "type": "boolean"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "csi": {
+                            "properties": {
+                              "driver": {
+                                "type": "string"
+                              },
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "nodePublishSecretRef": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "volumeAttributes": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "downwardAPI": {
+                            "properties": {
+                              "defaultMode": {
+                                "type": "integer"
+                              },
+                              "items": {
+                                "items": {
+                                  "properties": {
+                                    "fieldRef": {
+                                      "properties": {
+                                        "apiVersion": {
+                                          "type": "string"
+                                        },
+                                        "fieldPath": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "mode": {
+                                      "type": "integer"
+                                    },
+                                    "path": {
+                                      "type": "string"
+                                    },
+                                    "resourceFieldRef": {
+                                      "properties": {
+                                        "containerName": {
+                                          "type": "string"
+                                        },
+                                        "divisor": {
+                                          "anyOf": [
+                                            {
+                                              "type": "integer"
+                                            },
+                                            {
+                                              "type": "string"
+                                            }
+                                          ],
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "resource": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "emptyDir": {
+                            "properties": {
+                              "medium": {
+                                "type": "string"
+                              },
+                              "sizeLimit": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "ephemeral": {
+                            "properties": {
+                              "volumeClaimTemplate": {
+                                "properties": {
+                                  "metadata": {
+                                    "properties": {
+                                      "annotations": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
+                                      },
+                                      "creationTimestamp": {
+                                        "type": "string"
+                                      },
+                                      "deletionGracePeriodSeconds": {
+                                        "type": "integer"
+                                      },
+                                      "deletionTimestamp": {
+                                        "type": "string"
+                                      },
+                                      "finalizers": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "generateName": {
+                                        "type": "string"
+                                      },
+                                      "generation": {
+                                        "type": "integer"
+                                      },
+                                      "labels": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
+                                      },
+                                      "managedFields": {
+                                        "items": {
+                                          "properties": {
+                                            "apiVersion": {
+                                              "type": "string"
+                                            },
+                                            "fieldsType": {
+                                              "type": "string"
+                                            },
+                                            "fieldsV1": {
+                                              "type": "object"
+                                            },
+                                            "manager": {
+                                              "type": "string"
+                                            },
+                                            "operation": {
+                                              "type": "string"
+                                            },
+                                            "subresource": {
+                                              "type": "string"
+                                            },
+                                            "time": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "namespace": {
+                                        "type": "string"
+                                      },
+                                      "ownerReferences": {
+                                        "items": {
+                                          "properties": {
+                                            "apiVersion": {
+                                              "type": "string"
+                                            },
+                                            "blockOwnerDeletion": {
+                                              "type": "boolean"
+                                            },
+                                            "controller": {
+                                              "type": "boolean"
+                                            },
+                                            "kind": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "uid": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "resourceVersion": {
+                                        "type": "string"
+                                      },
+                                      "selfLink": {
+                                        "type": "string"
+                                      },
+                                      "uid": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "spec": {
+                                    "properties": {
+                                      "accessModes": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "dataSource": {
+                                        "properties": {
+                                          "apiGroup": {
+                                            "type": "string"
+                                          },
+                                          "kind": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "dataSourceRef": {
+                                        "properties": {
+                                          "apiGroup": {
+                                            "type": "string"
+                                          },
+                                          "kind": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "namespace": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "resources": {
+                                        "properties": {
+                                          "limits": {
+                                            "additionalProperties": {
+                                              "anyOf": [
+                                                {
+                                                  "type": "integer"
+                                                },
+                                                {
+                                                  "type": "string"
+                                                }
+                                              ],
+                                              "x-kubernetes-int-or-string": true
+                                            },
+                                            "type": "object"
+                                          },
+                                          "requests": {
+                                            "additionalProperties": {
+                                              "anyOf": [
+                                                {
+                                                  "type": "integer"
+                                                },
+                                                {
+                                                  "type": "string"
+                                                }
+                                              ],
+                                              "x-kubernetes-int-or-string": true
+                                            },
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "selector": {
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "matchLabels": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "storageClassName": {
+                                        "type": "string"
+                                      },
+                                      "volumeAttributesClassName": {
+                                        "type": "string"
+                                      },
+                                      "volumeMode": {
+                                        "type": "string"
+                                      },
+                                      "volumeName": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "fc": {
+                            "properties": {
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "lun": {
+                                "type": "integer"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "targetWWNs": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "wwids": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "flexVolume": {
+                            "properties": {
+                              "driver": {
+                                "type": "string"
+                              },
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "options": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "type": "object"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "secretRef": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "flocker": {
+                            "properties": {
+                              "datasetName": {
+                                "type": "string"
+                              },
+                              "datasetUUID": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "gcePersistentDisk": {
+                            "properties": {
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "partition": {
+                                "type": "integer"
+                              },
+                              "pdName": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "gitRepo": {
+                            "properties": {
+                              "directory": {
+                                "type": "string"
+                              },
+                              "repository": {
+                                "type": "string"
+                              },
+                              "revision": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "glusterfs": {
+                            "properties": {
+                              "endpoints": {
+                                "type": "string"
+                              },
+                              "path": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "hostPath": {
+                            "properties": {
+                              "path": {
+                                "type": "string"
+                              },
+                              "type": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "image": {
+                            "properties": {
+                              "pullPolicy": {
+                                "type": "string"
+                              },
+                              "reference": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "iscsi": {
+                            "properties": {
+                              "chapAuthDiscovery": {
+                                "type": "boolean"
+                              },
+                              "chapAuthSession": {
+                                "type": "boolean"
+                              },
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "initiatorName": {
+                                "type": "string"
+                              },
+                              "iqn": {
+                                "type": "string"
+                              },
+                              "iscsiInterface": {
+                                "type": "string"
+                              },
+                              "lun": {
+                                "type": "integer"
+                              },
+                              "portals": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "secretRef": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "targetPortal": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "nfs": {
+                            "properties": {
+                              "path": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "server": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "persistentVolumeClaim": {
+                            "properties": {
+                              "claimName": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "photonPersistentDisk": {
+                            "properties": {
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "pdID": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "portworxVolume": {
+                            "properties": {
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "volumeID": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "projected": {
+                            "properties": {
+                              "defaultMode": {
+                                "type": "integer"
+                              },
+                              "sources": {
+                                "items": {
+                                  "properties": {
+                                    "clusterTrustBundle": {
+                                      "properties": {
+                                        "labelSelector": {
+                                          "properties": {
+                                            "matchExpressions": {
+                                              "items": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "operator": {
+                                                    "type": "string"
+                                                  },
+                                                  "values": {
+                                                    "items": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "array"
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              "type": "array"
+                                            },
+                                            "matchLabels": {
+                                              "additionalProperties": {
+                                                "type": "string"
+                                              },
+                                              "type": "object"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        },
+                                        "path": {
+                                          "type": "string"
+                                        },
+                                        "signerName": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "configMap": {
+                                      "properties": {
+                                        "items": {
+                                          "items": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "mode": {
+                                                "type": "integer"
+                                              },
+                                              "path": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          "type": "array"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "downwardAPI": {
+                                      "properties": {
+                                        "items": {
+                                          "items": {
+                                            "properties": {
+                                              "fieldRef": {
+                                                "properties": {
+                                                  "apiVersion": {
+                                                    "type": "string"
+                                                  },
+                                                  "fieldPath": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              "mode": {
+                                                "type": "integer"
+                                              },
+                                              "path": {
+                                                "type": "string"
+                                              },
+                                              "resourceFieldRef": {
+                                                "properties": {
+                                                  "containerName": {
+                                                    "type": "string"
+                                                  },
+                                                  "divisor": {
+                                                    "anyOf": [
+                                                      {
+                                                        "type": "integer"
+                                                      },
+                                                      {
+                                                        "type": "string"
+                                                      }
+                                                    ],
+                                                    "x-kubernetes-int-or-string": true
+                                                  },
+                                                  "resource": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object"
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "secret": {
+                                      "properties": {
+                                        "items": {
+                                          "items": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "mode": {
+                                                "type": "integer"
+                                              },
+                                              "path": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          "type": "array"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "serviceAccountToken": {
+                                      "properties": {
+                                        "audience": {
+                                          "type": "string"
+                                        },
+                                        "expirationSeconds": {
+                                          "type": "integer"
+                                        },
+                                        "path": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "quobyte": {
+                            "properties": {
+                              "group": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "registry": {
+                                "type": "string"
+                              },
+                              "tenant": {
+                                "type": "string"
+                              },
+                              "user": {
+                                "type": "string"
+                              },
+                              "volume": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "rbd": {
+                            "properties": {
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "image": {
+                                "type": "string"
+                              },
+                              "keyring": {
+                                "type": "string"
+                              },
+                              "monitors": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "pool": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "secretRef": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "user": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "scaleIO": {
+                            "properties": {
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "gateway": {
+                                "type": "string"
+                              },
+                              "protectionDomain": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "secretRef": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "sslEnabled": {
+                                "type": "boolean"
+                              },
+                              "storageMode": {
+                                "type": "string"
+                              },
+                              "storagePool": {
+                                "type": "string"
+                              },
+                              "system": {
+                                "type": "string"
+                              },
+                              "volumeName": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "secret": {
+                            "properties": {
+                              "defaultMode": {
+                                "type": "integer"
+                              },
+                              "items": {
+                                "items": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "mode": {
+                                      "type": "integer"
+                                    },
+                                    "path": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "optional": {
+                                "type": "boolean"
+                              },
+                              "secretName": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "storageos": {
+                            "properties": {
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "secretRef": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "volumeName": {
+                                "type": "string"
+                              },
+                              "volumeNamespace": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "vsphereVolume": {
+                            "properties": {
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "storagePolicyID": {
+                                "type": "string"
+                              },
+                              "storagePolicyName": {
+                                "type": "string"
+                              },
+                              "volumePath": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "type": "object"
+        },
+        "files": {
+          "type": "string"
+        },
+        "jars": {
+          "type": "string"
+        },
+        "mainClass": {
+          "type": "string"
+        },
+        "proxyUser": {
+          "type": "string"
+        },
+        "pyFiles": {
+          "type": "string"
+        },
+        "runtimeVersions": {
+          "properties": {
+            "jdkVersion": {
+              "type": "string"
+            },
+            "scalaVersion": {
+              "type": "string"
+            },
+            "sparkVersion": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "sparkVersion"
+          ],
+          "type": "object"
+        },
+        "sparkConf": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "sparkRFiles": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "runtimeVersions"
+      ],
+      "type": "object"
+    },
+    "status": {
+      "properties": {
+        "currentAttemptSummary": {
+          "properties": {
+            "attemptInfo": {
+              "properties": {
+                "id": {
+                  "type": "integer"
+                }
+              },
+              "type": "object"
+            },
+            "stateTransitionHistory": {
+              "additionalProperties": {
+                "properties": {
+                  "currentStateSummary": {
+                    "enum": [
+                      "DriverEvicted",
+                      "DriverReady",
+                      "DriverReadyTimedOut",
+                      "DriverRequested",
+                      "DriverStartTimedOut",
+                      "DriverStarted",
+                      "ExecutorsStartTimedOut",
+                      "Failed",
+                      "InitializedBelowThresholdExecutors",
+                      "ResourceReleased",
+                      "RunningHealthy",
+                      "RunningWithBelowThresholdExecutors",
+                      "ScheduledToRestart",
+                      "SchedulingFailure",
+                      "Submitted",
+                      "Succeeded",
+                      "TerminatedWithoutReleaseResources"
+                    ],
+                    "type": "string"
+                  },
+                  "lastObservedDriverStatus": {
+                    "properties": {
+                      "conditions": {
+                        "items": {
+                          "properties": {
+                            "lastProbeTime": {
+                              "type": "string"
+                            },
+                            "lastTransitionTime": {
+                              "type": "string"
+                            },
+                            "message": {
+                              "type": "string"
+                            },
+                            "observedGeneration": {
+                              "type": "integer"
+                            },
+                            "reason": {
+                              "type": "string"
+                            },
+                            "status": {
+                              "type": "string"
+                            },
+                            "type": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "type": "array"
+                      },
+                      "containerStatuses": {
+                        "items": {
+                          "properties": {
+                            "allocatedResources": {
+                              "additionalProperties": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "type": "object"
+                            },
+                            "allocatedResourcesStatus": {
+                              "items": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "resources": {
+                                    "items": {
+                                      "properties": {
+                                        "health": {
+                                          "type": "string"
+                                        },
+                                        "resourceID": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "containerID": {
+                              "type": "string"
+                            },
+                            "image": {
+                              "type": "string"
+                            },
+                            "imageID": {
+                              "type": "string"
+                            },
+                            "lastState": {
+                              "properties": {
+                                "running": {
+                                  "properties": {
+                                    "startedAt": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "terminated": {
+                                  "properties": {
+                                    "containerID": {
+                                      "type": "string"
+                                    },
+                                    "exitCode": {
+                                      "type": "integer"
+                                    },
+                                    "finishedAt": {
+                                      "type": "string"
+                                    },
+                                    "message": {
+                                      "type": "string"
+                                    },
+                                    "reason": {
+                                      "type": "string"
+                                    },
+                                    "signal": {
+                                      "type": "integer"
+                                    },
+                                    "startedAt": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "waiting": {
+                                  "properties": {
+                                    "message": {
+                                      "type": "string"
+                                    },
+                                    "reason": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "ready": {
+                              "type": "boolean"
+                            },
+                            "resources": {
+                              "properties": {
+                                "claims": {
+                                  "items": {
+                                    "properties": {
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "request": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "type": "array"
+                                },
+                                "limits": {
+                                  "additionalProperties": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "type": "object"
+                                },
+                                "requests": {
+                                  "additionalProperties": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "restartCount": {
+                              "type": "integer"
+                            },
+                            "started": {
+                              "type": "boolean"
+                            },
+                            "state": {
+                              "properties": {
+                                "running": {
+                                  "properties": {
+                                    "startedAt": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "terminated": {
+                                  "properties": {
+                                    "containerID": {
+                                      "type": "string"
+                                    },
+                                    "exitCode": {
+                                      "type": "integer"
+                                    },
+                                    "finishedAt": {
+                                      "type": "string"
+                                    },
+                                    "message": {
+                                      "type": "string"
+                                    },
+                                    "reason": {
+                                      "type": "string"
+                                    },
+                                    "signal": {
+                                      "type": "integer"
+                                    },
+                                    "startedAt": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "waiting": {
+                                  "properties": {
+                                    "message": {
+                                      "type": "string"
+                                    },
+                                    "reason": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "stopSignal": {
+                              "type": "string"
+                            },
+                            "user": {
+                              "properties": {
+                                "linux": {
+                                  "properties": {
+                                    "gid": {
+                                      "type": "integer"
+                                    },
+                                    "supplementalGroups": {
+                                      "items": {
+                                        "type": "integer"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "uid": {
+                                      "type": "integer"
+                                    }
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "volumeMounts": {
+                              "items": {
+                                "properties": {
+                                  "mountPath": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  },
+                                  "recursiveReadOnly": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "type": "array"
+                      },
+                      "ephemeralContainerStatuses": {
+                        "items": {
+                          "properties": {
+                            "allocatedResources": {
+                              "additionalProperties": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "type": "object"
+                            },
+                            "allocatedResourcesStatus": {
+                              "items": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "resources": {
+                                    "items": {
+                                      "properties": {
+                                        "health": {
+                                          "type": "string"
+                                        },
+                                        "resourceID": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "containerID": {
+                              "type": "string"
+                            },
+                            "image": {
+                              "type": "string"
+                            },
+                            "imageID": {
+                              "type": "string"
+                            },
+                            "lastState": {
+                              "properties": {
+                                "running": {
+                                  "properties": {
+                                    "startedAt": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "terminated": {
+                                  "properties": {
+                                    "containerID": {
+                                      "type": "string"
+                                    },
+                                    "exitCode": {
+                                      "type": "integer"
+                                    },
+                                    "finishedAt": {
+                                      "type": "string"
+                                    },
+                                    "message": {
+                                      "type": "string"
+                                    },
+                                    "reason": {
+                                      "type": "string"
+                                    },
+                                    "signal": {
+                                      "type": "integer"
+                                    },
+                                    "startedAt": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "waiting": {
+                                  "properties": {
+                                    "message": {
+                                      "type": "string"
+                                    },
+                                    "reason": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "ready": {
+                              "type": "boolean"
+                            },
+                            "resources": {
+                              "properties": {
+                                "claims": {
+                                  "items": {
+                                    "properties": {
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "request": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "type": "array"
+                                },
+                                "limits": {
+                                  "additionalProperties": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "type": "object"
+                                },
+                                "requests": {
+                                  "additionalProperties": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "restartCount": {
+                              "type": "integer"
+                            },
+                            "started": {
+                              "type": "boolean"
+                            },
+                            "state": {
+                              "properties": {
+                                "running": {
+                                  "properties": {
+                                    "startedAt": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "terminated": {
+                                  "properties": {
+                                    "containerID": {
+                                      "type": "string"
+                                    },
+                                    "exitCode": {
+                                      "type": "integer"
+                                    },
+                                    "finishedAt": {
+                                      "type": "string"
+                                    },
+                                    "message": {
+                                      "type": "string"
+                                    },
+                                    "reason": {
+                                      "type": "string"
+                                    },
+                                    "signal": {
+                                      "type": "integer"
+                                    },
+                                    "startedAt": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "waiting": {
+                                  "properties": {
+                                    "message": {
+                                      "type": "string"
+                                    },
+                                    "reason": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "stopSignal": {
+                              "type": "string"
+                            },
+                            "user": {
+                              "properties": {
+                                "linux": {
+                                  "properties": {
+                                    "gid": {
+                                      "type": "integer"
+                                    },
+                                    "supplementalGroups": {
+                                      "items": {
+                                        "type": "integer"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "uid": {
+                                      "type": "integer"
+                                    }
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "volumeMounts": {
+                              "items": {
+                                "properties": {
+                                  "mountPath": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  },
+                                  "recursiveReadOnly": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "type": "array"
+                      },
+                      "hostIP": {
+                        "type": "string"
+                      },
+                      "hostIPs": {
+                        "items": {
+                          "properties": {
+                            "ip": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "type": "array"
+                      },
+                      "initContainerStatuses": {
+                        "items": {
+                          "properties": {
+                            "allocatedResources": {
+                              "additionalProperties": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "type": "object"
+                            },
+                            "allocatedResourcesStatus": {
+                              "items": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "resources": {
+                                    "items": {
+                                      "properties": {
+                                        "health": {
+                                          "type": "string"
+                                        },
+                                        "resourceID": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "containerID": {
+                              "type": "string"
+                            },
+                            "image": {
+                              "type": "string"
+                            },
+                            "imageID": {
+                              "type": "string"
+                            },
+                            "lastState": {
+                              "properties": {
+                                "running": {
+                                  "properties": {
+                                    "startedAt": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "terminated": {
+                                  "properties": {
+                                    "containerID": {
+                                      "type": "string"
+                                    },
+                                    "exitCode": {
+                                      "type": "integer"
+                                    },
+                                    "finishedAt": {
+                                      "type": "string"
+                                    },
+                                    "message": {
+                                      "type": "string"
+                                    },
+                                    "reason": {
+                                      "type": "string"
+                                    },
+                                    "signal": {
+                                      "type": "integer"
+                                    },
+                                    "startedAt": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "waiting": {
+                                  "properties": {
+                                    "message": {
+                                      "type": "string"
+                                    },
+                                    "reason": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "ready": {
+                              "type": "boolean"
+                            },
+                            "resources": {
+                              "properties": {
+                                "claims": {
+                                  "items": {
+                                    "properties": {
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "request": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "type": "array"
+                                },
+                                "limits": {
+                                  "additionalProperties": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "type": "object"
+                                },
+                                "requests": {
+                                  "additionalProperties": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "restartCount": {
+                              "type": "integer"
+                            },
+                            "started": {
+                              "type": "boolean"
+                            },
+                            "state": {
+                              "properties": {
+                                "running": {
+                                  "properties": {
+                                    "startedAt": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "terminated": {
+                                  "properties": {
+                                    "containerID": {
+                                      "type": "string"
+                                    },
+                                    "exitCode": {
+                                      "type": "integer"
+                                    },
+                                    "finishedAt": {
+                                      "type": "string"
+                                    },
+                                    "message": {
+                                      "type": "string"
+                                    },
+                                    "reason": {
+                                      "type": "string"
+                                    },
+                                    "signal": {
+                                      "type": "integer"
+                                    },
+                                    "startedAt": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "waiting": {
+                                  "properties": {
+                                    "message": {
+                                      "type": "string"
+                                    },
+                                    "reason": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "stopSignal": {
+                              "type": "string"
+                            },
+                            "user": {
+                              "properties": {
+                                "linux": {
+                                  "properties": {
+                                    "gid": {
+                                      "type": "integer"
+                                    },
+                                    "supplementalGroups": {
+                                      "items": {
+                                        "type": "integer"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "uid": {
+                                      "type": "integer"
+                                    }
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "volumeMounts": {
+                              "items": {
+                                "properties": {
+                                  "mountPath": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  },
+                                  "recursiveReadOnly": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "type": "array"
+                      },
+                      "message": {
+                        "type": "string"
+                      },
+                      "nominatedNodeName": {
+                        "type": "string"
+                      },
+                      "observedGeneration": {
+                        "type": "integer"
+                      },
+                      "phase": {
+                        "type": "string"
+                      },
+                      "podIP": {
+                        "type": "string"
+                      },
+                      "podIPs": {
+                        "items": {
+                          "properties": {
+                            "ip": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "type": "array"
+                      },
+                      "qosClass": {
+                        "type": "string"
+                      },
+                      "reason": {
+                        "type": "string"
+                      },
+                      "resize": {
+                        "type": "string"
+                      },
+                      "resourceClaimStatuses": {
+                        "items": {
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            },
+                            "resourceClaimName": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "type": "array"
+                      },
+                      "startTime": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "lastTransitionTime": {
+                    "type": "string"
+                  },
+                  "message": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "type": "object"
+            }
+          },
+          "type": "object"
+        },
+        "currentState": {
+          "properties": {
+            "currentStateSummary": {
+              "enum": [
+                "DriverEvicted",
+                "DriverReady",
+                "DriverReadyTimedOut",
+                "DriverRequested",
+                "DriverStartTimedOut",
+                "DriverStarted",
+                "ExecutorsStartTimedOut",
+                "Failed",
+                "InitializedBelowThresholdExecutors",
+                "ResourceReleased",
+                "RunningHealthy",
+                "RunningWithBelowThresholdExecutors",
+                "ScheduledToRestart",
+                "SchedulingFailure",
+                "Submitted",
+                "Succeeded",
+                "TerminatedWithoutReleaseResources"
+              ],
+              "type": "string"
+            },
+            "lastObservedDriverStatus": {
+              "properties": {
+                "conditions": {
+                  "items": {
+                    "properties": {
+                      "lastProbeTime": {
+                        "type": "string"
+                      },
+                      "lastTransitionTime": {
+                        "type": "string"
+                      },
+                      "message": {
+                        "type": "string"
+                      },
+                      "observedGeneration": {
+                        "type": "integer"
+                      },
+                      "reason": {
+                        "type": "string"
+                      },
+                      "status": {
+                        "type": "string"
+                      },
+                      "type": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "containerStatuses": {
+                  "items": {
+                    "properties": {
+                      "allocatedResources": {
+                        "additionalProperties": {
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "string"
+                            }
+                          ],
+                          "x-kubernetes-int-or-string": true
+                        },
+                        "type": "object"
+                      },
+                      "allocatedResourcesStatus": {
+                        "items": {
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            },
+                            "resources": {
+                              "items": {
+                                "properties": {
+                                  "health": {
+                                    "type": "string"
+                                  },
+                                  "resourceID": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "type": "array"
+                      },
+                      "containerID": {
+                        "type": "string"
+                      },
+                      "image": {
+                        "type": "string"
+                      },
+                      "imageID": {
+                        "type": "string"
+                      },
+                      "lastState": {
+                        "properties": {
+                          "running": {
+                            "properties": {
+                              "startedAt": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "terminated": {
+                            "properties": {
+                              "containerID": {
+                                "type": "string"
+                              },
+                              "exitCode": {
+                                "type": "integer"
+                              },
+                              "finishedAt": {
+                                "type": "string"
+                              },
+                              "message": {
+                                "type": "string"
+                              },
+                              "reason": {
+                                "type": "string"
+                              },
+                              "signal": {
+                                "type": "integer"
+                              },
+                              "startedAt": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "waiting": {
+                            "properties": {
+                              "message": {
+                                "type": "string"
+                              },
+                              "reason": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "ready": {
+                        "type": "boolean"
+                      },
+                      "resources": {
+                        "properties": {
+                          "claims": {
+                            "items": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "request": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "limits": {
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "type": "object"
+                          },
+                          "requests": {
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "type": "object"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "restartCount": {
+                        "type": "integer"
+                      },
+                      "started": {
+                        "type": "boolean"
+                      },
+                      "state": {
+                        "properties": {
+                          "running": {
+                            "properties": {
+                              "startedAt": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "terminated": {
+                            "properties": {
+                              "containerID": {
+                                "type": "string"
+                              },
+                              "exitCode": {
+                                "type": "integer"
+                              },
+                              "finishedAt": {
+                                "type": "string"
+                              },
+                              "message": {
+                                "type": "string"
+                              },
+                              "reason": {
+                                "type": "string"
+                              },
+                              "signal": {
+                                "type": "integer"
+                              },
+                              "startedAt": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "waiting": {
+                            "properties": {
+                              "message": {
+                                "type": "string"
+                              },
+                              "reason": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "stopSignal": {
+                        "type": "string"
+                      },
+                      "user": {
+                        "properties": {
+                          "linux": {
+                            "properties": {
+                              "gid": {
+                                "type": "integer"
+                              },
+                              "supplementalGroups": {
+                                "items": {
+                                  "type": "integer"
+                                },
+                                "type": "array"
+                              },
+                              "uid": {
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "volumeMounts": {
+                        "items": {
+                          "properties": {
+                            "mountPath": {
+                              "type": "string"
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "readOnly": {
+                              "type": "boolean"
+                            },
+                            "recursiveReadOnly": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "ephemeralContainerStatuses": {
+                  "items": {
+                    "properties": {
+                      "allocatedResources": {
+                        "additionalProperties": {
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "string"
+                            }
+                          ],
+                          "x-kubernetes-int-or-string": true
+                        },
+                        "type": "object"
+                      },
+                      "allocatedResourcesStatus": {
+                        "items": {
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            },
+                            "resources": {
+                              "items": {
+                                "properties": {
+                                  "health": {
+                                    "type": "string"
+                                  },
+                                  "resourceID": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "type": "array"
+                      },
+                      "containerID": {
+                        "type": "string"
+                      },
+                      "image": {
+                        "type": "string"
+                      },
+                      "imageID": {
+                        "type": "string"
+                      },
+                      "lastState": {
+                        "properties": {
+                          "running": {
+                            "properties": {
+                              "startedAt": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "terminated": {
+                            "properties": {
+                              "containerID": {
+                                "type": "string"
+                              },
+                              "exitCode": {
+                                "type": "integer"
+                              },
+                              "finishedAt": {
+                                "type": "string"
+                              },
+                              "message": {
+                                "type": "string"
+                              },
+                              "reason": {
+                                "type": "string"
+                              },
+                              "signal": {
+                                "type": "integer"
+                              },
+                              "startedAt": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "waiting": {
+                            "properties": {
+                              "message": {
+                                "type": "string"
+                              },
+                              "reason": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "ready": {
+                        "type": "boolean"
+                      },
+                      "resources": {
+                        "properties": {
+                          "claims": {
+                            "items": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "request": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "limits": {
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "type": "object"
+                          },
+                          "requests": {
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "type": "object"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "restartCount": {
+                        "type": "integer"
+                      },
+                      "started": {
+                        "type": "boolean"
+                      },
+                      "state": {
+                        "properties": {
+                          "running": {
+                            "properties": {
+                              "startedAt": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "terminated": {
+                            "properties": {
+                              "containerID": {
+                                "type": "string"
+                              },
+                              "exitCode": {
+                                "type": "integer"
+                              },
+                              "finishedAt": {
+                                "type": "string"
+                              },
+                              "message": {
+                                "type": "string"
+                              },
+                              "reason": {
+                                "type": "string"
+                              },
+                              "signal": {
+                                "type": "integer"
+                              },
+                              "startedAt": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "waiting": {
+                            "properties": {
+                              "message": {
+                                "type": "string"
+                              },
+                              "reason": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "stopSignal": {
+                        "type": "string"
+                      },
+                      "user": {
+                        "properties": {
+                          "linux": {
+                            "properties": {
+                              "gid": {
+                                "type": "integer"
+                              },
+                              "supplementalGroups": {
+                                "items": {
+                                  "type": "integer"
+                                },
+                                "type": "array"
+                              },
+                              "uid": {
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "volumeMounts": {
+                        "items": {
+                          "properties": {
+                            "mountPath": {
+                              "type": "string"
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "readOnly": {
+                              "type": "boolean"
+                            },
+                            "recursiveReadOnly": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "hostIP": {
+                  "type": "string"
+                },
+                "hostIPs": {
+                  "items": {
+                    "properties": {
+                      "ip": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "initContainerStatuses": {
+                  "items": {
+                    "properties": {
+                      "allocatedResources": {
+                        "additionalProperties": {
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "string"
+                            }
+                          ],
+                          "x-kubernetes-int-or-string": true
+                        },
+                        "type": "object"
+                      },
+                      "allocatedResourcesStatus": {
+                        "items": {
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            },
+                            "resources": {
+                              "items": {
+                                "properties": {
+                                  "health": {
+                                    "type": "string"
+                                  },
+                                  "resourceID": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "type": "array"
+                      },
+                      "containerID": {
+                        "type": "string"
+                      },
+                      "image": {
+                        "type": "string"
+                      },
+                      "imageID": {
+                        "type": "string"
+                      },
+                      "lastState": {
+                        "properties": {
+                          "running": {
+                            "properties": {
+                              "startedAt": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "terminated": {
+                            "properties": {
+                              "containerID": {
+                                "type": "string"
+                              },
+                              "exitCode": {
+                                "type": "integer"
+                              },
+                              "finishedAt": {
+                                "type": "string"
+                              },
+                              "message": {
+                                "type": "string"
+                              },
+                              "reason": {
+                                "type": "string"
+                              },
+                              "signal": {
+                                "type": "integer"
+                              },
+                              "startedAt": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "waiting": {
+                            "properties": {
+                              "message": {
+                                "type": "string"
+                              },
+                              "reason": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "ready": {
+                        "type": "boolean"
+                      },
+                      "resources": {
+                        "properties": {
+                          "claims": {
+                            "items": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "request": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "limits": {
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "type": "object"
+                          },
+                          "requests": {
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "type": "object"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "restartCount": {
+                        "type": "integer"
+                      },
+                      "started": {
+                        "type": "boolean"
+                      },
+                      "state": {
+                        "properties": {
+                          "running": {
+                            "properties": {
+                              "startedAt": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "terminated": {
+                            "properties": {
+                              "containerID": {
+                                "type": "string"
+                              },
+                              "exitCode": {
+                                "type": "integer"
+                              },
+                              "finishedAt": {
+                                "type": "string"
+                              },
+                              "message": {
+                                "type": "string"
+                              },
+                              "reason": {
+                                "type": "string"
+                              },
+                              "signal": {
+                                "type": "integer"
+                              },
+                              "startedAt": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "waiting": {
+                            "properties": {
+                              "message": {
+                                "type": "string"
+                              },
+                              "reason": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "stopSignal": {
+                        "type": "string"
+                      },
+                      "user": {
+                        "properties": {
+                          "linux": {
+                            "properties": {
+                              "gid": {
+                                "type": "integer"
+                              },
+                              "supplementalGroups": {
+                                "items": {
+                                  "type": "integer"
+                                },
+                                "type": "array"
+                              },
+                              "uid": {
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "volumeMounts": {
+                        "items": {
+                          "properties": {
+                            "mountPath": {
+                              "type": "string"
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "readOnly": {
+                              "type": "boolean"
+                            },
+                            "recursiveReadOnly": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "message": {
+                  "type": "string"
+                },
+                "nominatedNodeName": {
+                  "type": "string"
+                },
+                "observedGeneration": {
+                  "type": "integer"
+                },
+                "phase": {
+                  "type": "string"
+                },
+                "podIP": {
+                  "type": "string"
+                },
+                "podIPs": {
+                  "items": {
+                    "properties": {
+                      "ip": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "qosClass": {
+                  "type": "string"
+                },
+                "reason": {
+                  "type": "string"
+                },
+                "resize": {
+                  "type": "string"
+                },
+                "resourceClaimStatuses": {
+                  "items": {
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      },
+                      "resourceClaimName": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "startTime": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "lastTransitionTime": {
+              "type": "string"
+            },
+            "message": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "previousAttemptSummary": {
+          "properties": {
+            "attemptInfo": {
+              "properties": {
+                "id": {
+                  "type": "integer"
+                }
+              },
+              "type": "object"
+            },
+            "stateTransitionHistory": {
+              "additionalProperties": {
+                "properties": {
+                  "currentStateSummary": {
+                    "enum": [
+                      "DriverEvicted",
+                      "DriverReady",
+                      "DriverReadyTimedOut",
+                      "DriverRequested",
+                      "DriverStartTimedOut",
+                      "DriverStarted",
+                      "ExecutorsStartTimedOut",
+                      "Failed",
+                      "InitializedBelowThresholdExecutors",
+                      "ResourceReleased",
+                      "RunningHealthy",
+                      "RunningWithBelowThresholdExecutors",
+                      "ScheduledToRestart",
+                      "SchedulingFailure",
+                      "Submitted",
+                      "Succeeded",
+                      "TerminatedWithoutReleaseResources"
+                    ],
+                    "type": "string"
+                  },
+                  "lastObservedDriverStatus": {
+                    "properties": {
+                      "conditions": {
+                        "items": {
+                          "properties": {
+                            "lastProbeTime": {
+                              "type": "string"
+                            },
+                            "lastTransitionTime": {
+                              "type": "string"
+                            },
+                            "message": {
+                              "type": "string"
+                            },
+                            "observedGeneration": {
+                              "type": "integer"
+                            },
+                            "reason": {
+                              "type": "string"
+                            },
+                            "status": {
+                              "type": "string"
+                            },
+                            "type": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "type": "array"
+                      },
+                      "containerStatuses": {
+                        "items": {
+                          "properties": {
+                            "allocatedResources": {
+                              "additionalProperties": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "type": "object"
+                            },
+                            "allocatedResourcesStatus": {
+                              "items": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "resources": {
+                                    "items": {
+                                      "properties": {
+                                        "health": {
+                                          "type": "string"
+                                        },
+                                        "resourceID": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "containerID": {
+                              "type": "string"
+                            },
+                            "image": {
+                              "type": "string"
+                            },
+                            "imageID": {
+                              "type": "string"
+                            },
+                            "lastState": {
+                              "properties": {
+                                "running": {
+                                  "properties": {
+                                    "startedAt": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "terminated": {
+                                  "properties": {
+                                    "containerID": {
+                                      "type": "string"
+                                    },
+                                    "exitCode": {
+                                      "type": "integer"
+                                    },
+                                    "finishedAt": {
+                                      "type": "string"
+                                    },
+                                    "message": {
+                                      "type": "string"
+                                    },
+                                    "reason": {
+                                      "type": "string"
+                                    },
+                                    "signal": {
+                                      "type": "integer"
+                                    },
+                                    "startedAt": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "waiting": {
+                                  "properties": {
+                                    "message": {
+                                      "type": "string"
+                                    },
+                                    "reason": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "ready": {
+                              "type": "boolean"
+                            },
+                            "resources": {
+                              "properties": {
+                                "claims": {
+                                  "items": {
+                                    "properties": {
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "request": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "type": "array"
+                                },
+                                "limits": {
+                                  "additionalProperties": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "type": "object"
+                                },
+                                "requests": {
+                                  "additionalProperties": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "restartCount": {
+                              "type": "integer"
+                            },
+                            "started": {
+                              "type": "boolean"
+                            },
+                            "state": {
+                              "properties": {
+                                "running": {
+                                  "properties": {
+                                    "startedAt": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "terminated": {
+                                  "properties": {
+                                    "containerID": {
+                                      "type": "string"
+                                    },
+                                    "exitCode": {
+                                      "type": "integer"
+                                    },
+                                    "finishedAt": {
+                                      "type": "string"
+                                    },
+                                    "message": {
+                                      "type": "string"
+                                    },
+                                    "reason": {
+                                      "type": "string"
+                                    },
+                                    "signal": {
+                                      "type": "integer"
+                                    },
+                                    "startedAt": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "waiting": {
+                                  "properties": {
+                                    "message": {
+                                      "type": "string"
+                                    },
+                                    "reason": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "stopSignal": {
+                              "type": "string"
+                            },
+                            "user": {
+                              "properties": {
+                                "linux": {
+                                  "properties": {
+                                    "gid": {
+                                      "type": "integer"
+                                    },
+                                    "supplementalGroups": {
+                                      "items": {
+                                        "type": "integer"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "uid": {
+                                      "type": "integer"
+                                    }
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "volumeMounts": {
+                              "items": {
+                                "properties": {
+                                  "mountPath": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  },
+                                  "recursiveReadOnly": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "type": "array"
+                      },
+                      "ephemeralContainerStatuses": {
+                        "items": {
+                          "properties": {
+                            "allocatedResources": {
+                              "additionalProperties": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "type": "object"
+                            },
+                            "allocatedResourcesStatus": {
+                              "items": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "resources": {
+                                    "items": {
+                                      "properties": {
+                                        "health": {
+                                          "type": "string"
+                                        },
+                                        "resourceID": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "containerID": {
+                              "type": "string"
+                            },
+                            "image": {
+                              "type": "string"
+                            },
+                            "imageID": {
+                              "type": "string"
+                            },
+                            "lastState": {
+                              "properties": {
+                                "running": {
+                                  "properties": {
+                                    "startedAt": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "terminated": {
+                                  "properties": {
+                                    "containerID": {
+                                      "type": "string"
+                                    },
+                                    "exitCode": {
+                                      "type": "integer"
+                                    },
+                                    "finishedAt": {
+                                      "type": "string"
+                                    },
+                                    "message": {
+                                      "type": "string"
+                                    },
+                                    "reason": {
+                                      "type": "string"
+                                    },
+                                    "signal": {
+                                      "type": "integer"
+                                    },
+                                    "startedAt": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "waiting": {
+                                  "properties": {
+                                    "message": {
+                                      "type": "string"
+                                    },
+                                    "reason": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "ready": {
+                              "type": "boolean"
+                            },
+                            "resources": {
+                              "properties": {
+                                "claims": {
+                                  "items": {
+                                    "properties": {
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "request": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "type": "array"
+                                },
+                                "limits": {
+                                  "additionalProperties": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "type": "object"
+                                },
+                                "requests": {
+                                  "additionalProperties": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "restartCount": {
+                              "type": "integer"
+                            },
+                            "started": {
+                              "type": "boolean"
+                            },
+                            "state": {
+                              "properties": {
+                                "running": {
+                                  "properties": {
+                                    "startedAt": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "terminated": {
+                                  "properties": {
+                                    "containerID": {
+                                      "type": "string"
+                                    },
+                                    "exitCode": {
+                                      "type": "integer"
+                                    },
+                                    "finishedAt": {
+                                      "type": "string"
+                                    },
+                                    "message": {
+                                      "type": "string"
+                                    },
+                                    "reason": {
+                                      "type": "string"
+                                    },
+                                    "signal": {
+                                      "type": "integer"
+                                    },
+                                    "startedAt": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "waiting": {
+                                  "properties": {
+                                    "message": {
+                                      "type": "string"
+                                    },
+                                    "reason": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "stopSignal": {
+                              "type": "string"
+                            },
+                            "user": {
+                              "properties": {
+                                "linux": {
+                                  "properties": {
+                                    "gid": {
+                                      "type": "integer"
+                                    },
+                                    "supplementalGroups": {
+                                      "items": {
+                                        "type": "integer"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "uid": {
+                                      "type": "integer"
+                                    }
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "volumeMounts": {
+                              "items": {
+                                "properties": {
+                                  "mountPath": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  },
+                                  "recursiveReadOnly": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "type": "array"
+                      },
+                      "hostIP": {
+                        "type": "string"
+                      },
+                      "hostIPs": {
+                        "items": {
+                          "properties": {
+                            "ip": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "type": "array"
+                      },
+                      "initContainerStatuses": {
+                        "items": {
+                          "properties": {
+                            "allocatedResources": {
+                              "additionalProperties": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "type": "object"
+                            },
+                            "allocatedResourcesStatus": {
+                              "items": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "resources": {
+                                    "items": {
+                                      "properties": {
+                                        "health": {
+                                          "type": "string"
+                                        },
+                                        "resourceID": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "containerID": {
+                              "type": "string"
+                            },
+                            "image": {
+                              "type": "string"
+                            },
+                            "imageID": {
+                              "type": "string"
+                            },
+                            "lastState": {
+                              "properties": {
+                                "running": {
+                                  "properties": {
+                                    "startedAt": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "terminated": {
+                                  "properties": {
+                                    "containerID": {
+                                      "type": "string"
+                                    },
+                                    "exitCode": {
+                                      "type": "integer"
+                                    },
+                                    "finishedAt": {
+                                      "type": "string"
+                                    },
+                                    "message": {
+                                      "type": "string"
+                                    },
+                                    "reason": {
+                                      "type": "string"
+                                    },
+                                    "signal": {
+                                      "type": "integer"
+                                    },
+                                    "startedAt": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "waiting": {
+                                  "properties": {
+                                    "message": {
+                                      "type": "string"
+                                    },
+                                    "reason": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "ready": {
+                              "type": "boolean"
+                            },
+                            "resources": {
+                              "properties": {
+                                "claims": {
+                                  "items": {
+                                    "properties": {
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "request": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "type": "array"
+                                },
+                                "limits": {
+                                  "additionalProperties": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "type": "object"
+                                },
+                                "requests": {
+                                  "additionalProperties": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "restartCount": {
+                              "type": "integer"
+                            },
+                            "started": {
+                              "type": "boolean"
+                            },
+                            "state": {
+                              "properties": {
+                                "running": {
+                                  "properties": {
+                                    "startedAt": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "terminated": {
+                                  "properties": {
+                                    "containerID": {
+                                      "type": "string"
+                                    },
+                                    "exitCode": {
+                                      "type": "integer"
+                                    },
+                                    "finishedAt": {
+                                      "type": "string"
+                                    },
+                                    "message": {
+                                      "type": "string"
+                                    },
+                                    "reason": {
+                                      "type": "string"
+                                    },
+                                    "signal": {
+                                      "type": "integer"
+                                    },
+                                    "startedAt": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "waiting": {
+                                  "properties": {
+                                    "message": {
+                                      "type": "string"
+                                    },
+                                    "reason": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "stopSignal": {
+                              "type": "string"
+                            },
+                            "user": {
+                              "properties": {
+                                "linux": {
+                                  "properties": {
+                                    "gid": {
+                                      "type": "integer"
+                                    },
+                                    "supplementalGroups": {
+                                      "items": {
+                                        "type": "integer"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "uid": {
+                                      "type": "integer"
+                                    }
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "volumeMounts": {
+                              "items": {
+                                "properties": {
+                                  "mountPath": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  },
+                                  "recursiveReadOnly": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "type": "array"
+                      },
+                      "message": {
+                        "type": "string"
+                      },
+                      "nominatedNodeName": {
+                        "type": "string"
+                      },
+                      "observedGeneration": {
+                        "type": "integer"
+                      },
+                      "phase": {
+                        "type": "string"
+                      },
+                      "podIP": {
+                        "type": "string"
+                      },
+                      "podIPs": {
+                        "items": {
+                          "properties": {
+                            "ip": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "type": "array"
+                      },
+                      "qosClass": {
+                        "type": "string"
+                      },
+                      "reason": {
+                        "type": "string"
+                      },
+                      "resize": {
+                        "type": "string"
+                      },
+                      "resourceClaimStatuses": {
+                        "items": {
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            },
+                            "resourceClaimName": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "type": "array"
+                      },
+                      "startTime": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "lastTransitionTime": {
+                    "type": "string"
+                  },
+                  "message": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "type": "object"
+            }
+          },
+          "type": "object"
+        },
+        "stateTransitionHistory": {
+          "additionalProperties": {
+            "properties": {
+              "currentStateSummary": {
+                "enum": [
+                  "DriverEvicted",
+                  "DriverReady",
+                  "DriverReadyTimedOut",
+                  "DriverRequested",
+                  "DriverStartTimedOut",
+                  "DriverStarted",
+                  "ExecutorsStartTimedOut",
+                  "Failed",
+                  "InitializedBelowThresholdExecutors",
+                  "ResourceReleased",
+                  "RunningHealthy",
+                  "RunningWithBelowThresholdExecutors",
+                  "ScheduledToRestart",
+                  "SchedulingFailure",
+                  "Submitted",
+                  "Succeeded",
+                  "TerminatedWithoutReleaseResources"
+                ],
+                "type": "string"
+              },
+              "lastObservedDriverStatus": {
+                "properties": {
+                  "conditions": {
+                    "items": {
+                      "properties": {
+                        "lastProbeTime": {
+                          "type": "string"
+                        },
+                        "lastTransitionTime": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "observedGeneration": {
+                          "type": "integer"
+                        },
+                        "reason": {
+                          "type": "string"
+                        },
+                        "status": {
+                          "type": "string"
+                        },
+                        "type": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "containerStatuses": {
+                    "items": {
+                      "properties": {
+                        "allocatedResources": {
+                          "additionalProperties": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "x-kubernetes-int-or-string": true
+                          },
+                          "type": "object"
+                        },
+                        "allocatedResourcesStatus": {
+                          "items": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "resources": {
+                                "items": {
+                                  "properties": {
+                                    "health": {
+                                      "type": "string"
+                                    },
+                                    "resourceID": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "containerID": {
+                          "type": "string"
+                        },
+                        "image": {
+                          "type": "string"
+                        },
+                        "imageID": {
+                          "type": "string"
+                        },
+                        "lastState": {
+                          "properties": {
+                            "running": {
+                              "properties": {
+                                "startedAt": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "terminated": {
+                              "properties": {
+                                "containerID": {
+                                  "type": "string"
+                                },
+                                "exitCode": {
+                                  "type": "integer"
+                                },
+                                "finishedAt": {
+                                  "type": "string"
+                                },
+                                "message": {
+                                  "type": "string"
+                                },
+                                "reason": {
+                                  "type": "string"
+                                },
+                                "signal": {
+                                  "type": "integer"
+                                },
+                                "startedAt": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "waiting": {
+                              "properties": {
+                                "message": {
+                                  "type": "string"
+                                },
+                                "reason": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "ready": {
+                          "type": "boolean"
+                        },
+                        "resources": {
+                          "properties": {
+                            "claims": {
+                              "items": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "request": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "limits": {
+                              "additionalProperties": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "type": "object"
+                            },
+                            "requests": {
+                              "additionalProperties": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "type": "object"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "restartCount": {
+                          "type": "integer"
+                        },
+                        "started": {
+                          "type": "boolean"
+                        },
+                        "state": {
+                          "properties": {
+                            "running": {
+                              "properties": {
+                                "startedAt": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "terminated": {
+                              "properties": {
+                                "containerID": {
+                                  "type": "string"
+                                },
+                                "exitCode": {
+                                  "type": "integer"
+                                },
+                                "finishedAt": {
+                                  "type": "string"
+                                },
+                                "message": {
+                                  "type": "string"
+                                },
+                                "reason": {
+                                  "type": "string"
+                                },
+                                "signal": {
+                                  "type": "integer"
+                                },
+                                "startedAt": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "waiting": {
+                              "properties": {
+                                "message": {
+                                  "type": "string"
+                                },
+                                "reason": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "stopSignal": {
+                          "type": "string"
+                        },
+                        "user": {
+                          "properties": {
+                            "linux": {
+                              "properties": {
+                                "gid": {
+                                  "type": "integer"
+                                },
+                                "supplementalGroups": {
+                                  "items": {
+                                    "type": "integer"
+                                  },
+                                  "type": "array"
+                                },
+                                "uid": {
+                                  "type": "integer"
+                                }
+                              },
+                              "type": "object"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "volumeMounts": {
+                          "items": {
+                            "properties": {
+                              "mountPath": {
+                                "type": "string"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "recursiveReadOnly": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "ephemeralContainerStatuses": {
+                    "items": {
+                      "properties": {
+                        "allocatedResources": {
+                          "additionalProperties": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "x-kubernetes-int-or-string": true
+                          },
+                          "type": "object"
+                        },
+                        "allocatedResourcesStatus": {
+                          "items": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "resources": {
+                                "items": {
+                                  "properties": {
+                                    "health": {
+                                      "type": "string"
+                                    },
+                                    "resourceID": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "containerID": {
+                          "type": "string"
+                        },
+                        "image": {
+                          "type": "string"
+                        },
+                        "imageID": {
+                          "type": "string"
+                        },
+                        "lastState": {
+                          "properties": {
+                            "running": {
+                              "properties": {
+                                "startedAt": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "terminated": {
+                              "properties": {
+                                "containerID": {
+                                  "type": "string"
+                                },
+                                "exitCode": {
+                                  "type": "integer"
+                                },
+                                "finishedAt": {
+                                  "type": "string"
+                                },
+                                "message": {
+                                  "type": "string"
+                                },
+                                "reason": {
+                                  "type": "string"
+                                },
+                                "signal": {
+                                  "type": "integer"
+                                },
+                                "startedAt": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "waiting": {
+                              "properties": {
+                                "message": {
+                                  "type": "string"
+                                },
+                                "reason": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "ready": {
+                          "type": "boolean"
+                        },
+                        "resources": {
+                          "properties": {
+                            "claims": {
+                              "items": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "request": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "limits": {
+                              "additionalProperties": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "type": "object"
+                            },
+                            "requests": {
+                              "additionalProperties": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "type": "object"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "restartCount": {
+                          "type": "integer"
+                        },
+                        "started": {
+                          "type": "boolean"
+                        },
+                        "state": {
+                          "properties": {
+                            "running": {
+                              "properties": {
+                                "startedAt": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "terminated": {
+                              "properties": {
+                                "containerID": {
+                                  "type": "string"
+                                },
+                                "exitCode": {
+                                  "type": "integer"
+                                },
+                                "finishedAt": {
+                                  "type": "string"
+                                },
+                                "message": {
+                                  "type": "string"
+                                },
+                                "reason": {
+                                  "type": "string"
+                                },
+                                "signal": {
+                                  "type": "integer"
+                                },
+                                "startedAt": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "waiting": {
+                              "properties": {
+                                "message": {
+                                  "type": "string"
+                                },
+                                "reason": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "stopSignal": {
+                          "type": "string"
+                        },
+                        "user": {
+                          "properties": {
+                            "linux": {
+                              "properties": {
+                                "gid": {
+                                  "type": "integer"
+                                },
+                                "supplementalGroups": {
+                                  "items": {
+                                    "type": "integer"
+                                  },
+                                  "type": "array"
+                                },
+                                "uid": {
+                                  "type": "integer"
+                                }
+                              },
+                              "type": "object"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "volumeMounts": {
+                          "items": {
+                            "properties": {
+                              "mountPath": {
+                                "type": "string"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "recursiveReadOnly": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "hostIP": {
+                    "type": "string"
+                  },
+                  "hostIPs": {
+                    "items": {
+                      "properties": {
+                        "ip": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "initContainerStatuses": {
+                    "items": {
+                      "properties": {
+                        "allocatedResources": {
+                          "additionalProperties": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "x-kubernetes-int-or-string": true
+                          },
+                          "type": "object"
+                        },
+                        "allocatedResourcesStatus": {
+                          "items": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "resources": {
+                                "items": {
+                                  "properties": {
+                                    "health": {
+                                      "type": "string"
+                                    },
+                                    "resourceID": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "containerID": {
+                          "type": "string"
+                        },
+                        "image": {
+                          "type": "string"
+                        },
+                        "imageID": {
+                          "type": "string"
+                        },
+                        "lastState": {
+                          "properties": {
+                            "running": {
+                              "properties": {
+                                "startedAt": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "terminated": {
+                              "properties": {
+                                "containerID": {
+                                  "type": "string"
+                                },
+                                "exitCode": {
+                                  "type": "integer"
+                                },
+                                "finishedAt": {
+                                  "type": "string"
+                                },
+                                "message": {
+                                  "type": "string"
+                                },
+                                "reason": {
+                                  "type": "string"
+                                },
+                                "signal": {
+                                  "type": "integer"
+                                },
+                                "startedAt": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "waiting": {
+                              "properties": {
+                                "message": {
+                                  "type": "string"
+                                },
+                                "reason": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "ready": {
+                          "type": "boolean"
+                        },
+                        "resources": {
+                          "properties": {
+                            "claims": {
+                              "items": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "request": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "limits": {
+                              "additionalProperties": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "type": "object"
+                            },
+                            "requests": {
+                              "additionalProperties": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "type": "object"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "restartCount": {
+                          "type": "integer"
+                        },
+                        "started": {
+                          "type": "boolean"
+                        },
+                        "state": {
+                          "properties": {
+                            "running": {
+                              "properties": {
+                                "startedAt": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "terminated": {
+                              "properties": {
+                                "containerID": {
+                                  "type": "string"
+                                },
+                                "exitCode": {
+                                  "type": "integer"
+                                },
+                                "finishedAt": {
+                                  "type": "string"
+                                },
+                                "message": {
+                                  "type": "string"
+                                },
+                                "reason": {
+                                  "type": "string"
+                                },
+                                "signal": {
+                                  "type": "integer"
+                                },
+                                "startedAt": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "waiting": {
+                              "properties": {
+                                "message": {
+                                  "type": "string"
+                                },
+                                "reason": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "stopSignal": {
+                          "type": "string"
+                        },
+                        "user": {
+                          "properties": {
+                            "linux": {
+                              "properties": {
+                                "gid": {
+                                  "type": "integer"
+                                },
+                                "supplementalGroups": {
+                                  "items": {
+                                    "type": "integer"
+                                  },
+                                  "type": "array"
+                                },
+                                "uid": {
+                                  "type": "integer"
+                                }
+                              },
+                              "type": "object"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "volumeMounts": {
+                          "items": {
+                            "properties": {
+                              "mountPath": {
+                                "type": "string"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "recursiveReadOnly": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "message": {
+                    "type": "string"
+                  },
+                  "nominatedNodeName": {
+                    "type": "string"
+                  },
+                  "observedGeneration": {
+                    "type": "integer"
+                  },
+                  "phase": {
+                    "type": "string"
+                  },
+                  "podIP": {
+                    "type": "string"
+                  },
+                  "podIPs": {
+                    "items": {
+                      "properties": {
+                        "ip": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "qosClass": {
+                    "type": "string"
+                  },
+                  "reason": {
+                    "type": "string"
+                  },
+                  "resize": {
+                    "type": "string"
+                  },
+                  "resourceClaimStatuses": {
+                    "items": {
+                      "properties": {
+                        "name": {
+                          "type": "string"
+                        },
+                        "resourceClaimName": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "startTime": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "lastTransitionTime": {
+                "type": "string"
+              },
+              "message": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "type": "object"
+        }
+      },
+      "type": "object"
+    },
+    "apiVersion": {
+      "type": "string"
+    },
+    "kind": {
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    }
+  },
+  "type": "object"
+}

--- a/spark.apache.org/sparkcluster_v1.json
+++ b/spark.apache.org/sparkcluster_v1.json
@@ -1,0 +1,12012 @@
+{
+  "properties": {
+    "spec": {
+      "properties": {
+        "clusterTolerations": {
+          "properties": {
+            "instanceConfig": {
+              "properties": {
+                "initWorkers": {
+                  "type": "integer"
+                },
+                "maxWorkers": {
+                  "type": "integer"
+                },
+                "minWorkers": {
+                  "type": "integer"
+                }
+              },
+              "required": [
+                "initWorkers",
+                "maxWorkers",
+                "minWorkers"
+              ],
+              "type": "object"
+            }
+          },
+          "required": [
+            "instanceConfig"
+          ],
+          "type": "object"
+        },
+        "masterSpec": {
+          "properties": {
+            "serviceMetadata": {
+              "properties": {
+                "annotations": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                },
+                "creationTimestamp": {
+                  "type": "string"
+                },
+                "deletionGracePeriodSeconds": {
+                  "type": "integer"
+                },
+                "deletionTimestamp": {
+                  "type": "string"
+                },
+                "finalizers": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "generateName": {
+                  "type": "string"
+                },
+                "generation": {
+                  "type": "integer"
+                },
+                "labels": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                },
+                "managedFields": {
+                  "items": {
+                    "properties": {
+                      "apiVersion": {
+                        "type": "string"
+                      },
+                      "fieldsType": {
+                        "type": "string"
+                      },
+                      "fieldsV1": {
+                        "type": "object"
+                      },
+                      "manager": {
+                        "type": "string"
+                      },
+                      "operation": {
+                        "type": "string"
+                      },
+                      "subresource": {
+                        "type": "string"
+                      },
+                      "time": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "namespace": {
+                  "type": "string"
+                },
+                "ownerReferences": {
+                  "items": {
+                    "properties": {
+                      "apiVersion": {
+                        "type": "string"
+                      },
+                      "blockOwnerDeletion": {
+                        "type": "boolean"
+                      },
+                      "controller": {
+                        "type": "boolean"
+                      },
+                      "kind": {
+                        "type": "string"
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "uid": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "resourceVersion": {
+                  "type": "string"
+                },
+                "selfLink": {
+                  "type": "string"
+                },
+                "uid": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "serviceSpec": {
+              "properties": {
+                "allocateLoadBalancerNodePorts": {
+                  "type": "boolean"
+                },
+                "clusterIP": {
+                  "type": "string"
+                },
+                "clusterIPs": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "externalIPs": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "externalName": {
+                  "type": "string"
+                },
+                "externalTrafficPolicy": {
+                  "type": "string"
+                },
+                "healthCheckNodePort": {
+                  "type": "integer"
+                },
+                "internalTrafficPolicy": {
+                  "type": "string"
+                },
+                "ipFamilies": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "ipFamilyPolicy": {
+                  "type": "string"
+                },
+                "loadBalancerClass": {
+                  "type": "string"
+                },
+                "loadBalancerIP": {
+                  "type": "string"
+                },
+                "loadBalancerSourceRanges": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "ports": {
+                  "items": {
+                    "properties": {
+                      "appProtocol": {
+                        "type": "string"
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "nodePort": {
+                        "type": "integer"
+                      },
+                      "port": {
+                        "type": "integer"
+                      },
+                      "protocol": {
+                        "type": "string"
+                      },
+                      "targetPort": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "x-kubernetes-int-or-string": true
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "publishNotReadyAddresses": {
+                  "type": "boolean"
+                },
+                "selector": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                },
+                "sessionAffinity": {
+                  "type": "string"
+                },
+                "sessionAffinityConfig": {
+                  "properties": {
+                    "clientIP": {
+                      "properties": {
+                        "timeoutSeconds": {
+                          "type": "integer"
+                        }
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "type": "object"
+                },
+                "trafficDistribution": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "statefulSetMetadata": {
+              "properties": {
+                "annotations": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                },
+                "creationTimestamp": {
+                  "type": "string"
+                },
+                "deletionGracePeriodSeconds": {
+                  "type": "integer"
+                },
+                "deletionTimestamp": {
+                  "type": "string"
+                },
+                "finalizers": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "generateName": {
+                  "type": "string"
+                },
+                "generation": {
+                  "type": "integer"
+                },
+                "labels": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                },
+                "managedFields": {
+                  "items": {
+                    "properties": {
+                      "apiVersion": {
+                        "type": "string"
+                      },
+                      "fieldsType": {
+                        "type": "string"
+                      },
+                      "fieldsV1": {
+                        "type": "object"
+                      },
+                      "manager": {
+                        "type": "string"
+                      },
+                      "operation": {
+                        "type": "string"
+                      },
+                      "subresource": {
+                        "type": "string"
+                      },
+                      "time": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "namespace": {
+                  "type": "string"
+                },
+                "ownerReferences": {
+                  "items": {
+                    "properties": {
+                      "apiVersion": {
+                        "type": "string"
+                      },
+                      "blockOwnerDeletion": {
+                        "type": "boolean"
+                      },
+                      "controller": {
+                        "type": "boolean"
+                      },
+                      "kind": {
+                        "type": "string"
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "uid": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "resourceVersion": {
+                  "type": "string"
+                },
+                "selfLink": {
+                  "type": "string"
+                },
+                "uid": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "statefulSetSpec": {
+              "properties": {
+                "minReadySeconds": {
+                  "type": "integer"
+                },
+                "ordinals": {
+                  "properties": {
+                    "start": {
+                      "type": "integer"
+                    }
+                  },
+                  "type": "object"
+                },
+                "persistentVolumeClaimRetentionPolicy": {
+                  "properties": {
+                    "whenDeleted": {
+                      "type": "string"
+                    },
+                    "whenScaled": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "podManagementPolicy": {
+                  "type": "string"
+                },
+                "replicas": {
+                  "type": "integer"
+                },
+                "revisionHistoryLimit": {
+                  "type": "integer"
+                },
+                "selector": {
+                  "properties": {
+                    "matchExpressions": {
+                      "items": {
+                        "properties": {
+                          "key": {
+                            "type": "string"
+                          },
+                          "operator": {
+                            "type": "string"
+                          },
+                          "values": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "matchLabels": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "type": "object"
+                },
+                "serviceName": {
+                  "type": "string"
+                },
+                "template": {
+                  "properties": {
+                    "metadata": {
+                      "properties": {
+                        "annotations": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        "creationTimestamp": {
+                          "type": "string"
+                        },
+                        "deletionGracePeriodSeconds": {
+                          "type": "integer"
+                        },
+                        "deletionTimestamp": {
+                          "type": "string"
+                        },
+                        "finalizers": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "generateName": {
+                          "type": "string"
+                        },
+                        "generation": {
+                          "type": "integer"
+                        },
+                        "labels": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        "managedFields": {
+                          "items": {
+                            "properties": {
+                              "apiVersion": {
+                                "type": "string"
+                              },
+                              "fieldsType": {
+                                "type": "string"
+                              },
+                              "fieldsV1": {
+                                "type": "object"
+                              },
+                              "manager": {
+                                "type": "string"
+                              },
+                              "operation": {
+                                "type": "string"
+                              },
+                              "subresource": {
+                                "type": "string"
+                              },
+                              "time": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "namespace": {
+                          "type": "string"
+                        },
+                        "ownerReferences": {
+                          "items": {
+                            "properties": {
+                              "apiVersion": {
+                                "type": "string"
+                              },
+                              "blockOwnerDeletion": {
+                                "type": "boolean"
+                              },
+                              "controller": {
+                                "type": "boolean"
+                              },
+                              "kind": {
+                                "type": "string"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "uid": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "resourceVersion": {
+                          "type": "string"
+                        },
+                        "selfLink": {
+                          "type": "string"
+                        },
+                        "uid": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "spec": {
+                      "properties": {
+                        "activeDeadlineSeconds": {
+                          "type": "integer"
+                        },
+                        "affinity": {
+                          "properties": {
+                            "nodeAffinity": {
+                              "properties": {
+                                "preferredDuringSchedulingIgnoredDuringExecution": {
+                                  "items": {
+                                    "properties": {
+                                      "preference": {
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "matchFields": {
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "weight": {
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "type": "array"
+                                },
+                                "requiredDuringSchedulingIgnoredDuringExecution": {
+                                  "properties": {
+                                    "nodeSelectorTerms": {
+                                      "items": {
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "matchFields": {
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "podAffinity": {
+                              "properties": {
+                                "preferredDuringSchedulingIgnoredDuringExecution": {
+                                  "items": {
+                                    "properties": {
+                                      "podAffinityTerm": {
+                                        "properties": {
+                                          "labelSelector": {
+                                            "properties": {
+                                              "matchExpressions": {
+                                                "items": {
+                                                  "properties": {
+                                                    "key": {
+                                                      "type": "string"
+                                                    },
+                                                    "operator": {
+                                                      "type": "string"
+                                                    },
+                                                    "values": {
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    }
+                                                  },
+                                                  "type": "object"
+                                                },
+                                                "type": "array"
+                                              },
+                                              "matchLabels": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "type": "object"
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          "matchLabelKeys": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "mismatchLabelKeys": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "namespaceSelector": {
+                                            "properties": {
+                                              "matchExpressions": {
+                                                "items": {
+                                                  "properties": {
+                                                    "key": {
+                                                      "type": "string"
+                                                    },
+                                                    "operator": {
+                                                      "type": "string"
+                                                    },
+                                                    "values": {
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    }
+                                                  },
+                                                  "type": "object"
+                                                },
+                                                "type": "array"
+                                              },
+                                              "matchLabels": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "type": "object"
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          "namespaces": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "topologyKey": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "weight": {
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "type": "array"
+                                },
+                                "requiredDuringSchedulingIgnoredDuringExecution": {
+                                  "items": {
+                                    "properties": {
+                                      "labelSelector": {
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "matchLabels": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "matchLabelKeys": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "mismatchLabelKeys": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "namespaceSelector": {
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "matchLabels": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "namespaces": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "topologyKey": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "podAntiAffinity": {
+                              "properties": {
+                                "preferredDuringSchedulingIgnoredDuringExecution": {
+                                  "items": {
+                                    "properties": {
+                                      "podAffinityTerm": {
+                                        "properties": {
+                                          "labelSelector": {
+                                            "properties": {
+                                              "matchExpressions": {
+                                                "items": {
+                                                  "properties": {
+                                                    "key": {
+                                                      "type": "string"
+                                                    },
+                                                    "operator": {
+                                                      "type": "string"
+                                                    },
+                                                    "values": {
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    }
+                                                  },
+                                                  "type": "object"
+                                                },
+                                                "type": "array"
+                                              },
+                                              "matchLabels": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "type": "object"
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          "matchLabelKeys": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "mismatchLabelKeys": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "namespaceSelector": {
+                                            "properties": {
+                                              "matchExpressions": {
+                                                "items": {
+                                                  "properties": {
+                                                    "key": {
+                                                      "type": "string"
+                                                    },
+                                                    "operator": {
+                                                      "type": "string"
+                                                    },
+                                                    "values": {
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    }
+                                                  },
+                                                  "type": "object"
+                                                },
+                                                "type": "array"
+                                              },
+                                              "matchLabels": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "type": "object"
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          "namespaces": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "topologyKey": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "weight": {
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "type": "array"
+                                },
+                                "requiredDuringSchedulingIgnoredDuringExecution": {
+                                  "items": {
+                                    "properties": {
+                                      "labelSelector": {
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "matchLabels": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "matchLabelKeys": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "mismatchLabelKeys": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "namespaceSelector": {
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "matchLabels": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "namespaces": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "topologyKey": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "type": "object"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "automountServiceAccountToken": {
+                          "type": "boolean"
+                        },
+                        "containers": {
+                          "items": {
+                            "properties": {
+                              "args": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "command": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "env": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    },
+                                    "valueFrom": {
+                                      "properties": {
+                                        "configMapKeyRef": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "fieldRef": {
+                                          "properties": {
+                                            "apiVersion": {
+                                              "type": "string"
+                                            },
+                                            "fieldPath": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "fileKeyRef": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            },
+                                            "path": {
+                                              "type": "string"
+                                            },
+                                            "volumeName": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "resourceFieldRef": {
+                                          "properties": {
+                                            "containerName": {
+                                              "type": "string"
+                                            },
+                                            "divisor": {
+                                              "anyOf": [
+                                                {
+                                                  "type": "integer"
+                                                },
+                                                {
+                                                  "type": "string"
+                                                }
+                                              ],
+                                              "x-kubernetes-int-or-string": true
+                                            },
+                                            "resource": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "secretKeyRef": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "type": "object"
+                                        }
+                                      },
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "envFrom": {
+                                "items": {
+                                  "properties": {
+                                    "configMapRef": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "prefix": {
+                                      "type": "string"
+                                    },
+                                    "secretRef": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "image": {
+                                "type": "string"
+                              },
+                              "imagePullPolicy": {
+                                "type": "string"
+                              },
+                              "lifecycle": {
+                                "properties": {
+                                  "postStart": {
+                                    "properties": {
+                                      "exec": {
+                                        "properties": {
+                                          "command": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "httpGet": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "httpHeaders": {
+                                            "items": {
+                                              "properties": {
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "value": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          },
+                                          "scheme": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "sleep": {
+                                        "properties": {
+                                          "seconds": {
+                                            "type": "integer"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "tcpSocket": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          }
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "preStop": {
+                                    "properties": {
+                                      "exec": {
+                                        "properties": {
+                                          "command": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "httpGet": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "httpHeaders": {
+                                            "items": {
+                                              "properties": {
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "value": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          },
+                                          "scheme": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "sleep": {
+                                        "properties": {
+                                          "seconds": {
+                                            "type": "integer"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "tcpSocket": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          }
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "stopSignal": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "livenessProbe": {
+                                "properties": {
+                                  "exec": {
+                                    "properties": {
+                                      "command": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "failureThreshold": {
+                                    "type": "integer"
+                                  },
+                                  "grpc": {
+                                    "properties": {
+                                      "port": {
+                                        "type": "integer"
+                                      },
+                                      "service": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "httpGet": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "initialDelaySeconds": {
+                                    "type": "integer"
+                                  },
+                                  "periodSeconds": {
+                                    "type": "integer"
+                                  },
+                                  "successThreshold": {
+                                    "type": "integer"
+                                  },
+                                  "tcpSocket": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "terminationGracePeriodSeconds": {
+                                    "type": "integer"
+                                  },
+                                  "timeoutSeconds": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "ports": {
+                                "items": {
+                                  "properties": {
+                                    "containerPort": {
+                                      "type": "integer"
+                                    },
+                                    "hostIP": {
+                                      "type": "string"
+                                    },
+                                    "hostPort": {
+                                      "type": "integer"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "protocol": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "readinessProbe": {
+                                "properties": {
+                                  "exec": {
+                                    "properties": {
+                                      "command": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "failureThreshold": {
+                                    "type": "integer"
+                                  },
+                                  "grpc": {
+                                    "properties": {
+                                      "port": {
+                                        "type": "integer"
+                                      },
+                                      "service": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "httpGet": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "initialDelaySeconds": {
+                                    "type": "integer"
+                                  },
+                                  "periodSeconds": {
+                                    "type": "integer"
+                                  },
+                                  "successThreshold": {
+                                    "type": "integer"
+                                  },
+                                  "tcpSocket": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "terminationGracePeriodSeconds": {
+                                    "type": "integer"
+                                  },
+                                  "timeoutSeconds": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "resizePolicy": {
+                                "items": {
+                                  "properties": {
+                                    "resourceName": {
+                                      "type": "string"
+                                    },
+                                    "restartPolicy": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "resources": {
+                                "properties": {
+                                  "claims": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "request": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "limits": {
+                                    "additionalProperties": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "string"
+                                        }
+                                      ],
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "type": "object"
+                                  },
+                                  "requests": {
+                                    "additionalProperties": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "string"
+                                        }
+                                      ],
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "restartPolicy": {
+                                "type": "string"
+                              },
+                              "restartPolicyRules": {
+                                "items": {
+                                  "properties": {
+                                    "action": {
+                                      "type": "string"
+                                    },
+                                    "exitCodes": {
+                                      "properties": {
+                                        "operator": {
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "items": {
+                                            "type": "integer"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "securityContext": {
+                                "properties": {
+                                  "allowPrivilegeEscalation": {
+                                    "type": "boolean"
+                                  },
+                                  "appArmorProfile": {
+                                    "properties": {
+                                      "localhostProfile": {
+                                        "type": "string"
+                                      },
+                                      "type": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "capabilities": {
+                                    "properties": {
+                                      "add": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "drop": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "privileged": {
+                                    "type": "boolean"
+                                  },
+                                  "procMount": {
+                                    "type": "string"
+                                  },
+                                  "readOnlyRootFilesystem": {
+                                    "type": "boolean"
+                                  },
+                                  "runAsGroup": {
+                                    "type": "integer"
+                                  },
+                                  "runAsNonRoot": {
+                                    "type": "boolean"
+                                  },
+                                  "runAsUser": {
+                                    "type": "integer"
+                                  },
+                                  "seLinuxOptions": {
+                                    "properties": {
+                                      "level": {
+                                        "type": "string"
+                                      },
+                                      "role": {
+                                        "type": "string"
+                                      },
+                                      "type": {
+                                        "type": "string"
+                                      },
+                                      "user": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "seccompProfile": {
+                                    "properties": {
+                                      "localhostProfile": {
+                                        "type": "string"
+                                      },
+                                      "type": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "windowsOptions": {
+                                    "properties": {
+                                      "gmsaCredentialSpec": {
+                                        "type": "string"
+                                      },
+                                      "gmsaCredentialSpecName": {
+                                        "type": "string"
+                                      },
+                                      "hostProcess": {
+                                        "type": "boolean"
+                                      },
+                                      "runAsUserName": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "startupProbe": {
+                                "properties": {
+                                  "exec": {
+                                    "properties": {
+                                      "command": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "failureThreshold": {
+                                    "type": "integer"
+                                  },
+                                  "grpc": {
+                                    "properties": {
+                                      "port": {
+                                        "type": "integer"
+                                      },
+                                      "service": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "httpGet": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "initialDelaySeconds": {
+                                    "type": "integer"
+                                  },
+                                  "periodSeconds": {
+                                    "type": "integer"
+                                  },
+                                  "successThreshold": {
+                                    "type": "integer"
+                                  },
+                                  "tcpSocket": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "terminationGracePeriodSeconds": {
+                                    "type": "integer"
+                                  },
+                                  "timeoutSeconds": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "stdin": {
+                                "type": "boolean"
+                              },
+                              "stdinOnce": {
+                                "type": "boolean"
+                              },
+                              "terminationMessagePath": {
+                                "type": "string"
+                              },
+                              "terminationMessagePolicy": {
+                                "type": "string"
+                              },
+                              "tty": {
+                                "type": "boolean"
+                              },
+                              "volumeDevices": {
+                                "items": {
+                                  "properties": {
+                                    "devicePath": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "volumeMounts": {
+                                "items": {
+                                  "properties": {
+                                    "mountPath": {
+                                      "type": "string"
+                                    },
+                                    "mountPropagation": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "readOnly": {
+                                      "type": "boolean"
+                                    },
+                                    "recursiveReadOnly": {
+                                      "type": "string"
+                                    },
+                                    "subPath": {
+                                      "type": "string"
+                                    },
+                                    "subPathExpr": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "workingDir": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "dnsConfig": {
+                          "properties": {
+                            "nameservers": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "options": {
+                              "items": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "value": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "searches": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "dnsPolicy": {
+                          "type": "string"
+                        },
+                        "enableServiceLinks": {
+                          "type": "boolean"
+                        },
+                        "ephemeralContainers": {
+                          "items": {
+                            "properties": {
+                              "args": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "command": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "env": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    },
+                                    "valueFrom": {
+                                      "properties": {
+                                        "configMapKeyRef": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "fieldRef": {
+                                          "properties": {
+                                            "apiVersion": {
+                                              "type": "string"
+                                            },
+                                            "fieldPath": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "fileKeyRef": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            },
+                                            "path": {
+                                              "type": "string"
+                                            },
+                                            "volumeName": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "resourceFieldRef": {
+                                          "properties": {
+                                            "containerName": {
+                                              "type": "string"
+                                            },
+                                            "divisor": {
+                                              "anyOf": [
+                                                {
+                                                  "type": "integer"
+                                                },
+                                                {
+                                                  "type": "string"
+                                                }
+                                              ],
+                                              "x-kubernetes-int-or-string": true
+                                            },
+                                            "resource": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "secretKeyRef": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "type": "object"
+                                        }
+                                      },
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "envFrom": {
+                                "items": {
+                                  "properties": {
+                                    "configMapRef": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "prefix": {
+                                      "type": "string"
+                                    },
+                                    "secretRef": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "image": {
+                                "type": "string"
+                              },
+                              "imagePullPolicy": {
+                                "type": "string"
+                              },
+                              "lifecycle": {
+                                "properties": {
+                                  "postStart": {
+                                    "properties": {
+                                      "exec": {
+                                        "properties": {
+                                          "command": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "httpGet": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "httpHeaders": {
+                                            "items": {
+                                              "properties": {
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "value": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          },
+                                          "scheme": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "sleep": {
+                                        "properties": {
+                                          "seconds": {
+                                            "type": "integer"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "tcpSocket": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          }
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "preStop": {
+                                    "properties": {
+                                      "exec": {
+                                        "properties": {
+                                          "command": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "httpGet": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "httpHeaders": {
+                                            "items": {
+                                              "properties": {
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "value": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          },
+                                          "scheme": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "sleep": {
+                                        "properties": {
+                                          "seconds": {
+                                            "type": "integer"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "tcpSocket": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          }
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "stopSignal": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "livenessProbe": {
+                                "properties": {
+                                  "exec": {
+                                    "properties": {
+                                      "command": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "failureThreshold": {
+                                    "type": "integer"
+                                  },
+                                  "grpc": {
+                                    "properties": {
+                                      "port": {
+                                        "type": "integer"
+                                      },
+                                      "service": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "httpGet": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "initialDelaySeconds": {
+                                    "type": "integer"
+                                  },
+                                  "periodSeconds": {
+                                    "type": "integer"
+                                  },
+                                  "successThreshold": {
+                                    "type": "integer"
+                                  },
+                                  "tcpSocket": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "terminationGracePeriodSeconds": {
+                                    "type": "integer"
+                                  },
+                                  "timeoutSeconds": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "ports": {
+                                "items": {
+                                  "properties": {
+                                    "containerPort": {
+                                      "type": "integer"
+                                    },
+                                    "hostIP": {
+                                      "type": "string"
+                                    },
+                                    "hostPort": {
+                                      "type": "integer"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "protocol": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "readinessProbe": {
+                                "properties": {
+                                  "exec": {
+                                    "properties": {
+                                      "command": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "failureThreshold": {
+                                    "type": "integer"
+                                  },
+                                  "grpc": {
+                                    "properties": {
+                                      "port": {
+                                        "type": "integer"
+                                      },
+                                      "service": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "httpGet": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "initialDelaySeconds": {
+                                    "type": "integer"
+                                  },
+                                  "periodSeconds": {
+                                    "type": "integer"
+                                  },
+                                  "successThreshold": {
+                                    "type": "integer"
+                                  },
+                                  "tcpSocket": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "terminationGracePeriodSeconds": {
+                                    "type": "integer"
+                                  },
+                                  "timeoutSeconds": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "resizePolicy": {
+                                "items": {
+                                  "properties": {
+                                    "resourceName": {
+                                      "type": "string"
+                                    },
+                                    "restartPolicy": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "resources": {
+                                "properties": {
+                                  "claims": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "request": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "limits": {
+                                    "additionalProperties": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "string"
+                                        }
+                                      ],
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "type": "object"
+                                  },
+                                  "requests": {
+                                    "additionalProperties": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "string"
+                                        }
+                                      ],
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "restartPolicy": {
+                                "type": "string"
+                              },
+                              "restartPolicyRules": {
+                                "items": {
+                                  "properties": {
+                                    "action": {
+                                      "type": "string"
+                                    },
+                                    "exitCodes": {
+                                      "properties": {
+                                        "operator": {
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "items": {
+                                            "type": "integer"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "securityContext": {
+                                "properties": {
+                                  "allowPrivilegeEscalation": {
+                                    "type": "boolean"
+                                  },
+                                  "appArmorProfile": {
+                                    "properties": {
+                                      "localhostProfile": {
+                                        "type": "string"
+                                      },
+                                      "type": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "capabilities": {
+                                    "properties": {
+                                      "add": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "drop": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "privileged": {
+                                    "type": "boolean"
+                                  },
+                                  "procMount": {
+                                    "type": "string"
+                                  },
+                                  "readOnlyRootFilesystem": {
+                                    "type": "boolean"
+                                  },
+                                  "runAsGroup": {
+                                    "type": "integer"
+                                  },
+                                  "runAsNonRoot": {
+                                    "type": "boolean"
+                                  },
+                                  "runAsUser": {
+                                    "type": "integer"
+                                  },
+                                  "seLinuxOptions": {
+                                    "properties": {
+                                      "level": {
+                                        "type": "string"
+                                      },
+                                      "role": {
+                                        "type": "string"
+                                      },
+                                      "type": {
+                                        "type": "string"
+                                      },
+                                      "user": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "seccompProfile": {
+                                    "properties": {
+                                      "localhostProfile": {
+                                        "type": "string"
+                                      },
+                                      "type": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "windowsOptions": {
+                                    "properties": {
+                                      "gmsaCredentialSpec": {
+                                        "type": "string"
+                                      },
+                                      "gmsaCredentialSpecName": {
+                                        "type": "string"
+                                      },
+                                      "hostProcess": {
+                                        "type": "boolean"
+                                      },
+                                      "runAsUserName": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "startupProbe": {
+                                "properties": {
+                                  "exec": {
+                                    "properties": {
+                                      "command": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "failureThreshold": {
+                                    "type": "integer"
+                                  },
+                                  "grpc": {
+                                    "properties": {
+                                      "port": {
+                                        "type": "integer"
+                                      },
+                                      "service": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "httpGet": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "initialDelaySeconds": {
+                                    "type": "integer"
+                                  },
+                                  "periodSeconds": {
+                                    "type": "integer"
+                                  },
+                                  "successThreshold": {
+                                    "type": "integer"
+                                  },
+                                  "tcpSocket": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "terminationGracePeriodSeconds": {
+                                    "type": "integer"
+                                  },
+                                  "timeoutSeconds": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "stdin": {
+                                "type": "boolean"
+                              },
+                              "stdinOnce": {
+                                "type": "boolean"
+                              },
+                              "targetContainerName": {
+                                "type": "string"
+                              },
+                              "terminationMessagePath": {
+                                "type": "string"
+                              },
+                              "terminationMessagePolicy": {
+                                "type": "string"
+                              },
+                              "tty": {
+                                "type": "boolean"
+                              },
+                              "volumeDevices": {
+                                "items": {
+                                  "properties": {
+                                    "devicePath": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "volumeMounts": {
+                                "items": {
+                                  "properties": {
+                                    "mountPath": {
+                                      "type": "string"
+                                    },
+                                    "mountPropagation": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "readOnly": {
+                                      "type": "boolean"
+                                    },
+                                    "recursiveReadOnly": {
+                                      "type": "string"
+                                    },
+                                    "subPath": {
+                                      "type": "string"
+                                    },
+                                    "subPathExpr": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "workingDir": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "hostAliases": {
+                          "items": {
+                            "properties": {
+                              "hostnames": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "ip": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "hostIPC": {
+                          "type": "boolean"
+                        },
+                        "hostNetwork": {
+                          "type": "boolean"
+                        },
+                        "hostPID": {
+                          "type": "boolean"
+                        },
+                        "hostUsers": {
+                          "type": "boolean"
+                        },
+                        "hostname": {
+                          "type": "string"
+                        },
+                        "hostnameOverride": {
+                          "type": "string"
+                        },
+                        "imagePullSecrets": {
+                          "items": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "initContainers": {
+                          "items": {
+                            "properties": {
+                              "args": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "command": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "env": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    },
+                                    "valueFrom": {
+                                      "properties": {
+                                        "configMapKeyRef": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "fieldRef": {
+                                          "properties": {
+                                            "apiVersion": {
+                                              "type": "string"
+                                            },
+                                            "fieldPath": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "fileKeyRef": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            },
+                                            "path": {
+                                              "type": "string"
+                                            },
+                                            "volumeName": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "resourceFieldRef": {
+                                          "properties": {
+                                            "containerName": {
+                                              "type": "string"
+                                            },
+                                            "divisor": {
+                                              "anyOf": [
+                                                {
+                                                  "type": "integer"
+                                                },
+                                                {
+                                                  "type": "string"
+                                                }
+                                              ],
+                                              "x-kubernetes-int-or-string": true
+                                            },
+                                            "resource": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "secretKeyRef": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "type": "object"
+                                        }
+                                      },
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "envFrom": {
+                                "items": {
+                                  "properties": {
+                                    "configMapRef": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "prefix": {
+                                      "type": "string"
+                                    },
+                                    "secretRef": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "image": {
+                                "type": "string"
+                              },
+                              "imagePullPolicy": {
+                                "type": "string"
+                              },
+                              "lifecycle": {
+                                "properties": {
+                                  "postStart": {
+                                    "properties": {
+                                      "exec": {
+                                        "properties": {
+                                          "command": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "httpGet": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "httpHeaders": {
+                                            "items": {
+                                              "properties": {
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "value": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          },
+                                          "scheme": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "sleep": {
+                                        "properties": {
+                                          "seconds": {
+                                            "type": "integer"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "tcpSocket": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          }
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "preStop": {
+                                    "properties": {
+                                      "exec": {
+                                        "properties": {
+                                          "command": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "httpGet": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "httpHeaders": {
+                                            "items": {
+                                              "properties": {
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "value": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          },
+                                          "scheme": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "sleep": {
+                                        "properties": {
+                                          "seconds": {
+                                            "type": "integer"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "tcpSocket": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          }
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "stopSignal": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "livenessProbe": {
+                                "properties": {
+                                  "exec": {
+                                    "properties": {
+                                      "command": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "failureThreshold": {
+                                    "type": "integer"
+                                  },
+                                  "grpc": {
+                                    "properties": {
+                                      "port": {
+                                        "type": "integer"
+                                      },
+                                      "service": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "httpGet": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "initialDelaySeconds": {
+                                    "type": "integer"
+                                  },
+                                  "periodSeconds": {
+                                    "type": "integer"
+                                  },
+                                  "successThreshold": {
+                                    "type": "integer"
+                                  },
+                                  "tcpSocket": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "terminationGracePeriodSeconds": {
+                                    "type": "integer"
+                                  },
+                                  "timeoutSeconds": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "ports": {
+                                "items": {
+                                  "properties": {
+                                    "containerPort": {
+                                      "type": "integer"
+                                    },
+                                    "hostIP": {
+                                      "type": "string"
+                                    },
+                                    "hostPort": {
+                                      "type": "integer"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "protocol": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "readinessProbe": {
+                                "properties": {
+                                  "exec": {
+                                    "properties": {
+                                      "command": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "failureThreshold": {
+                                    "type": "integer"
+                                  },
+                                  "grpc": {
+                                    "properties": {
+                                      "port": {
+                                        "type": "integer"
+                                      },
+                                      "service": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "httpGet": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "initialDelaySeconds": {
+                                    "type": "integer"
+                                  },
+                                  "periodSeconds": {
+                                    "type": "integer"
+                                  },
+                                  "successThreshold": {
+                                    "type": "integer"
+                                  },
+                                  "tcpSocket": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "terminationGracePeriodSeconds": {
+                                    "type": "integer"
+                                  },
+                                  "timeoutSeconds": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "resizePolicy": {
+                                "items": {
+                                  "properties": {
+                                    "resourceName": {
+                                      "type": "string"
+                                    },
+                                    "restartPolicy": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "resources": {
+                                "properties": {
+                                  "claims": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "request": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "limits": {
+                                    "additionalProperties": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "string"
+                                        }
+                                      ],
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "type": "object"
+                                  },
+                                  "requests": {
+                                    "additionalProperties": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "string"
+                                        }
+                                      ],
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "restartPolicy": {
+                                "type": "string"
+                              },
+                              "restartPolicyRules": {
+                                "items": {
+                                  "properties": {
+                                    "action": {
+                                      "type": "string"
+                                    },
+                                    "exitCodes": {
+                                      "properties": {
+                                        "operator": {
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "items": {
+                                            "type": "integer"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "securityContext": {
+                                "properties": {
+                                  "allowPrivilegeEscalation": {
+                                    "type": "boolean"
+                                  },
+                                  "appArmorProfile": {
+                                    "properties": {
+                                      "localhostProfile": {
+                                        "type": "string"
+                                      },
+                                      "type": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "capabilities": {
+                                    "properties": {
+                                      "add": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "drop": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "privileged": {
+                                    "type": "boolean"
+                                  },
+                                  "procMount": {
+                                    "type": "string"
+                                  },
+                                  "readOnlyRootFilesystem": {
+                                    "type": "boolean"
+                                  },
+                                  "runAsGroup": {
+                                    "type": "integer"
+                                  },
+                                  "runAsNonRoot": {
+                                    "type": "boolean"
+                                  },
+                                  "runAsUser": {
+                                    "type": "integer"
+                                  },
+                                  "seLinuxOptions": {
+                                    "properties": {
+                                      "level": {
+                                        "type": "string"
+                                      },
+                                      "role": {
+                                        "type": "string"
+                                      },
+                                      "type": {
+                                        "type": "string"
+                                      },
+                                      "user": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "seccompProfile": {
+                                    "properties": {
+                                      "localhostProfile": {
+                                        "type": "string"
+                                      },
+                                      "type": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "windowsOptions": {
+                                    "properties": {
+                                      "gmsaCredentialSpec": {
+                                        "type": "string"
+                                      },
+                                      "gmsaCredentialSpecName": {
+                                        "type": "string"
+                                      },
+                                      "hostProcess": {
+                                        "type": "boolean"
+                                      },
+                                      "runAsUserName": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "startupProbe": {
+                                "properties": {
+                                  "exec": {
+                                    "properties": {
+                                      "command": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "failureThreshold": {
+                                    "type": "integer"
+                                  },
+                                  "grpc": {
+                                    "properties": {
+                                      "port": {
+                                        "type": "integer"
+                                      },
+                                      "service": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "httpGet": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "initialDelaySeconds": {
+                                    "type": "integer"
+                                  },
+                                  "periodSeconds": {
+                                    "type": "integer"
+                                  },
+                                  "successThreshold": {
+                                    "type": "integer"
+                                  },
+                                  "tcpSocket": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "terminationGracePeriodSeconds": {
+                                    "type": "integer"
+                                  },
+                                  "timeoutSeconds": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "stdin": {
+                                "type": "boolean"
+                              },
+                              "stdinOnce": {
+                                "type": "boolean"
+                              },
+                              "terminationMessagePath": {
+                                "type": "string"
+                              },
+                              "terminationMessagePolicy": {
+                                "type": "string"
+                              },
+                              "tty": {
+                                "type": "boolean"
+                              },
+                              "volumeDevices": {
+                                "items": {
+                                  "properties": {
+                                    "devicePath": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "volumeMounts": {
+                                "items": {
+                                  "properties": {
+                                    "mountPath": {
+                                      "type": "string"
+                                    },
+                                    "mountPropagation": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "readOnly": {
+                                      "type": "boolean"
+                                    },
+                                    "recursiveReadOnly": {
+                                      "type": "string"
+                                    },
+                                    "subPath": {
+                                      "type": "string"
+                                    },
+                                    "subPathExpr": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "workingDir": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "nodeName": {
+                          "type": "string"
+                        },
+                        "nodeSelector": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        "os": {
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "overhead": {
+                          "additionalProperties": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "x-kubernetes-int-or-string": true
+                          },
+                          "type": "object"
+                        },
+                        "preemptionPolicy": {
+                          "type": "string"
+                        },
+                        "priority": {
+                          "type": "integer"
+                        },
+                        "priorityClassName": {
+                          "type": "string"
+                        },
+                        "readinessGates": {
+                          "items": {
+                            "properties": {
+                              "conditionType": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "resourceClaims": {
+                          "items": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "resourceClaimName": {
+                                "type": "string"
+                              },
+                              "resourceClaimTemplateName": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "resources": {
+                          "properties": {
+                            "claims": {
+                              "items": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "request": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "limits": {
+                              "additionalProperties": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "type": "object"
+                            },
+                            "requests": {
+                              "additionalProperties": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "type": "object"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "restartPolicy": {
+                          "type": "string"
+                        },
+                        "runtimeClassName": {
+                          "type": "string"
+                        },
+                        "schedulerName": {
+                          "type": "string"
+                        },
+                        "schedulingGates": {
+                          "items": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "securityContext": {
+                          "properties": {
+                            "appArmorProfile": {
+                              "properties": {
+                                "localhostProfile": {
+                                  "type": "string"
+                                },
+                                "type": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "fsGroup": {
+                              "type": "integer"
+                            },
+                            "fsGroupChangePolicy": {
+                              "type": "string"
+                            },
+                            "runAsGroup": {
+                              "type": "integer"
+                            },
+                            "runAsNonRoot": {
+                              "type": "boolean"
+                            },
+                            "runAsUser": {
+                              "type": "integer"
+                            },
+                            "seLinuxChangePolicy": {
+                              "type": "string"
+                            },
+                            "seLinuxOptions": {
+                              "properties": {
+                                "level": {
+                                  "type": "string"
+                                },
+                                "role": {
+                                  "type": "string"
+                                },
+                                "type": {
+                                  "type": "string"
+                                },
+                                "user": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "seccompProfile": {
+                              "properties": {
+                                "localhostProfile": {
+                                  "type": "string"
+                                },
+                                "type": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "supplementalGroups": {
+                              "items": {
+                                "type": "integer"
+                              },
+                              "type": "array"
+                            },
+                            "supplementalGroupsPolicy": {
+                              "type": "string"
+                            },
+                            "sysctls": {
+                              "items": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "value": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "windowsOptions": {
+                              "properties": {
+                                "gmsaCredentialSpec": {
+                                  "type": "string"
+                                },
+                                "gmsaCredentialSpecName": {
+                                  "type": "string"
+                                },
+                                "hostProcess": {
+                                  "type": "boolean"
+                                },
+                                "runAsUserName": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "serviceAccount": {
+                          "type": "string"
+                        },
+                        "serviceAccountName": {
+                          "type": "string"
+                        },
+                        "setHostnameAsFQDN": {
+                          "type": "boolean"
+                        },
+                        "shareProcessNamespace": {
+                          "type": "boolean"
+                        },
+                        "subdomain": {
+                          "type": "string"
+                        },
+                        "terminationGracePeriodSeconds": {
+                          "type": "integer"
+                        },
+                        "tolerations": {
+                          "items": {
+                            "properties": {
+                              "effect": {
+                                "type": "string"
+                              },
+                              "key": {
+                                "type": "string"
+                              },
+                              "operator": {
+                                "type": "string"
+                              },
+                              "tolerationSeconds": {
+                                "type": "integer"
+                              },
+                              "value": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "topologySpreadConstraints": {
+                          "items": {
+                            "properties": {
+                              "labelSelector": {
+                                "properties": {
+                                  "matchExpressions": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "matchLabels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "matchLabelKeys": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "maxSkew": {
+                                "type": "integer"
+                              },
+                              "minDomains": {
+                                "type": "integer"
+                              },
+                              "nodeAffinityPolicy": {
+                                "type": "string"
+                              },
+                              "nodeTaintsPolicy": {
+                                "type": "string"
+                              },
+                              "topologyKey": {
+                                "type": "string"
+                              },
+                              "whenUnsatisfiable": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "volumes": {
+                          "items": {
+                            "properties": {
+                              "awsElasticBlockStore": {
+                                "properties": {
+                                  "fsType": {
+                                    "type": "string"
+                                  },
+                                  "partition": {
+                                    "type": "integer"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  },
+                                  "volumeID": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "azureDisk": {
+                                "properties": {
+                                  "cachingMode": {
+                                    "type": "string"
+                                  },
+                                  "diskName": {
+                                    "type": "string"
+                                  },
+                                  "diskURI": {
+                                    "type": "string"
+                                  },
+                                  "fsType": {
+                                    "type": "string"
+                                  },
+                                  "kind": {
+                                    "type": "string"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "azureFile": {
+                                "properties": {
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  },
+                                  "secretName": {
+                                    "type": "string"
+                                  },
+                                  "shareName": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "cephfs": {
+                                "properties": {
+                                  "monitors": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  },
+                                  "secretFile": {
+                                    "type": "string"
+                                  },
+                                  "secretRef": {
+                                    "properties": {
+                                      "name": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "user": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "cinder": {
+                                "properties": {
+                                  "fsType": {
+                                    "type": "string"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  },
+                                  "secretRef": {
+                                    "properties": {
+                                      "name": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "volumeID": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "configMap": {
+                                "properties": {
+                                  "defaultMode": {
+                                    "type": "integer"
+                                  },
+                                  "items": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "mode": {
+                                          "type": "integer"
+                                        },
+                                        "path": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "csi": {
+                                "properties": {
+                                  "driver": {
+                                    "type": "string"
+                                  },
+                                  "fsType": {
+                                    "type": "string"
+                                  },
+                                  "nodePublishSecretRef": {
+                                    "properties": {
+                                      "name": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  },
+                                  "volumeAttributes": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "downwardAPI": {
+                                "properties": {
+                                  "defaultMode": {
+                                    "type": "integer"
+                                  },
+                                  "items": {
+                                    "items": {
+                                      "properties": {
+                                        "fieldRef": {
+                                          "properties": {
+                                            "apiVersion": {
+                                              "type": "string"
+                                            },
+                                            "fieldPath": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "mode": {
+                                          "type": "integer"
+                                        },
+                                        "path": {
+                                          "type": "string"
+                                        },
+                                        "resourceFieldRef": {
+                                          "properties": {
+                                            "containerName": {
+                                              "type": "string"
+                                            },
+                                            "divisor": {
+                                              "anyOf": [
+                                                {
+                                                  "type": "integer"
+                                                },
+                                                {
+                                                  "type": "string"
+                                                }
+                                              ],
+                                              "x-kubernetes-int-or-string": true
+                                            },
+                                            "resource": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "emptyDir": {
+                                "properties": {
+                                  "medium": {
+                                    "type": "string"
+                                  },
+                                  "sizeLimit": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "ephemeral": {
+                                "properties": {
+                                  "volumeClaimTemplate": {
+                                    "properties": {
+                                      "metadata": {
+                                        "properties": {
+                                          "annotations": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
+                                          },
+                                          "creationTimestamp": {
+                                            "type": "string"
+                                          },
+                                          "deletionGracePeriodSeconds": {
+                                            "type": "integer"
+                                          },
+                                          "deletionTimestamp": {
+                                            "type": "string"
+                                          },
+                                          "finalizers": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "generateName": {
+                                            "type": "string"
+                                          },
+                                          "generation": {
+                                            "type": "integer"
+                                          },
+                                          "labels": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
+                                          },
+                                          "managedFields": {
+                                            "items": {
+                                              "properties": {
+                                                "apiVersion": {
+                                                  "type": "string"
+                                                },
+                                                "fieldsType": {
+                                                  "type": "string"
+                                                },
+                                                "fieldsV1": {
+                                                  "type": "object"
+                                                },
+                                                "manager": {
+                                                  "type": "string"
+                                                },
+                                                "operation": {
+                                                  "type": "string"
+                                                },
+                                                "subresource": {
+                                                  "type": "string"
+                                                },
+                                                "time": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "namespace": {
+                                            "type": "string"
+                                          },
+                                          "ownerReferences": {
+                                            "items": {
+                                              "properties": {
+                                                "apiVersion": {
+                                                  "type": "string"
+                                                },
+                                                "blockOwnerDeletion": {
+                                                  "type": "boolean"
+                                                },
+                                                "controller": {
+                                                  "type": "boolean"
+                                                },
+                                                "kind": {
+                                                  "type": "string"
+                                                },
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "uid": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "resourceVersion": {
+                                            "type": "string"
+                                          },
+                                          "selfLink": {
+                                            "type": "string"
+                                          },
+                                          "uid": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "spec": {
+                                        "properties": {
+                                          "accessModes": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "dataSource": {
+                                            "properties": {
+                                              "apiGroup": {
+                                                "type": "string"
+                                              },
+                                              "kind": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          "dataSourceRef": {
+                                            "properties": {
+                                              "apiGroup": {
+                                                "type": "string"
+                                              },
+                                              "kind": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "namespace": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          "resources": {
+                                            "properties": {
+                                              "limits": {
+                                                "additionalProperties": {
+                                                  "anyOf": [
+                                                    {
+                                                      "type": "integer"
+                                                    },
+                                                    {
+                                                      "type": "string"
+                                                    }
+                                                  ],
+                                                  "x-kubernetes-int-or-string": true
+                                                },
+                                                "type": "object"
+                                              },
+                                              "requests": {
+                                                "additionalProperties": {
+                                                  "anyOf": [
+                                                    {
+                                                      "type": "integer"
+                                                    },
+                                                    {
+                                                      "type": "string"
+                                                    }
+                                                  ],
+                                                  "x-kubernetes-int-or-string": true
+                                                },
+                                                "type": "object"
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          "selector": {
+                                            "properties": {
+                                              "matchExpressions": {
+                                                "items": {
+                                                  "properties": {
+                                                    "key": {
+                                                      "type": "string"
+                                                    },
+                                                    "operator": {
+                                                      "type": "string"
+                                                    },
+                                                    "values": {
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    }
+                                                  },
+                                                  "type": "object"
+                                                },
+                                                "type": "array"
+                                              },
+                                              "matchLabels": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "type": "object"
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          "storageClassName": {
+                                            "type": "string"
+                                          },
+                                          "volumeAttributesClassName": {
+                                            "type": "string"
+                                          },
+                                          "volumeMode": {
+                                            "type": "string"
+                                          },
+                                          "volumeName": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "fc": {
+                                "properties": {
+                                  "fsType": {
+                                    "type": "string"
+                                  },
+                                  "lun": {
+                                    "type": "integer"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  },
+                                  "targetWWNs": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "wwids": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "flexVolume": {
+                                "properties": {
+                                  "driver": {
+                                    "type": "string"
+                                  },
+                                  "fsType": {
+                                    "type": "string"
+                                  },
+                                  "options": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  },
+                                  "secretRef": {
+                                    "properties": {
+                                      "name": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "flocker": {
+                                "properties": {
+                                  "datasetName": {
+                                    "type": "string"
+                                  },
+                                  "datasetUUID": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "gcePersistentDisk": {
+                                "properties": {
+                                  "fsType": {
+                                    "type": "string"
+                                  },
+                                  "partition": {
+                                    "type": "integer"
+                                  },
+                                  "pdName": {
+                                    "type": "string"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "gitRepo": {
+                                "properties": {
+                                  "directory": {
+                                    "type": "string"
+                                  },
+                                  "repository": {
+                                    "type": "string"
+                                  },
+                                  "revision": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "glusterfs": {
+                                "properties": {
+                                  "endpoints": {
+                                    "type": "string"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "hostPath": {
+                                "properties": {
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "type": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "image": {
+                                "properties": {
+                                  "pullPolicy": {
+                                    "type": "string"
+                                  },
+                                  "reference": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "iscsi": {
+                                "properties": {
+                                  "chapAuthDiscovery": {
+                                    "type": "boolean"
+                                  },
+                                  "chapAuthSession": {
+                                    "type": "boolean"
+                                  },
+                                  "fsType": {
+                                    "type": "string"
+                                  },
+                                  "initiatorName": {
+                                    "type": "string"
+                                  },
+                                  "iqn": {
+                                    "type": "string"
+                                  },
+                                  "iscsiInterface": {
+                                    "type": "string"
+                                  },
+                                  "lun": {
+                                    "type": "integer"
+                                  },
+                                  "portals": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  },
+                                  "secretRef": {
+                                    "properties": {
+                                      "name": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "targetPortal": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "nfs": {
+                                "properties": {
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  },
+                                  "server": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "persistentVolumeClaim": {
+                                "properties": {
+                                  "claimName": {
+                                    "type": "string"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "photonPersistentDisk": {
+                                "properties": {
+                                  "fsType": {
+                                    "type": "string"
+                                  },
+                                  "pdID": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "portworxVolume": {
+                                "properties": {
+                                  "fsType": {
+                                    "type": "string"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  },
+                                  "volumeID": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "projected": {
+                                "properties": {
+                                  "defaultMode": {
+                                    "type": "integer"
+                                  },
+                                  "sources": {
+                                    "items": {
+                                      "properties": {
+                                        "clusterTrustBundle": {
+                                          "properties": {
+                                            "labelSelector": {
+                                              "properties": {
+                                                "matchExpressions": {
+                                                  "items": {
+                                                    "properties": {
+                                                      "key": {
+                                                        "type": "string"
+                                                      },
+                                                      "operator": {
+                                                        "type": "string"
+                                                      },
+                                                      "values": {
+                                                        "items": {
+                                                          "type": "string"
+                                                        },
+                                                        "type": "array"
+                                                      }
+                                                    },
+                                                    "type": "object"
+                                                  },
+                                                  "type": "array"
+                                                },
+                                                "matchLabels": {
+                                                  "additionalProperties": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "object"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            },
+                                            "path": {
+                                              "type": "string"
+                                            },
+                                            "signerName": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "configMap": {
+                                          "properties": {
+                                            "items": {
+                                              "items": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "mode": {
+                                                    "type": "integer"
+                                                  },
+                                                  "path": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              "type": "array"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "downwardAPI": {
+                                          "properties": {
+                                            "items": {
+                                              "items": {
+                                                "properties": {
+                                                  "fieldRef": {
+                                                    "properties": {
+                                                      "apiVersion": {
+                                                        "type": "string"
+                                                      },
+                                                      "fieldPath": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "type": "object"
+                                                  },
+                                                  "mode": {
+                                                    "type": "integer"
+                                                  },
+                                                  "path": {
+                                                    "type": "string"
+                                                  },
+                                                  "resourceFieldRef": {
+                                                    "properties": {
+                                                      "containerName": {
+                                                        "type": "string"
+                                                      },
+                                                      "divisor": {
+                                                        "anyOf": [
+                                                          {
+                                                            "type": "integer"
+                                                          },
+                                                          {
+                                                            "type": "string"
+                                                          }
+                                                        ],
+                                                        "x-kubernetes-int-or-string": true
+                                                      },
+                                                      "resource": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "type": "object"
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "podCertificate": {
+                                          "properties": {
+                                            "certificateChainPath": {
+                                              "type": "string"
+                                            },
+                                            "credentialBundlePath": {
+                                              "type": "string"
+                                            },
+                                            "keyPath": {
+                                              "type": "string"
+                                            },
+                                            "keyType": {
+                                              "type": "string"
+                                            },
+                                            "maxExpirationSeconds": {
+                                              "type": "integer"
+                                            },
+                                            "signerName": {
+                                              "type": "string"
+                                            },
+                                            "userAnnotations": {
+                                              "additionalProperties": {
+                                                "type": "string"
+                                              },
+                                              "type": "object"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "secret": {
+                                          "properties": {
+                                            "items": {
+                                              "items": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "mode": {
+                                                    "type": "integer"
+                                                  },
+                                                  "path": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              "type": "array"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "serviceAccountToken": {
+                                          "properties": {
+                                            "audience": {
+                                              "type": "string"
+                                            },
+                                            "expirationSeconds": {
+                                              "type": "integer"
+                                            },
+                                            "path": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "quobyte": {
+                                "properties": {
+                                  "group": {
+                                    "type": "string"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  },
+                                  "registry": {
+                                    "type": "string"
+                                  },
+                                  "tenant": {
+                                    "type": "string"
+                                  },
+                                  "user": {
+                                    "type": "string"
+                                  },
+                                  "volume": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "rbd": {
+                                "properties": {
+                                  "fsType": {
+                                    "type": "string"
+                                  },
+                                  "image": {
+                                    "type": "string"
+                                  },
+                                  "keyring": {
+                                    "type": "string"
+                                  },
+                                  "monitors": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "pool": {
+                                    "type": "string"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  },
+                                  "secretRef": {
+                                    "properties": {
+                                      "name": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "user": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "scaleIO": {
+                                "properties": {
+                                  "fsType": {
+                                    "type": "string"
+                                  },
+                                  "gateway": {
+                                    "type": "string"
+                                  },
+                                  "protectionDomain": {
+                                    "type": "string"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  },
+                                  "secretRef": {
+                                    "properties": {
+                                      "name": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "sslEnabled": {
+                                    "type": "boolean"
+                                  },
+                                  "storageMode": {
+                                    "type": "string"
+                                  },
+                                  "storagePool": {
+                                    "type": "string"
+                                  },
+                                  "system": {
+                                    "type": "string"
+                                  },
+                                  "volumeName": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "secret": {
+                                "properties": {
+                                  "defaultMode": {
+                                    "type": "integer"
+                                  },
+                                  "items": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "mode": {
+                                          "type": "integer"
+                                        },
+                                        "path": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  },
+                                  "secretName": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "storageos": {
+                                "properties": {
+                                  "fsType": {
+                                    "type": "string"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  },
+                                  "secretRef": {
+                                    "properties": {
+                                      "name": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "volumeName": {
+                                    "type": "string"
+                                  },
+                                  "volumeNamespace": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "vsphereVolume": {
+                                "properties": {
+                                  "fsType": {
+                                    "type": "string"
+                                  },
+                                  "storagePolicyID": {
+                                    "type": "string"
+                                  },
+                                  "storagePolicyName": {
+                                    "type": "string"
+                                  },
+                                  "volumePath": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "workloadRef": {
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            },
+                            "podGroup": {
+                              "type": "string"
+                            },
+                            "podGroupReplicaKey": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        }
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "type": "object"
+                },
+                "updateStrategy": {
+                  "properties": {
+                    "rollingUpdate": {
+                      "properties": {
+                        "maxUnavailable": {
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "string"
+                            }
+                          ],
+                          "x-kubernetes-int-or-string": true
+                        },
+                        "partition": {
+                          "type": "integer"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "type": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "volumeClaimTemplates": {
+                  "items": {
+                    "properties": {
+                      "apiVersion": {
+                        "type": "string"
+                      },
+                      "kind": {
+                        "type": "string"
+                      },
+                      "metadata": {
+                        "properties": {
+                          "annotations": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "type": "object"
+                          },
+                          "creationTimestamp": {
+                            "type": "string"
+                          },
+                          "deletionGracePeriodSeconds": {
+                            "type": "integer"
+                          },
+                          "deletionTimestamp": {
+                            "type": "string"
+                          },
+                          "finalizers": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "generateName": {
+                            "type": "string"
+                          },
+                          "generation": {
+                            "type": "integer"
+                          },
+                          "labels": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "type": "object"
+                          },
+                          "managedFields": {
+                            "items": {
+                              "properties": {
+                                "apiVersion": {
+                                  "type": "string"
+                                },
+                                "fieldsType": {
+                                  "type": "string"
+                                },
+                                "fieldsV1": {
+                                  "type": "object"
+                                },
+                                "manager": {
+                                  "type": "string"
+                                },
+                                "operation": {
+                                  "type": "string"
+                                },
+                                "subresource": {
+                                  "type": "string"
+                                },
+                                "time": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "namespace": {
+                            "type": "string"
+                          },
+                          "ownerReferences": {
+                            "items": {
+                              "properties": {
+                                "apiVersion": {
+                                  "type": "string"
+                                },
+                                "blockOwnerDeletion": {
+                                  "type": "boolean"
+                                },
+                                "controller": {
+                                  "type": "boolean"
+                                },
+                                "kind": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "uid": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "resourceVersion": {
+                            "type": "string"
+                          },
+                          "selfLink": {
+                            "type": "string"
+                          },
+                          "uid": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "spec": {
+                        "properties": {
+                          "accessModes": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "dataSource": {
+                            "properties": {
+                              "apiGroup": {
+                                "type": "string"
+                              },
+                              "kind": {
+                                "type": "string"
+                              },
+                              "name": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "dataSourceRef": {
+                            "properties": {
+                              "apiGroup": {
+                                "type": "string"
+                              },
+                              "kind": {
+                                "type": "string"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "namespace": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "resources": {
+                            "properties": {
+                              "limits": {
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "type": "object"
+                              },
+                              "requests": {
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "selector": {
+                            "properties": {
+                              "matchExpressions": {
+                                "items": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "matchLabels": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "storageClassName": {
+                            "type": "string"
+                          },
+                          "volumeAttributesClassName": {
+                            "type": "string"
+                          },
+                          "volumeMode": {
+                            "type": "string"
+                          },
+                          "volumeName": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "status": {
+                        "properties": {
+                          "accessModes": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "allocatedResourceStatuses": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "type": "object"
+                          },
+                          "allocatedResources": {
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "type": "object"
+                          },
+                          "capacity": {
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "type": "object"
+                          },
+                          "conditions": {
+                            "items": {
+                              "properties": {
+                                "lastProbeTime": {
+                                  "type": "string"
+                                },
+                                "lastTransitionTime": {
+                                  "type": "string"
+                                },
+                                "message": {
+                                  "type": "string"
+                                },
+                                "reason": {
+                                  "type": "string"
+                                },
+                                "status": {
+                                  "type": "string"
+                                },
+                                "type": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "currentVolumeAttributesClassName": {
+                            "type": "string"
+                          },
+                          "modifyVolumeStatus": {
+                            "properties": {
+                              "status": {
+                                "type": "string"
+                              },
+                              "targetVolumeAttributesClassName": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "phase": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "type": "object"
+        },
+        "runtimeVersions": {
+          "properties": {
+            "jdkVersion": {
+              "type": "string"
+            },
+            "scalaVersion": {
+              "type": "string"
+            },
+            "sparkVersion": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "sparkVersion"
+          ],
+          "type": "object"
+        },
+        "sparkConf": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "workerSpec": {
+          "properties": {
+            "horizontalPodAutoscalerSpec": {
+              "properties": {
+                "behavior": {
+                  "properties": {
+                    "scaleDown": {
+                      "properties": {
+                        "policies": {
+                          "items": {
+                            "properties": {
+                              "periodSeconds": {
+                                "type": "integer"
+                              },
+                              "type": {
+                                "type": "string"
+                              },
+                              "value": {
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "selectPolicy": {
+                          "type": "string"
+                        },
+                        "stabilizationWindowSeconds": {
+                          "type": "integer"
+                        },
+                        "tolerance": {
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "string"
+                            }
+                          ],
+                          "x-kubernetes-int-or-string": true
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "scaleUp": {
+                      "properties": {
+                        "policies": {
+                          "items": {
+                            "properties": {
+                              "periodSeconds": {
+                                "type": "integer"
+                              },
+                              "type": {
+                                "type": "string"
+                              },
+                              "value": {
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "selectPolicy": {
+                          "type": "string"
+                        },
+                        "stabilizationWindowSeconds": {
+                          "type": "integer"
+                        },
+                        "tolerance": {
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "string"
+                            }
+                          ],
+                          "x-kubernetes-int-or-string": true
+                        }
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "type": "object"
+                },
+                "maxReplicas": {
+                  "type": "integer"
+                },
+                "metrics": {
+                  "items": {
+                    "properties": {
+                      "containerResource": {
+                        "properties": {
+                          "container": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "target": {
+                            "properties": {
+                              "averageUtilization": {
+                                "type": "integer"
+                              },
+                              "averageValue": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "type": {
+                                "type": "string"
+                              },
+                              "value": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              }
+                            },
+                            "type": "object"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "external": {
+                        "properties": {
+                          "metric": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "selector": {
+                                "properties": {
+                                  "matchExpressions": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "matchLabels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "target": {
+                            "properties": {
+                              "averageUtilization": {
+                                "type": "integer"
+                              },
+                              "averageValue": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "type": {
+                                "type": "string"
+                              },
+                              "value": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              }
+                            },
+                            "type": "object"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "object": {
+                        "properties": {
+                          "describedObject": {
+                            "properties": {
+                              "apiVersion": {
+                                "type": "string"
+                              },
+                              "kind": {
+                                "type": "string"
+                              },
+                              "name": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "metric": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "selector": {
+                                "properties": {
+                                  "matchExpressions": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "matchLabels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "target": {
+                            "properties": {
+                              "averageUtilization": {
+                                "type": "integer"
+                              },
+                              "averageValue": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "type": {
+                                "type": "string"
+                              },
+                              "value": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              }
+                            },
+                            "type": "object"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "pods": {
+                        "properties": {
+                          "metric": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "selector": {
+                                "properties": {
+                                  "matchExpressions": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "matchLabels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "target": {
+                            "properties": {
+                              "averageUtilization": {
+                                "type": "integer"
+                              },
+                              "averageValue": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "type": {
+                                "type": "string"
+                              },
+                              "value": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              }
+                            },
+                            "type": "object"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "resource": {
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          },
+                          "target": {
+                            "properties": {
+                              "averageUtilization": {
+                                "type": "integer"
+                              },
+                              "averageValue": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "type": {
+                                "type": "string"
+                              },
+                              "value": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              }
+                            },
+                            "type": "object"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "minReplicas": {
+                  "type": "integer"
+                },
+                "scaleTargetRef": {
+                  "properties": {
+                    "apiVersion": {
+                      "type": "string"
+                    },
+                    "kind": {
+                      "type": "string"
+                    },
+                    "name": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object"
+            },
+            "serviceMetadata": {
+              "properties": {
+                "annotations": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                },
+                "creationTimestamp": {
+                  "type": "string"
+                },
+                "deletionGracePeriodSeconds": {
+                  "type": "integer"
+                },
+                "deletionTimestamp": {
+                  "type": "string"
+                },
+                "finalizers": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "generateName": {
+                  "type": "string"
+                },
+                "generation": {
+                  "type": "integer"
+                },
+                "labels": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                },
+                "managedFields": {
+                  "items": {
+                    "properties": {
+                      "apiVersion": {
+                        "type": "string"
+                      },
+                      "fieldsType": {
+                        "type": "string"
+                      },
+                      "fieldsV1": {
+                        "type": "object"
+                      },
+                      "manager": {
+                        "type": "string"
+                      },
+                      "operation": {
+                        "type": "string"
+                      },
+                      "subresource": {
+                        "type": "string"
+                      },
+                      "time": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "namespace": {
+                  "type": "string"
+                },
+                "ownerReferences": {
+                  "items": {
+                    "properties": {
+                      "apiVersion": {
+                        "type": "string"
+                      },
+                      "blockOwnerDeletion": {
+                        "type": "boolean"
+                      },
+                      "controller": {
+                        "type": "boolean"
+                      },
+                      "kind": {
+                        "type": "string"
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "uid": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "resourceVersion": {
+                  "type": "string"
+                },
+                "selfLink": {
+                  "type": "string"
+                },
+                "uid": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "serviceSpec": {
+              "properties": {
+                "allocateLoadBalancerNodePorts": {
+                  "type": "boolean"
+                },
+                "clusterIP": {
+                  "type": "string"
+                },
+                "clusterIPs": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "externalIPs": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "externalName": {
+                  "type": "string"
+                },
+                "externalTrafficPolicy": {
+                  "type": "string"
+                },
+                "healthCheckNodePort": {
+                  "type": "integer"
+                },
+                "internalTrafficPolicy": {
+                  "type": "string"
+                },
+                "ipFamilies": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "ipFamilyPolicy": {
+                  "type": "string"
+                },
+                "loadBalancerClass": {
+                  "type": "string"
+                },
+                "loadBalancerIP": {
+                  "type": "string"
+                },
+                "loadBalancerSourceRanges": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "ports": {
+                  "items": {
+                    "properties": {
+                      "appProtocol": {
+                        "type": "string"
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "nodePort": {
+                        "type": "integer"
+                      },
+                      "port": {
+                        "type": "integer"
+                      },
+                      "protocol": {
+                        "type": "string"
+                      },
+                      "targetPort": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "x-kubernetes-int-or-string": true
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "publishNotReadyAddresses": {
+                  "type": "boolean"
+                },
+                "selector": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                },
+                "sessionAffinity": {
+                  "type": "string"
+                },
+                "sessionAffinityConfig": {
+                  "properties": {
+                    "clientIP": {
+                      "properties": {
+                        "timeoutSeconds": {
+                          "type": "integer"
+                        }
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "type": "object"
+                },
+                "trafficDistribution": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "statefulSetMetadata": {
+              "properties": {
+                "annotations": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                },
+                "creationTimestamp": {
+                  "type": "string"
+                },
+                "deletionGracePeriodSeconds": {
+                  "type": "integer"
+                },
+                "deletionTimestamp": {
+                  "type": "string"
+                },
+                "finalizers": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "generateName": {
+                  "type": "string"
+                },
+                "generation": {
+                  "type": "integer"
+                },
+                "labels": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                },
+                "managedFields": {
+                  "items": {
+                    "properties": {
+                      "apiVersion": {
+                        "type": "string"
+                      },
+                      "fieldsType": {
+                        "type": "string"
+                      },
+                      "fieldsV1": {
+                        "type": "object"
+                      },
+                      "manager": {
+                        "type": "string"
+                      },
+                      "operation": {
+                        "type": "string"
+                      },
+                      "subresource": {
+                        "type": "string"
+                      },
+                      "time": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "namespace": {
+                  "type": "string"
+                },
+                "ownerReferences": {
+                  "items": {
+                    "properties": {
+                      "apiVersion": {
+                        "type": "string"
+                      },
+                      "blockOwnerDeletion": {
+                        "type": "boolean"
+                      },
+                      "controller": {
+                        "type": "boolean"
+                      },
+                      "kind": {
+                        "type": "string"
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "uid": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "resourceVersion": {
+                  "type": "string"
+                },
+                "selfLink": {
+                  "type": "string"
+                },
+                "uid": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "statefulSetSpec": {
+              "properties": {
+                "minReadySeconds": {
+                  "type": "integer"
+                },
+                "ordinals": {
+                  "properties": {
+                    "start": {
+                      "type": "integer"
+                    }
+                  },
+                  "type": "object"
+                },
+                "persistentVolumeClaimRetentionPolicy": {
+                  "properties": {
+                    "whenDeleted": {
+                      "type": "string"
+                    },
+                    "whenScaled": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "podManagementPolicy": {
+                  "type": "string"
+                },
+                "replicas": {
+                  "type": "integer"
+                },
+                "revisionHistoryLimit": {
+                  "type": "integer"
+                },
+                "selector": {
+                  "properties": {
+                    "matchExpressions": {
+                      "items": {
+                        "properties": {
+                          "key": {
+                            "type": "string"
+                          },
+                          "operator": {
+                            "type": "string"
+                          },
+                          "values": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "matchLabels": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "type": "object"
+                },
+                "serviceName": {
+                  "type": "string"
+                },
+                "template": {
+                  "properties": {
+                    "metadata": {
+                      "properties": {
+                        "annotations": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        "creationTimestamp": {
+                          "type": "string"
+                        },
+                        "deletionGracePeriodSeconds": {
+                          "type": "integer"
+                        },
+                        "deletionTimestamp": {
+                          "type": "string"
+                        },
+                        "finalizers": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "generateName": {
+                          "type": "string"
+                        },
+                        "generation": {
+                          "type": "integer"
+                        },
+                        "labels": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        "managedFields": {
+                          "items": {
+                            "properties": {
+                              "apiVersion": {
+                                "type": "string"
+                              },
+                              "fieldsType": {
+                                "type": "string"
+                              },
+                              "fieldsV1": {
+                                "type": "object"
+                              },
+                              "manager": {
+                                "type": "string"
+                              },
+                              "operation": {
+                                "type": "string"
+                              },
+                              "subresource": {
+                                "type": "string"
+                              },
+                              "time": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "namespace": {
+                          "type": "string"
+                        },
+                        "ownerReferences": {
+                          "items": {
+                            "properties": {
+                              "apiVersion": {
+                                "type": "string"
+                              },
+                              "blockOwnerDeletion": {
+                                "type": "boolean"
+                              },
+                              "controller": {
+                                "type": "boolean"
+                              },
+                              "kind": {
+                                "type": "string"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "uid": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "resourceVersion": {
+                          "type": "string"
+                        },
+                        "selfLink": {
+                          "type": "string"
+                        },
+                        "uid": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "spec": {
+                      "properties": {
+                        "activeDeadlineSeconds": {
+                          "type": "integer"
+                        },
+                        "affinity": {
+                          "properties": {
+                            "nodeAffinity": {
+                              "properties": {
+                                "preferredDuringSchedulingIgnoredDuringExecution": {
+                                  "items": {
+                                    "properties": {
+                                      "preference": {
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "matchFields": {
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "weight": {
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "type": "array"
+                                },
+                                "requiredDuringSchedulingIgnoredDuringExecution": {
+                                  "properties": {
+                                    "nodeSelectorTerms": {
+                                      "items": {
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "matchFields": {
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "podAffinity": {
+                              "properties": {
+                                "preferredDuringSchedulingIgnoredDuringExecution": {
+                                  "items": {
+                                    "properties": {
+                                      "podAffinityTerm": {
+                                        "properties": {
+                                          "labelSelector": {
+                                            "properties": {
+                                              "matchExpressions": {
+                                                "items": {
+                                                  "properties": {
+                                                    "key": {
+                                                      "type": "string"
+                                                    },
+                                                    "operator": {
+                                                      "type": "string"
+                                                    },
+                                                    "values": {
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    }
+                                                  },
+                                                  "type": "object"
+                                                },
+                                                "type": "array"
+                                              },
+                                              "matchLabels": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "type": "object"
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          "matchLabelKeys": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "mismatchLabelKeys": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "namespaceSelector": {
+                                            "properties": {
+                                              "matchExpressions": {
+                                                "items": {
+                                                  "properties": {
+                                                    "key": {
+                                                      "type": "string"
+                                                    },
+                                                    "operator": {
+                                                      "type": "string"
+                                                    },
+                                                    "values": {
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    }
+                                                  },
+                                                  "type": "object"
+                                                },
+                                                "type": "array"
+                                              },
+                                              "matchLabels": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "type": "object"
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          "namespaces": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "topologyKey": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "weight": {
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "type": "array"
+                                },
+                                "requiredDuringSchedulingIgnoredDuringExecution": {
+                                  "items": {
+                                    "properties": {
+                                      "labelSelector": {
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "matchLabels": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "matchLabelKeys": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "mismatchLabelKeys": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "namespaceSelector": {
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "matchLabels": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "namespaces": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "topologyKey": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "podAntiAffinity": {
+                              "properties": {
+                                "preferredDuringSchedulingIgnoredDuringExecution": {
+                                  "items": {
+                                    "properties": {
+                                      "podAffinityTerm": {
+                                        "properties": {
+                                          "labelSelector": {
+                                            "properties": {
+                                              "matchExpressions": {
+                                                "items": {
+                                                  "properties": {
+                                                    "key": {
+                                                      "type": "string"
+                                                    },
+                                                    "operator": {
+                                                      "type": "string"
+                                                    },
+                                                    "values": {
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    }
+                                                  },
+                                                  "type": "object"
+                                                },
+                                                "type": "array"
+                                              },
+                                              "matchLabels": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "type": "object"
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          "matchLabelKeys": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "mismatchLabelKeys": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "namespaceSelector": {
+                                            "properties": {
+                                              "matchExpressions": {
+                                                "items": {
+                                                  "properties": {
+                                                    "key": {
+                                                      "type": "string"
+                                                    },
+                                                    "operator": {
+                                                      "type": "string"
+                                                    },
+                                                    "values": {
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    }
+                                                  },
+                                                  "type": "object"
+                                                },
+                                                "type": "array"
+                                              },
+                                              "matchLabels": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "type": "object"
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          "namespaces": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "topologyKey": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "weight": {
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "type": "array"
+                                },
+                                "requiredDuringSchedulingIgnoredDuringExecution": {
+                                  "items": {
+                                    "properties": {
+                                      "labelSelector": {
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "matchLabels": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "matchLabelKeys": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "mismatchLabelKeys": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "namespaceSelector": {
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "matchLabels": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "namespaces": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "topologyKey": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "type": "object"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "automountServiceAccountToken": {
+                          "type": "boolean"
+                        },
+                        "containers": {
+                          "items": {
+                            "properties": {
+                              "args": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "command": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "env": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    },
+                                    "valueFrom": {
+                                      "properties": {
+                                        "configMapKeyRef": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "fieldRef": {
+                                          "properties": {
+                                            "apiVersion": {
+                                              "type": "string"
+                                            },
+                                            "fieldPath": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "fileKeyRef": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            },
+                                            "path": {
+                                              "type": "string"
+                                            },
+                                            "volumeName": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "resourceFieldRef": {
+                                          "properties": {
+                                            "containerName": {
+                                              "type": "string"
+                                            },
+                                            "divisor": {
+                                              "anyOf": [
+                                                {
+                                                  "type": "integer"
+                                                },
+                                                {
+                                                  "type": "string"
+                                                }
+                                              ],
+                                              "x-kubernetes-int-or-string": true
+                                            },
+                                            "resource": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "secretKeyRef": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "type": "object"
+                                        }
+                                      },
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "envFrom": {
+                                "items": {
+                                  "properties": {
+                                    "configMapRef": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "prefix": {
+                                      "type": "string"
+                                    },
+                                    "secretRef": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "image": {
+                                "type": "string"
+                              },
+                              "imagePullPolicy": {
+                                "type": "string"
+                              },
+                              "lifecycle": {
+                                "properties": {
+                                  "postStart": {
+                                    "properties": {
+                                      "exec": {
+                                        "properties": {
+                                          "command": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "httpGet": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "httpHeaders": {
+                                            "items": {
+                                              "properties": {
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "value": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          },
+                                          "scheme": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "sleep": {
+                                        "properties": {
+                                          "seconds": {
+                                            "type": "integer"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "tcpSocket": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          }
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "preStop": {
+                                    "properties": {
+                                      "exec": {
+                                        "properties": {
+                                          "command": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "httpGet": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "httpHeaders": {
+                                            "items": {
+                                              "properties": {
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "value": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          },
+                                          "scheme": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "sleep": {
+                                        "properties": {
+                                          "seconds": {
+                                            "type": "integer"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "tcpSocket": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          }
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "stopSignal": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "livenessProbe": {
+                                "properties": {
+                                  "exec": {
+                                    "properties": {
+                                      "command": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "failureThreshold": {
+                                    "type": "integer"
+                                  },
+                                  "grpc": {
+                                    "properties": {
+                                      "port": {
+                                        "type": "integer"
+                                      },
+                                      "service": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "httpGet": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "initialDelaySeconds": {
+                                    "type": "integer"
+                                  },
+                                  "periodSeconds": {
+                                    "type": "integer"
+                                  },
+                                  "successThreshold": {
+                                    "type": "integer"
+                                  },
+                                  "tcpSocket": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "terminationGracePeriodSeconds": {
+                                    "type": "integer"
+                                  },
+                                  "timeoutSeconds": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "ports": {
+                                "items": {
+                                  "properties": {
+                                    "containerPort": {
+                                      "type": "integer"
+                                    },
+                                    "hostIP": {
+                                      "type": "string"
+                                    },
+                                    "hostPort": {
+                                      "type": "integer"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "protocol": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "readinessProbe": {
+                                "properties": {
+                                  "exec": {
+                                    "properties": {
+                                      "command": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "failureThreshold": {
+                                    "type": "integer"
+                                  },
+                                  "grpc": {
+                                    "properties": {
+                                      "port": {
+                                        "type": "integer"
+                                      },
+                                      "service": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "httpGet": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "initialDelaySeconds": {
+                                    "type": "integer"
+                                  },
+                                  "periodSeconds": {
+                                    "type": "integer"
+                                  },
+                                  "successThreshold": {
+                                    "type": "integer"
+                                  },
+                                  "tcpSocket": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "terminationGracePeriodSeconds": {
+                                    "type": "integer"
+                                  },
+                                  "timeoutSeconds": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "resizePolicy": {
+                                "items": {
+                                  "properties": {
+                                    "resourceName": {
+                                      "type": "string"
+                                    },
+                                    "restartPolicy": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "resources": {
+                                "properties": {
+                                  "claims": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "request": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "limits": {
+                                    "additionalProperties": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "string"
+                                        }
+                                      ],
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "type": "object"
+                                  },
+                                  "requests": {
+                                    "additionalProperties": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "string"
+                                        }
+                                      ],
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "restartPolicy": {
+                                "type": "string"
+                              },
+                              "restartPolicyRules": {
+                                "items": {
+                                  "properties": {
+                                    "action": {
+                                      "type": "string"
+                                    },
+                                    "exitCodes": {
+                                      "properties": {
+                                        "operator": {
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "items": {
+                                            "type": "integer"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "securityContext": {
+                                "properties": {
+                                  "allowPrivilegeEscalation": {
+                                    "type": "boolean"
+                                  },
+                                  "appArmorProfile": {
+                                    "properties": {
+                                      "localhostProfile": {
+                                        "type": "string"
+                                      },
+                                      "type": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "capabilities": {
+                                    "properties": {
+                                      "add": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "drop": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "privileged": {
+                                    "type": "boolean"
+                                  },
+                                  "procMount": {
+                                    "type": "string"
+                                  },
+                                  "readOnlyRootFilesystem": {
+                                    "type": "boolean"
+                                  },
+                                  "runAsGroup": {
+                                    "type": "integer"
+                                  },
+                                  "runAsNonRoot": {
+                                    "type": "boolean"
+                                  },
+                                  "runAsUser": {
+                                    "type": "integer"
+                                  },
+                                  "seLinuxOptions": {
+                                    "properties": {
+                                      "level": {
+                                        "type": "string"
+                                      },
+                                      "role": {
+                                        "type": "string"
+                                      },
+                                      "type": {
+                                        "type": "string"
+                                      },
+                                      "user": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "seccompProfile": {
+                                    "properties": {
+                                      "localhostProfile": {
+                                        "type": "string"
+                                      },
+                                      "type": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "windowsOptions": {
+                                    "properties": {
+                                      "gmsaCredentialSpec": {
+                                        "type": "string"
+                                      },
+                                      "gmsaCredentialSpecName": {
+                                        "type": "string"
+                                      },
+                                      "hostProcess": {
+                                        "type": "boolean"
+                                      },
+                                      "runAsUserName": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "startupProbe": {
+                                "properties": {
+                                  "exec": {
+                                    "properties": {
+                                      "command": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "failureThreshold": {
+                                    "type": "integer"
+                                  },
+                                  "grpc": {
+                                    "properties": {
+                                      "port": {
+                                        "type": "integer"
+                                      },
+                                      "service": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "httpGet": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "initialDelaySeconds": {
+                                    "type": "integer"
+                                  },
+                                  "periodSeconds": {
+                                    "type": "integer"
+                                  },
+                                  "successThreshold": {
+                                    "type": "integer"
+                                  },
+                                  "tcpSocket": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "terminationGracePeriodSeconds": {
+                                    "type": "integer"
+                                  },
+                                  "timeoutSeconds": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "stdin": {
+                                "type": "boolean"
+                              },
+                              "stdinOnce": {
+                                "type": "boolean"
+                              },
+                              "terminationMessagePath": {
+                                "type": "string"
+                              },
+                              "terminationMessagePolicy": {
+                                "type": "string"
+                              },
+                              "tty": {
+                                "type": "boolean"
+                              },
+                              "volumeDevices": {
+                                "items": {
+                                  "properties": {
+                                    "devicePath": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "volumeMounts": {
+                                "items": {
+                                  "properties": {
+                                    "mountPath": {
+                                      "type": "string"
+                                    },
+                                    "mountPropagation": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "readOnly": {
+                                      "type": "boolean"
+                                    },
+                                    "recursiveReadOnly": {
+                                      "type": "string"
+                                    },
+                                    "subPath": {
+                                      "type": "string"
+                                    },
+                                    "subPathExpr": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "workingDir": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "dnsConfig": {
+                          "properties": {
+                            "nameservers": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "options": {
+                              "items": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "value": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "searches": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "dnsPolicy": {
+                          "type": "string"
+                        },
+                        "enableServiceLinks": {
+                          "type": "boolean"
+                        },
+                        "ephemeralContainers": {
+                          "items": {
+                            "properties": {
+                              "args": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "command": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "env": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    },
+                                    "valueFrom": {
+                                      "properties": {
+                                        "configMapKeyRef": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "fieldRef": {
+                                          "properties": {
+                                            "apiVersion": {
+                                              "type": "string"
+                                            },
+                                            "fieldPath": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "fileKeyRef": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            },
+                                            "path": {
+                                              "type": "string"
+                                            },
+                                            "volumeName": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "resourceFieldRef": {
+                                          "properties": {
+                                            "containerName": {
+                                              "type": "string"
+                                            },
+                                            "divisor": {
+                                              "anyOf": [
+                                                {
+                                                  "type": "integer"
+                                                },
+                                                {
+                                                  "type": "string"
+                                                }
+                                              ],
+                                              "x-kubernetes-int-or-string": true
+                                            },
+                                            "resource": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "secretKeyRef": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "type": "object"
+                                        }
+                                      },
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "envFrom": {
+                                "items": {
+                                  "properties": {
+                                    "configMapRef": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "prefix": {
+                                      "type": "string"
+                                    },
+                                    "secretRef": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "image": {
+                                "type": "string"
+                              },
+                              "imagePullPolicy": {
+                                "type": "string"
+                              },
+                              "lifecycle": {
+                                "properties": {
+                                  "postStart": {
+                                    "properties": {
+                                      "exec": {
+                                        "properties": {
+                                          "command": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "httpGet": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "httpHeaders": {
+                                            "items": {
+                                              "properties": {
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "value": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          },
+                                          "scheme": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "sleep": {
+                                        "properties": {
+                                          "seconds": {
+                                            "type": "integer"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "tcpSocket": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          }
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "preStop": {
+                                    "properties": {
+                                      "exec": {
+                                        "properties": {
+                                          "command": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "httpGet": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "httpHeaders": {
+                                            "items": {
+                                              "properties": {
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "value": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          },
+                                          "scheme": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "sleep": {
+                                        "properties": {
+                                          "seconds": {
+                                            "type": "integer"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "tcpSocket": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          }
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "stopSignal": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "livenessProbe": {
+                                "properties": {
+                                  "exec": {
+                                    "properties": {
+                                      "command": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "failureThreshold": {
+                                    "type": "integer"
+                                  },
+                                  "grpc": {
+                                    "properties": {
+                                      "port": {
+                                        "type": "integer"
+                                      },
+                                      "service": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "httpGet": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "initialDelaySeconds": {
+                                    "type": "integer"
+                                  },
+                                  "periodSeconds": {
+                                    "type": "integer"
+                                  },
+                                  "successThreshold": {
+                                    "type": "integer"
+                                  },
+                                  "tcpSocket": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "terminationGracePeriodSeconds": {
+                                    "type": "integer"
+                                  },
+                                  "timeoutSeconds": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "ports": {
+                                "items": {
+                                  "properties": {
+                                    "containerPort": {
+                                      "type": "integer"
+                                    },
+                                    "hostIP": {
+                                      "type": "string"
+                                    },
+                                    "hostPort": {
+                                      "type": "integer"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "protocol": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "readinessProbe": {
+                                "properties": {
+                                  "exec": {
+                                    "properties": {
+                                      "command": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "failureThreshold": {
+                                    "type": "integer"
+                                  },
+                                  "grpc": {
+                                    "properties": {
+                                      "port": {
+                                        "type": "integer"
+                                      },
+                                      "service": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "httpGet": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "initialDelaySeconds": {
+                                    "type": "integer"
+                                  },
+                                  "periodSeconds": {
+                                    "type": "integer"
+                                  },
+                                  "successThreshold": {
+                                    "type": "integer"
+                                  },
+                                  "tcpSocket": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "terminationGracePeriodSeconds": {
+                                    "type": "integer"
+                                  },
+                                  "timeoutSeconds": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "resizePolicy": {
+                                "items": {
+                                  "properties": {
+                                    "resourceName": {
+                                      "type": "string"
+                                    },
+                                    "restartPolicy": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "resources": {
+                                "properties": {
+                                  "claims": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "request": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "limits": {
+                                    "additionalProperties": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "string"
+                                        }
+                                      ],
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "type": "object"
+                                  },
+                                  "requests": {
+                                    "additionalProperties": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "string"
+                                        }
+                                      ],
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "restartPolicy": {
+                                "type": "string"
+                              },
+                              "restartPolicyRules": {
+                                "items": {
+                                  "properties": {
+                                    "action": {
+                                      "type": "string"
+                                    },
+                                    "exitCodes": {
+                                      "properties": {
+                                        "operator": {
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "items": {
+                                            "type": "integer"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "securityContext": {
+                                "properties": {
+                                  "allowPrivilegeEscalation": {
+                                    "type": "boolean"
+                                  },
+                                  "appArmorProfile": {
+                                    "properties": {
+                                      "localhostProfile": {
+                                        "type": "string"
+                                      },
+                                      "type": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "capabilities": {
+                                    "properties": {
+                                      "add": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "drop": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "privileged": {
+                                    "type": "boolean"
+                                  },
+                                  "procMount": {
+                                    "type": "string"
+                                  },
+                                  "readOnlyRootFilesystem": {
+                                    "type": "boolean"
+                                  },
+                                  "runAsGroup": {
+                                    "type": "integer"
+                                  },
+                                  "runAsNonRoot": {
+                                    "type": "boolean"
+                                  },
+                                  "runAsUser": {
+                                    "type": "integer"
+                                  },
+                                  "seLinuxOptions": {
+                                    "properties": {
+                                      "level": {
+                                        "type": "string"
+                                      },
+                                      "role": {
+                                        "type": "string"
+                                      },
+                                      "type": {
+                                        "type": "string"
+                                      },
+                                      "user": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "seccompProfile": {
+                                    "properties": {
+                                      "localhostProfile": {
+                                        "type": "string"
+                                      },
+                                      "type": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "windowsOptions": {
+                                    "properties": {
+                                      "gmsaCredentialSpec": {
+                                        "type": "string"
+                                      },
+                                      "gmsaCredentialSpecName": {
+                                        "type": "string"
+                                      },
+                                      "hostProcess": {
+                                        "type": "boolean"
+                                      },
+                                      "runAsUserName": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "startupProbe": {
+                                "properties": {
+                                  "exec": {
+                                    "properties": {
+                                      "command": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "failureThreshold": {
+                                    "type": "integer"
+                                  },
+                                  "grpc": {
+                                    "properties": {
+                                      "port": {
+                                        "type": "integer"
+                                      },
+                                      "service": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "httpGet": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "initialDelaySeconds": {
+                                    "type": "integer"
+                                  },
+                                  "periodSeconds": {
+                                    "type": "integer"
+                                  },
+                                  "successThreshold": {
+                                    "type": "integer"
+                                  },
+                                  "tcpSocket": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "terminationGracePeriodSeconds": {
+                                    "type": "integer"
+                                  },
+                                  "timeoutSeconds": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "stdin": {
+                                "type": "boolean"
+                              },
+                              "stdinOnce": {
+                                "type": "boolean"
+                              },
+                              "targetContainerName": {
+                                "type": "string"
+                              },
+                              "terminationMessagePath": {
+                                "type": "string"
+                              },
+                              "terminationMessagePolicy": {
+                                "type": "string"
+                              },
+                              "tty": {
+                                "type": "boolean"
+                              },
+                              "volumeDevices": {
+                                "items": {
+                                  "properties": {
+                                    "devicePath": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "volumeMounts": {
+                                "items": {
+                                  "properties": {
+                                    "mountPath": {
+                                      "type": "string"
+                                    },
+                                    "mountPropagation": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "readOnly": {
+                                      "type": "boolean"
+                                    },
+                                    "recursiveReadOnly": {
+                                      "type": "string"
+                                    },
+                                    "subPath": {
+                                      "type": "string"
+                                    },
+                                    "subPathExpr": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "workingDir": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "hostAliases": {
+                          "items": {
+                            "properties": {
+                              "hostnames": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "ip": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "hostIPC": {
+                          "type": "boolean"
+                        },
+                        "hostNetwork": {
+                          "type": "boolean"
+                        },
+                        "hostPID": {
+                          "type": "boolean"
+                        },
+                        "hostUsers": {
+                          "type": "boolean"
+                        },
+                        "hostname": {
+                          "type": "string"
+                        },
+                        "hostnameOverride": {
+                          "type": "string"
+                        },
+                        "imagePullSecrets": {
+                          "items": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "initContainers": {
+                          "items": {
+                            "properties": {
+                              "args": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "command": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "env": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    },
+                                    "valueFrom": {
+                                      "properties": {
+                                        "configMapKeyRef": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "fieldRef": {
+                                          "properties": {
+                                            "apiVersion": {
+                                              "type": "string"
+                                            },
+                                            "fieldPath": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "fileKeyRef": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            },
+                                            "path": {
+                                              "type": "string"
+                                            },
+                                            "volumeName": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "resourceFieldRef": {
+                                          "properties": {
+                                            "containerName": {
+                                              "type": "string"
+                                            },
+                                            "divisor": {
+                                              "anyOf": [
+                                                {
+                                                  "type": "integer"
+                                                },
+                                                {
+                                                  "type": "string"
+                                                }
+                                              ],
+                                              "x-kubernetes-int-or-string": true
+                                            },
+                                            "resource": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "secretKeyRef": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "type": "object"
+                                        }
+                                      },
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "envFrom": {
+                                "items": {
+                                  "properties": {
+                                    "configMapRef": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "prefix": {
+                                      "type": "string"
+                                    },
+                                    "secretRef": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "image": {
+                                "type": "string"
+                              },
+                              "imagePullPolicy": {
+                                "type": "string"
+                              },
+                              "lifecycle": {
+                                "properties": {
+                                  "postStart": {
+                                    "properties": {
+                                      "exec": {
+                                        "properties": {
+                                          "command": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "httpGet": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "httpHeaders": {
+                                            "items": {
+                                              "properties": {
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "value": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          },
+                                          "scheme": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "sleep": {
+                                        "properties": {
+                                          "seconds": {
+                                            "type": "integer"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "tcpSocket": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          }
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "preStop": {
+                                    "properties": {
+                                      "exec": {
+                                        "properties": {
+                                          "command": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "httpGet": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "httpHeaders": {
+                                            "items": {
+                                              "properties": {
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "value": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          },
+                                          "scheme": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "sleep": {
+                                        "properties": {
+                                          "seconds": {
+                                            "type": "integer"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "tcpSocket": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          }
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "stopSignal": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "livenessProbe": {
+                                "properties": {
+                                  "exec": {
+                                    "properties": {
+                                      "command": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "failureThreshold": {
+                                    "type": "integer"
+                                  },
+                                  "grpc": {
+                                    "properties": {
+                                      "port": {
+                                        "type": "integer"
+                                      },
+                                      "service": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "httpGet": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "initialDelaySeconds": {
+                                    "type": "integer"
+                                  },
+                                  "periodSeconds": {
+                                    "type": "integer"
+                                  },
+                                  "successThreshold": {
+                                    "type": "integer"
+                                  },
+                                  "tcpSocket": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "terminationGracePeriodSeconds": {
+                                    "type": "integer"
+                                  },
+                                  "timeoutSeconds": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "ports": {
+                                "items": {
+                                  "properties": {
+                                    "containerPort": {
+                                      "type": "integer"
+                                    },
+                                    "hostIP": {
+                                      "type": "string"
+                                    },
+                                    "hostPort": {
+                                      "type": "integer"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "protocol": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "readinessProbe": {
+                                "properties": {
+                                  "exec": {
+                                    "properties": {
+                                      "command": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "failureThreshold": {
+                                    "type": "integer"
+                                  },
+                                  "grpc": {
+                                    "properties": {
+                                      "port": {
+                                        "type": "integer"
+                                      },
+                                      "service": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "httpGet": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "initialDelaySeconds": {
+                                    "type": "integer"
+                                  },
+                                  "periodSeconds": {
+                                    "type": "integer"
+                                  },
+                                  "successThreshold": {
+                                    "type": "integer"
+                                  },
+                                  "tcpSocket": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "terminationGracePeriodSeconds": {
+                                    "type": "integer"
+                                  },
+                                  "timeoutSeconds": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "resizePolicy": {
+                                "items": {
+                                  "properties": {
+                                    "resourceName": {
+                                      "type": "string"
+                                    },
+                                    "restartPolicy": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "resources": {
+                                "properties": {
+                                  "claims": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "request": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "limits": {
+                                    "additionalProperties": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "string"
+                                        }
+                                      ],
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "type": "object"
+                                  },
+                                  "requests": {
+                                    "additionalProperties": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "string"
+                                        }
+                                      ],
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "restartPolicy": {
+                                "type": "string"
+                              },
+                              "restartPolicyRules": {
+                                "items": {
+                                  "properties": {
+                                    "action": {
+                                      "type": "string"
+                                    },
+                                    "exitCodes": {
+                                      "properties": {
+                                        "operator": {
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "items": {
+                                            "type": "integer"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "securityContext": {
+                                "properties": {
+                                  "allowPrivilegeEscalation": {
+                                    "type": "boolean"
+                                  },
+                                  "appArmorProfile": {
+                                    "properties": {
+                                      "localhostProfile": {
+                                        "type": "string"
+                                      },
+                                      "type": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "capabilities": {
+                                    "properties": {
+                                      "add": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "drop": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "privileged": {
+                                    "type": "boolean"
+                                  },
+                                  "procMount": {
+                                    "type": "string"
+                                  },
+                                  "readOnlyRootFilesystem": {
+                                    "type": "boolean"
+                                  },
+                                  "runAsGroup": {
+                                    "type": "integer"
+                                  },
+                                  "runAsNonRoot": {
+                                    "type": "boolean"
+                                  },
+                                  "runAsUser": {
+                                    "type": "integer"
+                                  },
+                                  "seLinuxOptions": {
+                                    "properties": {
+                                      "level": {
+                                        "type": "string"
+                                      },
+                                      "role": {
+                                        "type": "string"
+                                      },
+                                      "type": {
+                                        "type": "string"
+                                      },
+                                      "user": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "seccompProfile": {
+                                    "properties": {
+                                      "localhostProfile": {
+                                        "type": "string"
+                                      },
+                                      "type": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "windowsOptions": {
+                                    "properties": {
+                                      "gmsaCredentialSpec": {
+                                        "type": "string"
+                                      },
+                                      "gmsaCredentialSpecName": {
+                                        "type": "string"
+                                      },
+                                      "hostProcess": {
+                                        "type": "boolean"
+                                      },
+                                      "runAsUserName": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "startupProbe": {
+                                "properties": {
+                                  "exec": {
+                                    "properties": {
+                                      "command": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "failureThreshold": {
+                                    "type": "integer"
+                                  },
+                                  "grpc": {
+                                    "properties": {
+                                      "port": {
+                                        "type": "integer"
+                                      },
+                                      "service": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "httpGet": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "initialDelaySeconds": {
+                                    "type": "integer"
+                                  },
+                                  "periodSeconds": {
+                                    "type": "integer"
+                                  },
+                                  "successThreshold": {
+                                    "type": "integer"
+                                  },
+                                  "tcpSocket": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "terminationGracePeriodSeconds": {
+                                    "type": "integer"
+                                  },
+                                  "timeoutSeconds": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "stdin": {
+                                "type": "boolean"
+                              },
+                              "stdinOnce": {
+                                "type": "boolean"
+                              },
+                              "terminationMessagePath": {
+                                "type": "string"
+                              },
+                              "terminationMessagePolicy": {
+                                "type": "string"
+                              },
+                              "tty": {
+                                "type": "boolean"
+                              },
+                              "volumeDevices": {
+                                "items": {
+                                  "properties": {
+                                    "devicePath": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "volumeMounts": {
+                                "items": {
+                                  "properties": {
+                                    "mountPath": {
+                                      "type": "string"
+                                    },
+                                    "mountPropagation": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "readOnly": {
+                                      "type": "boolean"
+                                    },
+                                    "recursiveReadOnly": {
+                                      "type": "string"
+                                    },
+                                    "subPath": {
+                                      "type": "string"
+                                    },
+                                    "subPathExpr": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "workingDir": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "nodeName": {
+                          "type": "string"
+                        },
+                        "nodeSelector": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        "os": {
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "overhead": {
+                          "additionalProperties": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "x-kubernetes-int-or-string": true
+                          },
+                          "type": "object"
+                        },
+                        "preemptionPolicy": {
+                          "type": "string"
+                        },
+                        "priority": {
+                          "type": "integer"
+                        },
+                        "priorityClassName": {
+                          "type": "string"
+                        },
+                        "readinessGates": {
+                          "items": {
+                            "properties": {
+                              "conditionType": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "resourceClaims": {
+                          "items": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "resourceClaimName": {
+                                "type": "string"
+                              },
+                              "resourceClaimTemplateName": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "resources": {
+                          "properties": {
+                            "claims": {
+                              "items": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "request": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "limits": {
+                              "additionalProperties": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "type": "object"
+                            },
+                            "requests": {
+                              "additionalProperties": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "type": "object"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "restartPolicy": {
+                          "type": "string"
+                        },
+                        "runtimeClassName": {
+                          "type": "string"
+                        },
+                        "schedulerName": {
+                          "type": "string"
+                        },
+                        "schedulingGates": {
+                          "items": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "securityContext": {
+                          "properties": {
+                            "appArmorProfile": {
+                              "properties": {
+                                "localhostProfile": {
+                                  "type": "string"
+                                },
+                                "type": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "fsGroup": {
+                              "type": "integer"
+                            },
+                            "fsGroupChangePolicy": {
+                              "type": "string"
+                            },
+                            "runAsGroup": {
+                              "type": "integer"
+                            },
+                            "runAsNonRoot": {
+                              "type": "boolean"
+                            },
+                            "runAsUser": {
+                              "type": "integer"
+                            },
+                            "seLinuxChangePolicy": {
+                              "type": "string"
+                            },
+                            "seLinuxOptions": {
+                              "properties": {
+                                "level": {
+                                  "type": "string"
+                                },
+                                "role": {
+                                  "type": "string"
+                                },
+                                "type": {
+                                  "type": "string"
+                                },
+                                "user": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "seccompProfile": {
+                              "properties": {
+                                "localhostProfile": {
+                                  "type": "string"
+                                },
+                                "type": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "supplementalGroups": {
+                              "items": {
+                                "type": "integer"
+                              },
+                              "type": "array"
+                            },
+                            "supplementalGroupsPolicy": {
+                              "type": "string"
+                            },
+                            "sysctls": {
+                              "items": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "value": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "windowsOptions": {
+                              "properties": {
+                                "gmsaCredentialSpec": {
+                                  "type": "string"
+                                },
+                                "gmsaCredentialSpecName": {
+                                  "type": "string"
+                                },
+                                "hostProcess": {
+                                  "type": "boolean"
+                                },
+                                "runAsUserName": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "serviceAccount": {
+                          "type": "string"
+                        },
+                        "serviceAccountName": {
+                          "type": "string"
+                        },
+                        "setHostnameAsFQDN": {
+                          "type": "boolean"
+                        },
+                        "shareProcessNamespace": {
+                          "type": "boolean"
+                        },
+                        "subdomain": {
+                          "type": "string"
+                        },
+                        "terminationGracePeriodSeconds": {
+                          "type": "integer"
+                        },
+                        "tolerations": {
+                          "items": {
+                            "properties": {
+                              "effect": {
+                                "type": "string"
+                              },
+                              "key": {
+                                "type": "string"
+                              },
+                              "operator": {
+                                "type": "string"
+                              },
+                              "tolerationSeconds": {
+                                "type": "integer"
+                              },
+                              "value": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "topologySpreadConstraints": {
+                          "items": {
+                            "properties": {
+                              "labelSelector": {
+                                "properties": {
+                                  "matchExpressions": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "matchLabels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "matchLabelKeys": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "maxSkew": {
+                                "type": "integer"
+                              },
+                              "minDomains": {
+                                "type": "integer"
+                              },
+                              "nodeAffinityPolicy": {
+                                "type": "string"
+                              },
+                              "nodeTaintsPolicy": {
+                                "type": "string"
+                              },
+                              "topologyKey": {
+                                "type": "string"
+                              },
+                              "whenUnsatisfiable": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "volumes": {
+                          "items": {
+                            "properties": {
+                              "awsElasticBlockStore": {
+                                "properties": {
+                                  "fsType": {
+                                    "type": "string"
+                                  },
+                                  "partition": {
+                                    "type": "integer"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  },
+                                  "volumeID": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "azureDisk": {
+                                "properties": {
+                                  "cachingMode": {
+                                    "type": "string"
+                                  },
+                                  "diskName": {
+                                    "type": "string"
+                                  },
+                                  "diskURI": {
+                                    "type": "string"
+                                  },
+                                  "fsType": {
+                                    "type": "string"
+                                  },
+                                  "kind": {
+                                    "type": "string"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "azureFile": {
+                                "properties": {
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  },
+                                  "secretName": {
+                                    "type": "string"
+                                  },
+                                  "shareName": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "cephfs": {
+                                "properties": {
+                                  "monitors": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  },
+                                  "secretFile": {
+                                    "type": "string"
+                                  },
+                                  "secretRef": {
+                                    "properties": {
+                                      "name": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "user": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "cinder": {
+                                "properties": {
+                                  "fsType": {
+                                    "type": "string"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  },
+                                  "secretRef": {
+                                    "properties": {
+                                      "name": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "volumeID": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "configMap": {
+                                "properties": {
+                                  "defaultMode": {
+                                    "type": "integer"
+                                  },
+                                  "items": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "mode": {
+                                          "type": "integer"
+                                        },
+                                        "path": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "csi": {
+                                "properties": {
+                                  "driver": {
+                                    "type": "string"
+                                  },
+                                  "fsType": {
+                                    "type": "string"
+                                  },
+                                  "nodePublishSecretRef": {
+                                    "properties": {
+                                      "name": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  },
+                                  "volumeAttributes": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "downwardAPI": {
+                                "properties": {
+                                  "defaultMode": {
+                                    "type": "integer"
+                                  },
+                                  "items": {
+                                    "items": {
+                                      "properties": {
+                                        "fieldRef": {
+                                          "properties": {
+                                            "apiVersion": {
+                                              "type": "string"
+                                            },
+                                            "fieldPath": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "mode": {
+                                          "type": "integer"
+                                        },
+                                        "path": {
+                                          "type": "string"
+                                        },
+                                        "resourceFieldRef": {
+                                          "properties": {
+                                            "containerName": {
+                                              "type": "string"
+                                            },
+                                            "divisor": {
+                                              "anyOf": [
+                                                {
+                                                  "type": "integer"
+                                                },
+                                                {
+                                                  "type": "string"
+                                                }
+                                              ],
+                                              "x-kubernetes-int-or-string": true
+                                            },
+                                            "resource": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "emptyDir": {
+                                "properties": {
+                                  "medium": {
+                                    "type": "string"
+                                  },
+                                  "sizeLimit": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "ephemeral": {
+                                "properties": {
+                                  "volumeClaimTemplate": {
+                                    "properties": {
+                                      "metadata": {
+                                        "properties": {
+                                          "annotations": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
+                                          },
+                                          "creationTimestamp": {
+                                            "type": "string"
+                                          },
+                                          "deletionGracePeriodSeconds": {
+                                            "type": "integer"
+                                          },
+                                          "deletionTimestamp": {
+                                            "type": "string"
+                                          },
+                                          "finalizers": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "generateName": {
+                                            "type": "string"
+                                          },
+                                          "generation": {
+                                            "type": "integer"
+                                          },
+                                          "labels": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
+                                          },
+                                          "managedFields": {
+                                            "items": {
+                                              "properties": {
+                                                "apiVersion": {
+                                                  "type": "string"
+                                                },
+                                                "fieldsType": {
+                                                  "type": "string"
+                                                },
+                                                "fieldsV1": {
+                                                  "type": "object"
+                                                },
+                                                "manager": {
+                                                  "type": "string"
+                                                },
+                                                "operation": {
+                                                  "type": "string"
+                                                },
+                                                "subresource": {
+                                                  "type": "string"
+                                                },
+                                                "time": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "namespace": {
+                                            "type": "string"
+                                          },
+                                          "ownerReferences": {
+                                            "items": {
+                                              "properties": {
+                                                "apiVersion": {
+                                                  "type": "string"
+                                                },
+                                                "blockOwnerDeletion": {
+                                                  "type": "boolean"
+                                                },
+                                                "controller": {
+                                                  "type": "boolean"
+                                                },
+                                                "kind": {
+                                                  "type": "string"
+                                                },
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "uid": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "resourceVersion": {
+                                            "type": "string"
+                                          },
+                                          "selfLink": {
+                                            "type": "string"
+                                          },
+                                          "uid": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "spec": {
+                                        "properties": {
+                                          "accessModes": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "dataSource": {
+                                            "properties": {
+                                              "apiGroup": {
+                                                "type": "string"
+                                              },
+                                              "kind": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          "dataSourceRef": {
+                                            "properties": {
+                                              "apiGroup": {
+                                                "type": "string"
+                                              },
+                                              "kind": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "namespace": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          "resources": {
+                                            "properties": {
+                                              "limits": {
+                                                "additionalProperties": {
+                                                  "anyOf": [
+                                                    {
+                                                      "type": "integer"
+                                                    },
+                                                    {
+                                                      "type": "string"
+                                                    }
+                                                  ],
+                                                  "x-kubernetes-int-or-string": true
+                                                },
+                                                "type": "object"
+                                              },
+                                              "requests": {
+                                                "additionalProperties": {
+                                                  "anyOf": [
+                                                    {
+                                                      "type": "integer"
+                                                    },
+                                                    {
+                                                      "type": "string"
+                                                    }
+                                                  ],
+                                                  "x-kubernetes-int-or-string": true
+                                                },
+                                                "type": "object"
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          "selector": {
+                                            "properties": {
+                                              "matchExpressions": {
+                                                "items": {
+                                                  "properties": {
+                                                    "key": {
+                                                      "type": "string"
+                                                    },
+                                                    "operator": {
+                                                      "type": "string"
+                                                    },
+                                                    "values": {
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    }
+                                                  },
+                                                  "type": "object"
+                                                },
+                                                "type": "array"
+                                              },
+                                              "matchLabels": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "type": "object"
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          "storageClassName": {
+                                            "type": "string"
+                                          },
+                                          "volumeAttributesClassName": {
+                                            "type": "string"
+                                          },
+                                          "volumeMode": {
+                                            "type": "string"
+                                          },
+                                          "volumeName": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "fc": {
+                                "properties": {
+                                  "fsType": {
+                                    "type": "string"
+                                  },
+                                  "lun": {
+                                    "type": "integer"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  },
+                                  "targetWWNs": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "wwids": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "flexVolume": {
+                                "properties": {
+                                  "driver": {
+                                    "type": "string"
+                                  },
+                                  "fsType": {
+                                    "type": "string"
+                                  },
+                                  "options": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  },
+                                  "secretRef": {
+                                    "properties": {
+                                      "name": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "flocker": {
+                                "properties": {
+                                  "datasetName": {
+                                    "type": "string"
+                                  },
+                                  "datasetUUID": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "gcePersistentDisk": {
+                                "properties": {
+                                  "fsType": {
+                                    "type": "string"
+                                  },
+                                  "partition": {
+                                    "type": "integer"
+                                  },
+                                  "pdName": {
+                                    "type": "string"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "gitRepo": {
+                                "properties": {
+                                  "directory": {
+                                    "type": "string"
+                                  },
+                                  "repository": {
+                                    "type": "string"
+                                  },
+                                  "revision": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "glusterfs": {
+                                "properties": {
+                                  "endpoints": {
+                                    "type": "string"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "hostPath": {
+                                "properties": {
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "type": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "image": {
+                                "properties": {
+                                  "pullPolicy": {
+                                    "type": "string"
+                                  },
+                                  "reference": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "iscsi": {
+                                "properties": {
+                                  "chapAuthDiscovery": {
+                                    "type": "boolean"
+                                  },
+                                  "chapAuthSession": {
+                                    "type": "boolean"
+                                  },
+                                  "fsType": {
+                                    "type": "string"
+                                  },
+                                  "initiatorName": {
+                                    "type": "string"
+                                  },
+                                  "iqn": {
+                                    "type": "string"
+                                  },
+                                  "iscsiInterface": {
+                                    "type": "string"
+                                  },
+                                  "lun": {
+                                    "type": "integer"
+                                  },
+                                  "portals": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  },
+                                  "secretRef": {
+                                    "properties": {
+                                      "name": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "targetPortal": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "nfs": {
+                                "properties": {
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  },
+                                  "server": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "persistentVolumeClaim": {
+                                "properties": {
+                                  "claimName": {
+                                    "type": "string"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "photonPersistentDisk": {
+                                "properties": {
+                                  "fsType": {
+                                    "type": "string"
+                                  },
+                                  "pdID": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "portworxVolume": {
+                                "properties": {
+                                  "fsType": {
+                                    "type": "string"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  },
+                                  "volumeID": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "projected": {
+                                "properties": {
+                                  "defaultMode": {
+                                    "type": "integer"
+                                  },
+                                  "sources": {
+                                    "items": {
+                                      "properties": {
+                                        "clusterTrustBundle": {
+                                          "properties": {
+                                            "labelSelector": {
+                                              "properties": {
+                                                "matchExpressions": {
+                                                  "items": {
+                                                    "properties": {
+                                                      "key": {
+                                                        "type": "string"
+                                                      },
+                                                      "operator": {
+                                                        "type": "string"
+                                                      },
+                                                      "values": {
+                                                        "items": {
+                                                          "type": "string"
+                                                        },
+                                                        "type": "array"
+                                                      }
+                                                    },
+                                                    "type": "object"
+                                                  },
+                                                  "type": "array"
+                                                },
+                                                "matchLabels": {
+                                                  "additionalProperties": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "object"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            },
+                                            "path": {
+                                              "type": "string"
+                                            },
+                                            "signerName": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "configMap": {
+                                          "properties": {
+                                            "items": {
+                                              "items": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "mode": {
+                                                    "type": "integer"
+                                                  },
+                                                  "path": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              "type": "array"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "downwardAPI": {
+                                          "properties": {
+                                            "items": {
+                                              "items": {
+                                                "properties": {
+                                                  "fieldRef": {
+                                                    "properties": {
+                                                      "apiVersion": {
+                                                        "type": "string"
+                                                      },
+                                                      "fieldPath": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "type": "object"
+                                                  },
+                                                  "mode": {
+                                                    "type": "integer"
+                                                  },
+                                                  "path": {
+                                                    "type": "string"
+                                                  },
+                                                  "resourceFieldRef": {
+                                                    "properties": {
+                                                      "containerName": {
+                                                        "type": "string"
+                                                      },
+                                                      "divisor": {
+                                                        "anyOf": [
+                                                          {
+                                                            "type": "integer"
+                                                          },
+                                                          {
+                                                            "type": "string"
+                                                          }
+                                                        ],
+                                                        "x-kubernetes-int-or-string": true
+                                                      },
+                                                      "resource": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "type": "object"
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "podCertificate": {
+                                          "properties": {
+                                            "certificateChainPath": {
+                                              "type": "string"
+                                            },
+                                            "credentialBundlePath": {
+                                              "type": "string"
+                                            },
+                                            "keyPath": {
+                                              "type": "string"
+                                            },
+                                            "keyType": {
+                                              "type": "string"
+                                            },
+                                            "maxExpirationSeconds": {
+                                              "type": "integer"
+                                            },
+                                            "signerName": {
+                                              "type": "string"
+                                            },
+                                            "userAnnotations": {
+                                              "additionalProperties": {
+                                                "type": "string"
+                                              },
+                                              "type": "object"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "secret": {
+                                          "properties": {
+                                            "items": {
+                                              "items": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "mode": {
+                                                    "type": "integer"
+                                                  },
+                                                  "path": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              "type": "array"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "serviceAccountToken": {
+                                          "properties": {
+                                            "audience": {
+                                              "type": "string"
+                                            },
+                                            "expirationSeconds": {
+                                              "type": "integer"
+                                            },
+                                            "path": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "quobyte": {
+                                "properties": {
+                                  "group": {
+                                    "type": "string"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  },
+                                  "registry": {
+                                    "type": "string"
+                                  },
+                                  "tenant": {
+                                    "type": "string"
+                                  },
+                                  "user": {
+                                    "type": "string"
+                                  },
+                                  "volume": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "rbd": {
+                                "properties": {
+                                  "fsType": {
+                                    "type": "string"
+                                  },
+                                  "image": {
+                                    "type": "string"
+                                  },
+                                  "keyring": {
+                                    "type": "string"
+                                  },
+                                  "monitors": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "pool": {
+                                    "type": "string"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  },
+                                  "secretRef": {
+                                    "properties": {
+                                      "name": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "user": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "scaleIO": {
+                                "properties": {
+                                  "fsType": {
+                                    "type": "string"
+                                  },
+                                  "gateway": {
+                                    "type": "string"
+                                  },
+                                  "protectionDomain": {
+                                    "type": "string"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  },
+                                  "secretRef": {
+                                    "properties": {
+                                      "name": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "sslEnabled": {
+                                    "type": "boolean"
+                                  },
+                                  "storageMode": {
+                                    "type": "string"
+                                  },
+                                  "storagePool": {
+                                    "type": "string"
+                                  },
+                                  "system": {
+                                    "type": "string"
+                                  },
+                                  "volumeName": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "secret": {
+                                "properties": {
+                                  "defaultMode": {
+                                    "type": "integer"
+                                  },
+                                  "items": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "mode": {
+                                          "type": "integer"
+                                        },
+                                        "path": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  },
+                                  "secretName": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "storageos": {
+                                "properties": {
+                                  "fsType": {
+                                    "type": "string"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  },
+                                  "secretRef": {
+                                    "properties": {
+                                      "name": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "volumeName": {
+                                    "type": "string"
+                                  },
+                                  "volumeNamespace": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "vsphereVolume": {
+                                "properties": {
+                                  "fsType": {
+                                    "type": "string"
+                                  },
+                                  "storagePolicyID": {
+                                    "type": "string"
+                                  },
+                                  "storagePolicyName": {
+                                    "type": "string"
+                                  },
+                                  "volumePath": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "workloadRef": {
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            },
+                            "podGroup": {
+                              "type": "string"
+                            },
+                            "podGroupReplicaKey": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        }
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "type": "object"
+                },
+                "updateStrategy": {
+                  "properties": {
+                    "rollingUpdate": {
+                      "properties": {
+                        "maxUnavailable": {
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "string"
+                            }
+                          ],
+                          "x-kubernetes-int-or-string": true
+                        },
+                        "partition": {
+                          "type": "integer"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "type": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "volumeClaimTemplates": {
+                  "items": {
+                    "properties": {
+                      "apiVersion": {
+                        "type": "string"
+                      },
+                      "kind": {
+                        "type": "string"
+                      },
+                      "metadata": {
+                        "properties": {
+                          "annotations": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "type": "object"
+                          },
+                          "creationTimestamp": {
+                            "type": "string"
+                          },
+                          "deletionGracePeriodSeconds": {
+                            "type": "integer"
+                          },
+                          "deletionTimestamp": {
+                            "type": "string"
+                          },
+                          "finalizers": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "generateName": {
+                            "type": "string"
+                          },
+                          "generation": {
+                            "type": "integer"
+                          },
+                          "labels": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "type": "object"
+                          },
+                          "managedFields": {
+                            "items": {
+                              "properties": {
+                                "apiVersion": {
+                                  "type": "string"
+                                },
+                                "fieldsType": {
+                                  "type": "string"
+                                },
+                                "fieldsV1": {
+                                  "type": "object"
+                                },
+                                "manager": {
+                                  "type": "string"
+                                },
+                                "operation": {
+                                  "type": "string"
+                                },
+                                "subresource": {
+                                  "type": "string"
+                                },
+                                "time": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "namespace": {
+                            "type": "string"
+                          },
+                          "ownerReferences": {
+                            "items": {
+                              "properties": {
+                                "apiVersion": {
+                                  "type": "string"
+                                },
+                                "blockOwnerDeletion": {
+                                  "type": "boolean"
+                                },
+                                "controller": {
+                                  "type": "boolean"
+                                },
+                                "kind": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "uid": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "resourceVersion": {
+                            "type": "string"
+                          },
+                          "selfLink": {
+                            "type": "string"
+                          },
+                          "uid": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "spec": {
+                        "properties": {
+                          "accessModes": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "dataSource": {
+                            "properties": {
+                              "apiGroup": {
+                                "type": "string"
+                              },
+                              "kind": {
+                                "type": "string"
+                              },
+                              "name": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "dataSourceRef": {
+                            "properties": {
+                              "apiGroup": {
+                                "type": "string"
+                              },
+                              "kind": {
+                                "type": "string"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "namespace": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "resources": {
+                            "properties": {
+                              "limits": {
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "type": "object"
+                              },
+                              "requests": {
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "selector": {
+                            "properties": {
+                              "matchExpressions": {
+                                "items": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "matchLabels": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "storageClassName": {
+                            "type": "string"
+                          },
+                          "volumeAttributesClassName": {
+                            "type": "string"
+                          },
+                          "volumeMode": {
+                            "type": "string"
+                          },
+                          "volumeName": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "status": {
+                        "properties": {
+                          "accessModes": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "allocatedResourceStatuses": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "type": "object"
+                          },
+                          "allocatedResources": {
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "type": "object"
+                          },
+                          "capacity": {
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "type": "object"
+                          },
+                          "conditions": {
+                            "items": {
+                              "properties": {
+                                "lastProbeTime": {
+                                  "type": "string"
+                                },
+                                "lastTransitionTime": {
+                                  "type": "string"
+                                },
+                                "message": {
+                                  "type": "string"
+                                },
+                                "reason": {
+                                  "type": "string"
+                                },
+                                "status": {
+                                  "type": "string"
+                                },
+                                "type": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "currentVolumeAttributesClassName": {
+                            "type": "string"
+                          },
+                          "modifyVolumeStatus": {
+                            "properties": {
+                              "status": {
+                                "type": "string"
+                              },
+                              "targetVolumeAttributesClassName": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "phase": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "type": "object"
+        }
+      },
+      "required": [
+        "clusterTolerations",
+        "runtimeVersions"
+      ],
+      "type": "object"
+    },
+    "status": {
+      "properties": {
+        "currentAttemptSummary": {
+          "properties": {
+            "attemptInfo": {
+              "properties": {
+                "id": {
+                  "type": "integer"
+                },
+                "restartCounter": {
+                  "type": "integer"
+                }
+              },
+              "type": "object"
+            },
+            "stateTransitionHistory": {
+              "additionalProperties": {
+                "properties": {
+                  "currentStateSummary": {
+                    "enum": [
+                      "Failed",
+                      "ResourceReleased",
+                      "RunningHealthy",
+                      "SchedulingFailure",
+                      "Submitted"
+                    ],
+                    "type": "string"
+                  },
+                  "lastTransitionTime": {
+                    "type": "string"
+                  },
+                  "message": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "type": "object"
+            }
+          },
+          "type": "object"
+        },
+        "currentState": {
+          "properties": {
+            "currentStateSummary": {
+              "enum": [
+                "Failed",
+                "ResourceReleased",
+                "RunningHealthy",
+                "SchedulingFailure",
+                "Submitted"
+              ],
+              "type": "string"
+            },
+            "lastTransitionTime": {
+              "type": "string"
+            },
+            "message": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "previousAttemptSummary": {
+          "properties": {
+            "attemptInfo": {
+              "properties": {
+                "id": {
+                  "type": "integer"
+                },
+                "restartCounter": {
+                  "type": "integer"
+                }
+              },
+              "type": "object"
+            },
+            "stateTransitionHistory": {
+              "additionalProperties": {
+                "properties": {
+                  "currentStateSummary": {
+                    "enum": [
+                      "Failed",
+                      "ResourceReleased",
+                      "RunningHealthy",
+                      "SchedulingFailure",
+                      "Submitted"
+                    ],
+                    "type": "string"
+                  },
+                  "lastTransitionTime": {
+                    "type": "string"
+                  },
+                  "message": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "type": "object"
+            }
+          },
+          "type": "object"
+        },
+        "stateTransitionHistory": {
+          "additionalProperties": {
+            "properties": {
+              "currentStateSummary": {
+                "enum": [
+                  "Failed",
+                  "ResourceReleased",
+                  "RunningHealthy",
+                  "SchedulingFailure",
+                  "Submitted"
+                ],
+                "type": "string"
+              },
+              "lastTransitionTime": {
+                "type": "string"
+              },
+              "message": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "type": "object"
+        }
+      },
+      "type": "object"
+    },
+    "apiVersion": {
+      "type": "string"
+    },
+    "kind": {
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    }
+  },
+  "type": "object"
+}

--- a/spark.apache.org/sparkcluster_v1alpha1.json
+++ b/spark.apache.org/sparkcluster_v1alpha1.json
@@ -1,0 +1,11662 @@
+{
+  "properties": {
+    "spec": {
+      "properties": {
+        "clusterTolerations": {
+          "properties": {
+            "instanceConfig": {
+              "properties": {
+                "initWorkers": {
+                  "type": "integer"
+                },
+                "maxWorkers": {
+                  "type": "integer"
+                },
+                "minWorkers": {
+                  "type": "integer"
+                }
+              },
+              "required": [
+                "initWorkers",
+                "maxWorkers",
+                "minWorkers"
+              ],
+              "type": "object"
+            }
+          },
+          "required": [
+            "instanceConfig"
+          ],
+          "type": "object"
+        },
+        "masterSpec": {
+          "properties": {
+            "serviceMetadata": {
+              "properties": {
+                "annotations": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                },
+                "creationTimestamp": {
+                  "type": "string"
+                },
+                "deletionGracePeriodSeconds": {
+                  "type": "integer"
+                },
+                "deletionTimestamp": {
+                  "type": "string"
+                },
+                "finalizers": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "generateName": {
+                  "type": "string"
+                },
+                "generation": {
+                  "type": "integer"
+                },
+                "labels": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                },
+                "managedFields": {
+                  "items": {
+                    "properties": {
+                      "apiVersion": {
+                        "type": "string"
+                      },
+                      "fieldsType": {
+                        "type": "string"
+                      },
+                      "fieldsV1": {
+                        "type": "object"
+                      },
+                      "manager": {
+                        "type": "string"
+                      },
+                      "operation": {
+                        "type": "string"
+                      },
+                      "subresource": {
+                        "type": "string"
+                      },
+                      "time": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "namespace": {
+                  "type": "string"
+                },
+                "ownerReferences": {
+                  "items": {
+                    "properties": {
+                      "apiVersion": {
+                        "type": "string"
+                      },
+                      "blockOwnerDeletion": {
+                        "type": "boolean"
+                      },
+                      "controller": {
+                        "type": "boolean"
+                      },
+                      "kind": {
+                        "type": "string"
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "uid": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "resourceVersion": {
+                  "type": "string"
+                },
+                "selfLink": {
+                  "type": "string"
+                },
+                "uid": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "serviceSpec": {
+              "properties": {
+                "allocateLoadBalancerNodePorts": {
+                  "type": "boolean"
+                },
+                "clusterIP": {
+                  "type": "string"
+                },
+                "clusterIPs": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "externalIPs": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "externalName": {
+                  "type": "string"
+                },
+                "externalTrafficPolicy": {
+                  "type": "string"
+                },
+                "healthCheckNodePort": {
+                  "type": "integer"
+                },
+                "internalTrafficPolicy": {
+                  "type": "string"
+                },
+                "ipFamilies": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "ipFamilyPolicy": {
+                  "type": "string"
+                },
+                "loadBalancerClass": {
+                  "type": "string"
+                },
+                "loadBalancerIP": {
+                  "type": "string"
+                },
+                "loadBalancerSourceRanges": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "ports": {
+                  "items": {
+                    "properties": {
+                      "appProtocol": {
+                        "type": "string"
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "nodePort": {
+                        "type": "integer"
+                      },
+                      "port": {
+                        "type": "integer"
+                      },
+                      "protocol": {
+                        "type": "string"
+                      },
+                      "targetPort": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "x-kubernetes-int-or-string": true
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "publishNotReadyAddresses": {
+                  "type": "boolean"
+                },
+                "selector": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                },
+                "sessionAffinity": {
+                  "type": "string"
+                },
+                "sessionAffinityConfig": {
+                  "properties": {
+                    "clientIP": {
+                      "properties": {
+                        "timeoutSeconds": {
+                          "type": "integer"
+                        }
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "type": "object"
+                },
+                "trafficDistribution": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "statefulSetMetadata": {
+              "properties": {
+                "annotations": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                },
+                "creationTimestamp": {
+                  "type": "string"
+                },
+                "deletionGracePeriodSeconds": {
+                  "type": "integer"
+                },
+                "deletionTimestamp": {
+                  "type": "string"
+                },
+                "finalizers": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "generateName": {
+                  "type": "string"
+                },
+                "generation": {
+                  "type": "integer"
+                },
+                "labels": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                },
+                "managedFields": {
+                  "items": {
+                    "properties": {
+                      "apiVersion": {
+                        "type": "string"
+                      },
+                      "fieldsType": {
+                        "type": "string"
+                      },
+                      "fieldsV1": {
+                        "type": "object"
+                      },
+                      "manager": {
+                        "type": "string"
+                      },
+                      "operation": {
+                        "type": "string"
+                      },
+                      "subresource": {
+                        "type": "string"
+                      },
+                      "time": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "namespace": {
+                  "type": "string"
+                },
+                "ownerReferences": {
+                  "items": {
+                    "properties": {
+                      "apiVersion": {
+                        "type": "string"
+                      },
+                      "blockOwnerDeletion": {
+                        "type": "boolean"
+                      },
+                      "controller": {
+                        "type": "boolean"
+                      },
+                      "kind": {
+                        "type": "string"
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "uid": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "resourceVersion": {
+                  "type": "string"
+                },
+                "selfLink": {
+                  "type": "string"
+                },
+                "uid": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "statefulSetSpec": {
+              "properties": {
+                "minReadySeconds": {
+                  "type": "integer"
+                },
+                "ordinals": {
+                  "properties": {
+                    "start": {
+                      "type": "integer"
+                    }
+                  },
+                  "type": "object"
+                },
+                "persistentVolumeClaimRetentionPolicy": {
+                  "properties": {
+                    "whenDeleted": {
+                      "type": "string"
+                    },
+                    "whenScaled": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "podManagementPolicy": {
+                  "type": "string"
+                },
+                "replicas": {
+                  "type": "integer"
+                },
+                "revisionHistoryLimit": {
+                  "type": "integer"
+                },
+                "selector": {
+                  "properties": {
+                    "matchExpressions": {
+                      "items": {
+                        "properties": {
+                          "key": {
+                            "type": "string"
+                          },
+                          "operator": {
+                            "type": "string"
+                          },
+                          "values": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "matchLabels": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "type": "object"
+                },
+                "serviceName": {
+                  "type": "string"
+                },
+                "template": {
+                  "properties": {
+                    "metadata": {
+                      "properties": {
+                        "annotations": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        "creationTimestamp": {
+                          "type": "string"
+                        },
+                        "deletionGracePeriodSeconds": {
+                          "type": "integer"
+                        },
+                        "deletionTimestamp": {
+                          "type": "string"
+                        },
+                        "finalizers": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "generateName": {
+                          "type": "string"
+                        },
+                        "generation": {
+                          "type": "integer"
+                        },
+                        "labels": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        "managedFields": {
+                          "items": {
+                            "properties": {
+                              "apiVersion": {
+                                "type": "string"
+                              },
+                              "fieldsType": {
+                                "type": "string"
+                              },
+                              "fieldsV1": {
+                                "type": "object"
+                              },
+                              "manager": {
+                                "type": "string"
+                              },
+                              "operation": {
+                                "type": "string"
+                              },
+                              "subresource": {
+                                "type": "string"
+                              },
+                              "time": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "namespace": {
+                          "type": "string"
+                        },
+                        "ownerReferences": {
+                          "items": {
+                            "properties": {
+                              "apiVersion": {
+                                "type": "string"
+                              },
+                              "blockOwnerDeletion": {
+                                "type": "boolean"
+                              },
+                              "controller": {
+                                "type": "boolean"
+                              },
+                              "kind": {
+                                "type": "string"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "uid": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "resourceVersion": {
+                          "type": "string"
+                        },
+                        "selfLink": {
+                          "type": "string"
+                        },
+                        "uid": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "spec": {
+                      "properties": {
+                        "activeDeadlineSeconds": {
+                          "type": "integer"
+                        },
+                        "affinity": {
+                          "properties": {
+                            "nodeAffinity": {
+                              "properties": {
+                                "preferredDuringSchedulingIgnoredDuringExecution": {
+                                  "items": {
+                                    "properties": {
+                                      "preference": {
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "matchFields": {
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "weight": {
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "type": "array"
+                                },
+                                "requiredDuringSchedulingIgnoredDuringExecution": {
+                                  "properties": {
+                                    "nodeSelectorTerms": {
+                                      "items": {
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "matchFields": {
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "podAffinity": {
+                              "properties": {
+                                "preferredDuringSchedulingIgnoredDuringExecution": {
+                                  "items": {
+                                    "properties": {
+                                      "podAffinityTerm": {
+                                        "properties": {
+                                          "labelSelector": {
+                                            "properties": {
+                                              "matchExpressions": {
+                                                "items": {
+                                                  "properties": {
+                                                    "key": {
+                                                      "type": "string"
+                                                    },
+                                                    "operator": {
+                                                      "type": "string"
+                                                    },
+                                                    "values": {
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    }
+                                                  },
+                                                  "type": "object"
+                                                },
+                                                "type": "array"
+                                              },
+                                              "matchLabels": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "type": "object"
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          "matchLabelKeys": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "mismatchLabelKeys": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "namespaceSelector": {
+                                            "properties": {
+                                              "matchExpressions": {
+                                                "items": {
+                                                  "properties": {
+                                                    "key": {
+                                                      "type": "string"
+                                                    },
+                                                    "operator": {
+                                                      "type": "string"
+                                                    },
+                                                    "values": {
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    }
+                                                  },
+                                                  "type": "object"
+                                                },
+                                                "type": "array"
+                                              },
+                                              "matchLabels": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "type": "object"
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          "namespaces": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "topologyKey": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "weight": {
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "type": "array"
+                                },
+                                "requiredDuringSchedulingIgnoredDuringExecution": {
+                                  "items": {
+                                    "properties": {
+                                      "labelSelector": {
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "matchLabels": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "matchLabelKeys": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "mismatchLabelKeys": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "namespaceSelector": {
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "matchLabels": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "namespaces": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "topologyKey": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "podAntiAffinity": {
+                              "properties": {
+                                "preferredDuringSchedulingIgnoredDuringExecution": {
+                                  "items": {
+                                    "properties": {
+                                      "podAffinityTerm": {
+                                        "properties": {
+                                          "labelSelector": {
+                                            "properties": {
+                                              "matchExpressions": {
+                                                "items": {
+                                                  "properties": {
+                                                    "key": {
+                                                      "type": "string"
+                                                    },
+                                                    "operator": {
+                                                      "type": "string"
+                                                    },
+                                                    "values": {
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    }
+                                                  },
+                                                  "type": "object"
+                                                },
+                                                "type": "array"
+                                              },
+                                              "matchLabels": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "type": "object"
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          "matchLabelKeys": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "mismatchLabelKeys": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "namespaceSelector": {
+                                            "properties": {
+                                              "matchExpressions": {
+                                                "items": {
+                                                  "properties": {
+                                                    "key": {
+                                                      "type": "string"
+                                                    },
+                                                    "operator": {
+                                                      "type": "string"
+                                                    },
+                                                    "values": {
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    }
+                                                  },
+                                                  "type": "object"
+                                                },
+                                                "type": "array"
+                                              },
+                                              "matchLabels": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "type": "object"
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          "namespaces": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "topologyKey": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "weight": {
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "type": "array"
+                                },
+                                "requiredDuringSchedulingIgnoredDuringExecution": {
+                                  "items": {
+                                    "properties": {
+                                      "labelSelector": {
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "matchLabels": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "matchLabelKeys": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "mismatchLabelKeys": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "namespaceSelector": {
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "matchLabels": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "namespaces": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "topologyKey": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "type": "object"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "automountServiceAccountToken": {
+                          "type": "boolean"
+                        },
+                        "containers": {
+                          "items": {
+                            "properties": {
+                              "args": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "command": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "env": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    },
+                                    "valueFrom": {
+                                      "properties": {
+                                        "configMapKeyRef": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "fieldRef": {
+                                          "properties": {
+                                            "apiVersion": {
+                                              "type": "string"
+                                            },
+                                            "fieldPath": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "resourceFieldRef": {
+                                          "properties": {
+                                            "containerName": {
+                                              "type": "string"
+                                            },
+                                            "divisor": {
+                                              "anyOf": [
+                                                {
+                                                  "type": "integer"
+                                                },
+                                                {
+                                                  "type": "string"
+                                                }
+                                              ],
+                                              "x-kubernetes-int-or-string": true
+                                            },
+                                            "resource": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "secretKeyRef": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "type": "object"
+                                        }
+                                      },
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "envFrom": {
+                                "items": {
+                                  "properties": {
+                                    "configMapRef": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "prefix": {
+                                      "type": "string"
+                                    },
+                                    "secretRef": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "image": {
+                                "type": "string"
+                              },
+                              "imagePullPolicy": {
+                                "type": "string"
+                              },
+                              "lifecycle": {
+                                "properties": {
+                                  "postStart": {
+                                    "properties": {
+                                      "exec": {
+                                        "properties": {
+                                          "command": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "httpGet": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "httpHeaders": {
+                                            "items": {
+                                              "properties": {
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "value": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          },
+                                          "scheme": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "sleep": {
+                                        "properties": {
+                                          "seconds": {
+                                            "type": "integer"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "tcpSocket": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          }
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "preStop": {
+                                    "properties": {
+                                      "exec": {
+                                        "properties": {
+                                          "command": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "httpGet": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "httpHeaders": {
+                                            "items": {
+                                              "properties": {
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "value": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          },
+                                          "scheme": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "sleep": {
+                                        "properties": {
+                                          "seconds": {
+                                            "type": "integer"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "tcpSocket": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          }
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "stopSignal": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "livenessProbe": {
+                                "properties": {
+                                  "exec": {
+                                    "properties": {
+                                      "command": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "failureThreshold": {
+                                    "type": "integer"
+                                  },
+                                  "grpc": {
+                                    "properties": {
+                                      "port": {
+                                        "type": "integer"
+                                      },
+                                      "service": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "httpGet": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "initialDelaySeconds": {
+                                    "type": "integer"
+                                  },
+                                  "periodSeconds": {
+                                    "type": "integer"
+                                  },
+                                  "successThreshold": {
+                                    "type": "integer"
+                                  },
+                                  "tcpSocket": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "terminationGracePeriodSeconds": {
+                                    "type": "integer"
+                                  },
+                                  "timeoutSeconds": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "ports": {
+                                "items": {
+                                  "properties": {
+                                    "containerPort": {
+                                      "type": "integer"
+                                    },
+                                    "hostIP": {
+                                      "type": "string"
+                                    },
+                                    "hostPort": {
+                                      "type": "integer"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "protocol": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "readinessProbe": {
+                                "properties": {
+                                  "exec": {
+                                    "properties": {
+                                      "command": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "failureThreshold": {
+                                    "type": "integer"
+                                  },
+                                  "grpc": {
+                                    "properties": {
+                                      "port": {
+                                        "type": "integer"
+                                      },
+                                      "service": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "httpGet": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "initialDelaySeconds": {
+                                    "type": "integer"
+                                  },
+                                  "periodSeconds": {
+                                    "type": "integer"
+                                  },
+                                  "successThreshold": {
+                                    "type": "integer"
+                                  },
+                                  "tcpSocket": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "terminationGracePeriodSeconds": {
+                                    "type": "integer"
+                                  },
+                                  "timeoutSeconds": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "resizePolicy": {
+                                "items": {
+                                  "properties": {
+                                    "resourceName": {
+                                      "type": "string"
+                                    },
+                                    "restartPolicy": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "resources": {
+                                "properties": {
+                                  "claims": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "request": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "limits": {
+                                    "additionalProperties": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "string"
+                                        }
+                                      ],
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "type": "object"
+                                  },
+                                  "requests": {
+                                    "additionalProperties": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "string"
+                                        }
+                                      ],
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "restartPolicy": {
+                                "type": "string"
+                              },
+                              "securityContext": {
+                                "properties": {
+                                  "allowPrivilegeEscalation": {
+                                    "type": "boolean"
+                                  },
+                                  "appArmorProfile": {
+                                    "properties": {
+                                      "localhostProfile": {
+                                        "type": "string"
+                                      },
+                                      "type": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "capabilities": {
+                                    "properties": {
+                                      "add": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "drop": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "privileged": {
+                                    "type": "boolean"
+                                  },
+                                  "procMount": {
+                                    "type": "string"
+                                  },
+                                  "readOnlyRootFilesystem": {
+                                    "type": "boolean"
+                                  },
+                                  "runAsGroup": {
+                                    "type": "integer"
+                                  },
+                                  "runAsNonRoot": {
+                                    "type": "boolean"
+                                  },
+                                  "runAsUser": {
+                                    "type": "integer"
+                                  },
+                                  "seLinuxOptions": {
+                                    "properties": {
+                                      "level": {
+                                        "type": "string"
+                                      },
+                                      "role": {
+                                        "type": "string"
+                                      },
+                                      "type": {
+                                        "type": "string"
+                                      },
+                                      "user": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "seccompProfile": {
+                                    "properties": {
+                                      "localhostProfile": {
+                                        "type": "string"
+                                      },
+                                      "type": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "windowsOptions": {
+                                    "properties": {
+                                      "gmsaCredentialSpec": {
+                                        "type": "string"
+                                      },
+                                      "gmsaCredentialSpecName": {
+                                        "type": "string"
+                                      },
+                                      "hostProcess": {
+                                        "type": "boolean"
+                                      },
+                                      "runAsUserName": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "startupProbe": {
+                                "properties": {
+                                  "exec": {
+                                    "properties": {
+                                      "command": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "failureThreshold": {
+                                    "type": "integer"
+                                  },
+                                  "grpc": {
+                                    "properties": {
+                                      "port": {
+                                        "type": "integer"
+                                      },
+                                      "service": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "httpGet": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "initialDelaySeconds": {
+                                    "type": "integer"
+                                  },
+                                  "periodSeconds": {
+                                    "type": "integer"
+                                  },
+                                  "successThreshold": {
+                                    "type": "integer"
+                                  },
+                                  "tcpSocket": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "terminationGracePeriodSeconds": {
+                                    "type": "integer"
+                                  },
+                                  "timeoutSeconds": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "stdin": {
+                                "type": "boolean"
+                              },
+                              "stdinOnce": {
+                                "type": "boolean"
+                              },
+                              "terminationMessagePath": {
+                                "type": "string"
+                              },
+                              "terminationMessagePolicy": {
+                                "type": "string"
+                              },
+                              "tty": {
+                                "type": "boolean"
+                              },
+                              "volumeDevices": {
+                                "items": {
+                                  "properties": {
+                                    "devicePath": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "volumeMounts": {
+                                "items": {
+                                  "properties": {
+                                    "mountPath": {
+                                      "type": "string"
+                                    },
+                                    "mountPropagation": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "readOnly": {
+                                      "type": "boolean"
+                                    },
+                                    "recursiveReadOnly": {
+                                      "type": "string"
+                                    },
+                                    "subPath": {
+                                      "type": "string"
+                                    },
+                                    "subPathExpr": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "workingDir": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "dnsConfig": {
+                          "properties": {
+                            "nameservers": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "options": {
+                              "items": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "value": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "searches": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "dnsPolicy": {
+                          "type": "string"
+                        },
+                        "enableServiceLinks": {
+                          "type": "boolean"
+                        },
+                        "ephemeralContainers": {
+                          "items": {
+                            "properties": {
+                              "args": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "command": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "env": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    },
+                                    "valueFrom": {
+                                      "properties": {
+                                        "configMapKeyRef": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "fieldRef": {
+                                          "properties": {
+                                            "apiVersion": {
+                                              "type": "string"
+                                            },
+                                            "fieldPath": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "resourceFieldRef": {
+                                          "properties": {
+                                            "containerName": {
+                                              "type": "string"
+                                            },
+                                            "divisor": {
+                                              "anyOf": [
+                                                {
+                                                  "type": "integer"
+                                                },
+                                                {
+                                                  "type": "string"
+                                                }
+                                              ],
+                                              "x-kubernetes-int-or-string": true
+                                            },
+                                            "resource": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "secretKeyRef": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "type": "object"
+                                        }
+                                      },
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "envFrom": {
+                                "items": {
+                                  "properties": {
+                                    "configMapRef": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "prefix": {
+                                      "type": "string"
+                                    },
+                                    "secretRef": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "image": {
+                                "type": "string"
+                              },
+                              "imagePullPolicy": {
+                                "type": "string"
+                              },
+                              "lifecycle": {
+                                "properties": {
+                                  "postStart": {
+                                    "properties": {
+                                      "exec": {
+                                        "properties": {
+                                          "command": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "httpGet": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "httpHeaders": {
+                                            "items": {
+                                              "properties": {
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "value": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          },
+                                          "scheme": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "sleep": {
+                                        "properties": {
+                                          "seconds": {
+                                            "type": "integer"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "tcpSocket": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          }
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "preStop": {
+                                    "properties": {
+                                      "exec": {
+                                        "properties": {
+                                          "command": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "httpGet": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "httpHeaders": {
+                                            "items": {
+                                              "properties": {
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "value": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          },
+                                          "scheme": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "sleep": {
+                                        "properties": {
+                                          "seconds": {
+                                            "type": "integer"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "tcpSocket": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          }
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "stopSignal": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "livenessProbe": {
+                                "properties": {
+                                  "exec": {
+                                    "properties": {
+                                      "command": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "failureThreshold": {
+                                    "type": "integer"
+                                  },
+                                  "grpc": {
+                                    "properties": {
+                                      "port": {
+                                        "type": "integer"
+                                      },
+                                      "service": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "httpGet": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "initialDelaySeconds": {
+                                    "type": "integer"
+                                  },
+                                  "periodSeconds": {
+                                    "type": "integer"
+                                  },
+                                  "successThreshold": {
+                                    "type": "integer"
+                                  },
+                                  "tcpSocket": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "terminationGracePeriodSeconds": {
+                                    "type": "integer"
+                                  },
+                                  "timeoutSeconds": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "ports": {
+                                "items": {
+                                  "properties": {
+                                    "containerPort": {
+                                      "type": "integer"
+                                    },
+                                    "hostIP": {
+                                      "type": "string"
+                                    },
+                                    "hostPort": {
+                                      "type": "integer"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "protocol": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "readinessProbe": {
+                                "properties": {
+                                  "exec": {
+                                    "properties": {
+                                      "command": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "failureThreshold": {
+                                    "type": "integer"
+                                  },
+                                  "grpc": {
+                                    "properties": {
+                                      "port": {
+                                        "type": "integer"
+                                      },
+                                      "service": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "httpGet": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "initialDelaySeconds": {
+                                    "type": "integer"
+                                  },
+                                  "periodSeconds": {
+                                    "type": "integer"
+                                  },
+                                  "successThreshold": {
+                                    "type": "integer"
+                                  },
+                                  "tcpSocket": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "terminationGracePeriodSeconds": {
+                                    "type": "integer"
+                                  },
+                                  "timeoutSeconds": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "resizePolicy": {
+                                "items": {
+                                  "properties": {
+                                    "resourceName": {
+                                      "type": "string"
+                                    },
+                                    "restartPolicy": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "resources": {
+                                "properties": {
+                                  "claims": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "request": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "limits": {
+                                    "additionalProperties": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "string"
+                                        }
+                                      ],
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "type": "object"
+                                  },
+                                  "requests": {
+                                    "additionalProperties": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "string"
+                                        }
+                                      ],
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "restartPolicy": {
+                                "type": "string"
+                              },
+                              "securityContext": {
+                                "properties": {
+                                  "allowPrivilegeEscalation": {
+                                    "type": "boolean"
+                                  },
+                                  "appArmorProfile": {
+                                    "properties": {
+                                      "localhostProfile": {
+                                        "type": "string"
+                                      },
+                                      "type": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "capabilities": {
+                                    "properties": {
+                                      "add": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "drop": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "privileged": {
+                                    "type": "boolean"
+                                  },
+                                  "procMount": {
+                                    "type": "string"
+                                  },
+                                  "readOnlyRootFilesystem": {
+                                    "type": "boolean"
+                                  },
+                                  "runAsGroup": {
+                                    "type": "integer"
+                                  },
+                                  "runAsNonRoot": {
+                                    "type": "boolean"
+                                  },
+                                  "runAsUser": {
+                                    "type": "integer"
+                                  },
+                                  "seLinuxOptions": {
+                                    "properties": {
+                                      "level": {
+                                        "type": "string"
+                                      },
+                                      "role": {
+                                        "type": "string"
+                                      },
+                                      "type": {
+                                        "type": "string"
+                                      },
+                                      "user": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "seccompProfile": {
+                                    "properties": {
+                                      "localhostProfile": {
+                                        "type": "string"
+                                      },
+                                      "type": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "windowsOptions": {
+                                    "properties": {
+                                      "gmsaCredentialSpec": {
+                                        "type": "string"
+                                      },
+                                      "gmsaCredentialSpecName": {
+                                        "type": "string"
+                                      },
+                                      "hostProcess": {
+                                        "type": "boolean"
+                                      },
+                                      "runAsUserName": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "startupProbe": {
+                                "properties": {
+                                  "exec": {
+                                    "properties": {
+                                      "command": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "failureThreshold": {
+                                    "type": "integer"
+                                  },
+                                  "grpc": {
+                                    "properties": {
+                                      "port": {
+                                        "type": "integer"
+                                      },
+                                      "service": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "httpGet": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "initialDelaySeconds": {
+                                    "type": "integer"
+                                  },
+                                  "periodSeconds": {
+                                    "type": "integer"
+                                  },
+                                  "successThreshold": {
+                                    "type": "integer"
+                                  },
+                                  "tcpSocket": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "terminationGracePeriodSeconds": {
+                                    "type": "integer"
+                                  },
+                                  "timeoutSeconds": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "stdin": {
+                                "type": "boolean"
+                              },
+                              "stdinOnce": {
+                                "type": "boolean"
+                              },
+                              "targetContainerName": {
+                                "type": "string"
+                              },
+                              "terminationMessagePath": {
+                                "type": "string"
+                              },
+                              "terminationMessagePolicy": {
+                                "type": "string"
+                              },
+                              "tty": {
+                                "type": "boolean"
+                              },
+                              "volumeDevices": {
+                                "items": {
+                                  "properties": {
+                                    "devicePath": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "volumeMounts": {
+                                "items": {
+                                  "properties": {
+                                    "mountPath": {
+                                      "type": "string"
+                                    },
+                                    "mountPropagation": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "readOnly": {
+                                      "type": "boolean"
+                                    },
+                                    "recursiveReadOnly": {
+                                      "type": "string"
+                                    },
+                                    "subPath": {
+                                      "type": "string"
+                                    },
+                                    "subPathExpr": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "workingDir": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "hostAliases": {
+                          "items": {
+                            "properties": {
+                              "hostnames": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "ip": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "hostIPC": {
+                          "type": "boolean"
+                        },
+                        "hostNetwork": {
+                          "type": "boolean"
+                        },
+                        "hostPID": {
+                          "type": "boolean"
+                        },
+                        "hostUsers": {
+                          "type": "boolean"
+                        },
+                        "hostname": {
+                          "type": "string"
+                        },
+                        "imagePullSecrets": {
+                          "items": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "initContainers": {
+                          "items": {
+                            "properties": {
+                              "args": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "command": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "env": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    },
+                                    "valueFrom": {
+                                      "properties": {
+                                        "configMapKeyRef": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "fieldRef": {
+                                          "properties": {
+                                            "apiVersion": {
+                                              "type": "string"
+                                            },
+                                            "fieldPath": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "resourceFieldRef": {
+                                          "properties": {
+                                            "containerName": {
+                                              "type": "string"
+                                            },
+                                            "divisor": {
+                                              "anyOf": [
+                                                {
+                                                  "type": "integer"
+                                                },
+                                                {
+                                                  "type": "string"
+                                                }
+                                              ],
+                                              "x-kubernetes-int-or-string": true
+                                            },
+                                            "resource": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "secretKeyRef": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "type": "object"
+                                        }
+                                      },
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "envFrom": {
+                                "items": {
+                                  "properties": {
+                                    "configMapRef": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "prefix": {
+                                      "type": "string"
+                                    },
+                                    "secretRef": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "image": {
+                                "type": "string"
+                              },
+                              "imagePullPolicy": {
+                                "type": "string"
+                              },
+                              "lifecycle": {
+                                "properties": {
+                                  "postStart": {
+                                    "properties": {
+                                      "exec": {
+                                        "properties": {
+                                          "command": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "httpGet": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "httpHeaders": {
+                                            "items": {
+                                              "properties": {
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "value": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          },
+                                          "scheme": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "sleep": {
+                                        "properties": {
+                                          "seconds": {
+                                            "type": "integer"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "tcpSocket": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          }
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "preStop": {
+                                    "properties": {
+                                      "exec": {
+                                        "properties": {
+                                          "command": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "httpGet": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "httpHeaders": {
+                                            "items": {
+                                              "properties": {
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "value": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          },
+                                          "scheme": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "sleep": {
+                                        "properties": {
+                                          "seconds": {
+                                            "type": "integer"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "tcpSocket": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          }
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "stopSignal": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "livenessProbe": {
+                                "properties": {
+                                  "exec": {
+                                    "properties": {
+                                      "command": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "failureThreshold": {
+                                    "type": "integer"
+                                  },
+                                  "grpc": {
+                                    "properties": {
+                                      "port": {
+                                        "type": "integer"
+                                      },
+                                      "service": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "httpGet": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "initialDelaySeconds": {
+                                    "type": "integer"
+                                  },
+                                  "periodSeconds": {
+                                    "type": "integer"
+                                  },
+                                  "successThreshold": {
+                                    "type": "integer"
+                                  },
+                                  "tcpSocket": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "terminationGracePeriodSeconds": {
+                                    "type": "integer"
+                                  },
+                                  "timeoutSeconds": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "ports": {
+                                "items": {
+                                  "properties": {
+                                    "containerPort": {
+                                      "type": "integer"
+                                    },
+                                    "hostIP": {
+                                      "type": "string"
+                                    },
+                                    "hostPort": {
+                                      "type": "integer"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "protocol": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "readinessProbe": {
+                                "properties": {
+                                  "exec": {
+                                    "properties": {
+                                      "command": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "failureThreshold": {
+                                    "type": "integer"
+                                  },
+                                  "grpc": {
+                                    "properties": {
+                                      "port": {
+                                        "type": "integer"
+                                      },
+                                      "service": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "httpGet": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "initialDelaySeconds": {
+                                    "type": "integer"
+                                  },
+                                  "periodSeconds": {
+                                    "type": "integer"
+                                  },
+                                  "successThreshold": {
+                                    "type": "integer"
+                                  },
+                                  "tcpSocket": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "terminationGracePeriodSeconds": {
+                                    "type": "integer"
+                                  },
+                                  "timeoutSeconds": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "resizePolicy": {
+                                "items": {
+                                  "properties": {
+                                    "resourceName": {
+                                      "type": "string"
+                                    },
+                                    "restartPolicy": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "resources": {
+                                "properties": {
+                                  "claims": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "request": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "limits": {
+                                    "additionalProperties": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "string"
+                                        }
+                                      ],
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "type": "object"
+                                  },
+                                  "requests": {
+                                    "additionalProperties": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "string"
+                                        }
+                                      ],
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "restartPolicy": {
+                                "type": "string"
+                              },
+                              "securityContext": {
+                                "properties": {
+                                  "allowPrivilegeEscalation": {
+                                    "type": "boolean"
+                                  },
+                                  "appArmorProfile": {
+                                    "properties": {
+                                      "localhostProfile": {
+                                        "type": "string"
+                                      },
+                                      "type": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "capabilities": {
+                                    "properties": {
+                                      "add": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "drop": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "privileged": {
+                                    "type": "boolean"
+                                  },
+                                  "procMount": {
+                                    "type": "string"
+                                  },
+                                  "readOnlyRootFilesystem": {
+                                    "type": "boolean"
+                                  },
+                                  "runAsGroup": {
+                                    "type": "integer"
+                                  },
+                                  "runAsNonRoot": {
+                                    "type": "boolean"
+                                  },
+                                  "runAsUser": {
+                                    "type": "integer"
+                                  },
+                                  "seLinuxOptions": {
+                                    "properties": {
+                                      "level": {
+                                        "type": "string"
+                                      },
+                                      "role": {
+                                        "type": "string"
+                                      },
+                                      "type": {
+                                        "type": "string"
+                                      },
+                                      "user": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "seccompProfile": {
+                                    "properties": {
+                                      "localhostProfile": {
+                                        "type": "string"
+                                      },
+                                      "type": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "windowsOptions": {
+                                    "properties": {
+                                      "gmsaCredentialSpec": {
+                                        "type": "string"
+                                      },
+                                      "gmsaCredentialSpecName": {
+                                        "type": "string"
+                                      },
+                                      "hostProcess": {
+                                        "type": "boolean"
+                                      },
+                                      "runAsUserName": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "startupProbe": {
+                                "properties": {
+                                  "exec": {
+                                    "properties": {
+                                      "command": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "failureThreshold": {
+                                    "type": "integer"
+                                  },
+                                  "grpc": {
+                                    "properties": {
+                                      "port": {
+                                        "type": "integer"
+                                      },
+                                      "service": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "httpGet": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "initialDelaySeconds": {
+                                    "type": "integer"
+                                  },
+                                  "periodSeconds": {
+                                    "type": "integer"
+                                  },
+                                  "successThreshold": {
+                                    "type": "integer"
+                                  },
+                                  "tcpSocket": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "terminationGracePeriodSeconds": {
+                                    "type": "integer"
+                                  },
+                                  "timeoutSeconds": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "stdin": {
+                                "type": "boolean"
+                              },
+                              "stdinOnce": {
+                                "type": "boolean"
+                              },
+                              "terminationMessagePath": {
+                                "type": "string"
+                              },
+                              "terminationMessagePolicy": {
+                                "type": "string"
+                              },
+                              "tty": {
+                                "type": "boolean"
+                              },
+                              "volumeDevices": {
+                                "items": {
+                                  "properties": {
+                                    "devicePath": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "volumeMounts": {
+                                "items": {
+                                  "properties": {
+                                    "mountPath": {
+                                      "type": "string"
+                                    },
+                                    "mountPropagation": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "readOnly": {
+                                      "type": "boolean"
+                                    },
+                                    "recursiveReadOnly": {
+                                      "type": "string"
+                                    },
+                                    "subPath": {
+                                      "type": "string"
+                                    },
+                                    "subPathExpr": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "workingDir": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "nodeName": {
+                          "type": "string"
+                        },
+                        "nodeSelector": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        "os": {
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "overhead": {
+                          "additionalProperties": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "x-kubernetes-int-or-string": true
+                          },
+                          "type": "object"
+                        },
+                        "preemptionPolicy": {
+                          "type": "string"
+                        },
+                        "priority": {
+                          "type": "integer"
+                        },
+                        "priorityClassName": {
+                          "type": "string"
+                        },
+                        "readinessGates": {
+                          "items": {
+                            "properties": {
+                              "conditionType": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "resourceClaims": {
+                          "items": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "resourceClaimName": {
+                                "type": "string"
+                              },
+                              "resourceClaimTemplateName": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "resources": {
+                          "properties": {
+                            "claims": {
+                              "items": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "request": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "limits": {
+                              "additionalProperties": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "type": "object"
+                            },
+                            "requests": {
+                              "additionalProperties": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "type": "object"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "restartPolicy": {
+                          "type": "string"
+                        },
+                        "runtimeClassName": {
+                          "type": "string"
+                        },
+                        "schedulerName": {
+                          "type": "string"
+                        },
+                        "schedulingGates": {
+                          "items": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "securityContext": {
+                          "properties": {
+                            "appArmorProfile": {
+                              "properties": {
+                                "localhostProfile": {
+                                  "type": "string"
+                                },
+                                "type": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "fsGroup": {
+                              "type": "integer"
+                            },
+                            "fsGroupChangePolicy": {
+                              "type": "string"
+                            },
+                            "runAsGroup": {
+                              "type": "integer"
+                            },
+                            "runAsNonRoot": {
+                              "type": "boolean"
+                            },
+                            "runAsUser": {
+                              "type": "integer"
+                            },
+                            "seLinuxChangePolicy": {
+                              "type": "string"
+                            },
+                            "seLinuxOptions": {
+                              "properties": {
+                                "level": {
+                                  "type": "string"
+                                },
+                                "role": {
+                                  "type": "string"
+                                },
+                                "type": {
+                                  "type": "string"
+                                },
+                                "user": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "seccompProfile": {
+                              "properties": {
+                                "localhostProfile": {
+                                  "type": "string"
+                                },
+                                "type": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "supplementalGroups": {
+                              "items": {
+                                "type": "integer"
+                              },
+                              "type": "array"
+                            },
+                            "supplementalGroupsPolicy": {
+                              "type": "string"
+                            },
+                            "sysctls": {
+                              "items": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "value": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "windowsOptions": {
+                              "properties": {
+                                "gmsaCredentialSpec": {
+                                  "type": "string"
+                                },
+                                "gmsaCredentialSpecName": {
+                                  "type": "string"
+                                },
+                                "hostProcess": {
+                                  "type": "boolean"
+                                },
+                                "runAsUserName": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "serviceAccount": {
+                          "type": "string"
+                        },
+                        "serviceAccountName": {
+                          "type": "string"
+                        },
+                        "setHostnameAsFQDN": {
+                          "type": "boolean"
+                        },
+                        "shareProcessNamespace": {
+                          "type": "boolean"
+                        },
+                        "subdomain": {
+                          "type": "string"
+                        },
+                        "terminationGracePeriodSeconds": {
+                          "type": "integer"
+                        },
+                        "tolerations": {
+                          "items": {
+                            "properties": {
+                              "effect": {
+                                "type": "string"
+                              },
+                              "key": {
+                                "type": "string"
+                              },
+                              "operator": {
+                                "type": "string"
+                              },
+                              "tolerationSeconds": {
+                                "type": "integer"
+                              },
+                              "value": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "topologySpreadConstraints": {
+                          "items": {
+                            "properties": {
+                              "labelSelector": {
+                                "properties": {
+                                  "matchExpressions": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "matchLabels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "matchLabelKeys": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "maxSkew": {
+                                "type": "integer"
+                              },
+                              "minDomains": {
+                                "type": "integer"
+                              },
+                              "nodeAffinityPolicy": {
+                                "type": "string"
+                              },
+                              "nodeTaintsPolicy": {
+                                "type": "string"
+                              },
+                              "topologyKey": {
+                                "type": "string"
+                              },
+                              "whenUnsatisfiable": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "volumes": {
+                          "items": {
+                            "properties": {
+                              "awsElasticBlockStore": {
+                                "properties": {
+                                  "fsType": {
+                                    "type": "string"
+                                  },
+                                  "partition": {
+                                    "type": "integer"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  },
+                                  "volumeID": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "azureDisk": {
+                                "properties": {
+                                  "cachingMode": {
+                                    "type": "string"
+                                  },
+                                  "diskName": {
+                                    "type": "string"
+                                  },
+                                  "diskURI": {
+                                    "type": "string"
+                                  },
+                                  "fsType": {
+                                    "type": "string"
+                                  },
+                                  "kind": {
+                                    "type": "string"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "azureFile": {
+                                "properties": {
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  },
+                                  "secretName": {
+                                    "type": "string"
+                                  },
+                                  "shareName": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "cephfs": {
+                                "properties": {
+                                  "monitors": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  },
+                                  "secretFile": {
+                                    "type": "string"
+                                  },
+                                  "secretRef": {
+                                    "properties": {
+                                      "name": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "user": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "cinder": {
+                                "properties": {
+                                  "fsType": {
+                                    "type": "string"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  },
+                                  "secretRef": {
+                                    "properties": {
+                                      "name": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "volumeID": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "configMap": {
+                                "properties": {
+                                  "defaultMode": {
+                                    "type": "integer"
+                                  },
+                                  "items": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "mode": {
+                                          "type": "integer"
+                                        },
+                                        "path": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "csi": {
+                                "properties": {
+                                  "driver": {
+                                    "type": "string"
+                                  },
+                                  "fsType": {
+                                    "type": "string"
+                                  },
+                                  "nodePublishSecretRef": {
+                                    "properties": {
+                                      "name": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  },
+                                  "volumeAttributes": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "downwardAPI": {
+                                "properties": {
+                                  "defaultMode": {
+                                    "type": "integer"
+                                  },
+                                  "items": {
+                                    "items": {
+                                      "properties": {
+                                        "fieldRef": {
+                                          "properties": {
+                                            "apiVersion": {
+                                              "type": "string"
+                                            },
+                                            "fieldPath": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "mode": {
+                                          "type": "integer"
+                                        },
+                                        "path": {
+                                          "type": "string"
+                                        },
+                                        "resourceFieldRef": {
+                                          "properties": {
+                                            "containerName": {
+                                              "type": "string"
+                                            },
+                                            "divisor": {
+                                              "anyOf": [
+                                                {
+                                                  "type": "integer"
+                                                },
+                                                {
+                                                  "type": "string"
+                                                }
+                                              ],
+                                              "x-kubernetes-int-or-string": true
+                                            },
+                                            "resource": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "emptyDir": {
+                                "properties": {
+                                  "medium": {
+                                    "type": "string"
+                                  },
+                                  "sizeLimit": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "ephemeral": {
+                                "properties": {
+                                  "volumeClaimTemplate": {
+                                    "properties": {
+                                      "metadata": {
+                                        "properties": {
+                                          "annotations": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
+                                          },
+                                          "creationTimestamp": {
+                                            "type": "string"
+                                          },
+                                          "deletionGracePeriodSeconds": {
+                                            "type": "integer"
+                                          },
+                                          "deletionTimestamp": {
+                                            "type": "string"
+                                          },
+                                          "finalizers": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "generateName": {
+                                            "type": "string"
+                                          },
+                                          "generation": {
+                                            "type": "integer"
+                                          },
+                                          "labels": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
+                                          },
+                                          "managedFields": {
+                                            "items": {
+                                              "properties": {
+                                                "apiVersion": {
+                                                  "type": "string"
+                                                },
+                                                "fieldsType": {
+                                                  "type": "string"
+                                                },
+                                                "fieldsV1": {
+                                                  "type": "object"
+                                                },
+                                                "manager": {
+                                                  "type": "string"
+                                                },
+                                                "operation": {
+                                                  "type": "string"
+                                                },
+                                                "subresource": {
+                                                  "type": "string"
+                                                },
+                                                "time": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "namespace": {
+                                            "type": "string"
+                                          },
+                                          "ownerReferences": {
+                                            "items": {
+                                              "properties": {
+                                                "apiVersion": {
+                                                  "type": "string"
+                                                },
+                                                "blockOwnerDeletion": {
+                                                  "type": "boolean"
+                                                },
+                                                "controller": {
+                                                  "type": "boolean"
+                                                },
+                                                "kind": {
+                                                  "type": "string"
+                                                },
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "uid": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "resourceVersion": {
+                                            "type": "string"
+                                          },
+                                          "selfLink": {
+                                            "type": "string"
+                                          },
+                                          "uid": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "spec": {
+                                        "properties": {
+                                          "accessModes": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "dataSource": {
+                                            "properties": {
+                                              "apiGroup": {
+                                                "type": "string"
+                                              },
+                                              "kind": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          "dataSourceRef": {
+                                            "properties": {
+                                              "apiGroup": {
+                                                "type": "string"
+                                              },
+                                              "kind": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "namespace": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          "resources": {
+                                            "properties": {
+                                              "limits": {
+                                                "additionalProperties": {
+                                                  "anyOf": [
+                                                    {
+                                                      "type": "integer"
+                                                    },
+                                                    {
+                                                      "type": "string"
+                                                    }
+                                                  ],
+                                                  "x-kubernetes-int-or-string": true
+                                                },
+                                                "type": "object"
+                                              },
+                                              "requests": {
+                                                "additionalProperties": {
+                                                  "anyOf": [
+                                                    {
+                                                      "type": "integer"
+                                                    },
+                                                    {
+                                                      "type": "string"
+                                                    }
+                                                  ],
+                                                  "x-kubernetes-int-or-string": true
+                                                },
+                                                "type": "object"
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          "selector": {
+                                            "properties": {
+                                              "matchExpressions": {
+                                                "items": {
+                                                  "properties": {
+                                                    "key": {
+                                                      "type": "string"
+                                                    },
+                                                    "operator": {
+                                                      "type": "string"
+                                                    },
+                                                    "values": {
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    }
+                                                  },
+                                                  "type": "object"
+                                                },
+                                                "type": "array"
+                                              },
+                                              "matchLabels": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "type": "object"
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          "storageClassName": {
+                                            "type": "string"
+                                          },
+                                          "volumeAttributesClassName": {
+                                            "type": "string"
+                                          },
+                                          "volumeMode": {
+                                            "type": "string"
+                                          },
+                                          "volumeName": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "fc": {
+                                "properties": {
+                                  "fsType": {
+                                    "type": "string"
+                                  },
+                                  "lun": {
+                                    "type": "integer"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  },
+                                  "targetWWNs": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "wwids": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "flexVolume": {
+                                "properties": {
+                                  "driver": {
+                                    "type": "string"
+                                  },
+                                  "fsType": {
+                                    "type": "string"
+                                  },
+                                  "options": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  },
+                                  "secretRef": {
+                                    "properties": {
+                                      "name": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "flocker": {
+                                "properties": {
+                                  "datasetName": {
+                                    "type": "string"
+                                  },
+                                  "datasetUUID": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "gcePersistentDisk": {
+                                "properties": {
+                                  "fsType": {
+                                    "type": "string"
+                                  },
+                                  "partition": {
+                                    "type": "integer"
+                                  },
+                                  "pdName": {
+                                    "type": "string"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "gitRepo": {
+                                "properties": {
+                                  "directory": {
+                                    "type": "string"
+                                  },
+                                  "repository": {
+                                    "type": "string"
+                                  },
+                                  "revision": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "glusterfs": {
+                                "properties": {
+                                  "endpoints": {
+                                    "type": "string"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "hostPath": {
+                                "properties": {
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "type": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "image": {
+                                "properties": {
+                                  "pullPolicy": {
+                                    "type": "string"
+                                  },
+                                  "reference": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "iscsi": {
+                                "properties": {
+                                  "chapAuthDiscovery": {
+                                    "type": "boolean"
+                                  },
+                                  "chapAuthSession": {
+                                    "type": "boolean"
+                                  },
+                                  "fsType": {
+                                    "type": "string"
+                                  },
+                                  "initiatorName": {
+                                    "type": "string"
+                                  },
+                                  "iqn": {
+                                    "type": "string"
+                                  },
+                                  "iscsiInterface": {
+                                    "type": "string"
+                                  },
+                                  "lun": {
+                                    "type": "integer"
+                                  },
+                                  "portals": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  },
+                                  "secretRef": {
+                                    "properties": {
+                                      "name": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "targetPortal": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "nfs": {
+                                "properties": {
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  },
+                                  "server": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "persistentVolumeClaim": {
+                                "properties": {
+                                  "claimName": {
+                                    "type": "string"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "photonPersistentDisk": {
+                                "properties": {
+                                  "fsType": {
+                                    "type": "string"
+                                  },
+                                  "pdID": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "portworxVolume": {
+                                "properties": {
+                                  "fsType": {
+                                    "type": "string"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  },
+                                  "volumeID": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "projected": {
+                                "properties": {
+                                  "defaultMode": {
+                                    "type": "integer"
+                                  },
+                                  "sources": {
+                                    "items": {
+                                      "properties": {
+                                        "clusterTrustBundle": {
+                                          "properties": {
+                                            "labelSelector": {
+                                              "properties": {
+                                                "matchExpressions": {
+                                                  "items": {
+                                                    "properties": {
+                                                      "key": {
+                                                        "type": "string"
+                                                      },
+                                                      "operator": {
+                                                        "type": "string"
+                                                      },
+                                                      "values": {
+                                                        "items": {
+                                                          "type": "string"
+                                                        },
+                                                        "type": "array"
+                                                      }
+                                                    },
+                                                    "type": "object"
+                                                  },
+                                                  "type": "array"
+                                                },
+                                                "matchLabels": {
+                                                  "additionalProperties": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "object"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            },
+                                            "path": {
+                                              "type": "string"
+                                            },
+                                            "signerName": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "configMap": {
+                                          "properties": {
+                                            "items": {
+                                              "items": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "mode": {
+                                                    "type": "integer"
+                                                  },
+                                                  "path": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              "type": "array"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "downwardAPI": {
+                                          "properties": {
+                                            "items": {
+                                              "items": {
+                                                "properties": {
+                                                  "fieldRef": {
+                                                    "properties": {
+                                                      "apiVersion": {
+                                                        "type": "string"
+                                                      },
+                                                      "fieldPath": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "type": "object"
+                                                  },
+                                                  "mode": {
+                                                    "type": "integer"
+                                                  },
+                                                  "path": {
+                                                    "type": "string"
+                                                  },
+                                                  "resourceFieldRef": {
+                                                    "properties": {
+                                                      "containerName": {
+                                                        "type": "string"
+                                                      },
+                                                      "divisor": {
+                                                        "anyOf": [
+                                                          {
+                                                            "type": "integer"
+                                                          },
+                                                          {
+                                                            "type": "string"
+                                                          }
+                                                        ],
+                                                        "x-kubernetes-int-or-string": true
+                                                      },
+                                                      "resource": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "type": "object"
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "secret": {
+                                          "properties": {
+                                            "items": {
+                                              "items": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "mode": {
+                                                    "type": "integer"
+                                                  },
+                                                  "path": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              "type": "array"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "serviceAccountToken": {
+                                          "properties": {
+                                            "audience": {
+                                              "type": "string"
+                                            },
+                                            "expirationSeconds": {
+                                              "type": "integer"
+                                            },
+                                            "path": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "quobyte": {
+                                "properties": {
+                                  "group": {
+                                    "type": "string"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  },
+                                  "registry": {
+                                    "type": "string"
+                                  },
+                                  "tenant": {
+                                    "type": "string"
+                                  },
+                                  "user": {
+                                    "type": "string"
+                                  },
+                                  "volume": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "rbd": {
+                                "properties": {
+                                  "fsType": {
+                                    "type": "string"
+                                  },
+                                  "image": {
+                                    "type": "string"
+                                  },
+                                  "keyring": {
+                                    "type": "string"
+                                  },
+                                  "monitors": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "pool": {
+                                    "type": "string"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  },
+                                  "secretRef": {
+                                    "properties": {
+                                      "name": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "user": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "scaleIO": {
+                                "properties": {
+                                  "fsType": {
+                                    "type": "string"
+                                  },
+                                  "gateway": {
+                                    "type": "string"
+                                  },
+                                  "protectionDomain": {
+                                    "type": "string"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  },
+                                  "secretRef": {
+                                    "properties": {
+                                      "name": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "sslEnabled": {
+                                    "type": "boolean"
+                                  },
+                                  "storageMode": {
+                                    "type": "string"
+                                  },
+                                  "storagePool": {
+                                    "type": "string"
+                                  },
+                                  "system": {
+                                    "type": "string"
+                                  },
+                                  "volumeName": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "secret": {
+                                "properties": {
+                                  "defaultMode": {
+                                    "type": "integer"
+                                  },
+                                  "items": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "mode": {
+                                          "type": "integer"
+                                        },
+                                        "path": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  },
+                                  "secretName": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "storageos": {
+                                "properties": {
+                                  "fsType": {
+                                    "type": "string"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  },
+                                  "secretRef": {
+                                    "properties": {
+                                      "name": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "volumeName": {
+                                    "type": "string"
+                                  },
+                                  "volumeNamespace": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "vsphereVolume": {
+                                "properties": {
+                                  "fsType": {
+                                    "type": "string"
+                                  },
+                                  "storagePolicyID": {
+                                    "type": "string"
+                                  },
+                                  "storagePolicyName": {
+                                    "type": "string"
+                                  },
+                                  "volumePath": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "type": "object"
+                },
+                "updateStrategy": {
+                  "properties": {
+                    "rollingUpdate": {
+                      "properties": {
+                        "maxUnavailable": {
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "string"
+                            }
+                          ],
+                          "x-kubernetes-int-or-string": true
+                        },
+                        "partition": {
+                          "type": "integer"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "type": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "volumeClaimTemplates": {
+                  "items": {
+                    "properties": {
+                      "apiVersion": {
+                        "type": "string"
+                      },
+                      "kind": {
+                        "type": "string"
+                      },
+                      "metadata": {
+                        "properties": {
+                          "annotations": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "type": "object"
+                          },
+                          "creationTimestamp": {
+                            "type": "string"
+                          },
+                          "deletionGracePeriodSeconds": {
+                            "type": "integer"
+                          },
+                          "deletionTimestamp": {
+                            "type": "string"
+                          },
+                          "finalizers": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "generateName": {
+                            "type": "string"
+                          },
+                          "generation": {
+                            "type": "integer"
+                          },
+                          "labels": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "type": "object"
+                          },
+                          "managedFields": {
+                            "items": {
+                              "properties": {
+                                "apiVersion": {
+                                  "type": "string"
+                                },
+                                "fieldsType": {
+                                  "type": "string"
+                                },
+                                "fieldsV1": {
+                                  "type": "object"
+                                },
+                                "manager": {
+                                  "type": "string"
+                                },
+                                "operation": {
+                                  "type": "string"
+                                },
+                                "subresource": {
+                                  "type": "string"
+                                },
+                                "time": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "namespace": {
+                            "type": "string"
+                          },
+                          "ownerReferences": {
+                            "items": {
+                              "properties": {
+                                "apiVersion": {
+                                  "type": "string"
+                                },
+                                "blockOwnerDeletion": {
+                                  "type": "boolean"
+                                },
+                                "controller": {
+                                  "type": "boolean"
+                                },
+                                "kind": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "uid": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "resourceVersion": {
+                            "type": "string"
+                          },
+                          "selfLink": {
+                            "type": "string"
+                          },
+                          "uid": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "spec": {
+                        "properties": {
+                          "accessModes": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "dataSource": {
+                            "properties": {
+                              "apiGroup": {
+                                "type": "string"
+                              },
+                              "kind": {
+                                "type": "string"
+                              },
+                              "name": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "dataSourceRef": {
+                            "properties": {
+                              "apiGroup": {
+                                "type": "string"
+                              },
+                              "kind": {
+                                "type": "string"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "namespace": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "resources": {
+                            "properties": {
+                              "limits": {
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "type": "object"
+                              },
+                              "requests": {
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "selector": {
+                            "properties": {
+                              "matchExpressions": {
+                                "items": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "matchLabels": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "storageClassName": {
+                            "type": "string"
+                          },
+                          "volumeAttributesClassName": {
+                            "type": "string"
+                          },
+                          "volumeMode": {
+                            "type": "string"
+                          },
+                          "volumeName": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "status": {
+                        "properties": {
+                          "accessModes": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "allocatedResourceStatuses": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "type": "object"
+                          },
+                          "allocatedResources": {
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "type": "object"
+                          },
+                          "capacity": {
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "type": "object"
+                          },
+                          "conditions": {
+                            "items": {
+                              "properties": {
+                                "lastProbeTime": {
+                                  "type": "string"
+                                },
+                                "lastTransitionTime": {
+                                  "type": "string"
+                                },
+                                "message": {
+                                  "type": "string"
+                                },
+                                "reason": {
+                                  "type": "string"
+                                },
+                                "status": {
+                                  "type": "string"
+                                },
+                                "type": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "currentVolumeAttributesClassName": {
+                            "type": "string"
+                          },
+                          "modifyVolumeStatus": {
+                            "properties": {
+                              "status": {
+                                "type": "string"
+                              },
+                              "targetVolumeAttributesClassName": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "phase": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "type": "object"
+        },
+        "runtimeVersions": {
+          "properties": {
+            "jdkVersion": {
+              "type": "string"
+            },
+            "scalaVersion": {
+              "type": "string"
+            },
+            "sparkVersion": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "sparkVersion"
+          ],
+          "type": "object"
+        },
+        "sparkConf": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "workerSpec": {
+          "properties": {
+            "horizontalPodAutoscalerSpec": {
+              "properties": {
+                "behavior": {
+                  "properties": {
+                    "scaleDown": {
+                      "properties": {
+                        "policies": {
+                          "items": {
+                            "properties": {
+                              "periodSeconds": {
+                                "type": "integer"
+                              },
+                              "type": {
+                                "type": "string"
+                              },
+                              "value": {
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "selectPolicy": {
+                          "type": "string"
+                        },
+                        "stabilizationWindowSeconds": {
+                          "type": "integer"
+                        },
+                        "tolerance": {
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "string"
+                            }
+                          ],
+                          "x-kubernetes-int-or-string": true
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "scaleUp": {
+                      "properties": {
+                        "policies": {
+                          "items": {
+                            "properties": {
+                              "periodSeconds": {
+                                "type": "integer"
+                              },
+                              "type": {
+                                "type": "string"
+                              },
+                              "value": {
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "selectPolicy": {
+                          "type": "string"
+                        },
+                        "stabilizationWindowSeconds": {
+                          "type": "integer"
+                        },
+                        "tolerance": {
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "string"
+                            }
+                          ],
+                          "x-kubernetes-int-or-string": true
+                        }
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "type": "object"
+                },
+                "maxReplicas": {
+                  "type": "integer"
+                },
+                "metrics": {
+                  "items": {
+                    "properties": {
+                      "containerResource": {
+                        "properties": {
+                          "container": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "target": {
+                            "properties": {
+                              "averageUtilization": {
+                                "type": "integer"
+                              },
+                              "averageValue": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "type": {
+                                "type": "string"
+                              },
+                              "value": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              }
+                            },
+                            "type": "object"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "external": {
+                        "properties": {
+                          "metric": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "selector": {
+                                "properties": {
+                                  "matchExpressions": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "matchLabels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "target": {
+                            "properties": {
+                              "averageUtilization": {
+                                "type": "integer"
+                              },
+                              "averageValue": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "type": {
+                                "type": "string"
+                              },
+                              "value": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              }
+                            },
+                            "type": "object"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "object": {
+                        "properties": {
+                          "describedObject": {
+                            "properties": {
+                              "apiVersion": {
+                                "type": "string"
+                              },
+                              "kind": {
+                                "type": "string"
+                              },
+                              "name": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "metric": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "selector": {
+                                "properties": {
+                                  "matchExpressions": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "matchLabels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "target": {
+                            "properties": {
+                              "averageUtilization": {
+                                "type": "integer"
+                              },
+                              "averageValue": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "type": {
+                                "type": "string"
+                              },
+                              "value": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              }
+                            },
+                            "type": "object"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "pods": {
+                        "properties": {
+                          "metric": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "selector": {
+                                "properties": {
+                                  "matchExpressions": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "matchLabels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "target": {
+                            "properties": {
+                              "averageUtilization": {
+                                "type": "integer"
+                              },
+                              "averageValue": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "type": {
+                                "type": "string"
+                              },
+                              "value": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              }
+                            },
+                            "type": "object"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "resource": {
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          },
+                          "target": {
+                            "properties": {
+                              "averageUtilization": {
+                                "type": "integer"
+                              },
+                              "averageValue": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "type": {
+                                "type": "string"
+                              },
+                              "value": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              }
+                            },
+                            "type": "object"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "minReplicas": {
+                  "type": "integer"
+                },
+                "scaleTargetRef": {
+                  "properties": {
+                    "apiVersion": {
+                      "type": "string"
+                    },
+                    "kind": {
+                      "type": "string"
+                    },
+                    "name": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object"
+            },
+            "serviceMetadata": {
+              "properties": {
+                "annotations": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                },
+                "creationTimestamp": {
+                  "type": "string"
+                },
+                "deletionGracePeriodSeconds": {
+                  "type": "integer"
+                },
+                "deletionTimestamp": {
+                  "type": "string"
+                },
+                "finalizers": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "generateName": {
+                  "type": "string"
+                },
+                "generation": {
+                  "type": "integer"
+                },
+                "labels": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                },
+                "managedFields": {
+                  "items": {
+                    "properties": {
+                      "apiVersion": {
+                        "type": "string"
+                      },
+                      "fieldsType": {
+                        "type": "string"
+                      },
+                      "fieldsV1": {
+                        "type": "object"
+                      },
+                      "manager": {
+                        "type": "string"
+                      },
+                      "operation": {
+                        "type": "string"
+                      },
+                      "subresource": {
+                        "type": "string"
+                      },
+                      "time": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "namespace": {
+                  "type": "string"
+                },
+                "ownerReferences": {
+                  "items": {
+                    "properties": {
+                      "apiVersion": {
+                        "type": "string"
+                      },
+                      "blockOwnerDeletion": {
+                        "type": "boolean"
+                      },
+                      "controller": {
+                        "type": "boolean"
+                      },
+                      "kind": {
+                        "type": "string"
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "uid": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "resourceVersion": {
+                  "type": "string"
+                },
+                "selfLink": {
+                  "type": "string"
+                },
+                "uid": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "serviceSpec": {
+              "properties": {
+                "allocateLoadBalancerNodePorts": {
+                  "type": "boolean"
+                },
+                "clusterIP": {
+                  "type": "string"
+                },
+                "clusterIPs": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "externalIPs": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "externalName": {
+                  "type": "string"
+                },
+                "externalTrafficPolicy": {
+                  "type": "string"
+                },
+                "healthCheckNodePort": {
+                  "type": "integer"
+                },
+                "internalTrafficPolicy": {
+                  "type": "string"
+                },
+                "ipFamilies": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "ipFamilyPolicy": {
+                  "type": "string"
+                },
+                "loadBalancerClass": {
+                  "type": "string"
+                },
+                "loadBalancerIP": {
+                  "type": "string"
+                },
+                "loadBalancerSourceRanges": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "ports": {
+                  "items": {
+                    "properties": {
+                      "appProtocol": {
+                        "type": "string"
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "nodePort": {
+                        "type": "integer"
+                      },
+                      "port": {
+                        "type": "integer"
+                      },
+                      "protocol": {
+                        "type": "string"
+                      },
+                      "targetPort": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "x-kubernetes-int-or-string": true
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "publishNotReadyAddresses": {
+                  "type": "boolean"
+                },
+                "selector": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                },
+                "sessionAffinity": {
+                  "type": "string"
+                },
+                "sessionAffinityConfig": {
+                  "properties": {
+                    "clientIP": {
+                      "properties": {
+                        "timeoutSeconds": {
+                          "type": "integer"
+                        }
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "type": "object"
+                },
+                "trafficDistribution": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "statefulSetMetadata": {
+              "properties": {
+                "annotations": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                },
+                "creationTimestamp": {
+                  "type": "string"
+                },
+                "deletionGracePeriodSeconds": {
+                  "type": "integer"
+                },
+                "deletionTimestamp": {
+                  "type": "string"
+                },
+                "finalizers": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "generateName": {
+                  "type": "string"
+                },
+                "generation": {
+                  "type": "integer"
+                },
+                "labels": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                },
+                "managedFields": {
+                  "items": {
+                    "properties": {
+                      "apiVersion": {
+                        "type": "string"
+                      },
+                      "fieldsType": {
+                        "type": "string"
+                      },
+                      "fieldsV1": {
+                        "type": "object"
+                      },
+                      "manager": {
+                        "type": "string"
+                      },
+                      "operation": {
+                        "type": "string"
+                      },
+                      "subresource": {
+                        "type": "string"
+                      },
+                      "time": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "namespace": {
+                  "type": "string"
+                },
+                "ownerReferences": {
+                  "items": {
+                    "properties": {
+                      "apiVersion": {
+                        "type": "string"
+                      },
+                      "blockOwnerDeletion": {
+                        "type": "boolean"
+                      },
+                      "controller": {
+                        "type": "boolean"
+                      },
+                      "kind": {
+                        "type": "string"
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "uid": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "resourceVersion": {
+                  "type": "string"
+                },
+                "selfLink": {
+                  "type": "string"
+                },
+                "uid": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "statefulSetSpec": {
+              "properties": {
+                "minReadySeconds": {
+                  "type": "integer"
+                },
+                "ordinals": {
+                  "properties": {
+                    "start": {
+                      "type": "integer"
+                    }
+                  },
+                  "type": "object"
+                },
+                "persistentVolumeClaimRetentionPolicy": {
+                  "properties": {
+                    "whenDeleted": {
+                      "type": "string"
+                    },
+                    "whenScaled": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "podManagementPolicy": {
+                  "type": "string"
+                },
+                "replicas": {
+                  "type": "integer"
+                },
+                "revisionHistoryLimit": {
+                  "type": "integer"
+                },
+                "selector": {
+                  "properties": {
+                    "matchExpressions": {
+                      "items": {
+                        "properties": {
+                          "key": {
+                            "type": "string"
+                          },
+                          "operator": {
+                            "type": "string"
+                          },
+                          "values": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "matchLabels": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "type": "object"
+                },
+                "serviceName": {
+                  "type": "string"
+                },
+                "template": {
+                  "properties": {
+                    "metadata": {
+                      "properties": {
+                        "annotations": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        "creationTimestamp": {
+                          "type": "string"
+                        },
+                        "deletionGracePeriodSeconds": {
+                          "type": "integer"
+                        },
+                        "deletionTimestamp": {
+                          "type": "string"
+                        },
+                        "finalizers": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "generateName": {
+                          "type": "string"
+                        },
+                        "generation": {
+                          "type": "integer"
+                        },
+                        "labels": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        "managedFields": {
+                          "items": {
+                            "properties": {
+                              "apiVersion": {
+                                "type": "string"
+                              },
+                              "fieldsType": {
+                                "type": "string"
+                              },
+                              "fieldsV1": {
+                                "type": "object"
+                              },
+                              "manager": {
+                                "type": "string"
+                              },
+                              "operation": {
+                                "type": "string"
+                              },
+                              "subresource": {
+                                "type": "string"
+                              },
+                              "time": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "namespace": {
+                          "type": "string"
+                        },
+                        "ownerReferences": {
+                          "items": {
+                            "properties": {
+                              "apiVersion": {
+                                "type": "string"
+                              },
+                              "blockOwnerDeletion": {
+                                "type": "boolean"
+                              },
+                              "controller": {
+                                "type": "boolean"
+                              },
+                              "kind": {
+                                "type": "string"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "uid": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "resourceVersion": {
+                          "type": "string"
+                        },
+                        "selfLink": {
+                          "type": "string"
+                        },
+                        "uid": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "spec": {
+                      "properties": {
+                        "activeDeadlineSeconds": {
+                          "type": "integer"
+                        },
+                        "affinity": {
+                          "properties": {
+                            "nodeAffinity": {
+                              "properties": {
+                                "preferredDuringSchedulingIgnoredDuringExecution": {
+                                  "items": {
+                                    "properties": {
+                                      "preference": {
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "matchFields": {
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "weight": {
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "type": "array"
+                                },
+                                "requiredDuringSchedulingIgnoredDuringExecution": {
+                                  "properties": {
+                                    "nodeSelectorTerms": {
+                                      "items": {
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "matchFields": {
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "podAffinity": {
+                              "properties": {
+                                "preferredDuringSchedulingIgnoredDuringExecution": {
+                                  "items": {
+                                    "properties": {
+                                      "podAffinityTerm": {
+                                        "properties": {
+                                          "labelSelector": {
+                                            "properties": {
+                                              "matchExpressions": {
+                                                "items": {
+                                                  "properties": {
+                                                    "key": {
+                                                      "type": "string"
+                                                    },
+                                                    "operator": {
+                                                      "type": "string"
+                                                    },
+                                                    "values": {
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    }
+                                                  },
+                                                  "type": "object"
+                                                },
+                                                "type": "array"
+                                              },
+                                              "matchLabels": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "type": "object"
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          "matchLabelKeys": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "mismatchLabelKeys": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "namespaceSelector": {
+                                            "properties": {
+                                              "matchExpressions": {
+                                                "items": {
+                                                  "properties": {
+                                                    "key": {
+                                                      "type": "string"
+                                                    },
+                                                    "operator": {
+                                                      "type": "string"
+                                                    },
+                                                    "values": {
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    }
+                                                  },
+                                                  "type": "object"
+                                                },
+                                                "type": "array"
+                                              },
+                                              "matchLabels": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "type": "object"
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          "namespaces": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "topologyKey": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "weight": {
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "type": "array"
+                                },
+                                "requiredDuringSchedulingIgnoredDuringExecution": {
+                                  "items": {
+                                    "properties": {
+                                      "labelSelector": {
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "matchLabels": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "matchLabelKeys": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "mismatchLabelKeys": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "namespaceSelector": {
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "matchLabels": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "namespaces": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "topologyKey": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "podAntiAffinity": {
+                              "properties": {
+                                "preferredDuringSchedulingIgnoredDuringExecution": {
+                                  "items": {
+                                    "properties": {
+                                      "podAffinityTerm": {
+                                        "properties": {
+                                          "labelSelector": {
+                                            "properties": {
+                                              "matchExpressions": {
+                                                "items": {
+                                                  "properties": {
+                                                    "key": {
+                                                      "type": "string"
+                                                    },
+                                                    "operator": {
+                                                      "type": "string"
+                                                    },
+                                                    "values": {
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    }
+                                                  },
+                                                  "type": "object"
+                                                },
+                                                "type": "array"
+                                              },
+                                              "matchLabels": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "type": "object"
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          "matchLabelKeys": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "mismatchLabelKeys": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "namespaceSelector": {
+                                            "properties": {
+                                              "matchExpressions": {
+                                                "items": {
+                                                  "properties": {
+                                                    "key": {
+                                                      "type": "string"
+                                                    },
+                                                    "operator": {
+                                                      "type": "string"
+                                                    },
+                                                    "values": {
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    }
+                                                  },
+                                                  "type": "object"
+                                                },
+                                                "type": "array"
+                                              },
+                                              "matchLabels": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "type": "object"
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          "namespaces": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "topologyKey": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "weight": {
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "type": "array"
+                                },
+                                "requiredDuringSchedulingIgnoredDuringExecution": {
+                                  "items": {
+                                    "properties": {
+                                      "labelSelector": {
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "matchLabels": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "matchLabelKeys": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "mismatchLabelKeys": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "namespaceSelector": {
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "matchLabels": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "namespaces": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "topologyKey": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "type": "object"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "automountServiceAccountToken": {
+                          "type": "boolean"
+                        },
+                        "containers": {
+                          "items": {
+                            "properties": {
+                              "args": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "command": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "env": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    },
+                                    "valueFrom": {
+                                      "properties": {
+                                        "configMapKeyRef": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "fieldRef": {
+                                          "properties": {
+                                            "apiVersion": {
+                                              "type": "string"
+                                            },
+                                            "fieldPath": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "resourceFieldRef": {
+                                          "properties": {
+                                            "containerName": {
+                                              "type": "string"
+                                            },
+                                            "divisor": {
+                                              "anyOf": [
+                                                {
+                                                  "type": "integer"
+                                                },
+                                                {
+                                                  "type": "string"
+                                                }
+                                              ],
+                                              "x-kubernetes-int-or-string": true
+                                            },
+                                            "resource": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "secretKeyRef": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "type": "object"
+                                        }
+                                      },
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "envFrom": {
+                                "items": {
+                                  "properties": {
+                                    "configMapRef": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "prefix": {
+                                      "type": "string"
+                                    },
+                                    "secretRef": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "image": {
+                                "type": "string"
+                              },
+                              "imagePullPolicy": {
+                                "type": "string"
+                              },
+                              "lifecycle": {
+                                "properties": {
+                                  "postStart": {
+                                    "properties": {
+                                      "exec": {
+                                        "properties": {
+                                          "command": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "httpGet": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "httpHeaders": {
+                                            "items": {
+                                              "properties": {
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "value": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          },
+                                          "scheme": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "sleep": {
+                                        "properties": {
+                                          "seconds": {
+                                            "type": "integer"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "tcpSocket": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          }
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "preStop": {
+                                    "properties": {
+                                      "exec": {
+                                        "properties": {
+                                          "command": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "httpGet": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "httpHeaders": {
+                                            "items": {
+                                              "properties": {
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "value": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          },
+                                          "scheme": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "sleep": {
+                                        "properties": {
+                                          "seconds": {
+                                            "type": "integer"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "tcpSocket": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          }
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "stopSignal": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "livenessProbe": {
+                                "properties": {
+                                  "exec": {
+                                    "properties": {
+                                      "command": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "failureThreshold": {
+                                    "type": "integer"
+                                  },
+                                  "grpc": {
+                                    "properties": {
+                                      "port": {
+                                        "type": "integer"
+                                      },
+                                      "service": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "httpGet": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "initialDelaySeconds": {
+                                    "type": "integer"
+                                  },
+                                  "periodSeconds": {
+                                    "type": "integer"
+                                  },
+                                  "successThreshold": {
+                                    "type": "integer"
+                                  },
+                                  "tcpSocket": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "terminationGracePeriodSeconds": {
+                                    "type": "integer"
+                                  },
+                                  "timeoutSeconds": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "ports": {
+                                "items": {
+                                  "properties": {
+                                    "containerPort": {
+                                      "type": "integer"
+                                    },
+                                    "hostIP": {
+                                      "type": "string"
+                                    },
+                                    "hostPort": {
+                                      "type": "integer"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "protocol": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "readinessProbe": {
+                                "properties": {
+                                  "exec": {
+                                    "properties": {
+                                      "command": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "failureThreshold": {
+                                    "type": "integer"
+                                  },
+                                  "grpc": {
+                                    "properties": {
+                                      "port": {
+                                        "type": "integer"
+                                      },
+                                      "service": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "httpGet": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "initialDelaySeconds": {
+                                    "type": "integer"
+                                  },
+                                  "periodSeconds": {
+                                    "type": "integer"
+                                  },
+                                  "successThreshold": {
+                                    "type": "integer"
+                                  },
+                                  "tcpSocket": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "terminationGracePeriodSeconds": {
+                                    "type": "integer"
+                                  },
+                                  "timeoutSeconds": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "resizePolicy": {
+                                "items": {
+                                  "properties": {
+                                    "resourceName": {
+                                      "type": "string"
+                                    },
+                                    "restartPolicy": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "resources": {
+                                "properties": {
+                                  "claims": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "request": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "limits": {
+                                    "additionalProperties": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "string"
+                                        }
+                                      ],
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "type": "object"
+                                  },
+                                  "requests": {
+                                    "additionalProperties": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "string"
+                                        }
+                                      ],
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "restartPolicy": {
+                                "type": "string"
+                              },
+                              "securityContext": {
+                                "properties": {
+                                  "allowPrivilegeEscalation": {
+                                    "type": "boolean"
+                                  },
+                                  "appArmorProfile": {
+                                    "properties": {
+                                      "localhostProfile": {
+                                        "type": "string"
+                                      },
+                                      "type": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "capabilities": {
+                                    "properties": {
+                                      "add": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "drop": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "privileged": {
+                                    "type": "boolean"
+                                  },
+                                  "procMount": {
+                                    "type": "string"
+                                  },
+                                  "readOnlyRootFilesystem": {
+                                    "type": "boolean"
+                                  },
+                                  "runAsGroup": {
+                                    "type": "integer"
+                                  },
+                                  "runAsNonRoot": {
+                                    "type": "boolean"
+                                  },
+                                  "runAsUser": {
+                                    "type": "integer"
+                                  },
+                                  "seLinuxOptions": {
+                                    "properties": {
+                                      "level": {
+                                        "type": "string"
+                                      },
+                                      "role": {
+                                        "type": "string"
+                                      },
+                                      "type": {
+                                        "type": "string"
+                                      },
+                                      "user": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "seccompProfile": {
+                                    "properties": {
+                                      "localhostProfile": {
+                                        "type": "string"
+                                      },
+                                      "type": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "windowsOptions": {
+                                    "properties": {
+                                      "gmsaCredentialSpec": {
+                                        "type": "string"
+                                      },
+                                      "gmsaCredentialSpecName": {
+                                        "type": "string"
+                                      },
+                                      "hostProcess": {
+                                        "type": "boolean"
+                                      },
+                                      "runAsUserName": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "startupProbe": {
+                                "properties": {
+                                  "exec": {
+                                    "properties": {
+                                      "command": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "failureThreshold": {
+                                    "type": "integer"
+                                  },
+                                  "grpc": {
+                                    "properties": {
+                                      "port": {
+                                        "type": "integer"
+                                      },
+                                      "service": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "httpGet": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "initialDelaySeconds": {
+                                    "type": "integer"
+                                  },
+                                  "periodSeconds": {
+                                    "type": "integer"
+                                  },
+                                  "successThreshold": {
+                                    "type": "integer"
+                                  },
+                                  "tcpSocket": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "terminationGracePeriodSeconds": {
+                                    "type": "integer"
+                                  },
+                                  "timeoutSeconds": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "stdin": {
+                                "type": "boolean"
+                              },
+                              "stdinOnce": {
+                                "type": "boolean"
+                              },
+                              "terminationMessagePath": {
+                                "type": "string"
+                              },
+                              "terminationMessagePolicy": {
+                                "type": "string"
+                              },
+                              "tty": {
+                                "type": "boolean"
+                              },
+                              "volumeDevices": {
+                                "items": {
+                                  "properties": {
+                                    "devicePath": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "volumeMounts": {
+                                "items": {
+                                  "properties": {
+                                    "mountPath": {
+                                      "type": "string"
+                                    },
+                                    "mountPropagation": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "readOnly": {
+                                      "type": "boolean"
+                                    },
+                                    "recursiveReadOnly": {
+                                      "type": "string"
+                                    },
+                                    "subPath": {
+                                      "type": "string"
+                                    },
+                                    "subPathExpr": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "workingDir": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "dnsConfig": {
+                          "properties": {
+                            "nameservers": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "options": {
+                              "items": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "value": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "searches": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "dnsPolicy": {
+                          "type": "string"
+                        },
+                        "enableServiceLinks": {
+                          "type": "boolean"
+                        },
+                        "ephemeralContainers": {
+                          "items": {
+                            "properties": {
+                              "args": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "command": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "env": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    },
+                                    "valueFrom": {
+                                      "properties": {
+                                        "configMapKeyRef": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "fieldRef": {
+                                          "properties": {
+                                            "apiVersion": {
+                                              "type": "string"
+                                            },
+                                            "fieldPath": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "resourceFieldRef": {
+                                          "properties": {
+                                            "containerName": {
+                                              "type": "string"
+                                            },
+                                            "divisor": {
+                                              "anyOf": [
+                                                {
+                                                  "type": "integer"
+                                                },
+                                                {
+                                                  "type": "string"
+                                                }
+                                              ],
+                                              "x-kubernetes-int-or-string": true
+                                            },
+                                            "resource": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "secretKeyRef": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "type": "object"
+                                        }
+                                      },
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "envFrom": {
+                                "items": {
+                                  "properties": {
+                                    "configMapRef": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "prefix": {
+                                      "type": "string"
+                                    },
+                                    "secretRef": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "image": {
+                                "type": "string"
+                              },
+                              "imagePullPolicy": {
+                                "type": "string"
+                              },
+                              "lifecycle": {
+                                "properties": {
+                                  "postStart": {
+                                    "properties": {
+                                      "exec": {
+                                        "properties": {
+                                          "command": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "httpGet": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "httpHeaders": {
+                                            "items": {
+                                              "properties": {
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "value": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          },
+                                          "scheme": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "sleep": {
+                                        "properties": {
+                                          "seconds": {
+                                            "type": "integer"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "tcpSocket": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          }
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "preStop": {
+                                    "properties": {
+                                      "exec": {
+                                        "properties": {
+                                          "command": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "httpGet": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "httpHeaders": {
+                                            "items": {
+                                              "properties": {
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "value": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          },
+                                          "scheme": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "sleep": {
+                                        "properties": {
+                                          "seconds": {
+                                            "type": "integer"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "tcpSocket": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          }
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "stopSignal": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "livenessProbe": {
+                                "properties": {
+                                  "exec": {
+                                    "properties": {
+                                      "command": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "failureThreshold": {
+                                    "type": "integer"
+                                  },
+                                  "grpc": {
+                                    "properties": {
+                                      "port": {
+                                        "type": "integer"
+                                      },
+                                      "service": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "httpGet": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "initialDelaySeconds": {
+                                    "type": "integer"
+                                  },
+                                  "periodSeconds": {
+                                    "type": "integer"
+                                  },
+                                  "successThreshold": {
+                                    "type": "integer"
+                                  },
+                                  "tcpSocket": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "terminationGracePeriodSeconds": {
+                                    "type": "integer"
+                                  },
+                                  "timeoutSeconds": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "ports": {
+                                "items": {
+                                  "properties": {
+                                    "containerPort": {
+                                      "type": "integer"
+                                    },
+                                    "hostIP": {
+                                      "type": "string"
+                                    },
+                                    "hostPort": {
+                                      "type": "integer"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "protocol": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "readinessProbe": {
+                                "properties": {
+                                  "exec": {
+                                    "properties": {
+                                      "command": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "failureThreshold": {
+                                    "type": "integer"
+                                  },
+                                  "grpc": {
+                                    "properties": {
+                                      "port": {
+                                        "type": "integer"
+                                      },
+                                      "service": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "httpGet": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "initialDelaySeconds": {
+                                    "type": "integer"
+                                  },
+                                  "periodSeconds": {
+                                    "type": "integer"
+                                  },
+                                  "successThreshold": {
+                                    "type": "integer"
+                                  },
+                                  "tcpSocket": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "terminationGracePeriodSeconds": {
+                                    "type": "integer"
+                                  },
+                                  "timeoutSeconds": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "resizePolicy": {
+                                "items": {
+                                  "properties": {
+                                    "resourceName": {
+                                      "type": "string"
+                                    },
+                                    "restartPolicy": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "resources": {
+                                "properties": {
+                                  "claims": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "request": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "limits": {
+                                    "additionalProperties": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "string"
+                                        }
+                                      ],
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "type": "object"
+                                  },
+                                  "requests": {
+                                    "additionalProperties": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "string"
+                                        }
+                                      ],
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "restartPolicy": {
+                                "type": "string"
+                              },
+                              "securityContext": {
+                                "properties": {
+                                  "allowPrivilegeEscalation": {
+                                    "type": "boolean"
+                                  },
+                                  "appArmorProfile": {
+                                    "properties": {
+                                      "localhostProfile": {
+                                        "type": "string"
+                                      },
+                                      "type": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "capabilities": {
+                                    "properties": {
+                                      "add": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "drop": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "privileged": {
+                                    "type": "boolean"
+                                  },
+                                  "procMount": {
+                                    "type": "string"
+                                  },
+                                  "readOnlyRootFilesystem": {
+                                    "type": "boolean"
+                                  },
+                                  "runAsGroup": {
+                                    "type": "integer"
+                                  },
+                                  "runAsNonRoot": {
+                                    "type": "boolean"
+                                  },
+                                  "runAsUser": {
+                                    "type": "integer"
+                                  },
+                                  "seLinuxOptions": {
+                                    "properties": {
+                                      "level": {
+                                        "type": "string"
+                                      },
+                                      "role": {
+                                        "type": "string"
+                                      },
+                                      "type": {
+                                        "type": "string"
+                                      },
+                                      "user": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "seccompProfile": {
+                                    "properties": {
+                                      "localhostProfile": {
+                                        "type": "string"
+                                      },
+                                      "type": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "windowsOptions": {
+                                    "properties": {
+                                      "gmsaCredentialSpec": {
+                                        "type": "string"
+                                      },
+                                      "gmsaCredentialSpecName": {
+                                        "type": "string"
+                                      },
+                                      "hostProcess": {
+                                        "type": "boolean"
+                                      },
+                                      "runAsUserName": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "startupProbe": {
+                                "properties": {
+                                  "exec": {
+                                    "properties": {
+                                      "command": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "failureThreshold": {
+                                    "type": "integer"
+                                  },
+                                  "grpc": {
+                                    "properties": {
+                                      "port": {
+                                        "type": "integer"
+                                      },
+                                      "service": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "httpGet": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "initialDelaySeconds": {
+                                    "type": "integer"
+                                  },
+                                  "periodSeconds": {
+                                    "type": "integer"
+                                  },
+                                  "successThreshold": {
+                                    "type": "integer"
+                                  },
+                                  "tcpSocket": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "terminationGracePeriodSeconds": {
+                                    "type": "integer"
+                                  },
+                                  "timeoutSeconds": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "stdin": {
+                                "type": "boolean"
+                              },
+                              "stdinOnce": {
+                                "type": "boolean"
+                              },
+                              "targetContainerName": {
+                                "type": "string"
+                              },
+                              "terminationMessagePath": {
+                                "type": "string"
+                              },
+                              "terminationMessagePolicy": {
+                                "type": "string"
+                              },
+                              "tty": {
+                                "type": "boolean"
+                              },
+                              "volumeDevices": {
+                                "items": {
+                                  "properties": {
+                                    "devicePath": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "volumeMounts": {
+                                "items": {
+                                  "properties": {
+                                    "mountPath": {
+                                      "type": "string"
+                                    },
+                                    "mountPropagation": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "readOnly": {
+                                      "type": "boolean"
+                                    },
+                                    "recursiveReadOnly": {
+                                      "type": "string"
+                                    },
+                                    "subPath": {
+                                      "type": "string"
+                                    },
+                                    "subPathExpr": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "workingDir": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "hostAliases": {
+                          "items": {
+                            "properties": {
+                              "hostnames": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "ip": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "hostIPC": {
+                          "type": "boolean"
+                        },
+                        "hostNetwork": {
+                          "type": "boolean"
+                        },
+                        "hostPID": {
+                          "type": "boolean"
+                        },
+                        "hostUsers": {
+                          "type": "boolean"
+                        },
+                        "hostname": {
+                          "type": "string"
+                        },
+                        "imagePullSecrets": {
+                          "items": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "initContainers": {
+                          "items": {
+                            "properties": {
+                              "args": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "command": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "env": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    },
+                                    "valueFrom": {
+                                      "properties": {
+                                        "configMapKeyRef": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "fieldRef": {
+                                          "properties": {
+                                            "apiVersion": {
+                                              "type": "string"
+                                            },
+                                            "fieldPath": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "resourceFieldRef": {
+                                          "properties": {
+                                            "containerName": {
+                                              "type": "string"
+                                            },
+                                            "divisor": {
+                                              "anyOf": [
+                                                {
+                                                  "type": "integer"
+                                                },
+                                                {
+                                                  "type": "string"
+                                                }
+                                              ],
+                                              "x-kubernetes-int-or-string": true
+                                            },
+                                            "resource": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "secretKeyRef": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "type": "object"
+                                        }
+                                      },
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "envFrom": {
+                                "items": {
+                                  "properties": {
+                                    "configMapRef": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "prefix": {
+                                      "type": "string"
+                                    },
+                                    "secretRef": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "image": {
+                                "type": "string"
+                              },
+                              "imagePullPolicy": {
+                                "type": "string"
+                              },
+                              "lifecycle": {
+                                "properties": {
+                                  "postStart": {
+                                    "properties": {
+                                      "exec": {
+                                        "properties": {
+                                          "command": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "httpGet": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "httpHeaders": {
+                                            "items": {
+                                              "properties": {
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "value": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          },
+                                          "scheme": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "sleep": {
+                                        "properties": {
+                                          "seconds": {
+                                            "type": "integer"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "tcpSocket": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          }
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "preStop": {
+                                    "properties": {
+                                      "exec": {
+                                        "properties": {
+                                          "command": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "httpGet": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "httpHeaders": {
+                                            "items": {
+                                              "properties": {
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "value": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          },
+                                          "scheme": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "sleep": {
+                                        "properties": {
+                                          "seconds": {
+                                            "type": "integer"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "tcpSocket": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          }
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "stopSignal": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "livenessProbe": {
+                                "properties": {
+                                  "exec": {
+                                    "properties": {
+                                      "command": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "failureThreshold": {
+                                    "type": "integer"
+                                  },
+                                  "grpc": {
+                                    "properties": {
+                                      "port": {
+                                        "type": "integer"
+                                      },
+                                      "service": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "httpGet": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "initialDelaySeconds": {
+                                    "type": "integer"
+                                  },
+                                  "periodSeconds": {
+                                    "type": "integer"
+                                  },
+                                  "successThreshold": {
+                                    "type": "integer"
+                                  },
+                                  "tcpSocket": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "terminationGracePeriodSeconds": {
+                                    "type": "integer"
+                                  },
+                                  "timeoutSeconds": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "ports": {
+                                "items": {
+                                  "properties": {
+                                    "containerPort": {
+                                      "type": "integer"
+                                    },
+                                    "hostIP": {
+                                      "type": "string"
+                                    },
+                                    "hostPort": {
+                                      "type": "integer"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "protocol": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "readinessProbe": {
+                                "properties": {
+                                  "exec": {
+                                    "properties": {
+                                      "command": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "failureThreshold": {
+                                    "type": "integer"
+                                  },
+                                  "grpc": {
+                                    "properties": {
+                                      "port": {
+                                        "type": "integer"
+                                      },
+                                      "service": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "httpGet": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "initialDelaySeconds": {
+                                    "type": "integer"
+                                  },
+                                  "periodSeconds": {
+                                    "type": "integer"
+                                  },
+                                  "successThreshold": {
+                                    "type": "integer"
+                                  },
+                                  "tcpSocket": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "terminationGracePeriodSeconds": {
+                                    "type": "integer"
+                                  },
+                                  "timeoutSeconds": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "resizePolicy": {
+                                "items": {
+                                  "properties": {
+                                    "resourceName": {
+                                      "type": "string"
+                                    },
+                                    "restartPolicy": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "resources": {
+                                "properties": {
+                                  "claims": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "request": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "limits": {
+                                    "additionalProperties": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "string"
+                                        }
+                                      ],
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "type": "object"
+                                  },
+                                  "requests": {
+                                    "additionalProperties": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "string"
+                                        }
+                                      ],
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "restartPolicy": {
+                                "type": "string"
+                              },
+                              "securityContext": {
+                                "properties": {
+                                  "allowPrivilegeEscalation": {
+                                    "type": "boolean"
+                                  },
+                                  "appArmorProfile": {
+                                    "properties": {
+                                      "localhostProfile": {
+                                        "type": "string"
+                                      },
+                                      "type": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "capabilities": {
+                                    "properties": {
+                                      "add": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "drop": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "privileged": {
+                                    "type": "boolean"
+                                  },
+                                  "procMount": {
+                                    "type": "string"
+                                  },
+                                  "readOnlyRootFilesystem": {
+                                    "type": "boolean"
+                                  },
+                                  "runAsGroup": {
+                                    "type": "integer"
+                                  },
+                                  "runAsNonRoot": {
+                                    "type": "boolean"
+                                  },
+                                  "runAsUser": {
+                                    "type": "integer"
+                                  },
+                                  "seLinuxOptions": {
+                                    "properties": {
+                                      "level": {
+                                        "type": "string"
+                                      },
+                                      "role": {
+                                        "type": "string"
+                                      },
+                                      "type": {
+                                        "type": "string"
+                                      },
+                                      "user": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "seccompProfile": {
+                                    "properties": {
+                                      "localhostProfile": {
+                                        "type": "string"
+                                      },
+                                      "type": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "windowsOptions": {
+                                    "properties": {
+                                      "gmsaCredentialSpec": {
+                                        "type": "string"
+                                      },
+                                      "gmsaCredentialSpecName": {
+                                        "type": "string"
+                                      },
+                                      "hostProcess": {
+                                        "type": "boolean"
+                                      },
+                                      "runAsUserName": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "startupProbe": {
+                                "properties": {
+                                  "exec": {
+                                    "properties": {
+                                      "command": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "failureThreshold": {
+                                    "type": "integer"
+                                  },
+                                  "grpc": {
+                                    "properties": {
+                                      "port": {
+                                        "type": "integer"
+                                      },
+                                      "service": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "httpGet": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "initialDelaySeconds": {
+                                    "type": "integer"
+                                  },
+                                  "periodSeconds": {
+                                    "type": "integer"
+                                  },
+                                  "successThreshold": {
+                                    "type": "integer"
+                                  },
+                                  "tcpSocket": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "terminationGracePeriodSeconds": {
+                                    "type": "integer"
+                                  },
+                                  "timeoutSeconds": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "stdin": {
+                                "type": "boolean"
+                              },
+                              "stdinOnce": {
+                                "type": "boolean"
+                              },
+                              "terminationMessagePath": {
+                                "type": "string"
+                              },
+                              "terminationMessagePolicy": {
+                                "type": "string"
+                              },
+                              "tty": {
+                                "type": "boolean"
+                              },
+                              "volumeDevices": {
+                                "items": {
+                                  "properties": {
+                                    "devicePath": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "volumeMounts": {
+                                "items": {
+                                  "properties": {
+                                    "mountPath": {
+                                      "type": "string"
+                                    },
+                                    "mountPropagation": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "readOnly": {
+                                      "type": "boolean"
+                                    },
+                                    "recursiveReadOnly": {
+                                      "type": "string"
+                                    },
+                                    "subPath": {
+                                      "type": "string"
+                                    },
+                                    "subPathExpr": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "workingDir": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "nodeName": {
+                          "type": "string"
+                        },
+                        "nodeSelector": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        "os": {
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "overhead": {
+                          "additionalProperties": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "x-kubernetes-int-or-string": true
+                          },
+                          "type": "object"
+                        },
+                        "preemptionPolicy": {
+                          "type": "string"
+                        },
+                        "priority": {
+                          "type": "integer"
+                        },
+                        "priorityClassName": {
+                          "type": "string"
+                        },
+                        "readinessGates": {
+                          "items": {
+                            "properties": {
+                              "conditionType": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "resourceClaims": {
+                          "items": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "resourceClaimName": {
+                                "type": "string"
+                              },
+                              "resourceClaimTemplateName": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "resources": {
+                          "properties": {
+                            "claims": {
+                              "items": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "request": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "limits": {
+                              "additionalProperties": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "type": "object"
+                            },
+                            "requests": {
+                              "additionalProperties": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "type": "object"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "restartPolicy": {
+                          "type": "string"
+                        },
+                        "runtimeClassName": {
+                          "type": "string"
+                        },
+                        "schedulerName": {
+                          "type": "string"
+                        },
+                        "schedulingGates": {
+                          "items": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "securityContext": {
+                          "properties": {
+                            "appArmorProfile": {
+                              "properties": {
+                                "localhostProfile": {
+                                  "type": "string"
+                                },
+                                "type": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "fsGroup": {
+                              "type": "integer"
+                            },
+                            "fsGroupChangePolicy": {
+                              "type": "string"
+                            },
+                            "runAsGroup": {
+                              "type": "integer"
+                            },
+                            "runAsNonRoot": {
+                              "type": "boolean"
+                            },
+                            "runAsUser": {
+                              "type": "integer"
+                            },
+                            "seLinuxChangePolicy": {
+                              "type": "string"
+                            },
+                            "seLinuxOptions": {
+                              "properties": {
+                                "level": {
+                                  "type": "string"
+                                },
+                                "role": {
+                                  "type": "string"
+                                },
+                                "type": {
+                                  "type": "string"
+                                },
+                                "user": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "seccompProfile": {
+                              "properties": {
+                                "localhostProfile": {
+                                  "type": "string"
+                                },
+                                "type": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "supplementalGroups": {
+                              "items": {
+                                "type": "integer"
+                              },
+                              "type": "array"
+                            },
+                            "supplementalGroupsPolicy": {
+                              "type": "string"
+                            },
+                            "sysctls": {
+                              "items": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "value": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "windowsOptions": {
+                              "properties": {
+                                "gmsaCredentialSpec": {
+                                  "type": "string"
+                                },
+                                "gmsaCredentialSpecName": {
+                                  "type": "string"
+                                },
+                                "hostProcess": {
+                                  "type": "boolean"
+                                },
+                                "runAsUserName": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "serviceAccount": {
+                          "type": "string"
+                        },
+                        "serviceAccountName": {
+                          "type": "string"
+                        },
+                        "setHostnameAsFQDN": {
+                          "type": "boolean"
+                        },
+                        "shareProcessNamespace": {
+                          "type": "boolean"
+                        },
+                        "subdomain": {
+                          "type": "string"
+                        },
+                        "terminationGracePeriodSeconds": {
+                          "type": "integer"
+                        },
+                        "tolerations": {
+                          "items": {
+                            "properties": {
+                              "effect": {
+                                "type": "string"
+                              },
+                              "key": {
+                                "type": "string"
+                              },
+                              "operator": {
+                                "type": "string"
+                              },
+                              "tolerationSeconds": {
+                                "type": "integer"
+                              },
+                              "value": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "topologySpreadConstraints": {
+                          "items": {
+                            "properties": {
+                              "labelSelector": {
+                                "properties": {
+                                  "matchExpressions": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "matchLabels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "matchLabelKeys": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "maxSkew": {
+                                "type": "integer"
+                              },
+                              "minDomains": {
+                                "type": "integer"
+                              },
+                              "nodeAffinityPolicy": {
+                                "type": "string"
+                              },
+                              "nodeTaintsPolicy": {
+                                "type": "string"
+                              },
+                              "topologyKey": {
+                                "type": "string"
+                              },
+                              "whenUnsatisfiable": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "volumes": {
+                          "items": {
+                            "properties": {
+                              "awsElasticBlockStore": {
+                                "properties": {
+                                  "fsType": {
+                                    "type": "string"
+                                  },
+                                  "partition": {
+                                    "type": "integer"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  },
+                                  "volumeID": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "azureDisk": {
+                                "properties": {
+                                  "cachingMode": {
+                                    "type": "string"
+                                  },
+                                  "diskName": {
+                                    "type": "string"
+                                  },
+                                  "diskURI": {
+                                    "type": "string"
+                                  },
+                                  "fsType": {
+                                    "type": "string"
+                                  },
+                                  "kind": {
+                                    "type": "string"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "azureFile": {
+                                "properties": {
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  },
+                                  "secretName": {
+                                    "type": "string"
+                                  },
+                                  "shareName": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "cephfs": {
+                                "properties": {
+                                  "monitors": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  },
+                                  "secretFile": {
+                                    "type": "string"
+                                  },
+                                  "secretRef": {
+                                    "properties": {
+                                      "name": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "user": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "cinder": {
+                                "properties": {
+                                  "fsType": {
+                                    "type": "string"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  },
+                                  "secretRef": {
+                                    "properties": {
+                                      "name": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "volumeID": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "configMap": {
+                                "properties": {
+                                  "defaultMode": {
+                                    "type": "integer"
+                                  },
+                                  "items": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "mode": {
+                                          "type": "integer"
+                                        },
+                                        "path": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "csi": {
+                                "properties": {
+                                  "driver": {
+                                    "type": "string"
+                                  },
+                                  "fsType": {
+                                    "type": "string"
+                                  },
+                                  "nodePublishSecretRef": {
+                                    "properties": {
+                                      "name": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  },
+                                  "volumeAttributes": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "downwardAPI": {
+                                "properties": {
+                                  "defaultMode": {
+                                    "type": "integer"
+                                  },
+                                  "items": {
+                                    "items": {
+                                      "properties": {
+                                        "fieldRef": {
+                                          "properties": {
+                                            "apiVersion": {
+                                              "type": "string"
+                                            },
+                                            "fieldPath": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "mode": {
+                                          "type": "integer"
+                                        },
+                                        "path": {
+                                          "type": "string"
+                                        },
+                                        "resourceFieldRef": {
+                                          "properties": {
+                                            "containerName": {
+                                              "type": "string"
+                                            },
+                                            "divisor": {
+                                              "anyOf": [
+                                                {
+                                                  "type": "integer"
+                                                },
+                                                {
+                                                  "type": "string"
+                                                }
+                                              ],
+                                              "x-kubernetes-int-or-string": true
+                                            },
+                                            "resource": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "emptyDir": {
+                                "properties": {
+                                  "medium": {
+                                    "type": "string"
+                                  },
+                                  "sizeLimit": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "ephemeral": {
+                                "properties": {
+                                  "volumeClaimTemplate": {
+                                    "properties": {
+                                      "metadata": {
+                                        "properties": {
+                                          "annotations": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
+                                          },
+                                          "creationTimestamp": {
+                                            "type": "string"
+                                          },
+                                          "deletionGracePeriodSeconds": {
+                                            "type": "integer"
+                                          },
+                                          "deletionTimestamp": {
+                                            "type": "string"
+                                          },
+                                          "finalizers": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "generateName": {
+                                            "type": "string"
+                                          },
+                                          "generation": {
+                                            "type": "integer"
+                                          },
+                                          "labels": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
+                                          },
+                                          "managedFields": {
+                                            "items": {
+                                              "properties": {
+                                                "apiVersion": {
+                                                  "type": "string"
+                                                },
+                                                "fieldsType": {
+                                                  "type": "string"
+                                                },
+                                                "fieldsV1": {
+                                                  "type": "object"
+                                                },
+                                                "manager": {
+                                                  "type": "string"
+                                                },
+                                                "operation": {
+                                                  "type": "string"
+                                                },
+                                                "subresource": {
+                                                  "type": "string"
+                                                },
+                                                "time": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "namespace": {
+                                            "type": "string"
+                                          },
+                                          "ownerReferences": {
+                                            "items": {
+                                              "properties": {
+                                                "apiVersion": {
+                                                  "type": "string"
+                                                },
+                                                "blockOwnerDeletion": {
+                                                  "type": "boolean"
+                                                },
+                                                "controller": {
+                                                  "type": "boolean"
+                                                },
+                                                "kind": {
+                                                  "type": "string"
+                                                },
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "uid": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "resourceVersion": {
+                                            "type": "string"
+                                          },
+                                          "selfLink": {
+                                            "type": "string"
+                                          },
+                                          "uid": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "spec": {
+                                        "properties": {
+                                          "accessModes": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "dataSource": {
+                                            "properties": {
+                                              "apiGroup": {
+                                                "type": "string"
+                                              },
+                                              "kind": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          "dataSourceRef": {
+                                            "properties": {
+                                              "apiGroup": {
+                                                "type": "string"
+                                              },
+                                              "kind": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "namespace": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          "resources": {
+                                            "properties": {
+                                              "limits": {
+                                                "additionalProperties": {
+                                                  "anyOf": [
+                                                    {
+                                                      "type": "integer"
+                                                    },
+                                                    {
+                                                      "type": "string"
+                                                    }
+                                                  ],
+                                                  "x-kubernetes-int-or-string": true
+                                                },
+                                                "type": "object"
+                                              },
+                                              "requests": {
+                                                "additionalProperties": {
+                                                  "anyOf": [
+                                                    {
+                                                      "type": "integer"
+                                                    },
+                                                    {
+                                                      "type": "string"
+                                                    }
+                                                  ],
+                                                  "x-kubernetes-int-or-string": true
+                                                },
+                                                "type": "object"
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          "selector": {
+                                            "properties": {
+                                              "matchExpressions": {
+                                                "items": {
+                                                  "properties": {
+                                                    "key": {
+                                                      "type": "string"
+                                                    },
+                                                    "operator": {
+                                                      "type": "string"
+                                                    },
+                                                    "values": {
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    }
+                                                  },
+                                                  "type": "object"
+                                                },
+                                                "type": "array"
+                                              },
+                                              "matchLabels": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "type": "object"
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          "storageClassName": {
+                                            "type": "string"
+                                          },
+                                          "volumeAttributesClassName": {
+                                            "type": "string"
+                                          },
+                                          "volumeMode": {
+                                            "type": "string"
+                                          },
+                                          "volumeName": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "fc": {
+                                "properties": {
+                                  "fsType": {
+                                    "type": "string"
+                                  },
+                                  "lun": {
+                                    "type": "integer"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  },
+                                  "targetWWNs": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "wwids": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "flexVolume": {
+                                "properties": {
+                                  "driver": {
+                                    "type": "string"
+                                  },
+                                  "fsType": {
+                                    "type": "string"
+                                  },
+                                  "options": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  },
+                                  "secretRef": {
+                                    "properties": {
+                                      "name": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "flocker": {
+                                "properties": {
+                                  "datasetName": {
+                                    "type": "string"
+                                  },
+                                  "datasetUUID": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "gcePersistentDisk": {
+                                "properties": {
+                                  "fsType": {
+                                    "type": "string"
+                                  },
+                                  "partition": {
+                                    "type": "integer"
+                                  },
+                                  "pdName": {
+                                    "type": "string"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "gitRepo": {
+                                "properties": {
+                                  "directory": {
+                                    "type": "string"
+                                  },
+                                  "repository": {
+                                    "type": "string"
+                                  },
+                                  "revision": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "glusterfs": {
+                                "properties": {
+                                  "endpoints": {
+                                    "type": "string"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "hostPath": {
+                                "properties": {
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "type": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "image": {
+                                "properties": {
+                                  "pullPolicy": {
+                                    "type": "string"
+                                  },
+                                  "reference": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "iscsi": {
+                                "properties": {
+                                  "chapAuthDiscovery": {
+                                    "type": "boolean"
+                                  },
+                                  "chapAuthSession": {
+                                    "type": "boolean"
+                                  },
+                                  "fsType": {
+                                    "type": "string"
+                                  },
+                                  "initiatorName": {
+                                    "type": "string"
+                                  },
+                                  "iqn": {
+                                    "type": "string"
+                                  },
+                                  "iscsiInterface": {
+                                    "type": "string"
+                                  },
+                                  "lun": {
+                                    "type": "integer"
+                                  },
+                                  "portals": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  },
+                                  "secretRef": {
+                                    "properties": {
+                                      "name": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "targetPortal": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "nfs": {
+                                "properties": {
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  },
+                                  "server": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "persistentVolumeClaim": {
+                                "properties": {
+                                  "claimName": {
+                                    "type": "string"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "photonPersistentDisk": {
+                                "properties": {
+                                  "fsType": {
+                                    "type": "string"
+                                  },
+                                  "pdID": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "portworxVolume": {
+                                "properties": {
+                                  "fsType": {
+                                    "type": "string"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  },
+                                  "volumeID": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "projected": {
+                                "properties": {
+                                  "defaultMode": {
+                                    "type": "integer"
+                                  },
+                                  "sources": {
+                                    "items": {
+                                      "properties": {
+                                        "clusterTrustBundle": {
+                                          "properties": {
+                                            "labelSelector": {
+                                              "properties": {
+                                                "matchExpressions": {
+                                                  "items": {
+                                                    "properties": {
+                                                      "key": {
+                                                        "type": "string"
+                                                      },
+                                                      "operator": {
+                                                        "type": "string"
+                                                      },
+                                                      "values": {
+                                                        "items": {
+                                                          "type": "string"
+                                                        },
+                                                        "type": "array"
+                                                      }
+                                                    },
+                                                    "type": "object"
+                                                  },
+                                                  "type": "array"
+                                                },
+                                                "matchLabels": {
+                                                  "additionalProperties": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "object"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            },
+                                            "path": {
+                                              "type": "string"
+                                            },
+                                            "signerName": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "configMap": {
+                                          "properties": {
+                                            "items": {
+                                              "items": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "mode": {
+                                                    "type": "integer"
+                                                  },
+                                                  "path": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              "type": "array"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "downwardAPI": {
+                                          "properties": {
+                                            "items": {
+                                              "items": {
+                                                "properties": {
+                                                  "fieldRef": {
+                                                    "properties": {
+                                                      "apiVersion": {
+                                                        "type": "string"
+                                                      },
+                                                      "fieldPath": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "type": "object"
+                                                  },
+                                                  "mode": {
+                                                    "type": "integer"
+                                                  },
+                                                  "path": {
+                                                    "type": "string"
+                                                  },
+                                                  "resourceFieldRef": {
+                                                    "properties": {
+                                                      "containerName": {
+                                                        "type": "string"
+                                                      },
+                                                      "divisor": {
+                                                        "anyOf": [
+                                                          {
+                                                            "type": "integer"
+                                                          },
+                                                          {
+                                                            "type": "string"
+                                                          }
+                                                        ],
+                                                        "x-kubernetes-int-or-string": true
+                                                      },
+                                                      "resource": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "type": "object"
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "secret": {
+                                          "properties": {
+                                            "items": {
+                                              "items": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "mode": {
+                                                    "type": "integer"
+                                                  },
+                                                  "path": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              "type": "array"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "serviceAccountToken": {
+                                          "properties": {
+                                            "audience": {
+                                              "type": "string"
+                                            },
+                                            "expirationSeconds": {
+                                              "type": "integer"
+                                            },
+                                            "path": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "quobyte": {
+                                "properties": {
+                                  "group": {
+                                    "type": "string"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  },
+                                  "registry": {
+                                    "type": "string"
+                                  },
+                                  "tenant": {
+                                    "type": "string"
+                                  },
+                                  "user": {
+                                    "type": "string"
+                                  },
+                                  "volume": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "rbd": {
+                                "properties": {
+                                  "fsType": {
+                                    "type": "string"
+                                  },
+                                  "image": {
+                                    "type": "string"
+                                  },
+                                  "keyring": {
+                                    "type": "string"
+                                  },
+                                  "monitors": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "pool": {
+                                    "type": "string"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  },
+                                  "secretRef": {
+                                    "properties": {
+                                      "name": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "user": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "scaleIO": {
+                                "properties": {
+                                  "fsType": {
+                                    "type": "string"
+                                  },
+                                  "gateway": {
+                                    "type": "string"
+                                  },
+                                  "protectionDomain": {
+                                    "type": "string"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  },
+                                  "secretRef": {
+                                    "properties": {
+                                      "name": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "sslEnabled": {
+                                    "type": "boolean"
+                                  },
+                                  "storageMode": {
+                                    "type": "string"
+                                  },
+                                  "storagePool": {
+                                    "type": "string"
+                                  },
+                                  "system": {
+                                    "type": "string"
+                                  },
+                                  "volumeName": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "secret": {
+                                "properties": {
+                                  "defaultMode": {
+                                    "type": "integer"
+                                  },
+                                  "items": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "mode": {
+                                          "type": "integer"
+                                        },
+                                        "path": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  },
+                                  "secretName": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "storageos": {
+                                "properties": {
+                                  "fsType": {
+                                    "type": "string"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  },
+                                  "secretRef": {
+                                    "properties": {
+                                      "name": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "volumeName": {
+                                    "type": "string"
+                                  },
+                                  "volumeNamespace": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "vsphereVolume": {
+                                "properties": {
+                                  "fsType": {
+                                    "type": "string"
+                                  },
+                                  "storagePolicyID": {
+                                    "type": "string"
+                                  },
+                                  "storagePolicyName": {
+                                    "type": "string"
+                                  },
+                                  "volumePath": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "type": "object"
+                },
+                "updateStrategy": {
+                  "properties": {
+                    "rollingUpdate": {
+                      "properties": {
+                        "maxUnavailable": {
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "string"
+                            }
+                          ],
+                          "x-kubernetes-int-or-string": true
+                        },
+                        "partition": {
+                          "type": "integer"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "type": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "volumeClaimTemplates": {
+                  "items": {
+                    "properties": {
+                      "apiVersion": {
+                        "type": "string"
+                      },
+                      "kind": {
+                        "type": "string"
+                      },
+                      "metadata": {
+                        "properties": {
+                          "annotations": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "type": "object"
+                          },
+                          "creationTimestamp": {
+                            "type": "string"
+                          },
+                          "deletionGracePeriodSeconds": {
+                            "type": "integer"
+                          },
+                          "deletionTimestamp": {
+                            "type": "string"
+                          },
+                          "finalizers": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "generateName": {
+                            "type": "string"
+                          },
+                          "generation": {
+                            "type": "integer"
+                          },
+                          "labels": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "type": "object"
+                          },
+                          "managedFields": {
+                            "items": {
+                              "properties": {
+                                "apiVersion": {
+                                  "type": "string"
+                                },
+                                "fieldsType": {
+                                  "type": "string"
+                                },
+                                "fieldsV1": {
+                                  "type": "object"
+                                },
+                                "manager": {
+                                  "type": "string"
+                                },
+                                "operation": {
+                                  "type": "string"
+                                },
+                                "subresource": {
+                                  "type": "string"
+                                },
+                                "time": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "namespace": {
+                            "type": "string"
+                          },
+                          "ownerReferences": {
+                            "items": {
+                              "properties": {
+                                "apiVersion": {
+                                  "type": "string"
+                                },
+                                "blockOwnerDeletion": {
+                                  "type": "boolean"
+                                },
+                                "controller": {
+                                  "type": "boolean"
+                                },
+                                "kind": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "uid": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "resourceVersion": {
+                            "type": "string"
+                          },
+                          "selfLink": {
+                            "type": "string"
+                          },
+                          "uid": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "spec": {
+                        "properties": {
+                          "accessModes": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "dataSource": {
+                            "properties": {
+                              "apiGroup": {
+                                "type": "string"
+                              },
+                              "kind": {
+                                "type": "string"
+                              },
+                              "name": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "dataSourceRef": {
+                            "properties": {
+                              "apiGroup": {
+                                "type": "string"
+                              },
+                              "kind": {
+                                "type": "string"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "namespace": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "resources": {
+                            "properties": {
+                              "limits": {
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "type": "object"
+                              },
+                              "requests": {
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "selector": {
+                            "properties": {
+                              "matchExpressions": {
+                                "items": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "matchLabels": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "storageClassName": {
+                            "type": "string"
+                          },
+                          "volumeAttributesClassName": {
+                            "type": "string"
+                          },
+                          "volumeMode": {
+                            "type": "string"
+                          },
+                          "volumeName": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "status": {
+                        "properties": {
+                          "accessModes": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "allocatedResourceStatuses": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "type": "object"
+                          },
+                          "allocatedResources": {
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "type": "object"
+                          },
+                          "capacity": {
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "type": "object"
+                          },
+                          "conditions": {
+                            "items": {
+                              "properties": {
+                                "lastProbeTime": {
+                                  "type": "string"
+                                },
+                                "lastTransitionTime": {
+                                  "type": "string"
+                                },
+                                "message": {
+                                  "type": "string"
+                                },
+                                "reason": {
+                                  "type": "string"
+                                },
+                                "status": {
+                                  "type": "string"
+                                },
+                                "type": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "currentVolumeAttributesClassName": {
+                            "type": "string"
+                          },
+                          "modifyVolumeStatus": {
+                            "properties": {
+                              "status": {
+                                "type": "string"
+                              },
+                              "targetVolumeAttributesClassName": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "phase": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "type": "object"
+        }
+      },
+      "required": [
+        "clusterTolerations",
+        "runtimeVersions"
+      ],
+      "type": "object"
+    },
+    "status": {
+      "properties": {
+        "currentAttemptSummary": {
+          "properties": {
+            "attemptInfo": {
+              "properties": {
+                "id": {
+                  "type": "integer"
+                }
+              },
+              "type": "object"
+            },
+            "stateTransitionHistory": {
+              "additionalProperties": {
+                "properties": {
+                  "currentStateSummary": {
+                    "enum": [
+                      "Failed",
+                      "ResourceReleased",
+                      "RunningHealthy",
+                      "SchedulingFailure",
+                      "Submitted"
+                    ],
+                    "type": "string"
+                  },
+                  "lastTransitionTime": {
+                    "type": "string"
+                  },
+                  "message": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "type": "object"
+            }
+          },
+          "type": "object"
+        },
+        "currentState": {
+          "properties": {
+            "currentStateSummary": {
+              "enum": [
+                "Failed",
+                "ResourceReleased",
+                "RunningHealthy",
+                "SchedulingFailure",
+                "Submitted"
+              ],
+              "type": "string"
+            },
+            "lastTransitionTime": {
+              "type": "string"
+            },
+            "message": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "previousAttemptSummary": {
+          "properties": {
+            "attemptInfo": {
+              "properties": {
+                "id": {
+                  "type": "integer"
+                }
+              },
+              "type": "object"
+            },
+            "stateTransitionHistory": {
+              "additionalProperties": {
+                "properties": {
+                  "currentStateSummary": {
+                    "enum": [
+                      "Failed",
+                      "ResourceReleased",
+                      "RunningHealthy",
+                      "SchedulingFailure",
+                      "Submitted"
+                    ],
+                    "type": "string"
+                  },
+                  "lastTransitionTime": {
+                    "type": "string"
+                  },
+                  "message": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "type": "object"
+            }
+          },
+          "type": "object"
+        },
+        "stateTransitionHistory": {
+          "additionalProperties": {
+            "properties": {
+              "currentStateSummary": {
+                "enum": [
+                  "Failed",
+                  "ResourceReleased",
+                  "RunningHealthy",
+                  "SchedulingFailure",
+                  "Submitted"
+                ],
+                "type": "string"
+              },
+              "lastTransitionTime": {
+                "type": "string"
+              },
+              "message": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "type": "object"
+        }
+      },
+      "type": "object"
+    },
+    "apiVersion": {
+      "type": "string"
+    },
+    "kind": {
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    }
+  },
+  "type": "object"
+}

--- a/spark.apache.org/sparkcluster_v1beta1.json
+++ b/spark.apache.org/sparkcluster_v1beta1.json
@@ -1,0 +1,11662 @@
+{
+  "properties": {
+    "spec": {
+      "properties": {
+        "clusterTolerations": {
+          "properties": {
+            "instanceConfig": {
+              "properties": {
+                "initWorkers": {
+                  "type": "integer"
+                },
+                "maxWorkers": {
+                  "type": "integer"
+                },
+                "minWorkers": {
+                  "type": "integer"
+                }
+              },
+              "required": [
+                "initWorkers",
+                "maxWorkers",
+                "minWorkers"
+              ],
+              "type": "object"
+            }
+          },
+          "required": [
+            "instanceConfig"
+          ],
+          "type": "object"
+        },
+        "masterSpec": {
+          "properties": {
+            "serviceMetadata": {
+              "properties": {
+                "annotations": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                },
+                "creationTimestamp": {
+                  "type": "string"
+                },
+                "deletionGracePeriodSeconds": {
+                  "type": "integer"
+                },
+                "deletionTimestamp": {
+                  "type": "string"
+                },
+                "finalizers": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "generateName": {
+                  "type": "string"
+                },
+                "generation": {
+                  "type": "integer"
+                },
+                "labels": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                },
+                "managedFields": {
+                  "items": {
+                    "properties": {
+                      "apiVersion": {
+                        "type": "string"
+                      },
+                      "fieldsType": {
+                        "type": "string"
+                      },
+                      "fieldsV1": {
+                        "type": "object"
+                      },
+                      "manager": {
+                        "type": "string"
+                      },
+                      "operation": {
+                        "type": "string"
+                      },
+                      "subresource": {
+                        "type": "string"
+                      },
+                      "time": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "namespace": {
+                  "type": "string"
+                },
+                "ownerReferences": {
+                  "items": {
+                    "properties": {
+                      "apiVersion": {
+                        "type": "string"
+                      },
+                      "blockOwnerDeletion": {
+                        "type": "boolean"
+                      },
+                      "controller": {
+                        "type": "boolean"
+                      },
+                      "kind": {
+                        "type": "string"
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "uid": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "resourceVersion": {
+                  "type": "string"
+                },
+                "selfLink": {
+                  "type": "string"
+                },
+                "uid": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "serviceSpec": {
+              "properties": {
+                "allocateLoadBalancerNodePorts": {
+                  "type": "boolean"
+                },
+                "clusterIP": {
+                  "type": "string"
+                },
+                "clusterIPs": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "externalIPs": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "externalName": {
+                  "type": "string"
+                },
+                "externalTrafficPolicy": {
+                  "type": "string"
+                },
+                "healthCheckNodePort": {
+                  "type": "integer"
+                },
+                "internalTrafficPolicy": {
+                  "type": "string"
+                },
+                "ipFamilies": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "ipFamilyPolicy": {
+                  "type": "string"
+                },
+                "loadBalancerClass": {
+                  "type": "string"
+                },
+                "loadBalancerIP": {
+                  "type": "string"
+                },
+                "loadBalancerSourceRanges": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "ports": {
+                  "items": {
+                    "properties": {
+                      "appProtocol": {
+                        "type": "string"
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "nodePort": {
+                        "type": "integer"
+                      },
+                      "port": {
+                        "type": "integer"
+                      },
+                      "protocol": {
+                        "type": "string"
+                      },
+                      "targetPort": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "x-kubernetes-int-or-string": true
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "publishNotReadyAddresses": {
+                  "type": "boolean"
+                },
+                "selector": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                },
+                "sessionAffinity": {
+                  "type": "string"
+                },
+                "sessionAffinityConfig": {
+                  "properties": {
+                    "clientIP": {
+                      "properties": {
+                        "timeoutSeconds": {
+                          "type": "integer"
+                        }
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "type": "object"
+                },
+                "trafficDistribution": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "statefulSetMetadata": {
+              "properties": {
+                "annotations": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                },
+                "creationTimestamp": {
+                  "type": "string"
+                },
+                "deletionGracePeriodSeconds": {
+                  "type": "integer"
+                },
+                "deletionTimestamp": {
+                  "type": "string"
+                },
+                "finalizers": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "generateName": {
+                  "type": "string"
+                },
+                "generation": {
+                  "type": "integer"
+                },
+                "labels": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                },
+                "managedFields": {
+                  "items": {
+                    "properties": {
+                      "apiVersion": {
+                        "type": "string"
+                      },
+                      "fieldsType": {
+                        "type": "string"
+                      },
+                      "fieldsV1": {
+                        "type": "object"
+                      },
+                      "manager": {
+                        "type": "string"
+                      },
+                      "operation": {
+                        "type": "string"
+                      },
+                      "subresource": {
+                        "type": "string"
+                      },
+                      "time": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "namespace": {
+                  "type": "string"
+                },
+                "ownerReferences": {
+                  "items": {
+                    "properties": {
+                      "apiVersion": {
+                        "type": "string"
+                      },
+                      "blockOwnerDeletion": {
+                        "type": "boolean"
+                      },
+                      "controller": {
+                        "type": "boolean"
+                      },
+                      "kind": {
+                        "type": "string"
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "uid": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "resourceVersion": {
+                  "type": "string"
+                },
+                "selfLink": {
+                  "type": "string"
+                },
+                "uid": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "statefulSetSpec": {
+              "properties": {
+                "minReadySeconds": {
+                  "type": "integer"
+                },
+                "ordinals": {
+                  "properties": {
+                    "start": {
+                      "type": "integer"
+                    }
+                  },
+                  "type": "object"
+                },
+                "persistentVolumeClaimRetentionPolicy": {
+                  "properties": {
+                    "whenDeleted": {
+                      "type": "string"
+                    },
+                    "whenScaled": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "podManagementPolicy": {
+                  "type": "string"
+                },
+                "replicas": {
+                  "type": "integer"
+                },
+                "revisionHistoryLimit": {
+                  "type": "integer"
+                },
+                "selector": {
+                  "properties": {
+                    "matchExpressions": {
+                      "items": {
+                        "properties": {
+                          "key": {
+                            "type": "string"
+                          },
+                          "operator": {
+                            "type": "string"
+                          },
+                          "values": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "matchLabels": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "type": "object"
+                },
+                "serviceName": {
+                  "type": "string"
+                },
+                "template": {
+                  "properties": {
+                    "metadata": {
+                      "properties": {
+                        "annotations": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        "creationTimestamp": {
+                          "type": "string"
+                        },
+                        "deletionGracePeriodSeconds": {
+                          "type": "integer"
+                        },
+                        "deletionTimestamp": {
+                          "type": "string"
+                        },
+                        "finalizers": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "generateName": {
+                          "type": "string"
+                        },
+                        "generation": {
+                          "type": "integer"
+                        },
+                        "labels": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        "managedFields": {
+                          "items": {
+                            "properties": {
+                              "apiVersion": {
+                                "type": "string"
+                              },
+                              "fieldsType": {
+                                "type": "string"
+                              },
+                              "fieldsV1": {
+                                "type": "object"
+                              },
+                              "manager": {
+                                "type": "string"
+                              },
+                              "operation": {
+                                "type": "string"
+                              },
+                              "subresource": {
+                                "type": "string"
+                              },
+                              "time": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "namespace": {
+                          "type": "string"
+                        },
+                        "ownerReferences": {
+                          "items": {
+                            "properties": {
+                              "apiVersion": {
+                                "type": "string"
+                              },
+                              "blockOwnerDeletion": {
+                                "type": "boolean"
+                              },
+                              "controller": {
+                                "type": "boolean"
+                              },
+                              "kind": {
+                                "type": "string"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "uid": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "resourceVersion": {
+                          "type": "string"
+                        },
+                        "selfLink": {
+                          "type": "string"
+                        },
+                        "uid": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "spec": {
+                      "properties": {
+                        "activeDeadlineSeconds": {
+                          "type": "integer"
+                        },
+                        "affinity": {
+                          "properties": {
+                            "nodeAffinity": {
+                              "properties": {
+                                "preferredDuringSchedulingIgnoredDuringExecution": {
+                                  "items": {
+                                    "properties": {
+                                      "preference": {
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "matchFields": {
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "weight": {
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "type": "array"
+                                },
+                                "requiredDuringSchedulingIgnoredDuringExecution": {
+                                  "properties": {
+                                    "nodeSelectorTerms": {
+                                      "items": {
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "matchFields": {
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "podAffinity": {
+                              "properties": {
+                                "preferredDuringSchedulingIgnoredDuringExecution": {
+                                  "items": {
+                                    "properties": {
+                                      "podAffinityTerm": {
+                                        "properties": {
+                                          "labelSelector": {
+                                            "properties": {
+                                              "matchExpressions": {
+                                                "items": {
+                                                  "properties": {
+                                                    "key": {
+                                                      "type": "string"
+                                                    },
+                                                    "operator": {
+                                                      "type": "string"
+                                                    },
+                                                    "values": {
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    }
+                                                  },
+                                                  "type": "object"
+                                                },
+                                                "type": "array"
+                                              },
+                                              "matchLabels": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "type": "object"
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          "matchLabelKeys": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "mismatchLabelKeys": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "namespaceSelector": {
+                                            "properties": {
+                                              "matchExpressions": {
+                                                "items": {
+                                                  "properties": {
+                                                    "key": {
+                                                      "type": "string"
+                                                    },
+                                                    "operator": {
+                                                      "type": "string"
+                                                    },
+                                                    "values": {
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    }
+                                                  },
+                                                  "type": "object"
+                                                },
+                                                "type": "array"
+                                              },
+                                              "matchLabels": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "type": "object"
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          "namespaces": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "topologyKey": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "weight": {
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "type": "array"
+                                },
+                                "requiredDuringSchedulingIgnoredDuringExecution": {
+                                  "items": {
+                                    "properties": {
+                                      "labelSelector": {
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "matchLabels": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "matchLabelKeys": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "mismatchLabelKeys": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "namespaceSelector": {
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "matchLabels": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "namespaces": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "topologyKey": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "podAntiAffinity": {
+                              "properties": {
+                                "preferredDuringSchedulingIgnoredDuringExecution": {
+                                  "items": {
+                                    "properties": {
+                                      "podAffinityTerm": {
+                                        "properties": {
+                                          "labelSelector": {
+                                            "properties": {
+                                              "matchExpressions": {
+                                                "items": {
+                                                  "properties": {
+                                                    "key": {
+                                                      "type": "string"
+                                                    },
+                                                    "operator": {
+                                                      "type": "string"
+                                                    },
+                                                    "values": {
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    }
+                                                  },
+                                                  "type": "object"
+                                                },
+                                                "type": "array"
+                                              },
+                                              "matchLabels": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "type": "object"
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          "matchLabelKeys": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "mismatchLabelKeys": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "namespaceSelector": {
+                                            "properties": {
+                                              "matchExpressions": {
+                                                "items": {
+                                                  "properties": {
+                                                    "key": {
+                                                      "type": "string"
+                                                    },
+                                                    "operator": {
+                                                      "type": "string"
+                                                    },
+                                                    "values": {
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    }
+                                                  },
+                                                  "type": "object"
+                                                },
+                                                "type": "array"
+                                              },
+                                              "matchLabels": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "type": "object"
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          "namespaces": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "topologyKey": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "weight": {
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "type": "array"
+                                },
+                                "requiredDuringSchedulingIgnoredDuringExecution": {
+                                  "items": {
+                                    "properties": {
+                                      "labelSelector": {
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "matchLabels": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "matchLabelKeys": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "mismatchLabelKeys": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "namespaceSelector": {
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "matchLabels": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "namespaces": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "topologyKey": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "type": "object"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "automountServiceAccountToken": {
+                          "type": "boolean"
+                        },
+                        "containers": {
+                          "items": {
+                            "properties": {
+                              "args": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "command": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "env": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    },
+                                    "valueFrom": {
+                                      "properties": {
+                                        "configMapKeyRef": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "fieldRef": {
+                                          "properties": {
+                                            "apiVersion": {
+                                              "type": "string"
+                                            },
+                                            "fieldPath": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "resourceFieldRef": {
+                                          "properties": {
+                                            "containerName": {
+                                              "type": "string"
+                                            },
+                                            "divisor": {
+                                              "anyOf": [
+                                                {
+                                                  "type": "integer"
+                                                },
+                                                {
+                                                  "type": "string"
+                                                }
+                                              ],
+                                              "x-kubernetes-int-or-string": true
+                                            },
+                                            "resource": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "secretKeyRef": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "type": "object"
+                                        }
+                                      },
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "envFrom": {
+                                "items": {
+                                  "properties": {
+                                    "configMapRef": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "prefix": {
+                                      "type": "string"
+                                    },
+                                    "secretRef": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "image": {
+                                "type": "string"
+                              },
+                              "imagePullPolicy": {
+                                "type": "string"
+                              },
+                              "lifecycle": {
+                                "properties": {
+                                  "postStart": {
+                                    "properties": {
+                                      "exec": {
+                                        "properties": {
+                                          "command": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "httpGet": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "httpHeaders": {
+                                            "items": {
+                                              "properties": {
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "value": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          },
+                                          "scheme": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "sleep": {
+                                        "properties": {
+                                          "seconds": {
+                                            "type": "integer"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "tcpSocket": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          }
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "preStop": {
+                                    "properties": {
+                                      "exec": {
+                                        "properties": {
+                                          "command": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "httpGet": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "httpHeaders": {
+                                            "items": {
+                                              "properties": {
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "value": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          },
+                                          "scheme": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "sleep": {
+                                        "properties": {
+                                          "seconds": {
+                                            "type": "integer"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "tcpSocket": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          }
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "stopSignal": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "livenessProbe": {
+                                "properties": {
+                                  "exec": {
+                                    "properties": {
+                                      "command": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "failureThreshold": {
+                                    "type": "integer"
+                                  },
+                                  "grpc": {
+                                    "properties": {
+                                      "port": {
+                                        "type": "integer"
+                                      },
+                                      "service": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "httpGet": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "initialDelaySeconds": {
+                                    "type": "integer"
+                                  },
+                                  "periodSeconds": {
+                                    "type": "integer"
+                                  },
+                                  "successThreshold": {
+                                    "type": "integer"
+                                  },
+                                  "tcpSocket": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "terminationGracePeriodSeconds": {
+                                    "type": "integer"
+                                  },
+                                  "timeoutSeconds": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "ports": {
+                                "items": {
+                                  "properties": {
+                                    "containerPort": {
+                                      "type": "integer"
+                                    },
+                                    "hostIP": {
+                                      "type": "string"
+                                    },
+                                    "hostPort": {
+                                      "type": "integer"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "protocol": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "readinessProbe": {
+                                "properties": {
+                                  "exec": {
+                                    "properties": {
+                                      "command": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "failureThreshold": {
+                                    "type": "integer"
+                                  },
+                                  "grpc": {
+                                    "properties": {
+                                      "port": {
+                                        "type": "integer"
+                                      },
+                                      "service": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "httpGet": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "initialDelaySeconds": {
+                                    "type": "integer"
+                                  },
+                                  "periodSeconds": {
+                                    "type": "integer"
+                                  },
+                                  "successThreshold": {
+                                    "type": "integer"
+                                  },
+                                  "tcpSocket": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "terminationGracePeriodSeconds": {
+                                    "type": "integer"
+                                  },
+                                  "timeoutSeconds": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "resizePolicy": {
+                                "items": {
+                                  "properties": {
+                                    "resourceName": {
+                                      "type": "string"
+                                    },
+                                    "restartPolicy": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "resources": {
+                                "properties": {
+                                  "claims": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "request": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "limits": {
+                                    "additionalProperties": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "string"
+                                        }
+                                      ],
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "type": "object"
+                                  },
+                                  "requests": {
+                                    "additionalProperties": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "string"
+                                        }
+                                      ],
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "restartPolicy": {
+                                "type": "string"
+                              },
+                              "securityContext": {
+                                "properties": {
+                                  "allowPrivilegeEscalation": {
+                                    "type": "boolean"
+                                  },
+                                  "appArmorProfile": {
+                                    "properties": {
+                                      "localhostProfile": {
+                                        "type": "string"
+                                      },
+                                      "type": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "capabilities": {
+                                    "properties": {
+                                      "add": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "drop": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "privileged": {
+                                    "type": "boolean"
+                                  },
+                                  "procMount": {
+                                    "type": "string"
+                                  },
+                                  "readOnlyRootFilesystem": {
+                                    "type": "boolean"
+                                  },
+                                  "runAsGroup": {
+                                    "type": "integer"
+                                  },
+                                  "runAsNonRoot": {
+                                    "type": "boolean"
+                                  },
+                                  "runAsUser": {
+                                    "type": "integer"
+                                  },
+                                  "seLinuxOptions": {
+                                    "properties": {
+                                      "level": {
+                                        "type": "string"
+                                      },
+                                      "role": {
+                                        "type": "string"
+                                      },
+                                      "type": {
+                                        "type": "string"
+                                      },
+                                      "user": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "seccompProfile": {
+                                    "properties": {
+                                      "localhostProfile": {
+                                        "type": "string"
+                                      },
+                                      "type": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "windowsOptions": {
+                                    "properties": {
+                                      "gmsaCredentialSpec": {
+                                        "type": "string"
+                                      },
+                                      "gmsaCredentialSpecName": {
+                                        "type": "string"
+                                      },
+                                      "hostProcess": {
+                                        "type": "boolean"
+                                      },
+                                      "runAsUserName": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "startupProbe": {
+                                "properties": {
+                                  "exec": {
+                                    "properties": {
+                                      "command": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "failureThreshold": {
+                                    "type": "integer"
+                                  },
+                                  "grpc": {
+                                    "properties": {
+                                      "port": {
+                                        "type": "integer"
+                                      },
+                                      "service": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "httpGet": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "initialDelaySeconds": {
+                                    "type": "integer"
+                                  },
+                                  "periodSeconds": {
+                                    "type": "integer"
+                                  },
+                                  "successThreshold": {
+                                    "type": "integer"
+                                  },
+                                  "tcpSocket": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "terminationGracePeriodSeconds": {
+                                    "type": "integer"
+                                  },
+                                  "timeoutSeconds": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "stdin": {
+                                "type": "boolean"
+                              },
+                              "stdinOnce": {
+                                "type": "boolean"
+                              },
+                              "terminationMessagePath": {
+                                "type": "string"
+                              },
+                              "terminationMessagePolicy": {
+                                "type": "string"
+                              },
+                              "tty": {
+                                "type": "boolean"
+                              },
+                              "volumeDevices": {
+                                "items": {
+                                  "properties": {
+                                    "devicePath": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "volumeMounts": {
+                                "items": {
+                                  "properties": {
+                                    "mountPath": {
+                                      "type": "string"
+                                    },
+                                    "mountPropagation": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "readOnly": {
+                                      "type": "boolean"
+                                    },
+                                    "recursiveReadOnly": {
+                                      "type": "string"
+                                    },
+                                    "subPath": {
+                                      "type": "string"
+                                    },
+                                    "subPathExpr": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "workingDir": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "dnsConfig": {
+                          "properties": {
+                            "nameservers": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "options": {
+                              "items": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "value": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "searches": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "dnsPolicy": {
+                          "type": "string"
+                        },
+                        "enableServiceLinks": {
+                          "type": "boolean"
+                        },
+                        "ephemeralContainers": {
+                          "items": {
+                            "properties": {
+                              "args": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "command": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "env": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    },
+                                    "valueFrom": {
+                                      "properties": {
+                                        "configMapKeyRef": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "fieldRef": {
+                                          "properties": {
+                                            "apiVersion": {
+                                              "type": "string"
+                                            },
+                                            "fieldPath": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "resourceFieldRef": {
+                                          "properties": {
+                                            "containerName": {
+                                              "type": "string"
+                                            },
+                                            "divisor": {
+                                              "anyOf": [
+                                                {
+                                                  "type": "integer"
+                                                },
+                                                {
+                                                  "type": "string"
+                                                }
+                                              ],
+                                              "x-kubernetes-int-or-string": true
+                                            },
+                                            "resource": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "secretKeyRef": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "type": "object"
+                                        }
+                                      },
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "envFrom": {
+                                "items": {
+                                  "properties": {
+                                    "configMapRef": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "prefix": {
+                                      "type": "string"
+                                    },
+                                    "secretRef": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "image": {
+                                "type": "string"
+                              },
+                              "imagePullPolicy": {
+                                "type": "string"
+                              },
+                              "lifecycle": {
+                                "properties": {
+                                  "postStart": {
+                                    "properties": {
+                                      "exec": {
+                                        "properties": {
+                                          "command": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "httpGet": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "httpHeaders": {
+                                            "items": {
+                                              "properties": {
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "value": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          },
+                                          "scheme": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "sleep": {
+                                        "properties": {
+                                          "seconds": {
+                                            "type": "integer"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "tcpSocket": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          }
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "preStop": {
+                                    "properties": {
+                                      "exec": {
+                                        "properties": {
+                                          "command": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "httpGet": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "httpHeaders": {
+                                            "items": {
+                                              "properties": {
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "value": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          },
+                                          "scheme": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "sleep": {
+                                        "properties": {
+                                          "seconds": {
+                                            "type": "integer"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "tcpSocket": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          }
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "stopSignal": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "livenessProbe": {
+                                "properties": {
+                                  "exec": {
+                                    "properties": {
+                                      "command": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "failureThreshold": {
+                                    "type": "integer"
+                                  },
+                                  "grpc": {
+                                    "properties": {
+                                      "port": {
+                                        "type": "integer"
+                                      },
+                                      "service": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "httpGet": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "initialDelaySeconds": {
+                                    "type": "integer"
+                                  },
+                                  "periodSeconds": {
+                                    "type": "integer"
+                                  },
+                                  "successThreshold": {
+                                    "type": "integer"
+                                  },
+                                  "tcpSocket": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "terminationGracePeriodSeconds": {
+                                    "type": "integer"
+                                  },
+                                  "timeoutSeconds": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "ports": {
+                                "items": {
+                                  "properties": {
+                                    "containerPort": {
+                                      "type": "integer"
+                                    },
+                                    "hostIP": {
+                                      "type": "string"
+                                    },
+                                    "hostPort": {
+                                      "type": "integer"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "protocol": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "readinessProbe": {
+                                "properties": {
+                                  "exec": {
+                                    "properties": {
+                                      "command": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "failureThreshold": {
+                                    "type": "integer"
+                                  },
+                                  "grpc": {
+                                    "properties": {
+                                      "port": {
+                                        "type": "integer"
+                                      },
+                                      "service": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "httpGet": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "initialDelaySeconds": {
+                                    "type": "integer"
+                                  },
+                                  "periodSeconds": {
+                                    "type": "integer"
+                                  },
+                                  "successThreshold": {
+                                    "type": "integer"
+                                  },
+                                  "tcpSocket": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "terminationGracePeriodSeconds": {
+                                    "type": "integer"
+                                  },
+                                  "timeoutSeconds": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "resizePolicy": {
+                                "items": {
+                                  "properties": {
+                                    "resourceName": {
+                                      "type": "string"
+                                    },
+                                    "restartPolicy": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "resources": {
+                                "properties": {
+                                  "claims": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "request": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "limits": {
+                                    "additionalProperties": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "string"
+                                        }
+                                      ],
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "type": "object"
+                                  },
+                                  "requests": {
+                                    "additionalProperties": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "string"
+                                        }
+                                      ],
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "restartPolicy": {
+                                "type": "string"
+                              },
+                              "securityContext": {
+                                "properties": {
+                                  "allowPrivilegeEscalation": {
+                                    "type": "boolean"
+                                  },
+                                  "appArmorProfile": {
+                                    "properties": {
+                                      "localhostProfile": {
+                                        "type": "string"
+                                      },
+                                      "type": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "capabilities": {
+                                    "properties": {
+                                      "add": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "drop": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "privileged": {
+                                    "type": "boolean"
+                                  },
+                                  "procMount": {
+                                    "type": "string"
+                                  },
+                                  "readOnlyRootFilesystem": {
+                                    "type": "boolean"
+                                  },
+                                  "runAsGroup": {
+                                    "type": "integer"
+                                  },
+                                  "runAsNonRoot": {
+                                    "type": "boolean"
+                                  },
+                                  "runAsUser": {
+                                    "type": "integer"
+                                  },
+                                  "seLinuxOptions": {
+                                    "properties": {
+                                      "level": {
+                                        "type": "string"
+                                      },
+                                      "role": {
+                                        "type": "string"
+                                      },
+                                      "type": {
+                                        "type": "string"
+                                      },
+                                      "user": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "seccompProfile": {
+                                    "properties": {
+                                      "localhostProfile": {
+                                        "type": "string"
+                                      },
+                                      "type": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "windowsOptions": {
+                                    "properties": {
+                                      "gmsaCredentialSpec": {
+                                        "type": "string"
+                                      },
+                                      "gmsaCredentialSpecName": {
+                                        "type": "string"
+                                      },
+                                      "hostProcess": {
+                                        "type": "boolean"
+                                      },
+                                      "runAsUserName": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "startupProbe": {
+                                "properties": {
+                                  "exec": {
+                                    "properties": {
+                                      "command": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "failureThreshold": {
+                                    "type": "integer"
+                                  },
+                                  "grpc": {
+                                    "properties": {
+                                      "port": {
+                                        "type": "integer"
+                                      },
+                                      "service": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "httpGet": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "initialDelaySeconds": {
+                                    "type": "integer"
+                                  },
+                                  "periodSeconds": {
+                                    "type": "integer"
+                                  },
+                                  "successThreshold": {
+                                    "type": "integer"
+                                  },
+                                  "tcpSocket": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "terminationGracePeriodSeconds": {
+                                    "type": "integer"
+                                  },
+                                  "timeoutSeconds": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "stdin": {
+                                "type": "boolean"
+                              },
+                              "stdinOnce": {
+                                "type": "boolean"
+                              },
+                              "targetContainerName": {
+                                "type": "string"
+                              },
+                              "terminationMessagePath": {
+                                "type": "string"
+                              },
+                              "terminationMessagePolicy": {
+                                "type": "string"
+                              },
+                              "tty": {
+                                "type": "boolean"
+                              },
+                              "volumeDevices": {
+                                "items": {
+                                  "properties": {
+                                    "devicePath": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "volumeMounts": {
+                                "items": {
+                                  "properties": {
+                                    "mountPath": {
+                                      "type": "string"
+                                    },
+                                    "mountPropagation": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "readOnly": {
+                                      "type": "boolean"
+                                    },
+                                    "recursiveReadOnly": {
+                                      "type": "string"
+                                    },
+                                    "subPath": {
+                                      "type": "string"
+                                    },
+                                    "subPathExpr": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "workingDir": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "hostAliases": {
+                          "items": {
+                            "properties": {
+                              "hostnames": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "ip": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "hostIPC": {
+                          "type": "boolean"
+                        },
+                        "hostNetwork": {
+                          "type": "boolean"
+                        },
+                        "hostPID": {
+                          "type": "boolean"
+                        },
+                        "hostUsers": {
+                          "type": "boolean"
+                        },
+                        "hostname": {
+                          "type": "string"
+                        },
+                        "imagePullSecrets": {
+                          "items": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "initContainers": {
+                          "items": {
+                            "properties": {
+                              "args": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "command": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "env": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    },
+                                    "valueFrom": {
+                                      "properties": {
+                                        "configMapKeyRef": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "fieldRef": {
+                                          "properties": {
+                                            "apiVersion": {
+                                              "type": "string"
+                                            },
+                                            "fieldPath": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "resourceFieldRef": {
+                                          "properties": {
+                                            "containerName": {
+                                              "type": "string"
+                                            },
+                                            "divisor": {
+                                              "anyOf": [
+                                                {
+                                                  "type": "integer"
+                                                },
+                                                {
+                                                  "type": "string"
+                                                }
+                                              ],
+                                              "x-kubernetes-int-or-string": true
+                                            },
+                                            "resource": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "secretKeyRef": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "type": "object"
+                                        }
+                                      },
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "envFrom": {
+                                "items": {
+                                  "properties": {
+                                    "configMapRef": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "prefix": {
+                                      "type": "string"
+                                    },
+                                    "secretRef": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "image": {
+                                "type": "string"
+                              },
+                              "imagePullPolicy": {
+                                "type": "string"
+                              },
+                              "lifecycle": {
+                                "properties": {
+                                  "postStart": {
+                                    "properties": {
+                                      "exec": {
+                                        "properties": {
+                                          "command": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "httpGet": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "httpHeaders": {
+                                            "items": {
+                                              "properties": {
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "value": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          },
+                                          "scheme": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "sleep": {
+                                        "properties": {
+                                          "seconds": {
+                                            "type": "integer"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "tcpSocket": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          }
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "preStop": {
+                                    "properties": {
+                                      "exec": {
+                                        "properties": {
+                                          "command": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "httpGet": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "httpHeaders": {
+                                            "items": {
+                                              "properties": {
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "value": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          },
+                                          "scheme": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "sleep": {
+                                        "properties": {
+                                          "seconds": {
+                                            "type": "integer"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "tcpSocket": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          }
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "stopSignal": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "livenessProbe": {
+                                "properties": {
+                                  "exec": {
+                                    "properties": {
+                                      "command": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "failureThreshold": {
+                                    "type": "integer"
+                                  },
+                                  "grpc": {
+                                    "properties": {
+                                      "port": {
+                                        "type": "integer"
+                                      },
+                                      "service": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "httpGet": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "initialDelaySeconds": {
+                                    "type": "integer"
+                                  },
+                                  "periodSeconds": {
+                                    "type": "integer"
+                                  },
+                                  "successThreshold": {
+                                    "type": "integer"
+                                  },
+                                  "tcpSocket": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "terminationGracePeriodSeconds": {
+                                    "type": "integer"
+                                  },
+                                  "timeoutSeconds": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "ports": {
+                                "items": {
+                                  "properties": {
+                                    "containerPort": {
+                                      "type": "integer"
+                                    },
+                                    "hostIP": {
+                                      "type": "string"
+                                    },
+                                    "hostPort": {
+                                      "type": "integer"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "protocol": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "readinessProbe": {
+                                "properties": {
+                                  "exec": {
+                                    "properties": {
+                                      "command": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "failureThreshold": {
+                                    "type": "integer"
+                                  },
+                                  "grpc": {
+                                    "properties": {
+                                      "port": {
+                                        "type": "integer"
+                                      },
+                                      "service": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "httpGet": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "initialDelaySeconds": {
+                                    "type": "integer"
+                                  },
+                                  "periodSeconds": {
+                                    "type": "integer"
+                                  },
+                                  "successThreshold": {
+                                    "type": "integer"
+                                  },
+                                  "tcpSocket": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "terminationGracePeriodSeconds": {
+                                    "type": "integer"
+                                  },
+                                  "timeoutSeconds": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "resizePolicy": {
+                                "items": {
+                                  "properties": {
+                                    "resourceName": {
+                                      "type": "string"
+                                    },
+                                    "restartPolicy": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "resources": {
+                                "properties": {
+                                  "claims": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "request": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "limits": {
+                                    "additionalProperties": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "string"
+                                        }
+                                      ],
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "type": "object"
+                                  },
+                                  "requests": {
+                                    "additionalProperties": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "string"
+                                        }
+                                      ],
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "restartPolicy": {
+                                "type": "string"
+                              },
+                              "securityContext": {
+                                "properties": {
+                                  "allowPrivilegeEscalation": {
+                                    "type": "boolean"
+                                  },
+                                  "appArmorProfile": {
+                                    "properties": {
+                                      "localhostProfile": {
+                                        "type": "string"
+                                      },
+                                      "type": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "capabilities": {
+                                    "properties": {
+                                      "add": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "drop": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "privileged": {
+                                    "type": "boolean"
+                                  },
+                                  "procMount": {
+                                    "type": "string"
+                                  },
+                                  "readOnlyRootFilesystem": {
+                                    "type": "boolean"
+                                  },
+                                  "runAsGroup": {
+                                    "type": "integer"
+                                  },
+                                  "runAsNonRoot": {
+                                    "type": "boolean"
+                                  },
+                                  "runAsUser": {
+                                    "type": "integer"
+                                  },
+                                  "seLinuxOptions": {
+                                    "properties": {
+                                      "level": {
+                                        "type": "string"
+                                      },
+                                      "role": {
+                                        "type": "string"
+                                      },
+                                      "type": {
+                                        "type": "string"
+                                      },
+                                      "user": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "seccompProfile": {
+                                    "properties": {
+                                      "localhostProfile": {
+                                        "type": "string"
+                                      },
+                                      "type": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "windowsOptions": {
+                                    "properties": {
+                                      "gmsaCredentialSpec": {
+                                        "type": "string"
+                                      },
+                                      "gmsaCredentialSpecName": {
+                                        "type": "string"
+                                      },
+                                      "hostProcess": {
+                                        "type": "boolean"
+                                      },
+                                      "runAsUserName": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "startupProbe": {
+                                "properties": {
+                                  "exec": {
+                                    "properties": {
+                                      "command": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "failureThreshold": {
+                                    "type": "integer"
+                                  },
+                                  "grpc": {
+                                    "properties": {
+                                      "port": {
+                                        "type": "integer"
+                                      },
+                                      "service": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "httpGet": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "initialDelaySeconds": {
+                                    "type": "integer"
+                                  },
+                                  "periodSeconds": {
+                                    "type": "integer"
+                                  },
+                                  "successThreshold": {
+                                    "type": "integer"
+                                  },
+                                  "tcpSocket": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "terminationGracePeriodSeconds": {
+                                    "type": "integer"
+                                  },
+                                  "timeoutSeconds": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "stdin": {
+                                "type": "boolean"
+                              },
+                              "stdinOnce": {
+                                "type": "boolean"
+                              },
+                              "terminationMessagePath": {
+                                "type": "string"
+                              },
+                              "terminationMessagePolicy": {
+                                "type": "string"
+                              },
+                              "tty": {
+                                "type": "boolean"
+                              },
+                              "volumeDevices": {
+                                "items": {
+                                  "properties": {
+                                    "devicePath": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "volumeMounts": {
+                                "items": {
+                                  "properties": {
+                                    "mountPath": {
+                                      "type": "string"
+                                    },
+                                    "mountPropagation": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "readOnly": {
+                                      "type": "boolean"
+                                    },
+                                    "recursiveReadOnly": {
+                                      "type": "string"
+                                    },
+                                    "subPath": {
+                                      "type": "string"
+                                    },
+                                    "subPathExpr": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "workingDir": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "nodeName": {
+                          "type": "string"
+                        },
+                        "nodeSelector": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        "os": {
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "overhead": {
+                          "additionalProperties": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "x-kubernetes-int-or-string": true
+                          },
+                          "type": "object"
+                        },
+                        "preemptionPolicy": {
+                          "type": "string"
+                        },
+                        "priority": {
+                          "type": "integer"
+                        },
+                        "priorityClassName": {
+                          "type": "string"
+                        },
+                        "readinessGates": {
+                          "items": {
+                            "properties": {
+                              "conditionType": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "resourceClaims": {
+                          "items": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "resourceClaimName": {
+                                "type": "string"
+                              },
+                              "resourceClaimTemplateName": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "resources": {
+                          "properties": {
+                            "claims": {
+                              "items": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "request": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "limits": {
+                              "additionalProperties": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "type": "object"
+                            },
+                            "requests": {
+                              "additionalProperties": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "type": "object"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "restartPolicy": {
+                          "type": "string"
+                        },
+                        "runtimeClassName": {
+                          "type": "string"
+                        },
+                        "schedulerName": {
+                          "type": "string"
+                        },
+                        "schedulingGates": {
+                          "items": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "securityContext": {
+                          "properties": {
+                            "appArmorProfile": {
+                              "properties": {
+                                "localhostProfile": {
+                                  "type": "string"
+                                },
+                                "type": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "fsGroup": {
+                              "type": "integer"
+                            },
+                            "fsGroupChangePolicy": {
+                              "type": "string"
+                            },
+                            "runAsGroup": {
+                              "type": "integer"
+                            },
+                            "runAsNonRoot": {
+                              "type": "boolean"
+                            },
+                            "runAsUser": {
+                              "type": "integer"
+                            },
+                            "seLinuxChangePolicy": {
+                              "type": "string"
+                            },
+                            "seLinuxOptions": {
+                              "properties": {
+                                "level": {
+                                  "type": "string"
+                                },
+                                "role": {
+                                  "type": "string"
+                                },
+                                "type": {
+                                  "type": "string"
+                                },
+                                "user": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "seccompProfile": {
+                              "properties": {
+                                "localhostProfile": {
+                                  "type": "string"
+                                },
+                                "type": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "supplementalGroups": {
+                              "items": {
+                                "type": "integer"
+                              },
+                              "type": "array"
+                            },
+                            "supplementalGroupsPolicy": {
+                              "type": "string"
+                            },
+                            "sysctls": {
+                              "items": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "value": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "windowsOptions": {
+                              "properties": {
+                                "gmsaCredentialSpec": {
+                                  "type": "string"
+                                },
+                                "gmsaCredentialSpecName": {
+                                  "type": "string"
+                                },
+                                "hostProcess": {
+                                  "type": "boolean"
+                                },
+                                "runAsUserName": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "serviceAccount": {
+                          "type": "string"
+                        },
+                        "serviceAccountName": {
+                          "type": "string"
+                        },
+                        "setHostnameAsFQDN": {
+                          "type": "boolean"
+                        },
+                        "shareProcessNamespace": {
+                          "type": "boolean"
+                        },
+                        "subdomain": {
+                          "type": "string"
+                        },
+                        "terminationGracePeriodSeconds": {
+                          "type": "integer"
+                        },
+                        "tolerations": {
+                          "items": {
+                            "properties": {
+                              "effect": {
+                                "type": "string"
+                              },
+                              "key": {
+                                "type": "string"
+                              },
+                              "operator": {
+                                "type": "string"
+                              },
+                              "tolerationSeconds": {
+                                "type": "integer"
+                              },
+                              "value": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "topologySpreadConstraints": {
+                          "items": {
+                            "properties": {
+                              "labelSelector": {
+                                "properties": {
+                                  "matchExpressions": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "matchLabels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "matchLabelKeys": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "maxSkew": {
+                                "type": "integer"
+                              },
+                              "minDomains": {
+                                "type": "integer"
+                              },
+                              "nodeAffinityPolicy": {
+                                "type": "string"
+                              },
+                              "nodeTaintsPolicy": {
+                                "type": "string"
+                              },
+                              "topologyKey": {
+                                "type": "string"
+                              },
+                              "whenUnsatisfiable": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "volumes": {
+                          "items": {
+                            "properties": {
+                              "awsElasticBlockStore": {
+                                "properties": {
+                                  "fsType": {
+                                    "type": "string"
+                                  },
+                                  "partition": {
+                                    "type": "integer"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  },
+                                  "volumeID": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "azureDisk": {
+                                "properties": {
+                                  "cachingMode": {
+                                    "type": "string"
+                                  },
+                                  "diskName": {
+                                    "type": "string"
+                                  },
+                                  "diskURI": {
+                                    "type": "string"
+                                  },
+                                  "fsType": {
+                                    "type": "string"
+                                  },
+                                  "kind": {
+                                    "type": "string"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "azureFile": {
+                                "properties": {
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  },
+                                  "secretName": {
+                                    "type": "string"
+                                  },
+                                  "shareName": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "cephfs": {
+                                "properties": {
+                                  "monitors": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  },
+                                  "secretFile": {
+                                    "type": "string"
+                                  },
+                                  "secretRef": {
+                                    "properties": {
+                                      "name": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "user": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "cinder": {
+                                "properties": {
+                                  "fsType": {
+                                    "type": "string"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  },
+                                  "secretRef": {
+                                    "properties": {
+                                      "name": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "volumeID": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "configMap": {
+                                "properties": {
+                                  "defaultMode": {
+                                    "type": "integer"
+                                  },
+                                  "items": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "mode": {
+                                          "type": "integer"
+                                        },
+                                        "path": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "csi": {
+                                "properties": {
+                                  "driver": {
+                                    "type": "string"
+                                  },
+                                  "fsType": {
+                                    "type": "string"
+                                  },
+                                  "nodePublishSecretRef": {
+                                    "properties": {
+                                      "name": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  },
+                                  "volumeAttributes": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "downwardAPI": {
+                                "properties": {
+                                  "defaultMode": {
+                                    "type": "integer"
+                                  },
+                                  "items": {
+                                    "items": {
+                                      "properties": {
+                                        "fieldRef": {
+                                          "properties": {
+                                            "apiVersion": {
+                                              "type": "string"
+                                            },
+                                            "fieldPath": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "mode": {
+                                          "type": "integer"
+                                        },
+                                        "path": {
+                                          "type": "string"
+                                        },
+                                        "resourceFieldRef": {
+                                          "properties": {
+                                            "containerName": {
+                                              "type": "string"
+                                            },
+                                            "divisor": {
+                                              "anyOf": [
+                                                {
+                                                  "type": "integer"
+                                                },
+                                                {
+                                                  "type": "string"
+                                                }
+                                              ],
+                                              "x-kubernetes-int-or-string": true
+                                            },
+                                            "resource": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "emptyDir": {
+                                "properties": {
+                                  "medium": {
+                                    "type": "string"
+                                  },
+                                  "sizeLimit": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "ephemeral": {
+                                "properties": {
+                                  "volumeClaimTemplate": {
+                                    "properties": {
+                                      "metadata": {
+                                        "properties": {
+                                          "annotations": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
+                                          },
+                                          "creationTimestamp": {
+                                            "type": "string"
+                                          },
+                                          "deletionGracePeriodSeconds": {
+                                            "type": "integer"
+                                          },
+                                          "deletionTimestamp": {
+                                            "type": "string"
+                                          },
+                                          "finalizers": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "generateName": {
+                                            "type": "string"
+                                          },
+                                          "generation": {
+                                            "type": "integer"
+                                          },
+                                          "labels": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
+                                          },
+                                          "managedFields": {
+                                            "items": {
+                                              "properties": {
+                                                "apiVersion": {
+                                                  "type": "string"
+                                                },
+                                                "fieldsType": {
+                                                  "type": "string"
+                                                },
+                                                "fieldsV1": {
+                                                  "type": "object"
+                                                },
+                                                "manager": {
+                                                  "type": "string"
+                                                },
+                                                "operation": {
+                                                  "type": "string"
+                                                },
+                                                "subresource": {
+                                                  "type": "string"
+                                                },
+                                                "time": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "namespace": {
+                                            "type": "string"
+                                          },
+                                          "ownerReferences": {
+                                            "items": {
+                                              "properties": {
+                                                "apiVersion": {
+                                                  "type": "string"
+                                                },
+                                                "blockOwnerDeletion": {
+                                                  "type": "boolean"
+                                                },
+                                                "controller": {
+                                                  "type": "boolean"
+                                                },
+                                                "kind": {
+                                                  "type": "string"
+                                                },
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "uid": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "resourceVersion": {
+                                            "type": "string"
+                                          },
+                                          "selfLink": {
+                                            "type": "string"
+                                          },
+                                          "uid": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "spec": {
+                                        "properties": {
+                                          "accessModes": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "dataSource": {
+                                            "properties": {
+                                              "apiGroup": {
+                                                "type": "string"
+                                              },
+                                              "kind": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          "dataSourceRef": {
+                                            "properties": {
+                                              "apiGroup": {
+                                                "type": "string"
+                                              },
+                                              "kind": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "namespace": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          "resources": {
+                                            "properties": {
+                                              "limits": {
+                                                "additionalProperties": {
+                                                  "anyOf": [
+                                                    {
+                                                      "type": "integer"
+                                                    },
+                                                    {
+                                                      "type": "string"
+                                                    }
+                                                  ],
+                                                  "x-kubernetes-int-or-string": true
+                                                },
+                                                "type": "object"
+                                              },
+                                              "requests": {
+                                                "additionalProperties": {
+                                                  "anyOf": [
+                                                    {
+                                                      "type": "integer"
+                                                    },
+                                                    {
+                                                      "type": "string"
+                                                    }
+                                                  ],
+                                                  "x-kubernetes-int-or-string": true
+                                                },
+                                                "type": "object"
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          "selector": {
+                                            "properties": {
+                                              "matchExpressions": {
+                                                "items": {
+                                                  "properties": {
+                                                    "key": {
+                                                      "type": "string"
+                                                    },
+                                                    "operator": {
+                                                      "type": "string"
+                                                    },
+                                                    "values": {
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    }
+                                                  },
+                                                  "type": "object"
+                                                },
+                                                "type": "array"
+                                              },
+                                              "matchLabels": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "type": "object"
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          "storageClassName": {
+                                            "type": "string"
+                                          },
+                                          "volumeAttributesClassName": {
+                                            "type": "string"
+                                          },
+                                          "volumeMode": {
+                                            "type": "string"
+                                          },
+                                          "volumeName": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "fc": {
+                                "properties": {
+                                  "fsType": {
+                                    "type": "string"
+                                  },
+                                  "lun": {
+                                    "type": "integer"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  },
+                                  "targetWWNs": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "wwids": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "flexVolume": {
+                                "properties": {
+                                  "driver": {
+                                    "type": "string"
+                                  },
+                                  "fsType": {
+                                    "type": "string"
+                                  },
+                                  "options": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  },
+                                  "secretRef": {
+                                    "properties": {
+                                      "name": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "flocker": {
+                                "properties": {
+                                  "datasetName": {
+                                    "type": "string"
+                                  },
+                                  "datasetUUID": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "gcePersistentDisk": {
+                                "properties": {
+                                  "fsType": {
+                                    "type": "string"
+                                  },
+                                  "partition": {
+                                    "type": "integer"
+                                  },
+                                  "pdName": {
+                                    "type": "string"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "gitRepo": {
+                                "properties": {
+                                  "directory": {
+                                    "type": "string"
+                                  },
+                                  "repository": {
+                                    "type": "string"
+                                  },
+                                  "revision": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "glusterfs": {
+                                "properties": {
+                                  "endpoints": {
+                                    "type": "string"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "hostPath": {
+                                "properties": {
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "type": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "image": {
+                                "properties": {
+                                  "pullPolicy": {
+                                    "type": "string"
+                                  },
+                                  "reference": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "iscsi": {
+                                "properties": {
+                                  "chapAuthDiscovery": {
+                                    "type": "boolean"
+                                  },
+                                  "chapAuthSession": {
+                                    "type": "boolean"
+                                  },
+                                  "fsType": {
+                                    "type": "string"
+                                  },
+                                  "initiatorName": {
+                                    "type": "string"
+                                  },
+                                  "iqn": {
+                                    "type": "string"
+                                  },
+                                  "iscsiInterface": {
+                                    "type": "string"
+                                  },
+                                  "lun": {
+                                    "type": "integer"
+                                  },
+                                  "portals": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  },
+                                  "secretRef": {
+                                    "properties": {
+                                      "name": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "targetPortal": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "nfs": {
+                                "properties": {
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  },
+                                  "server": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "persistentVolumeClaim": {
+                                "properties": {
+                                  "claimName": {
+                                    "type": "string"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "photonPersistentDisk": {
+                                "properties": {
+                                  "fsType": {
+                                    "type": "string"
+                                  },
+                                  "pdID": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "portworxVolume": {
+                                "properties": {
+                                  "fsType": {
+                                    "type": "string"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  },
+                                  "volumeID": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "projected": {
+                                "properties": {
+                                  "defaultMode": {
+                                    "type": "integer"
+                                  },
+                                  "sources": {
+                                    "items": {
+                                      "properties": {
+                                        "clusterTrustBundle": {
+                                          "properties": {
+                                            "labelSelector": {
+                                              "properties": {
+                                                "matchExpressions": {
+                                                  "items": {
+                                                    "properties": {
+                                                      "key": {
+                                                        "type": "string"
+                                                      },
+                                                      "operator": {
+                                                        "type": "string"
+                                                      },
+                                                      "values": {
+                                                        "items": {
+                                                          "type": "string"
+                                                        },
+                                                        "type": "array"
+                                                      }
+                                                    },
+                                                    "type": "object"
+                                                  },
+                                                  "type": "array"
+                                                },
+                                                "matchLabels": {
+                                                  "additionalProperties": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "object"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            },
+                                            "path": {
+                                              "type": "string"
+                                            },
+                                            "signerName": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "configMap": {
+                                          "properties": {
+                                            "items": {
+                                              "items": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "mode": {
+                                                    "type": "integer"
+                                                  },
+                                                  "path": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              "type": "array"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "downwardAPI": {
+                                          "properties": {
+                                            "items": {
+                                              "items": {
+                                                "properties": {
+                                                  "fieldRef": {
+                                                    "properties": {
+                                                      "apiVersion": {
+                                                        "type": "string"
+                                                      },
+                                                      "fieldPath": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "type": "object"
+                                                  },
+                                                  "mode": {
+                                                    "type": "integer"
+                                                  },
+                                                  "path": {
+                                                    "type": "string"
+                                                  },
+                                                  "resourceFieldRef": {
+                                                    "properties": {
+                                                      "containerName": {
+                                                        "type": "string"
+                                                      },
+                                                      "divisor": {
+                                                        "anyOf": [
+                                                          {
+                                                            "type": "integer"
+                                                          },
+                                                          {
+                                                            "type": "string"
+                                                          }
+                                                        ],
+                                                        "x-kubernetes-int-or-string": true
+                                                      },
+                                                      "resource": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "type": "object"
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "secret": {
+                                          "properties": {
+                                            "items": {
+                                              "items": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "mode": {
+                                                    "type": "integer"
+                                                  },
+                                                  "path": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              "type": "array"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "serviceAccountToken": {
+                                          "properties": {
+                                            "audience": {
+                                              "type": "string"
+                                            },
+                                            "expirationSeconds": {
+                                              "type": "integer"
+                                            },
+                                            "path": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "quobyte": {
+                                "properties": {
+                                  "group": {
+                                    "type": "string"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  },
+                                  "registry": {
+                                    "type": "string"
+                                  },
+                                  "tenant": {
+                                    "type": "string"
+                                  },
+                                  "user": {
+                                    "type": "string"
+                                  },
+                                  "volume": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "rbd": {
+                                "properties": {
+                                  "fsType": {
+                                    "type": "string"
+                                  },
+                                  "image": {
+                                    "type": "string"
+                                  },
+                                  "keyring": {
+                                    "type": "string"
+                                  },
+                                  "monitors": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "pool": {
+                                    "type": "string"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  },
+                                  "secretRef": {
+                                    "properties": {
+                                      "name": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "user": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "scaleIO": {
+                                "properties": {
+                                  "fsType": {
+                                    "type": "string"
+                                  },
+                                  "gateway": {
+                                    "type": "string"
+                                  },
+                                  "protectionDomain": {
+                                    "type": "string"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  },
+                                  "secretRef": {
+                                    "properties": {
+                                      "name": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "sslEnabled": {
+                                    "type": "boolean"
+                                  },
+                                  "storageMode": {
+                                    "type": "string"
+                                  },
+                                  "storagePool": {
+                                    "type": "string"
+                                  },
+                                  "system": {
+                                    "type": "string"
+                                  },
+                                  "volumeName": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "secret": {
+                                "properties": {
+                                  "defaultMode": {
+                                    "type": "integer"
+                                  },
+                                  "items": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "mode": {
+                                          "type": "integer"
+                                        },
+                                        "path": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  },
+                                  "secretName": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "storageos": {
+                                "properties": {
+                                  "fsType": {
+                                    "type": "string"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  },
+                                  "secretRef": {
+                                    "properties": {
+                                      "name": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "volumeName": {
+                                    "type": "string"
+                                  },
+                                  "volumeNamespace": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "vsphereVolume": {
+                                "properties": {
+                                  "fsType": {
+                                    "type": "string"
+                                  },
+                                  "storagePolicyID": {
+                                    "type": "string"
+                                  },
+                                  "storagePolicyName": {
+                                    "type": "string"
+                                  },
+                                  "volumePath": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "type": "object"
+                },
+                "updateStrategy": {
+                  "properties": {
+                    "rollingUpdate": {
+                      "properties": {
+                        "maxUnavailable": {
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "string"
+                            }
+                          ],
+                          "x-kubernetes-int-or-string": true
+                        },
+                        "partition": {
+                          "type": "integer"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "type": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "volumeClaimTemplates": {
+                  "items": {
+                    "properties": {
+                      "apiVersion": {
+                        "type": "string"
+                      },
+                      "kind": {
+                        "type": "string"
+                      },
+                      "metadata": {
+                        "properties": {
+                          "annotations": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "type": "object"
+                          },
+                          "creationTimestamp": {
+                            "type": "string"
+                          },
+                          "deletionGracePeriodSeconds": {
+                            "type": "integer"
+                          },
+                          "deletionTimestamp": {
+                            "type": "string"
+                          },
+                          "finalizers": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "generateName": {
+                            "type": "string"
+                          },
+                          "generation": {
+                            "type": "integer"
+                          },
+                          "labels": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "type": "object"
+                          },
+                          "managedFields": {
+                            "items": {
+                              "properties": {
+                                "apiVersion": {
+                                  "type": "string"
+                                },
+                                "fieldsType": {
+                                  "type": "string"
+                                },
+                                "fieldsV1": {
+                                  "type": "object"
+                                },
+                                "manager": {
+                                  "type": "string"
+                                },
+                                "operation": {
+                                  "type": "string"
+                                },
+                                "subresource": {
+                                  "type": "string"
+                                },
+                                "time": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "namespace": {
+                            "type": "string"
+                          },
+                          "ownerReferences": {
+                            "items": {
+                              "properties": {
+                                "apiVersion": {
+                                  "type": "string"
+                                },
+                                "blockOwnerDeletion": {
+                                  "type": "boolean"
+                                },
+                                "controller": {
+                                  "type": "boolean"
+                                },
+                                "kind": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "uid": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "resourceVersion": {
+                            "type": "string"
+                          },
+                          "selfLink": {
+                            "type": "string"
+                          },
+                          "uid": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "spec": {
+                        "properties": {
+                          "accessModes": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "dataSource": {
+                            "properties": {
+                              "apiGroup": {
+                                "type": "string"
+                              },
+                              "kind": {
+                                "type": "string"
+                              },
+                              "name": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "dataSourceRef": {
+                            "properties": {
+                              "apiGroup": {
+                                "type": "string"
+                              },
+                              "kind": {
+                                "type": "string"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "namespace": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "resources": {
+                            "properties": {
+                              "limits": {
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "type": "object"
+                              },
+                              "requests": {
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "selector": {
+                            "properties": {
+                              "matchExpressions": {
+                                "items": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "matchLabels": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "storageClassName": {
+                            "type": "string"
+                          },
+                          "volumeAttributesClassName": {
+                            "type": "string"
+                          },
+                          "volumeMode": {
+                            "type": "string"
+                          },
+                          "volumeName": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "status": {
+                        "properties": {
+                          "accessModes": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "allocatedResourceStatuses": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "type": "object"
+                          },
+                          "allocatedResources": {
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "type": "object"
+                          },
+                          "capacity": {
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "type": "object"
+                          },
+                          "conditions": {
+                            "items": {
+                              "properties": {
+                                "lastProbeTime": {
+                                  "type": "string"
+                                },
+                                "lastTransitionTime": {
+                                  "type": "string"
+                                },
+                                "message": {
+                                  "type": "string"
+                                },
+                                "reason": {
+                                  "type": "string"
+                                },
+                                "status": {
+                                  "type": "string"
+                                },
+                                "type": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "currentVolumeAttributesClassName": {
+                            "type": "string"
+                          },
+                          "modifyVolumeStatus": {
+                            "properties": {
+                              "status": {
+                                "type": "string"
+                              },
+                              "targetVolumeAttributesClassName": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "phase": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "type": "object"
+        },
+        "runtimeVersions": {
+          "properties": {
+            "jdkVersion": {
+              "type": "string"
+            },
+            "scalaVersion": {
+              "type": "string"
+            },
+            "sparkVersion": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "sparkVersion"
+          ],
+          "type": "object"
+        },
+        "sparkConf": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "workerSpec": {
+          "properties": {
+            "horizontalPodAutoscalerSpec": {
+              "properties": {
+                "behavior": {
+                  "properties": {
+                    "scaleDown": {
+                      "properties": {
+                        "policies": {
+                          "items": {
+                            "properties": {
+                              "periodSeconds": {
+                                "type": "integer"
+                              },
+                              "type": {
+                                "type": "string"
+                              },
+                              "value": {
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "selectPolicy": {
+                          "type": "string"
+                        },
+                        "stabilizationWindowSeconds": {
+                          "type": "integer"
+                        },
+                        "tolerance": {
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "string"
+                            }
+                          ],
+                          "x-kubernetes-int-or-string": true
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "scaleUp": {
+                      "properties": {
+                        "policies": {
+                          "items": {
+                            "properties": {
+                              "periodSeconds": {
+                                "type": "integer"
+                              },
+                              "type": {
+                                "type": "string"
+                              },
+                              "value": {
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "selectPolicy": {
+                          "type": "string"
+                        },
+                        "stabilizationWindowSeconds": {
+                          "type": "integer"
+                        },
+                        "tolerance": {
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "string"
+                            }
+                          ],
+                          "x-kubernetes-int-or-string": true
+                        }
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "type": "object"
+                },
+                "maxReplicas": {
+                  "type": "integer"
+                },
+                "metrics": {
+                  "items": {
+                    "properties": {
+                      "containerResource": {
+                        "properties": {
+                          "container": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "target": {
+                            "properties": {
+                              "averageUtilization": {
+                                "type": "integer"
+                              },
+                              "averageValue": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "type": {
+                                "type": "string"
+                              },
+                              "value": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              }
+                            },
+                            "type": "object"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "external": {
+                        "properties": {
+                          "metric": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "selector": {
+                                "properties": {
+                                  "matchExpressions": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "matchLabels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "target": {
+                            "properties": {
+                              "averageUtilization": {
+                                "type": "integer"
+                              },
+                              "averageValue": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "type": {
+                                "type": "string"
+                              },
+                              "value": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              }
+                            },
+                            "type": "object"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "object": {
+                        "properties": {
+                          "describedObject": {
+                            "properties": {
+                              "apiVersion": {
+                                "type": "string"
+                              },
+                              "kind": {
+                                "type": "string"
+                              },
+                              "name": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "metric": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "selector": {
+                                "properties": {
+                                  "matchExpressions": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "matchLabels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "target": {
+                            "properties": {
+                              "averageUtilization": {
+                                "type": "integer"
+                              },
+                              "averageValue": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "type": {
+                                "type": "string"
+                              },
+                              "value": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              }
+                            },
+                            "type": "object"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "pods": {
+                        "properties": {
+                          "metric": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "selector": {
+                                "properties": {
+                                  "matchExpressions": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "matchLabels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "target": {
+                            "properties": {
+                              "averageUtilization": {
+                                "type": "integer"
+                              },
+                              "averageValue": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "type": {
+                                "type": "string"
+                              },
+                              "value": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              }
+                            },
+                            "type": "object"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "resource": {
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          },
+                          "target": {
+                            "properties": {
+                              "averageUtilization": {
+                                "type": "integer"
+                              },
+                              "averageValue": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "type": {
+                                "type": "string"
+                              },
+                              "value": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              }
+                            },
+                            "type": "object"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "minReplicas": {
+                  "type": "integer"
+                },
+                "scaleTargetRef": {
+                  "properties": {
+                    "apiVersion": {
+                      "type": "string"
+                    },
+                    "kind": {
+                      "type": "string"
+                    },
+                    "name": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object"
+            },
+            "serviceMetadata": {
+              "properties": {
+                "annotations": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                },
+                "creationTimestamp": {
+                  "type": "string"
+                },
+                "deletionGracePeriodSeconds": {
+                  "type": "integer"
+                },
+                "deletionTimestamp": {
+                  "type": "string"
+                },
+                "finalizers": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "generateName": {
+                  "type": "string"
+                },
+                "generation": {
+                  "type": "integer"
+                },
+                "labels": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                },
+                "managedFields": {
+                  "items": {
+                    "properties": {
+                      "apiVersion": {
+                        "type": "string"
+                      },
+                      "fieldsType": {
+                        "type": "string"
+                      },
+                      "fieldsV1": {
+                        "type": "object"
+                      },
+                      "manager": {
+                        "type": "string"
+                      },
+                      "operation": {
+                        "type": "string"
+                      },
+                      "subresource": {
+                        "type": "string"
+                      },
+                      "time": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "namespace": {
+                  "type": "string"
+                },
+                "ownerReferences": {
+                  "items": {
+                    "properties": {
+                      "apiVersion": {
+                        "type": "string"
+                      },
+                      "blockOwnerDeletion": {
+                        "type": "boolean"
+                      },
+                      "controller": {
+                        "type": "boolean"
+                      },
+                      "kind": {
+                        "type": "string"
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "uid": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "resourceVersion": {
+                  "type": "string"
+                },
+                "selfLink": {
+                  "type": "string"
+                },
+                "uid": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "serviceSpec": {
+              "properties": {
+                "allocateLoadBalancerNodePorts": {
+                  "type": "boolean"
+                },
+                "clusterIP": {
+                  "type": "string"
+                },
+                "clusterIPs": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "externalIPs": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "externalName": {
+                  "type": "string"
+                },
+                "externalTrafficPolicy": {
+                  "type": "string"
+                },
+                "healthCheckNodePort": {
+                  "type": "integer"
+                },
+                "internalTrafficPolicy": {
+                  "type": "string"
+                },
+                "ipFamilies": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "ipFamilyPolicy": {
+                  "type": "string"
+                },
+                "loadBalancerClass": {
+                  "type": "string"
+                },
+                "loadBalancerIP": {
+                  "type": "string"
+                },
+                "loadBalancerSourceRanges": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "ports": {
+                  "items": {
+                    "properties": {
+                      "appProtocol": {
+                        "type": "string"
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "nodePort": {
+                        "type": "integer"
+                      },
+                      "port": {
+                        "type": "integer"
+                      },
+                      "protocol": {
+                        "type": "string"
+                      },
+                      "targetPort": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "x-kubernetes-int-or-string": true
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "publishNotReadyAddresses": {
+                  "type": "boolean"
+                },
+                "selector": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                },
+                "sessionAffinity": {
+                  "type": "string"
+                },
+                "sessionAffinityConfig": {
+                  "properties": {
+                    "clientIP": {
+                      "properties": {
+                        "timeoutSeconds": {
+                          "type": "integer"
+                        }
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "type": "object"
+                },
+                "trafficDistribution": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "statefulSetMetadata": {
+              "properties": {
+                "annotations": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                },
+                "creationTimestamp": {
+                  "type": "string"
+                },
+                "deletionGracePeriodSeconds": {
+                  "type": "integer"
+                },
+                "deletionTimestamp": {
+                  "type": "string"
+                },
+                "finalizers": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "generateName": {
+                  "type": "string"
+                },
+                "generation": {
+                  "type": "integer"
+                },
+                "labels": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                },
+                "managedFields": {
+                  "items": {
+                    "properties": {
+                      "apiVersion": {
+                        "type": "string"
+                      },
+                      "fieldsType": {
+                        "type": "string"
+                      },
+                      "fieldsV1": {
+                        "type": "object"
+                      },
+                      "manager": {
+                        "type": "string"
+                      },
+                      "operation": {
+                        "type": "string"
+                      },
+                      "subresource": {
+                        "type": "string"
+                      },
+                      "time": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "namespace": {
+                  "type": "string"
+                },
+                "ownerReferences": {
+                  "items": {
+                    "properties": {
+                      "apiVersion": {
+                        "type": "string"
+                      },
+                      "blockOwnerDeletion": {
+                        "type": "boolean"
+                      },
+                      "controller": {
+                        "type": "boolean"
+                      },
+                      "kind": {
+                        "type": "string"
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "uid": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "resourceVersion": {
+                  "type": "string"
+                },
+                "selfLink": {
+                  "type": "string"
+                },
+                "uid": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "statefulSetSpec": {
+              "properties": {
+                "minReadySeconds": {
+                  "type": "integer"
+                },
+                "ordinals": {
+                  "properties": {
+                    "start": {
+                      "type": "integer"
+                    }
+                  },
+                  "type": "object"
+                },
+                "persistentVolumeClaimRetentionPolicy": {
+                  "properties": {
+                    "whenDeleted": {
+                      "type": "string"
+                    },
+                    "whenScaled": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "podManagementPolicy": {
+                  "type": "string"
+                },
+                "replicas": {
+                  "type": "integer"
+                },
+                "revisionHistoryLimit": {
+                  "type": "integer"
+                },
+                "selector": {
+                  "properties": {
+                    "matchExpressions": {
+                      "items": {
+                        "properties": {
+                          "key": {
+                            "type": "string"
+                          },
+                          "operator": {
+                            "type": "string"
+                          },
+                          "values": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "matchLabels": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "type": "object"
+                },
+                "serviceName": {
+                  "type": "string"
+                },
+                "template": {
+                  "properties": {
+                    "metadata": {
+                      "properties": {
+                        "annotations": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        "creationTimestamp": {
+                          "type": "string"
+                        },
+                        "deletionGracePeriodSeconds": {
+                          "type": "integer"
+                        },
+                        "deletionTimestamp": {
+                          "type": "string"
+                        },
+                        "finalizers": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "generateName": {
+                          "type": "string"
+                        },
+                        "generation": {
+                          "type": "integer"
+                        },
+                        "labels": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        "managedFields": {
+                          "items": {
+                            "properties": {
+                              "apiVersion": {
+                                "type": "string"
+                              },
+                              "fieldsType": {
+                                "type": "string"
+                              },
+                              "fieldsV1": {
+                                "type": "object"
+                              },
+                              "manager": {
+                                "type": "string"
+                              },
+                              "operation": {
+                                "type": "string"
+                              },
+                              "subresource": {
+                                "type": "string"
+                              },
+                              "time": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "namespace": {
+                          "type": "string"
+                        },
+                        "ownerReferences": {
+                          "items": {
+                            "properties": {
+                              "apiVersion": {
+                                "type": "string"
+                              },
+                              "blockOwnerDeletion": {
+                                "type": "boolean"
+                              },
+                              "controller": {
+                                "type": "boolean"
+                              },
+                              "kind": {
+                                "type": "string"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "uid": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "resourceVersion": {
+                          "type": "string"
+                        },
+                        "selfLink": {
+                          "type": "string"
+                        },
+                        "uid": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "spec": {
+                      "properties": {
+                        "activeDeadlineSeconds": {
+                          "type": "integer"
+                        },
+                        "affinity": {
+                          "properties": {
+                            "nodeAffinity": {
+                              "properties": {
+                                "preferredDuringSchedulingIgnoredDuringExecution": {
+                                  "items": {
+                                    "properties": {
+                                      "preference": {
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "matchFields": {
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "weight": {
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "type": "array"
+                                },
+                                "requiredDuringSchedulingIgnoredDuringExecution": {
+                                  "properties": {
+                                    "nodeSelectorTerms": {
+                                      "items": {
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "matchFields": {
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "podAffinity": {
+                              "properties": {
+                                "preferredDuringSchedulingIgnoredDuringExecution": {
+                                  "items": {
+                                    "properties": {
+                                      "podAffinityTerm": {
+                                        "properties": {
+                                          "labelSelector": {
+                                            "properties": {
+                                              "matchExpressions": {
+                                                "items": {
+                                                  "properties": {
+                                                    "key": {
+                                                      "type": "string"
+                                                    },
+                                                    "operator": {
+                                                      "type": "string"
+                                                    },
+                                                    "values": {
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    }
+                                                  },
+                                                  "type": "object"
+                                                },
+                                                "type": "array"
+                                              },
+                                              "matchLabels": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "type": "object"
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          "matchLabelKeys": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "mismatchLabelKeys": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "namespaceSelector": {
+                                            "properties": {
+                                              "matchExpressions": {
+                                                "items": {
+                                                  "properties": {
+                                                    "key": {
+                                                      "type": "string"
+                                                    },
+                                                    "operator": {
+                                                      "type": "string"
+                                                    },
+                                                    "values": {
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    }
+                                                  },
+                                                  "type": "object"
+                                                },
+                                                "type": "array"
+                                              },
+                                              "matchLabels": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "type": "object"
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          "namespaces": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "topologyKey": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "weight": {
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "type": "array"
+                                },
+                                "requiredDuringSchedulingIgnoredDuringExecution": {
+                                  "items": {
+                                    "properties": {
+                                      "labelSelector": {
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "matchLabels": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "matchLabelKeys": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "mismatchLabelKeys": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "namespaceSelector": {
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "matchLabels": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "namespaces": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "topologyKey": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "podAntiAffinity": {
+                              "properties": {
+                                "preferredDuringSchedulingIgnoredDuringExecution": {
+                                  "items": {
+                                    "properties": {
+                                      "podAffinityTerm": {
+                                        "properties": {
+                                          "labelSelector": {
+                                            "properties": {
+                                              "matchExpressions": {
+                                                "items": {
+                                                  "properties": {
+                                                    "key": {
+                                                      "type": "string"
+                                                    },
+                                                    "operator": {
+                                                      "type": "string"
+                                                    },
+                                                    "values": {
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    }
+                                                  },
+                                                  "type": "object"
+                                                },
+                                                "type": "array"
+                                              },
+                                              "matchLabels": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "type": "object"
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          "matchLabelKeys": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "mismatchLabelKeys": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "namespaceSelector": {
+                                            "properties": {
+                                              "matchExpressions": {
+                                                "items": {
+                                                  "properties": {
+                                                    "key": {
+                                                      "type": "string"
+                                                    },
+                                                    "operator": {
+                                                      "type": "string"
+                                                    },
+                                                    "values": {
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    }
+                                                  },
+                                                  "type": "object"
+                                                },
+                                                "type": "array"
+                                              },
+                                              "matchLabels": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "type": "object"
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          "namespaces": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "topologyKey": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "weight": {
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "type": "array"
+                                },
+                                "requiredDuringSchedulingIgnoredDuringExecution": {
+                                  "items": {
+                                    "properties": {
+                                      "labelSelector": {
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "matchLabels": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "matchLabelKeys": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "mismatchLabelKeys": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "namespaceSelector": {
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "matchLabels": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "namespaces": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "topologyKey": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "type": "object"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "automountServiceAccountToken": {
+                          "type": "boolean"
+                        },
+                        "containers": {
+                          "items": {
+                            "properties": {
+                              "args": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "command": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "env": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    },
+                                    "valueFrom": {
+                                      "properties": {
+                                        "configMapKeyRef": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "fieldRef": {
+                                          "properties": {
+                                            "apiVersion": {
+                                              "type": "string"
+                                            },
+                                            "fieldPath": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "resourceFieldRef": {
+                                          "properties": {
+                                            "containerName": {
+                                              "type": "string"
+                                            },
+                                            "divisor": {
+                                              "anyOf": [
+                                                {
+                                                  "type": "integer"
+                                                },
+                                                {
+                                                  "type": "string"
+                                                }
+                                              ],
+                                              "x-kubernetes-int-or-string": true
+                                            },
+                                            "resource": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "secretKeyRef": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "type": "object"
+                                        }
+                                      },
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "envFrom": {
+                                "items": {
+                                  "properties": {
+                                    "configMapRef": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "prefix": {
+                                      "type": "string"
+                                    },
+                                    "secretRef": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "image": {
+                                "type": "string"
+                              },
+                              "imagePullPolicy": {
+                                "type": "string"
+                              },
+                              "lifecycle": {
+                                "properties": {
+                                  "postStart": {
+                                    "properties": {
+                                      "exec": {
+                                        "properties": {
+                                          "command": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "httpGet": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "httpHeaders": {
+                                            "items": {
+                                              "properties": {
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "value": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          },
+                                          "scheme": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "sleep": {
+                                        "properties": {
+                                          "seconds": {
+                                            "type": "integer"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "tcpSocket": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          }
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "preStop": {
+                                    "properties": {
+                                      "exec": {
+                                        "properties": {
+                                          "command": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "httpGet": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "httpHeaders": {
+                                            "items": {
+                                              "properties": {
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "value": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          },
+                                          "scheme": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "sleep": {
+                                        "properties": {
+                                          "seconds": {
+                                            "type": "integer"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "tcpSocket": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          }
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "stopSignal": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "livenessProbe": {
+                                "properties": {
+                                  "exec": {
+                                    "properties": {
+                                      "command": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "failureThreshold": {
+                                    "type": "integer"
+                                  },
+                                  "grpc": {
+                                    "properties": {
+                                      "port": {
+                                        "type": "integer"
+                                      },
+                                      "service": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "httpGet": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "initialDelaySeconds": {
+                                    "type": "integer"
+                                  },
+                                  "periodSeconds": {
+                                    "type": "integer"
+                                  },
+                                  "successThreshold": {
+                                    "type": "integer"
+                                  },
+                                  "tcpSocket": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "terminationGracePeriodSeconds": {
+                                    "type": "integer"
+                                  },
+                                  "timeoutSeconds": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "ports": {
+                                "items": {
+                                  "properties": {
+                                    "containerPort": {
+                                      "type": "integer"
+                                    },
+                                    "hostIP": {
+                                      "type": "string"
+                                    },
+                                    "hostPort": {
+                                      "type": "integer"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "protocol": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "readinessProbe": {
+                                "properties": {
+                                  "exec": {
+                                    "properties": {
+                                      "command": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "failureThreshold": {
+                                    "type": "integer"
+                                  },
+                                  "grpc": {
+                                    "properties": {
+                                      "port": {
+                                        "type": "integer"
+                                      },
+                                      "service": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "httpGet": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "initialDelaySeconds": {
+                                    "type": "integer"
+                                  },
+                                  "periodSeconds": {
+                                    "type": "integer"
+                                  },
+                                  "successThreshold": {
+                                    "type": "integer"
+                                  },
+                                  "tcpSocket": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "terminationGracePeriodSeconds": {
+                                    "type": "integer"
+                                  },
+                                  "timeoutSeconds": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "resizePolicy": {
+                                "items": {
+                                  "properties": {
+                                    "resourceName": {
+                                      "type": "string"
+                                    },
+                                    "restartPolicy": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "resources": {
+                                "properties": {
+                                  "claims": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "request": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "limits": {
+                                    "additionalProperties": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "string"
+                                        }
+                                      ],
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "type": "object"
+                                  },
+                                  "requests": {
+                                    "additionalProperties": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "string"
+                                        }
+                                      ],
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "restartPolicy": {
+                                "type": "string"
+                              },
+                              "securityContext": {
+                                "properties": {
+                                  "allowPrivilegeEscalation": {
+                                    "type": "boolean"
+                                  },
+                                  "appArmorProfile": {
+                                    "properties": {
+                                      "localhostProfile": {
+                                        "type": "string"
+                                      },
+                                      "type": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "capabilities": {
+                                    "properties": {
+                                      "add": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "drop": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "privileged": {
+                                    "type": "boolean"
+                                  },
+                                  "procMount": {
+                                    "type": "string"
+                                  },
+                                  "readOnlyRootFilesystem": {
+                                    "type": "boolean"
+                                  },
+                                  "runAsGroup": {
+                                    "type": "integer"
+                                  },
+                                  "runAsNonRoot": {
+                                    "type": "boolean"
+                                  },
+                                  "runAsUser": {
+                                    "type": "integer"
+                                  },
+                                  "seLinuxOptions": {
+                                    "properties": {
+                                      "level": {
+                                        "type": "string"
+                                      },
+                                      "role": {
+                                        "type": "string"
+                                      },
+                                      "type": {
+                                        "type": "string"
+                                      },
+                                      "user": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "seccompProfile": {
+                                    "properties": {
+                                      "localhostProfile": {
+                                        "type": "string"
+                                      },
+                                      "type": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "windowsOptions": {
+                                    "properties": {
+                                      "gmsaCredentialSpec": {
+                                        "type": "string"
+                                      },
+                                      "gmsaCredentialSpecName": {
+                                        "type": "string"
+                                      },
+                                      "hostProcess": {
+                                        "type": "boolean"
+                                      },
+                                      "runAsUserName": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "startupProbe": {
+                                "properties": {
+                                  "exec": {
+                                    "properties": {
+                                      "command": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "failureThreshold": {
+                                    "type": "integer"
+                                  },
+                                  "grpc": {
+                                    "properties": {
+                                      "port": {
+                                        "type": "integer"
+                                      },
+                                      "service": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "httpGet": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "initialDelaySeconds": {
+                                    "type": "integer"
+                                  },
+                                  "periodSeconds": {
+                                    "type": "integer"
+                                  },
+                                  "successThreshold": {
+                                    "type": "integer"
+                                  },
+                                  "tcpSocket": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "terminationGracePeriodSeconds": {
+                                    "type": "integer"
+                                  },
+                                  "timeoutSeconds": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "stdin": {
+                                "type": "boolean"
+                              },
+                              "stdinOnce": {
+                                "type": "boolean"
+                              },
+                              "terminationMessagePath": {
+                                "type": "string"
+                              },
+                              "terminationMessagePolicy": {
+                                "type": "string"
+                              },
+                              "tty": {
+                                "type": "boolean"
+                              },
+                              "volumeDevices": {
+                                "items": {
+                                  "properties": {
+                                    "devicePath": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "volumeMounts": {
+                                "items": {
+                                  "properties": {
+                                    "mountPath": {
+                                      "type": "string"
+                                    },
+                                    "mountPropagation": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "readOnly": {
+                                      "type": "boolean"
+                                    },
+                                    "recursiveReadOnly": {
+                                      "type": "string"
+                                    },
+                                    "subPath": {
+                                      "type": "string"
+                                    },
+                                    "subPathExpr": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "workingDir": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "dnsConfig": {
+                          "properties": {
+                            "nameservers": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "options": {
+                              "items": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "value": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "searches": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "dnsPolicy": {
+                          "type": "string"
+                        },
+                        "enableServiceLinks": {
+                          "type": "boolean"
+                        },
+                        "ephemeralContainers": {
+                          "items": {
+                            "properties": {
+                              "args": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "command": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "env": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    },
+                                    "valueFrom": {
+                                      "properties": {
+                                        "configMapKeyRef": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "fieldRef": {
+                                          "properties": {
+                                            "apiVersion": {
+                                              "type": "string"
+                                            },
+                                            "fieldPath": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "resourceFieldRef": {
+                                          "properties": {
+                                            "containerName": {
+                                              "type": "string"
+                                            },
+                                            "divisor": {
+                                              "anyOf": [
+                                                {
+                                                  "type": "integer"
+                                                },
+                                                {
+                                                  "type": "string"
+                                                }
+                                              ],
+                                              "x-kubernetes-int-or-string": true
+                                            },
+                                            "resource": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "secretKeyRef": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "type": "object"
+                                        }
+                                      },
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "envFrom": {
+                                "items": {
+                                  "properties": {
+                                    "configMapRef": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "prefix": {
+                                      "type": "string"
+                                    },
+                                    "secretRef": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "image": {
+                                "type": "string"
+                              },
+                              "imagePullPolicy": {
+                                "type": "string"
+                              },
+                              "lifecycle": {
+                                "properties": {
+                                  "postStart": {
+                                    "properties": {
+                                      "exec": {
+                                        "properties": {
+                                          "command": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "httpGet": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "httpHeaders": {
+                                            "items": {
+                                              "properties": {
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "value": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          },
+                                          "scheme": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "sleep": {
+                                        "properties": {
+                                          "seconds": {
+                                            "type": "integer"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "tcpSocket": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          }
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "preStop": {
+                                    "properties": {
+                                      "exec": {
+                                        "properties": {
+                                          "command": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "httpGet": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "httpHeaders": {
+                                            "items": {
+                                              "properties": {
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "value": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          },
+                                          "scheme": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "sleep": {
+                                        "properties": {
+                                          "seconds": {
+                                            "type": "integer"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "tcpSocket": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          }
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "stopSignal": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "livenessProbe": {
+                                "properties": {
+                                  "exec": {
+                                    "properties": {
+                                      "command": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "failureThreshold": {
+                                    "type": "integer"
+                                  },
+                                  "grpc": {
+                                    "properties": {
+                                      "port": {
+                                        "type": "integer"
+                                      },
+                                      "service": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "httpGet": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "initialDelaySeconds": {
+                                    "type": "integer"
+                                  },
+                                  "periodSeconds": {
+                                    "type": "integer"
+                                  },
+                                  "successThreshold": {
+                                    "type": "integer"
+                                  },
+                                  "tcpSocket": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "terminationGracePeriodSeconds": {
+                                    "type": "integer"
+                                  },
+                                  "timeoutSeconds": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "ports": {
+                                "items": {
+                                  "properties": {
+                                    "containerPort": {
+                                      "type": "integer"
+                                    },
+                                    "hostIP": {
+                                      "type": "string"
+                                    },
+                                    "hostPort": {
+                                      "type": "integer"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "protocol": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "readinessProbe": {
+                                "properties": {
+                                  "exec": {
+                                    "properties": {
+                                      "command": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "failureThreshold": {
+                                    "type": "integer"
+                                  },
+                                  "grpc": {
+                                    "properties": {
+                                      "port": {
+                                        "type": "integer"
+                                      },
+                                      "service": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "httpGet": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "initialDelaySeconds": {
+                                    "type": "integer"
+                                  },
+                                  "periodSeconds": {
+                                    "type": "integer"
+                                  },
+                                  "successThreshold": {
+                                    "type": "integer"
+                                  },
+                                  "tcpSocket": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "terminationGracePeriodSeconds": {
+                                    "type": "integer"
+                                  },
+                                  "timeoutSeconds": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "resizePolicy": {
+                                "items": {
+                                  "properties": {
+                                    "resourceName": {
+                                      "type": "string"
+                                    },
+                                    "restartPolicy": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "resources": {
+                                "properties": {
+                                  "claims": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "request": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "limits": {
+                                    "additionalProperties": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "string"
+                                        }
+                                      ],
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "type": "object"
+                                  },
+                                  "requests": {
+                                    "additionalProperties": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "string"
+                                        }
+                                      ],
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "restartPolicy": {
+                                "type": "string"
+                              },
+                              "securityContext": {
+                                "properties": {
+                                  "allowPrivilegeEscalation": {
+                                    "type": "boolean"
+                                  },
+                                  "appArmorProfile": {
+                                    "properties": {
+                                      "localhostProfile": {
+                                        "type": "string"
+                                      },
+                                      "type": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "capabilities": {
+                                    "properties": {
+                                      "add": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "drop": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "privileged": {
+                                    "type": "boolean"
+                                  },
+                                  "procMount": {
+                                    "type": "string"
+                                  },
+                                  "readOnlyRootFilesystem": {
+                                    "type": "boolean"
+                                  },
+                                  "runAsGroup": {
+                                    "type": "integer"
+                                  },
+                                  "runAsNonRoot": {
+                                    "type": "boolean"
+                                  },
+                                  "runAsUser": {
+                                    "type": "integer"
+                                  },
+                                  "seLinuxOptions": {
+                                    "properties": {
+                                      "level": {
+                                        "type": "string"
+                                      },
+                                      "role": {
+                                        "type": "string"
+                                      },
+                                      "type": {
+                                        "type": "string"
+                                      },
+                                      "user": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "seccompProfile": {
+                                    "properties": {
+                                      "localhostProfile": {
+                                        "type": "string"
+                                      },
+                                      "type": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "windowsOptions": {
+                                    "properties": {
+                                      "gmsaCredentialSpec": {
+                                        "type": "string"
+                                      },
+                                      "gmsaCredentialSpecName": {
+                                        "type": "string"
+                                      },
+                                      "hostProcess": {
+                                        "type": "boolean"
+                                      },
+                                      "runAsUserName": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "startupProbe": {
+                                "properties": {
+                                  "exec": {
+                                    "properties": {
+                                      "command": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "failureThreshold": {
+                                    "type": "integer"
+                                  },
+                                  "grpc": {
+                                    "properties": {
+                                      "port": {
+                                        "type": "integer"
+                                      },
+                                      "service": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "httpGet": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "initialDelaySeconds": {
+                                    "type": "integer"
+                                  },
+                                  "periodSeconds": {
+                                    "type": "integer"
+                                  },
+                                  "successThreshold": {
+                                    "type": "integer"
+                                  },
+                                  "tcpSocket": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "terminationGracePeriodSeconds": {
+                                    "type": "integer"
+                                  },
+                                  "timeoutSeconds": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "stdin": {
+                                "type": "boolean"
+                              },
+                              "stdinOnce": {
+                                "type": "boolean"
+                              },
+                              "targetContainerName": {
+                                "type": "string"
+                              },
+                              "terminationMessagePath": {
+                                "type": "string"
+                              },
+                              "terminationMessagePolicy": {
+                                "type": "string"
+                              },
+                              "tty": {
+                                "type": "boolean"
+                              },
+                              "volumeDevices": {
+                                "items": {
+                                  "properties": {
+                                    "devicePath": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "volumeMounts": {
+                                "items": {
+                                  "properties": {
+                                    "mountPath": {
+                                      "type": "string"
+                                    },
+                                    "mountPropagation": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "readOnly": {
+                                      "type": "boolean"
+                                    },
+                                    "recursiveReadOnly": {
+                                      "type": "string"
+                                    },
+                                    "subPath": {
+                                      "type": "string"
+                                    },
+                                    "subPathExpr": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "workingDir": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "hostAliases": {
+                          "items": {
+                            "properties": {
+                              "hostnames": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "ip": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "hostIPC": {
+                          "type": "boolean"
+                        },
+                        "hostNetwork": {
+                          "type": "boolean"
+                        },
+                        "hostPID": {
+                          "type": "boolean"
+                        },
+                        "hostUsers": {
+                          "type": "boolean"
+                        },
+                        "hostname": {
+                          "type": "string"
+                        },
+                        "imagePullSecrets": {
+                          "items": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "initContainers": {
+                          "items": {
+                            "properties": {
+                              "args": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "command": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "env": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    },
+                                    "valueFrom": {
+                                      "properties": {
+                                        "configMapKeyRef": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "fieldRef": {
+                                          "properties": {
+                                            "apiVersion": {
+                                              "type": "string"
+                                            },
+                                            "fieldPath": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "resourceFieldRef": {
+                                          "properties": {
+                                            "containerName": {
+                                              "type": "string"
+                                            },
+                                            "divisor": {
+                                              "anyOf": [
+                                                {
+                                                  "type": "integer"
+                                                },
+                                                {
+                                                  "type": "string"
+                                                }
+                                              ],
+                                              "x-kubernetes-int-or-string": true
+                                            },
+                                            "resource": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "secretKeyRef": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "type": "object"
+                                        }
+                                      },
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "envFrom": {
+                                "items": {
+                                  "properties": {
+                                    "configMapRef": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "prefix": {
+                                      "type": "string"
+                                    },
+                                    "secretRef": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "image": {
+                                "type": "string"
+                              },
+                              "imagePullPolicy": {
+                                "type": "string"
+                              },
+                              "lifecycle": {
+                                "properties": {
+                                  "postStart": {
+                                    "properties": {
+                                      "exec": {
+                                        "properties": {
+                                          "command": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "httpGet": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "httpHeaders": {
+                                            "items": {
+                                              "properties": {
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "value": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          },
+                                          "scheme": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "sleep": {
+                                        "properties": {
+                                          "seconds": {
+                                            "type": "integer"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "tcpSocket": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          }
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "preStop": {
+                                    "properties": {
+                                      "exec": {
+                                        "properties": {
+                                          "command": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "httpGet": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "httpHeaders": {
+                                            "items": {
+                                              "properties": {
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "value": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          },
+                                          "scheme": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "sleep": {
+                                        "properties": {
+                                          "seconds": {
+                                            "type": "integer"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "tcpSocket": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          }
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "stopSignal": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "livenessProbe": {
+                                "properties": {
+                                  "exec": {
+                                    "properties": {
+                                      "command": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "failureThreshold": {
+                                    "type": "integer"
+                                  },
+                                  "grpc": {
+                                    "properties": {
+                                      "port": {
+                                        "type": "integer"
+                                      },
+                                      "service": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "httpGet": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "initialDelaySeconds": {
+                                    "type": "integer"
+                                  },
+                                  "periodSeconds": {
+                                    "type": "integer"
+                                  },
+                                  "successThreshold": {
+                                    "type": "integer"
+                                  },
+                                  "tcpSocket": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "terminationGracePeriodSeconds": {
+                                    "type": "integer"
+                                  },
+                                  "timeoutSeconds": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "ports": {
+                                "items": {
+                                  "properties": {
+                                    "containerPort": {
+                                      "type": "integer"
+                                    },
+                                    "hostIP": {
+                                      "type": "string"
+                                    },
+                                    "hostPort": {
+                                      "type": "integer"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "protocol": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "readinessProbe": {
+                                "properties": {
+                                  "exec": {
+                                    "properties": {
+                                      "command": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "failureThreshold": {
+                                    "type": "integer"
+                                  },
+                                  "grpc": {
+                                    "properties": {
+                                      "port": {
+                                        "type": "integer"
+                                      },
+                                      "service": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "httpGet": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "initialDelaySeconds": {
+                                    "type": "integer"
+                                  },
+                                  "periodSeconds": {
+                                    "type": "integer"
+                                  },
+                                  "successThreshold": {
+                                    "type": "integer"
+                                  },
+                                  "tcpSocket": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "terminationGracePeriodSeconds": {
+                                    "type": "integer"
+                                  },
+                                  "timeoutSeconds": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "resizePolicy": {
+                                "items": {
+                                  "properties": {
+                                    "resourceName": {
+                                      "type": "string"
+                                    },
+                                    "restartPolicy": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "resources": {
+                                "properties": {
+                                  "claims": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "request": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "limits": {
+                                    "additionalProperties": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "string"
+                                        }
+                                      ],
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "type": "object"
+                                  },
+                                  "requests": {
+                                    "additionalProperties": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "string"
+                                        }
+                                      ],
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "restartPolicy": {
+                                "type": "string"
+                              },
+                              "securityContext": {
+                                "properties": {
+                                  "allowPrivilegeEscalation": {
+                                    "type": "boolean"
+                                  },
+                                  "appArmorProfile": {
+                                    "properties": {
+                                      "localhostProfile": {
+                                        "type": "string"
+                                      },
+                                      "type": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "capabilities": {
+                                    "properties": {
+                                      "add": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "drop": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "privileged": {
+                                    "type": "boolean"
+                                  },
+                                  "procMount": {
+                                    "type": "string"
+                                  },
+                                  "readOnlyRootFilesystem": {
+                                    "type": "boolean"
+                                  },
+                                  "runAsGroup": {
+                                    "type": "integer"
+                                  },
+                                  "runAsNonRoot": {
+                                    "type": "boolean"
+                                  },
+                                  "runAsUser": {
+                                    "type": "integer"
+                                  },
+                                  "seLinuxOptions": {
+                                    "properties": {
+                                      "level": {
+                                        "type": "string"
+                                      },
+                                      "role": {
+                                        "type": "string"
+                                      },
+                                      "type": {
+                                        "type": "string"
+                                      },
+                                      "user": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "seccompProfile": {
+                                    "properties": {
+                                      "localhostProfile": {
+                                        "type": "string"
+                                      },
+                                      "type": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "windowsOptions": {
+                                    "properties": {
+                                      "gmsaCredentialSpec": {
+                                        "type": "string"
+                                      },
+                                      "gmsaCredentialSpecName": {
+                                        "type": "string"
+                                      },
+                                      "hostProcess": {
+                                        "type": "boolean"
+                                      },
+                                      "runAsUserName": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "startupProbe": {
+                                "properties": {
+                                  "exec": {
+                                    "properties": {
+                                      "command": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "failureThreshold": {
+                                    "type": "integer"
+                                  },
+                                  "grpc": {
+                                    "properties": {
+                                      "port": {
+                                        "type": "integer"
+                                      },
+                                      "service": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "httpGet": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "initialDelaySeconds": {
+                                    "type": "integer"
+                                  },
+                                  "periodSeconds": {
+                                    "type": "integer"
+                                  },
+                                  "successThreshold": {
+                                    "type": "integer"
+                                  },
+                                  "tcpSocket": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "terminationGracePeriodSeconds": {
+                                    "type": "integer"
+                                  },
+                                  "timeoutSeconds": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "stdin": {
+                                "type": "boolean"
+                              },
+                              "stdinOnce": {
+                                "type": "boolean"
+                              },
+                              "terminationMessagePath": {
+                                "type": "string"
+                              },
+                              "terminationMessagePolicy": {
+                                "type": "string"
+                              },
+                              "tty": {
+                                "type": "boolean"
+                              },
+                              "volumeDevices": {
+                                "items": {
+                                  "properties": {
+                                    "devicePath": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "volumeMounts": {
+                                "items": {
+                                  "properties": {
+                                    "mountPath": {
+                                      "type": "string"
+                                    },
+                                    "mountPropagation": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "readOnly": {
+                                      "type": "boolean"
+                                    },
+                                    "recursiveReadOnly": {
+                                      "type": "string"
+                                    },
+                                    "subPath": {
+                                      "type": "string"
+                                    },
+                                    "subPathExpr": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "workingDir": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "nodeName": {
+                          "type": "string"
+                        },
+                        "nodeSelector": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        "os": {
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "overhead": {
+                          "additionalProperties": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "x-kubernetes-int-or-string": true
+                          },
+                          "type": "object"
+                        },
+                        "preemptionPolicy": {
+                          "type": "string"
+                        },
+                        "priority": {
+                          "type": "integer"
+                        },
+                        "priorityClassName": {
+                          "type": "string"
+                        },
+                        "readinessGates": {
+                          "items": {
+                            "properties": {
+                              "conditionType": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "resourceClaims": {
+                          "items": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "resourceClaimName": {
+                                "type": "string"
+                              },
+                              "resourceClaimTemplateName": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "resources": {
+                          "properties": {
+                            "claims": {
+                              "items": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "request": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "limits": {
+                              "additionalProperties": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "type": "object"
+                            },
+                            "requests": {
+                              "additionalProperties": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "type": "object"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "restartPolicy": {
+                          "type": "string"
+                        },
+                        "runtimeClassName": {
+                          "type": "string"
+                        },
+                        "schedulerName": {
+                          "type": "string"
+                        },
+                        "schedulingGates": {
+                          "items": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "securityContext": {
+                          "properties": {
+                            "appArmorProfile": {
+                              "properties": {
+                                "localhostProfile": {
+                                  "type": "string"
+                                },
+                                "type": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "fsGroup": {
+                              "type": "integer"
+                            },
+                            "fsGroupChangePolicy": {
+                              "type": "string"
+                            },
+                            "runAsGroup": {
+                              "type": "integer"
+                            },
+                            "runAsNonRoot": {
+                              "type": "boolean"
+                            },
+                            "runAsUser": {
+                              "type": "integer"
+                            },
+                            "seLinuxChangePolicy": {
+                              "type": "string"
+                            },
+                            "seLinuxOptions": {
+                              "properties": {
+                                "level": {
+                                  "type": "string"
+                                },
+                                "role": {
+                                  "type": "string"
+                                },
+                                "type": {
+                                  "type": "string"
+                                },
+                                "user": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "seccompProfile": {
+                              "properties": {
+                                "localhostProfile": {
+                                  "type": "string"
+                                },
+                                "type": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "supplementalGroups": {
+                              "items": {
+                                "type": "integer"
+                              },
+                              "type": "array"
+                            },
+                            "supplementalGroupsPolicy": {
+                              "type": "string"
+                            },
+                            "sysctls": {
+                              "items": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "value": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "windowsOptions": {
+                              "properties": {
+                                "gmsaCredentialSpec": {
+                                  "type": "string"
+                                },
+                                "gmsaCredentialSpecName": {
+                                  "type": "string"
+                                },
+                                "hostProcess": {
+                                  "type": "boolean"
+                                },
+                                "runAsUserName": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "serviceAccount": {
+                          "type": "string"
+                        },
+                        "serviceAccountName": {
+                          "type": "string"
+                        },
+                        "setHostnameAsFQDN": {
+                          "type": "boolean"
+                        },
+                        "shareProcessNamespace": {
+                          "type": "boolean"
+                        },
+                        "subdomain": {
+                          "type": "string"
+                        },
+                        "terminationGracePeriodSeconds": {
+                          "type": "integer"
+                        },
+                        "tolerations": {
+                          "items": {
+                            "properties": {
+                              "effect": {
+                                "type": "string"
+                              },
+                              "key": {
+                                "type": "string"
+                              },
+                              "operator": {
+                                "type": "string"
+                              },
+                              "tolerationSeconds": {
+                                "type": "integer"
+                              },
+                              "value": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "topologySpreadConstraints": {
+                          "items": {
+                            "properties": {
+                              "labelSelector": {
+                                "properties": {
+                                  "matchExpressions": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "matchLabels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "matchLabelKeys": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "maxSkew": {
+                                "type": "integer"
+                              },
+                              "minDomains": {
+                                "type": "integer"
+                              },
+                              "nodeAffinityPolicy": {
+                                "type": "string"
+                              },
+                              "nodeTaintsPolicy": {
+                                "type": "string"
+                              },
+                              "topologyKey": {
+                                "type": "string"
+                              },
+                              "whenUnsatisfiable": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "volumes": {
+                          "items": {
+                            "properties": {
+                              "awsElasticBlockStore": {
+                                "properties": {
+                                  "fsType": {
+                                    "type": "string"
+                                  },
+                                  "partition": {
+                                    "type": "integer"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  },
+                                  "volumeID": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "azureDisk": {
+                                "properties": {
+                                  "cachingMode": {
+                                    "type": "string"
+                                  },
+                                  "diskName": {
+                                    "type": "string"
+                                  },
+                                  "diskURI": {
+                                    "type": "string"
+                                  },
+                                  "fsType": {
+                                    "type": "string"
+                                  },
+                                  "kind": {
+                                    "type": "string"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "azureFile": {
+                                "properties": {
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  },
+                                  "secretName": {
+                                    "type": "string"
+                                  },
+                                  "shareName": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "cephfs": {
+                                "properties": {
+                                  "monitors": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  },
+                                  "secretFile": {
+                                    "type": "string"
+                                  },
+                                  "secretRef": {
+                                    "properties": {
+                                      "name": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "user": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "cinder": {
+                                "properties": {
+                                  "fsType": {
+                                    "type": "string"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  },
+                                  "secretRef": {
+                                    "properties": {
+                                      "name": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "volumeID": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "configMap": {
+                                "properties": {
+                                  "defaultMode": {
+                                    "type": "integer"
+                                  },
+                                  "items": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "mode": {
+                                          "type": "integer"
+                                        },
+                                        "path": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "csi": {
+                                "properties": {
+                                  "driver": {
+                                    "type": "string"
+                                  },
+                                  "fsType": {
+                                    "type": "string"
+                                  },
+                                  "nodePublishSecretRef": {
+                                    "properties": {
+                                      "name": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  },
+                                  "volumeAttributes": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "downwardAPI": {
+                                "properties": {
+                                  "defaultMode": {
+                                    "type": "integer"
+                                  },
+                                  "items": {
+                                    "items": {
+                                      "properties": {
+                                        "fieldRef": {
+                                          "properties": {
+                                            "apiVersion": {
+                                              "type": "string"
+                                            },
+                                            "fieldPath": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "mode": {
+                                          "type": "integer"
+                                        },
+                                        "path": {
+                                          "type": "string"
+                                        },
+                                        "resourceFieldRef": {
+                                          "properties": {
+                                            "containerName": {
+                                              "type": "string"
+                                            },
+                                            "divisor": {
+                                              "anyOf": [
+                                                {
+                                                  "type": "integer"
+                                                },
+                                                {
+                                                  "type": "string"
+                                                }
+                                              ],
+                                              "x-kubernetes-int-or-string": true
+                                            },
+                                            "resource": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "emptyDir": {
+                                "properties": {
+                                  "medium": {
+                                    "type": "string"
+                                  },
+                                  "sizeLimit": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "ephemeral": {
+                                "properties": {
+                                  "volumeClaimTemplate": {
+                                    "properties": {
+                                      "metadata": {
+                                        "properties": {
+                                          "annotations": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
+                                          },
+                                          "creationTimestamp": {
+                                            "type": "string"
+                                          },
+                                          "deletionGracePeriodSeconds": {
+                                            "type": "integer"
+                                          },
+                                          "deletionTimestamp": {
+                                            "type": "string"
+                                          },
+                                          "finalizers": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "generateName": {
+                                            "type": "string"
+                                          },
+                                          "generation": {
+                                            "type": "integer"
+                                          },
+                                          "labels": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
+                                          },
+                                          "managedFields": {
+                                            "items": {
+                                              "properties": {
+                                                "apiVersion": {
+                                                  "type": "string"
+                                                },
+                                                "fieldsType": {
+                                                  "type": "string"
+                                                },
+                                                "fieldsV1": {
+                                                  "type": "object"
+                                                },
+                                                "manager": {
+                                                  "type": "string"
+                                                },
+                                                "operation": {
+                                                  "type": "string"
+                                                },
+                                                "subresource": {
+                                                  "type": "string"
+                                                },
+                                                "time": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "namespace": {
+                                            "type": "string"
+                                          },
+                                          "ownerReferences": {
+                                            "items": {
+                                              "properties": {
+                                                "apiVersion": {
+                                                  "type": "string"
+                                                },
+                                                "blockOwnerDeletion": {
+                                                  "type": "boolean"
+                                                },
+                                                "controller": {
+                                                  "type": "boolean"
+                                                },
+                                                "kind": {
+                                                  "type": "string"
+                                                },
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "uid": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "resourceVersion": {
+                                            "type": "string"
+                                          },
+                                          "selfLink": {
+                                            "type": "string"
+                                          },
+                                          "uid": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "spec": {
+                                        "properties": {
+                                          "accessModes": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "dataSource": {
+                                            "properties": {
+                                              "apiGroup": {
+                                                "type": "string"
+                                              },
+                                              "kind": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          "dataSourceRef": {
+                                            "properties": {
+                                              "apiGroup": {
+                                                "type": "string"
+                                              },
+                                              "kind": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "namespace": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          "resources": {
+                                            "properties": {
+                                              "limits": {
+                                                "additionalProperties": {
+                                                  "anyOf": [
+                                                    {
+                                                      "type": "integer"
+                                                    },
+                                                    {
+                                                      "type": "string"
+                                                    }
+                                                  ],
+                                                  "x-kubernetes-int-or-string": true
+                                                },
+                                                "type": "object"
+                                              },
+                                              "requests": {
+                                                "additionalProperties": {
+                                                  "anyOf": [
+                                                    {
+                                                      "type": "integer"
+                                                    },
+                                                    {
+                                                      "type": "string"
+                                                    }
+                                                  ],
+                                                  "x-kubernetes-int-or-string": true
+                                                },
+                                                "type": "object"
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          "selector": {
+                                            "properties": {
+                                              "matchExpressions": {
+                                                "items": {
+                                                  "properties": {
+                                                    "key": {
+                                                      "type": "string"
+                                                    },
+                                                    "operator": {
+                                                      "type": "string"
+                                                    },
+                                                    "values": {
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    }
+                                                  },
+                                                  "type": "object"
+                                                },
+                                                "type": "array"
+                                              },
+                                              "matchLabels": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "type": "object"
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          "storageClassName": {
+                                            "type": "string"
+                                          },
+                                          "volumeAttributesClassName": {
+                                            "type": "string"
+                                          },
+                                          "volumeMode": {
+                                            "type": "string"
+                                          },
+                                          "volumeName": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "fc": {
+                                "properties": {
+                                  "fsType": {
+                                    "type": "string"
+                                  },
+                                  "lun": {
+                                    "type": "integer"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  },
+                                  "targetWWNs": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "wwids": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "flexVolume": {
+                                "properties": {
+                                  "driver": {
+                                    "type": "string"
+                                  },
+                                  "fsType": {
+                                    "type": "string"
+                                  },
+                                  "options": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  },
+                                  "secretRef": {
+                                    "properties": {
+                                      "name": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "flocker": {
+                                "properties": {
+                                  "datasetName": {
+                                    "type": "string"
+                                  },
+                                  "datasetUUID": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "gcePersistentDisk": {
+                                "properties": {
+                                  "fsType": {
+                                    "type": "string"
+                                  },
+                                  "partition": {
+                                    "type": "integer"
+                                  },
+                                  "pdName": {
+                                    "type": "string"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "gitRepo": {
+                                "properties": {
+                                  "directory": {
+                                    "type": "string"
+                                  },
+                                  "repository": {
+                                    "type": "string"
+                                  },
+                                  "revision": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "glusterfs": {
+                                "properties": {
+                                  "endpoints": {
+                                    "type": "string"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "hostPath": {
+                                "properties": {
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "type": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "image": {
+                                "properties": {
+                                  "pullPolicy": {
+                                    "type": "string"
+                                  },
+                                  "reference": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "iscsi": {
+                                "properties": {
+                                  "chapAuthDiscovery": {
+                                    "type": "boolean"
+                                  },
+                                  "chapAuthSession": {
+                                    "type": "boolean"
+                                  },
+                                  "fsType": {
+                                    "type": "string"
+                                  },
+                                  "initiatorName": {
+                                    "type": "string"
+                                  },
+                                  "iqn": {
+                                    "type": "string"
+                                  },
+                                  "iscsiInterface": {
+                                    "type": "string"
+                                  },
+                                  "lun": {
+                                    "type": "integer"
+                                  },
+                                  "portals": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  },
+                                  "secretRef": {
+                                    "properties": {
+                                      "name": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "targetPortal": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "nfs": {
+                                "properties": {
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  },
+                                  "server": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "persistentVolumeClaim": {
+                                "properties": {
+                                  "claimName": {
+                                    "type": "string"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "photonPersistentDisk": {
+                                "properties": {
+                                  "fsType": {
+                                    "type": "string"
+                                  },
+                                  "pdID": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "portworxVolume": {
+                                "properties": {
+                                  "fsType": {
+                                    "type": "string"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  },
+                                  "volumeID": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "projected": {
+                                "properties": {
+                                  "defaultMode": {
+                                    "type": "integer"
+                                  },
+                                  "sources": {
+                                    "items": {
+                                      "properties": {
+                                        "clusterTrustBundle": {
+                                          "properties": {
+                                            "labelSelector": {
+                                              "properties": {
+                                                "matchExpressions": {
+                                                  "items": {
+                                                    "properties": {
+                                                      "key": {
+                                                        "type": "string"
+                                                      },
+                                                      "operator": {
+                                                        "type": "string"
+                                                      },
+                                                      "values": {
+                                                        "items": {
+                                                          "type": "string"
+                                                        },
+                                                        "type": "array"
+                                                      }
+                                                    },
+                                                    "type": "object"
+                                                  },
+                                                  "type": "array"
+                                                },
+                                                "matchLabels": {
+                                                  "additionalProperties": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "object"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            },
+                                            "path": {
+                                              "type": "string"
+                                            },
+                                            "signerName": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "configMap": {
+                                          "properties": {
+                                            "items": {
+                                              "items": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "mode": {
+                                                    "type": "integer"
+                                                  },
+                                                  "path": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              "type": "array"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "downwardAPI": {
+                                          "properties": {
+                                            "items": {
+                                              "items": {
+                                                "properties": {
+                                                  "fieldRef": {
+                                                    "properties": {
+                                                      "apiVersion": {
+                                                        "type": "string"
+                                                      },
+                                                      "fieldPath": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "type": "object"
+                                                  },
+                                                  "mode": {
+                                                    "type": "integer"
+                                                  },
+                                                  "path": {
+                                                    "type": "string"
+                                                  },
+                                                  "resourceFieldRef": {
+                                                    "properties": {
+                                                      "containerName": {
+                                                        "type": "string"
+                                                      },
+                                                      "divisor": {
+                                                        "anyOf": [
+                                                          {
+                                                            "type": "integer"
+                                                          },
+                                                          {
+                                                            "type": "string"
+                                                          }
+                                                        ],
+                                                        "x-kubernetes-int-or-string": true
+                                                      },
+                                                      "resource": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "type": "object"
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "secret": {
+                                          "properties": {
+                                            "items": {
+                                              "items": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "mode": {
+                                                    "type": "integer"
+                                                  },
+                                                  "path": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              "type": "array"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "serviceAccountToken": {
+                                          "properties": {
+                                            "audience": {
+                                              "type": "string"
+                                            },
+                                            "expirationSeconds": {
+                                              "type": "integer"
+                                            },
+                                            "path": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "quobyte": {
+                                "properties": {
+                                  "group": {
+                                    "type": "string"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  },
+                                  "registry": {
+                                    "type": "string"
+                                  },
+                                  "tenant": {
+                                    "type": "string"
+                                  },
+                                  "user": {
+                                    "type": "string"
+                                  },
+                                  "volume": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "rbd": {
+                                "properties": {
+                                  "fsType": {
+                                    "type": "string"
+                                  },
+                                  "image": {
+                                    "type": "string"
+                                  },
+                                  "keyring": {
+                                    "type": "string"
+                                  },
+                                  "monitors": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "pool": {
+                                    "type": "string"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  },
+                                  "secretRef": {
+                                    "properties": {
+                                      "name": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "user": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "scaleIO": {
+                                "properties": {
+                                  "fsType": {
+                                    "type": "string"
+                                  },
+                                  "gateway": {
+                                    "type": "string"
+                                  },
+                                  "protectionDomain": {
+                                    "type": "string"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  },
+                                  "secretRef": {
+                                    "properties": {
+                                      "name": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "sslEnabled": {
+                                    "type": "boolean"
+                                  },
+                                  "storageMode": {
+                                    "type": "string"
+                                  },
+                                  "storagePool": {
+                                    "type": "string"
+                                  },
+                                  "system": {
+                                    "type": "string"
+                                  },
+                                  "volumeName": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "secret": {
+                                "properties": {
+                                  "defaultMode": {
+                                    "type": "integer"
+                                  },
+                                  "items": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "mode": {
+                                          "type": "integer"
+                                        },
+                                        "path": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  },
+                                  "secretName": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "storageos": {
+                                "properties": {
+                                  "fsType": {
+                                    "type": "string"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  },
+                                  "secretRef": {
+                                    "properties": {
+                                      "name": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "volumeName": {
+                                    "type": "string"
+                                  },
+                                  "volumeNamespace": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "vsphereVolume": {
+                                "properties": {
+                                  "fsType": {
+                                    "type": "string"
+                                  },
+                                  "storagePolicyID": {
+                                    "type": "string"
+                                  },
+                                  "storagePolicyName": {
+                                    "type": "string"
+                                  },
+                                  "volumePath": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "type": "object"
+                },
+                "updateStrategy": {
+                  "properties": {
+                    "rollingUpdate": {
+                      "properties": {
+                        "maxUnavailable": {
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "string"
+                            }
+                          ],
+                          "x-kubernetes-int-or-string": true
+                        },
+                        "partition": {
+                          "type": "integer"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "type": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "volumeClaimTemplates": {
+                  "items": {
+                    "properties": {
+                      "apiVersion": {
+                        "type": "string"
+                      },
+                      "kind": {
+                        "type": "string"
+                      },
+                      "metadata": {
+                        "properties": {
+                          "annotations": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "type": "object"
+                          },
+                          "creationTimestamp": {
+                            "type": "string"
+                          },
+                          "deletionGracePeriodSeconds": {
+                            "type": "integer"
+                          },
+                          "deletionTimestamp": {
+                            "type": "string"
+                          },
+                          "finalizers": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "generateName": {
+                            "type": "string"
+                          },
+                          "generation": {
+                            "type": "integer"
+                          },
+                          "labels": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "type": "object"
+                          },
+                          "managedFields": {
+                            "items": {
+                              "properties": {
+                                "apiVersion": {
+                                  "type": "string"
+                                },
+                                "fieldsType": {
+                                  "type": "string"
+                                },
+                                "fieldsV1": {
+                                  "type": "object"
+                                },
+                                "manager": {
+                                  "type": "string"
+                                },
+                                "operation": {
+                                  "type": "string"
+                                },
+                                "subresource": {
+                                  "type": "string"
+                                },
+                                "time": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "namespace": {
+                            "type": "string"
+                          },
+                          "ownerReferences": {
+                            "items": {
+                              "properties": {
+                                "apiVersion": {
+                                  "type": "string"
+                                },
+                                "blockOwnerDeletion": {
+                                  "type": "boolean"
+                                },
+                                "controller": {
+                                  "type": "boolean"
+                                },
+                                "kind": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "uid": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "resourceVersion": {
+                            "type": "string"
+                          },
+                          "selfLink": {
+                            "type": "string"
+                          },
+                          "uid": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "spec": {
+                        "properties": {
+                          "accessModes": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "dataSource": {
+                            "properties": {
+                              "apiGroup": {
+                                "type": "string"
+                              },
+                              "kind": {
+                                "type": "string"
+                              },
+                              "name": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "dataSourceRef": {
+                            "properties": {
+                              "apiGroup": {
+                                "type": "string"
+                              },
+                              "kind": {
+                                "type": "string"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "namespace": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "resources": {
+                            "properties": {
+                              "limits": {
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "type": "object"
+                              },
+                              "requests": {
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "selector": {
+                            "properties": {
+                              "matchExpressions": {
+                                "items": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "matchLabels": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "storageClassName": {
+                            "type": "string"
+                          },
+                          "volumeAttributesClassName": {
+                            "type": "string"
+                          },
+                          "volumeMode": {
+                            "type": "string"
+                          },
+                          "volumeName": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "status": {
+                        "properties": {
+                          "accessModes": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "allocatedResourceStatuses": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "type": "object"
+                          },
+                          "allocatedResources": {
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "type": "object"
+                          },
+                          "capacity": {
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "type": "object"
+                          },
+                          "conditions": {
+                            "items": {
+                              "properties": {
+                                "lastProbeTime": {
+                                  "type": "string"
+                                },
+                                "lastTransitionTime": {
+                                  "type": "string"
+                                },
+                                "message": {
+                                  "type": "string"
+                                },
+                                "reason": {
+                                  "type": "string"
+                                },
+                                "status": {
+                                  "type": "string"
+                                },
+                                "type": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "currentVolumeAttributesClassName": {
+                            "type": "string"
+                          },
+                          "modifyVolumeStatus": {
+                            "properties": {
+                              "status": {
+                                "type": "string"
+                              },
+                              "targetVolumeAttributesClassName": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "phase": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "type": "object"
+        }
+      },
+      "required": [
+        "clusterTolerations",
+        "runtimeVersions"
+      ],
+      "type": "object"
+    },
+    "status": {
+      "properties": {
+        "currentAttemptSummary": {
+          "properties": {
+            "attemptInfo": {
+              "properties": {
+                "id": {
+                  "type": "integer"
+                }
+              },
+              "type": "object"
+            },
+            "stateTransitionHistory": {
+              "additionalProperties": {
+                "properties": {
+                  "currentStateSummary": {
+                    "enum": [
+                      "Failed",
+                      "ResourceReleased",
+                      "RunningHealthy",
+                      "SchedulingFailure",
+                      "Submitted"
+                    ],
+                    "type": "string"
+                  },
+                  "lastTransitionTime": {
+                    "type": "string"
+                  },
+                  "message": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "type": "object"
+            }
+          },
+          "type": "object"
+        },
+        "currentState": {
+          "properties": {
+            "currentStateSummary": {
+              "enum": [
+                "Failed",
+                "ResourceReleased",
+                "RunningHealthy",
+                "SchedulingFailure",
+                "Submitted"
+              ],
+              "type": "string"
+            },
+            "lastTransitionTime": {
+              "type": "string"
+            },
+            "message": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "previousAttemptSummary": {
+          "properties": {
+            "attemptInfo": {
+              "properties": {
+                "id": {
+                  "type": "integer"
+                }
+              },
+              "type": "object"
+            },
+            "stateTransitionHistory": {
+              "additionalProperties": {
+                "properties": {
+                  "currentStateSummary": {
+                    "enum": [
+                      "Failed",
+                      "ResourceReleased",
+                      "RunningHealthy",
+                      "SchedulingFailure",
+                      "Submitted"
+                    ],
+                    "type": "string"
+                  },
+                  "lastTransitionTime": {
+                    "type": "string"
+                  },
+                  "message": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "type": "object"
+            }
+          },
+          "type": "object"
+        },
+        "stateTransitionHistory": {
+          "additionalProperties": {
+            "properties": {
+              "currentStateSummary": {
+                "enum": [
+                  "Failed",
+                  "ResourceReleased",
+                  "RunningHealthy",
+                  "SchedulingFailure",
+                  "Submitted"
+                ],
+                "type": "string"
+              },
+              "lastTransitionTime": {
+                "type": "string"
+              },
+              "message": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "type": "object"
+        }
+      },
+      "type": "object"
+    },
+    "apiVersion": {
+      "type": "string"
+    },
+    "kind": {
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    }
+  },
+  "type": "object"
+}


### PR DESCRIPTION
## Summary
- Adds kubeconform JSON schemas for **SparkApplication** and **SparkCluster** CRDs from the [Apache Spark Kubernetes Operator](https://github.com/apache/spark-kubernetes-operator)
- Covers API versions: `v1`, `v1beta1`, and `v1alpha1`
- Schemas extracted from live CRD definitions and converted using the standard openapi2jsonschema pipeline

## Files added
- `spark.apache.org/sparkapplication_v1.json`
- `spark.apache.org/sparkapplication_v1alpha1.json`
- `spark.apache.org/sparkapplication_v1beta1.json`
- `spark.apache.org/sparkcluster_v1.json`
- `spark.apache.org/sparkcluster_v1alpha1.json`
- `spark.apache.org/sparkcluster_v1beta1.json`
