### PR TITLE
Argo-workflows schemas from v3.7.7 CRDs

### DIFF
--- a/argoproj.io/clusterworkflowtemplate_v1alpha1.json
+++ b/argoproj.io/clusterworkflowtemplate_v1alpha1.json
@@ -3087,10 +3087,6 @@
           "type": "object",
           "additionalProperties": false
         },
-        "podPriority": {
-          "format": "int32",
-          "type": "integer"
-        },
         "podPriorityClassName": {
           "type": "string"
         },
@@ -3114,6 +3110,9 @@
             },
             "backoff": {
               "properties": {
+                "cap": {
+                  "type": "string"
+                },
                 "duration": {
                   "type": "string"
                 },
@@ -3194,6 +3193,9 @@
               "format": "int64",
               "type": "integer"
             },
+            "seLinuxChangePolicy": {
+              "type": "string"
+            },
             "seLinuxOptions": {
               "properties": {
                 "level": {
@@ -3234,6 +3236,9 @@
               },
               "type": "array",
               "x-kubernetes-list-type": "atomic"
+            },
+            "supplementalGroupsPolicy": {
+              "type": "string"
             },
             "sysctls": {
               "items": {
@@ -3290,6 +3295,9 @@
           "properties": {
             "mutex": {
               "properties": {
+                "database": {
+                  "type": "boolean"
+                },
                 "name": {
                   "type": "string"
                 },
@@ -3303,6 +3311,9 @@
             "mutexes": {
               "items": {
                 "properties": {
+                  "database": {
+                    "type": "boolean"
+                  },
                   "name": {
                     "type": "string"
                   },
@@ -3337,6 +3348,18 @@
                   "x-kubernetes-map-type": "atomic",
                   "additionalProperties": false
                 },
+                "database": {
+                  "properties": {
+                    "key": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "key"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
                 "namespace": {
                   "type": "string"
                 }
@@ -3365,6 +3388,18 @@
                     ],
                     "type": "object",
                     "x-kubernetes-map-type": "atomic",
+                    "additionalProperties": false
+                  },
+                  "database": {
+                    "properties": {
+                      "key": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "key"
+                    ],
+                    "type": "object",
                     "additionalProperties": false
                   },
                   "namespace": {
@@ -4066,6 +4101,12 @@
               },
               "type": "object",
               "additionalProperties": false
+            },
+            "annotations": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
             },
             "archiveLocation": {
               "properties": {
@@ -5252,6 +5293,9 @@
                       },
                       "type": "object",
                       "additionalProperties": false
+                    },
+                    "stopSignal": {
+                      "type": "string"
                     }
                   },
                   "type": "object",
@@ -5283,6 +5327,7 @@
                           "type": "integer"
                         },
                         "service": {
+                          "default": "",
                           "type": "string"
                         }
                       },
@@ -5452,6 +5497,7 @@
                           "type": "integer"
                         },
                         "service": {
+                          "default": "",
                           "type": "string"
                         }
                       },
@@ -5583,6 +5629,9 @@
                       "items": {
                         "properties": {
                           "name": {
+                            "type": "string"
+                          },
+                          "request": {
                             "type": "string"
                           }
                         },
@@ -5776,6 +5825,7 @@
                           "type": "integer"
                         },
                         "service": {
+                          "default": "",
                           "type": "string"
                         }
                       },
@@ -5961,9 +6011,6 @@
                   "type": "string"
                 }
               },
-              "required": [
-                "name"
-              ],
               "type": "object",
               "additionalProperties": false
             },
@@ -6360,6 +6407,9 @@
                             },
                             "type": "object",
                             "additionalProperties": false
+                          },
+                          "stopSignal": {
+                            "type": "string"
                           }
                         },
                         "type": "object",
@@ -6391,6 +6441,7 @@
                                 "type": "integer"
                               },
                               "service": {
+                                "default": "",
                                 "type": "string"
                               }
                             },
@@ -6560,6 +6611,7 @@
                                 "type": "integer"
                               },
                               "service": {
+                                "default": "",
                                 "type": "string"
                               }
                             },
@@ -6691,6 +6743,9 @@
                             "items": {
                               "properties": {
                                 "name": {
+                                  "type": "string"
+                                },
+                                "request": {
                                   "type": "string"
                                 }
                               },
@@ -6884,6 +6939,7 @@
                                 "type": "integer"
                               },
                               "service": {
+                                "default": "",
                                 "type": "string"
                               }
                             },
@@ -9170,7 +9226,9 @@
                         },
                         "type": "object"
                       },
-                      "inline": {},
+                      "inline": {
+                        "x-kubernetes-preserve-unknown-fields": true
+                      },
                       "name": {
                         "type": "string"
                       },
@@ -9199,10 +9257,7 @@
                         "type": "string"
                       },
                       "withItems": {
-                        "items": {
-                          "type": "object"
-                        },
-                        "type": "array"
+                        "x-kubernetes-preserve-unknown-fields": true
                       },
                       "withParam": {
                         "type": "string"
@@ -10687,6 +10742,9 @@
                         },
                         "type": "object",
                         "additionalProperties": false
+                      },
+                      "stopSignal": {
+                        "type": "string"
                       }
                     },
                     "type": "object",
@@ -10718,6 +10776,7 @@
                             "type": "integer"
                           },
                           "service": {
+                            "default": "",
                             "type": "string"
                           }
                         },
@@ -10890,6 +10949,7 @@
                             "type": "integer"
                           },
                           "service": {
+                            "default": "",
                             "type": "string"
                           }
                         },
@@ -11021,6 +11081,9 @@
                         "items": {
                           "properties": {
                             "name": {
+                              "type": "string"
+                            },
+                            "request": {
                               "type": "string"
                             }
                           },
@@ -11214,6 +11277,7 @@
                             "type": "integer"
                           },
                           "service": {
+                            "default": "",
                             "type": "string"
                           }
                         },
@@ -13555,14 +13619,11 @@
               "type": "integer"
             },
             "plugin": {
-              "type": "object"
+              "type": "object",
+              "x-kubernetes-preserve-unknown-fields": true
             },
             "podSpecPatch": {
               "type": "string"
-            },
-            "priority": {
-              "format": "int32",
-              "type": "integer"
             },
             "priorityClassName": {
               "type": "string"
@@ -14512,6 +14573,9 @@
                 },
                 "backoff": {
                   "properties": {
+                    "cap": {
+                      "type": "string"
+                    },
                     "duration": {
                       "type": "string"
                     },
@@ -14941,6 +15005,9 @@
                       },
                       "type": "object",
                       "additionalProperties": false
+                    },
+                    "stopSignal": {
+                      "type": "string"
                     }
                   },
                   "type": "object",
@@ -14972,6 +15039,7 @@
                           "type": "integer"
                         },
                         "service": {
+                          "default": "",
                           "type": "string"
                         }
                       },
@@ -15141,6 +15209,7 @@
                           "type": "integer"
                         },
                         "service": {
+                          "default": "",
                           "type": "string"
                         }
                       },
@@ -15272,6 +15341,9 @@
                       "items": {
                         "properties": {
                           "name": {
+                            "type": "string"
+                          },
+                          "request": {
                             "type": "string"
                           }
                         },
@@ -15468,6 +15540,7 @@
                           "type": "integer"
                         },
                         "service": {
+                          "default": "",
                           "type": "string"
                         }
                       },
@@ -15653,10 +15726,6 @@
                   "type": "string"
                 }
               },
-              "required": [
-                "name",
-                "source"
-              ],
               "type": "object",
               "additionalProperties": false
             },
@@ -15694,6 +15763,9 @@
                 "runAsUser": {
                   "format": "int64",
                   "type": "integer"
+                },
+                "seLinuxChangePolicy": {
+                  "type": "string"
                 },
                 "seLinuxOptions": {
                   "properties": {
@@ -15735,6 +15807,9 @@
                   },
                   "type": "array",
                   "x-kubernetes-list-type": "atomic"
+                },
+                "supplementalGroupsPolicy": {
+                  "type": "string"
                 },
                 "sysctls": {
                   "items": {
@@ -16166,6 +16241,9 @@
                         },
                         "type": "object",
                         "additionalProperties": false
+                      },
+                      "stopSignal": {
+                        "type": "string"
                       }
                     },
                     "type": "object",
@@ -16197,6 +16275,7 @@
                             "type": "integer"
                           },
                           "service": {
+                            "default": "",
                             "type": "string"
                           }
                         },
@@ -16369,6 +16448,7 @@
                             "type": "integer"
                           },
                           "service": {
+                            "default": "",
                             "type": "string"
                           }
                         },
@@ -16500,6 +16580,9 @@
                         "items": {
                           "properties": {
                             "name": {
+                              "type": "string"
+                            },
+                            "request": {
                               "type": "string"
                             }
                           },
@@ -16693,6 +16776,7 @@
                             "type": "integer"
                           },
                           "service": {
+                            "default": "",
                             "type": "string"
                           }
                         },
@@ -16888,6 +16972,2096 @@
             },
             "steps": {
               "items": {
+                "items": {
+                  "properties": {
+                    "arguments": {
+                      "properties": {
+                        "artifacts": {
+                          "items": {
+                            "properties": {
+                              "archive": {
+                                "properties": {
+                                  "none": {
+                                    "type": "object"
+                                  },
+                                  "tar": {
+                                    "properties": {
+                                      "compressionLevel": {
+                                        "format": "int32",
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "zip": {
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "archiveLogs": {
+                                "type": "boolean"
+                              },
+                              "artifactGC": {
+                                "properties": {
+                                  "podMetadata": {
+                                    "properties": {
+                                      "annotations": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
+                                      },
+                                      "labels": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "serviceAccountName": {
+                                    "type": "string"
+                                  },
+                                  "strategy": {
+                                    "enum": [
+                                      "",
+                                      "OnWorkflowCompletion",
+                                      "OnWorkflowDeletion",
+                                      "Never"
+                                    ],
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "artifactory": {
+                                "properties": {
+                                  "passwordSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "default": "",
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "x-kubernetes-map-type": "atomic",
+                                    "additionalProperties": false
+                                  },
+                                  "url": {
+                                    "type": "string"
+                                  },
+                                  "usernameSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "default": "",
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "x-kubernetes-map-type": "atomic",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "required": [
+                                  "url"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "azure": {
+                                "properties": {
+                                  "accountKeySecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "default": "",
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "x-kubernetes-map-type": "atomic",
+                                    "additionalProperties": false
+                                  },
+                                  "blob": {
+                                    "type": "string"
+                                  },
+                                  "container": {
+                                    "type": "string"
+                                  },
+                                  "endpoint": {
+                                    "type": "string"
+                                  },
+                                  "useSDKCreds": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "blob",
+                                  "container",
+                                  "endpoint"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "deleted": {
+                                "type": "boolean"
+                              },
+                              "from": {
+                                "type": "string"
+                              },
+                              "fromExpression": {
+                                "type": "string"
+                              },
+                              "gcs": {
+                                "properties": {
+                                  "bucket": {
+                                    "type": "string"
+                                  },
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "serviceAccountKeySecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "default": "",
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "x-kubernetes-map-type": "atomic",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "git": {
+                                "properties": {
+                                  "branch": {
+                                    "type": "string"
+                                  },
+                                  "depth": {
+                                    "format": "int64",
+                                    "type": "integer"
+                                  },
+                                  "disableSubmodules": {
+                                    "type": "boolean"
+                                  },
+                                  "fetch": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "insecureIgnoreHostKey": {
+                                    "type": "boolean"
+                                  },
+                                  "insecureSkipTLS": {
+                                    "type": "boolean"
+                                  },
+                                  "passwordSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "default": "",
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "x-kubernetes-map-type": "atomic",
+                                    "additionalProperties": false
+                                  },
+                                  "repo": {
+                                    "type": "string"
+                                  },
+                                  "revision": {
+                                    "type": "string"
+                                  },
+                                  "singleBranch": {
+                                    "type": "boolean"
+                                  },
+                                  "sshPrivateKeySecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "default": "",
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "x-kubernetes-map-type": "atomic",
+                                    "additionalProperties": false
+                                  },
+                                  "usernameSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "default": "",
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "x-kubernetes-map-type": "atomic",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "required": [
+                                  "repo"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "globalName": {
+                                "type": "string"
+                              },
+                              "hdfs": {
+                                "properties": {
+                                  "addresses": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "dataTransferProtection": {
+                                    "type": "string"
+                                  },
+                                  "force": {
+                                    "type": "boolean"
+                                  },
+                                  "hdfsUser": {
+                                    "type": "string"
+                                  },
+                                  "krbCCacheSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "default": "",
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "x-kubernetes-map-type": "atomic",
+                                    "additionalProperties": false
+                                  },
+                                  "krbConfigConfigMap": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "default": "",
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "x-kubernetes-map-type": "atomic",
+                                    "additionalProperties": false
+                                  },
+                                  "krbKeytabSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "default": "",
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "x-kubernetes-map-type": "atomic",
+                                    "additionalProperties": false
+                                  },
+                                  "krbRealm": {
+                                    "type": "string"
+                                  },
+                                  "krbServicePrincipalName": {
+                                    "type": "string"
+                                  },
+                                  "krbUsername": {
+                                    "type": "string"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "path"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "http": {
+                                "properties": {
+                                  "auth": {
+                                    "properties": {
+                                      "basicAuth": {
+                                        "properties": {
+                                          "passwordSecret": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "default": "",
+                                                "type": "string"
+                                              },
+                                              "optional": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "required": [
+                                              "key"
+                                            ],
+                                            "type": "object",
+                                            "x-kubernetes-map-type": "atomic",
+                                            "additionalProperties": false
+                                          },
+                                          "usernameSecret": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "default": "",
+                                                "type": "string"
+                                              },
+                                              "optional": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "required": [
+                                              "key"
+                                            ],
+                                            "type": "object",
+                                            "x-kubernetes-map-type": "atomic",
+                                            "additionalProperties": false
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "clientCert": {
+                                        "properties": {
+                                          "clientCertSecret": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "default": "",
+                                                "type": "string"
+                                              },
+                                              "optional": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "required": [
+                                              "key"
+                                            ],
+                                            "type": "object",
+                                            "x-kubernetes-map-type": "atomic",
+                                            "additionalProperties": false
+                                          },
+                                          "clientKeySecret": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "default": "",
+                                                "type": "string"
+                                              },
+                                              "optional": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "required": [
+                                              "key"
+                                            ],
+                                            "type": "object",
+                                            "x-kubernetes-map-type": "atomic",
+                                            "additionalProperties": false
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "oauth2": {
+                                        "properties": {
+                                          "clientIDSecret": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "default": "",
+                                                "type": "string"
+                                              },
+                                              "optional": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "required": [
+                                              "key"
+                                            ],
+                                            "type": "object",
+                                            "x-kubernetes-map-type": "atomic",
+                                            "additionalProperties": false
+                                          },
+                                          "clientSecretSecret": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "default": "",
+                                                "type": "string"
+                                              },
+                                              "optional": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "required": [
+                                              "key"
+                                            ],
+                                            "type": "object",
+                                            "x-kubernetes-map-type": "atomic",
+                                            "additionalProperties": false
+                                          },
+                                          "endpointParams": {
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "value": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "required": [
+                                                "key"
+                                              ],
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          },
+                                          "scopes": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "tokenURLSecret": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "default": "",
+                                                "type": "string"
+                                              },
+                                              "optional": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "required": [
+                                              "key"
+                                            ],
+                                            "type": "object",
+                                            "x-kubernetes-map-type": "atomic",
+                                            "additionalProperties": false
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "headers": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "name",
+                                        "value"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "url": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "url"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "mode": {
+                                "format": "int32",
+                                "type": "integer"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "optional": {
+                                "type": "boolean"
+                              },
+                              "oss": {
+                                "properties": {
+                                  "accessKeySecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "default": "",
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "x-kubernetes-map-type": "atomic",
+                                    "additionalProperties": false
+                                  },
+                                  "bucket": {
+                                    "type": "string"
+                                  },
+                                  "createBucketIfNotPresent": {
+                                    "type": "boolean"
+                                  },
+                                  "endpoint": {
+                                    "type": "string"
+                                  },
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "lifecycleRule": {
+                                    "properties": {
+                                      "markDeletionAfterDays": {
+                                        "format": "int32",
+                                        "type": "integer"
+                                      },
+                                      "markInfrequentAccessAfterDays": {
+                                        "format": "int32",
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "secretKeySecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "default": "",
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "x-kubernetes-map-type": "atomic",
+                                    "additionalProperties": false
+                                  },
+                                  "securityToken": {
+                                    "type": "string"
+                                  },
+                                  "useSDKCreds": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "path": {
+                                "type": "string"
+                              },
+                              "raw": {
+                                "properties": {
+                                  "data": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "data"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "recurseMode": {
+                                "type": "boolean"
+                              },
+                              "s3": {
+                                "properties": {
+                                  "accessKeySecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "default": "",
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "x-kubernetes-map-type": "atomic",
+                                    "additionalProperties": false
+                                  },
+                                  "bucket": {
+                                    "type": "string"
+                                  },
+                                  "caSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "default": "",
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "x-kubernetes-map-type": "atomic",
+                                    "additionalProperties": false
+                                  },
+                                  "createBucketIfNotPresent": {
+                                    "properties": {
+                                      "objectLocking": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "encryptionOptions": {
+                                    "properties": {
+                                      "enableEncryption": {
+                                        "type": "boolean"
+                                      },
+                                      "kmsEncryptionContext": {
+                                        "type": "string"
+                                      },
+                                      "kmsKeyId": {
+                                        "type": "string"
+                                      },
+                                      "serverSideCustomerKeySecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "default": "",
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "x-kubernetes-map-type": "atomic",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "endpoint": {
+                                    "type": "string"
+                                  },
+                                  "insecure": {
+                                    "type": "boolean"
+                                  },
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "region": {
+                                    "type": "string"
+                                  },
+                                  "roleARN": {
+                                    "type": "string"
+                                  },
+                                  "secretKeySecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "default": "",
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "x-kubernetes-map-type": "atomic",
+                                    "additionalProperties": false
+                                  },
+                                  "sessionTokenSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "default": "",
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "x-kubernetes-map-type": "atomic",
+                                    "additionalProperties": false
+                                  },
+                                  "useSDKCreds": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "subPath": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "name"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "parameters": {
+                          "items": {
+                            "properties": {
+                              "default": {
+                                "type": "string"
+                              },
+                              "description": {
+                                "type": "string"
+                              },
+                              "enum": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "globalName": {
+                                "type": "string"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "value": {
+                                "type": "string"
+                              },
+                              "valueFrom": {
+                                "properties": {
+                                  "configMapKeyRef": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "default": "",
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "x-kubernetes-map-type": "atomic",
+                                    "additionalProperties": false
+                                  },
+                                  "default": {
+                                    "type": "string"
+                                  },
+                                  "event": {
+                                    "type": "string"
+                                  },
+                                  "expression": {
+                                    "type": "string"
+                                  },
+                                  "jqFilter": {
+                                    "type": "string"
+                                  },
+                                  "jsonPath": {
+                                    "type": "string"
+                                  },
+                                  "parameter": {
+                                    "type": "string"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "supplied": {
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "required": [
+                              "name"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "continueOn": {
+                      "properties": {
+                        "error": {
+                          "type": "boolean"
+                        },
+                        "failed": {
+                          "type": "boolean"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "hooks": {
+                      "additionalProperties": {
+                        "properties": {
+                          "arguments": {
+                            "properties": {
+                              "artifacts": {
+                                "items": {
+                                  "properties": {
+                                    "archive": {
+                                      "properties": {
+                                        "none": {
+                                          "type": "object"
+                                        },
+                                        "tar": {
+                                          "properties": {
+                                            "compressionLevel": {
+                                              "format": "int32",
+                                              "type": "integer"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "zip": {
+                                          "type": "object"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "archiveLogs": {
+                                      "type": "boolean"
+                                    },
+                                    "artifactGC": {
+                                      "properties": {
+                                        "podMetadata": {
+                                          "properties": {
+                                            "annotations": {
+                                              "additionalProperties": {
+                                                "type": "string"
+                                              },
+                                              "type": "object"
+                                            },
+                                            "labels": {
+                                              "additionalProperties": {
+                                                "type": "string"
+                                              },
+                                              "type": "object"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "serviceAccountName": {
+                                          "type": "string"
+                                        },
+                                        "strategy": {
+                                          "enum": [
+                                            "",
+                                            "OnWorkflowCompletion",
+                                            "OnWorkflowDeletion",
+                                            "Never"
+                                          ],
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "artifactory": {
+                                      "properties": {
+                                        "passwordSecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "default": "",
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "x-kubernetes-map-type": "atomic",
+                                          "additionalProperties": false
+                                        },
+                                        "url": {
+                                          "type": "string"
+                                        },
+                                        "usernameSecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "default": "",
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "x-kubernetes-map-type": "atomic",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "required": [
+                                        "url"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "azure": {
+                                      "properties": {
+                                        "accountKeySecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "default": "",
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "x-kubernetes-map-type": "atomic",
+                                          "additionalProperties": false
+                                        },
+                                        "blob": {
+                                          "type": "string"
+                                        },
+                                        "container": {
+                                          "type": "string"
+                                        },
+                                        "endpoint": {
+                                          "type": "string"
+                                        },
+                                        "useSDKCreds": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "blob",
+                                        "container",
+                                        "endpoint"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "deleted": {
+                                      "type": "boolean"
+                                    },
+                                    "from": {
+                                      "type": "string"
+                                    },
+                                    "fromExpression": {
+                                      "type": "string"
+                                    },
+                                    "gcs": {
+                                      "properties": {
+                                        "bucket": {
+                                          "type": "string"
+                                        },
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "serviceAccountKeySecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "default": "",
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "x-kubernetes-map-type": "atomic",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "git": {
+                                      "properties": {
+                                        "branch": {
+                                          "type": "string"
+                                        },
+                                        "depth": {
+                                          "format": "int64",
+                                          "type": "integer"
+                                        },
+                                        "disableSubmodules": {
+                                          "type": "boolean"
+                                        },
+                                        "fetch": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        },
+                                        "insecureIgnoreHostKey": {
+                                          "type": "boolean"
+                                        },
+                                        "insecureSkipTLS": {
+                                          "type": "boolean"
+                                        },
+                                        "passwordSecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "default": "",
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "x-kubernetes-map-type": "atomic",
+                                          "additionalProperties": false
+                                        },
+                                        "repo": {
+                                          "type": "string"
+                                        },
+                                        "revision": {
+                                          "type": "string"
+                                        },
+                                        "singleBranch": {
+                                          "type": "boolean"
+                                        },
+                                        "sshPrivateKeySecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "default": "",
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "x-kubernetes-map-type": "atomic",
+                                          "additionalProperties": false
+                                        },
+                                        "usernameSecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "default": "",
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "x-kubernetes-map-type": "atomic",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "required": [
+                                        "repo"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "globalName": {
+                                      "type": "string"
+                                    },
+                                    "hdfs": {
+                                      "properties": {
+                                        "addresses": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        },
+                                        "dataTransferProtection": {
+                                          "type": "string"
+                                        },
+                                        "force": {
+                                          "type": "boolean"
+                                        },
+                                        "hdfsUser": {
+                                          "type": "string"
+                                        },
+                                        "krbCCacheSecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "default": "",
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "x-kubernetes-map-type": "atomic",
+                                          "additionalProperties": false
+                                        },
+                                        "krbConfigConfigMap": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "default": "",
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "x-kubernetes-map-type": "atomic",
+                                          "additionalProperties": false
+                                        },
+                                        "krbKeytabSecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "default": "",
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "x-kubernetes-map-type": "atomic",
+                                          "additionalProperties": false
+                                        },
+                                        "krbRealm": {
+                                          "type": "string"
+                                        },
+                                        "krbServicePrincipalName": {
+                                          "type": "string"
+                                        },
+                                        "krbUsername": {
+                                          "type": "string"
+                                        },
+                                        "path": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "path"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "http": {
+                                      "properties": {
+                                        "auth": {
+                                          "properties": {
+                                            "basicAuth": {
+                                              "properties": {
+                                                "passwordSecret": {
+                                                  "properties": {
+                                                    "key": {
+                                                      "type": "string"
+                                                    },
+                                                    "name": {
+                                                      "default": "",
+                                                      "type": "string"
+                                                    },
+                                                    "optional": {
+                                                      "type": "boolean"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "key"
+                                                  ],
+                                                  "type": "object",
+                                                  "x-kubernetes-map-type": "atomic",
+                                                  "additionalProperties": false
+                                                },
+                                                "usernameSecret": {
+                                                  "properties": {
+                                                    "key": {
+                                                      "type": "string"
+                                                    },
+                                                    "name": {
+                                                      "default": "",
+                                                      "type": "string"
+                                                    },
+                                                    "optional": {
+                                                      "type": "boolean"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "key"
+                                                  ],
+                                                  "type": "object",
+                                                  "x-kubernetes-map-type": "atomic",
+                                                  "additionalProperties": false
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "clientCert": {
+                                              "properties": {
+                                                "clientCertSecret": {
+                                                  "properties": {
+                                                    "key": {
+                                                      "type": "string"
+                                                    },
+                                                    "name": {
+                                                      "default": "",
+                                                      "type": "string"
+                                                    },
+                                                    "optional": {
+                                                      "type": "boolean"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "key"
+                                                  ],
+                                                  "type": "object",
+                                                  "x-kubernetes-map-type": "atomic",
+                                                  "additionalProperties": false
+                                                },
+                                                "clientKeySecret": {
+                                                  "properties": {
+                                                    "key": {
+                                                      "type": "string"
+                                                    },
+                                                    "name": {
+                                                      "default": "",
+                                                      "type": "string"
+                                                    },
+                                                    "optional": {
+                                                      "type": "boolean"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "key"
+                                                  ],
+                                                  "type": "object",
+                                                  "x-kubernetes-map-type": "atomic",
+                                                  "additionalProperties": false
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "oauth2": {
+                                              "properties": {
+                                                "clientIDSecret": {
+                                                  "properties": {
+                                                    "key": {
+                                                      "type": "string"
+                                                    },
+                                                    "name": {
+                                                      "default": "",
+                                                      "type": "string"
+                                                    },
+                                                    "optional": {
+                                                      "type": "boolean"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "key"
+                                                  ],
+                                                  "type": "object",
+                                                  "x-kubernetes-map-type": "atomic",
+                                                  "additionalProperties": false
+                                                },
+                                                "clientSecretSecret": {
+                                                  "properties": {
+                                                    "key": {
+                                                      "type": "string"
+                                                    },
+                                                    "name": {
+                                                      "default": "",
+                                                      "type": "string"
+                                                    },
+                                                    "optional": {
+                                                      "type": "boolean"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "key"
+                                                  ],
+                                                  "type": "object",
+                                                  "x-kubernetes-map-type": "atomic",
+                                                  "additionalProperties": false
+                                                },
+                                                "endpointParams": {
+                                                  "items": {
+                                                    "properties": {
+                                                      "key": {
+                                                        "type": "string"
+                                                      },
+                                                      "value": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "key"
+                                                    ],
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "type": "array"
+                                                },
+                                                "scopes": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                },
+                                                "tokenURLSecret": {
+                                                  "properties": {
+                                                    "key": {
+                                                      "type": "string"
+                                                    },
+                                                    "name": {
+                                                      "default": "",
+                                                      "type": "string"
+                                                    },
+                                                    "optional": {
+                                                      "type": "boolean"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "key"
+                                                  ],
+                                                  "type": "object",
+                                                  "x-kubernetes-map-type": "atomic",
+                                                  "additionalProperties": false
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "headers": {
+                                          "items": {
+                                            "properties": {
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "value": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name",
+                                              "value"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "array"
+                                        },
+                                        "url": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "url"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "mode": {
+                                      "format": "int32",
+                                      "type": "integer"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    },
+                                    "oss": {
+                                      "properties": {
+                                        "accessKeySecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "default": "",
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "x-kubernetes-map-type": "atomic",
+                                          "additionalProperties": false
+                                        },
+                                        "bucket": {
+                                          "type": "string"
+                                        },
+                                        "createBucketIfNotPresent": {
+                                          "type": "boolean"
+                                        },
+                                        "endpoint": {
+                                          "type": "string"
+                                        },
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "lifecycleRule": {
+                                          "properties": {
+                                            "markDeletionAfterDays": {
+                                              "format": "int32",
+                                              "type": "integer"
+                                            },
+                                            "markInfrequentAccessAfterDays": {
+                                              "format": "int32",
+                                              "type": "integer"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "secretKeySecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "default": "",
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "x-kubernetes-map-type": "atomic",
+                                          "additionalProperties": false
+                                        },
+                                        "securityToken": {
+                                          "type": "string"
+                                        },
+                                        "useSDKCreds": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "path": {
+                                      "type": "string"
+                                    },
+                                    "raw": {
+                                      "properties": {
+                                        "data": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "data"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "recurseMode": {
+                                      "type": "boolean"
+                                    },
+                                    "s3": {
+                                      "properties": {
+                                        "accessKeySecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "default": "",
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "x-kubernetes-map-type": "atomic",
+                                          "additionalProperties": false
+                                        },
+                                        "bucket": {
+                                          "type": "string"
+                                        },
+                                        "caSecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "default": "",
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "x-kubernetes-map-type": "atomic",
+                                          "additionalProperties": false
+                                        },
+                                        "createBucketIfNotPresent": {
+                                          "properties": {
+                                            "objectLocking": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "encryptionOptions": {
+                                          "properties": {
+                                            "enableEncryption": {
+                                              "type": "boolean"
+                                            },
+                                            "kmsEncryptionContext": {
+                                              "type": "string"
+                                            },
+                                            "kmsKeyId": {
+                                              "type": "string"
+                                            },
+                                            "serverSideCustomerKeySecret": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "name": {
+                                                  "default": "",
+                                                  "type": "string"
+                                                },
+                                                "optional": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              "required": [
+                                                "key"
+                                              ],
+                                              "type": "object",
+                                              "x-kubernetes-map-type": "atomic",
+                                              "additionalProperties": false
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "endpoint": {
+                                          "type": "string"
+                                        },
+                                        "insecure": {
+                                          "type": "boolean"
+                                        },
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "region": {
+                                          "type": "string"
+                                        },
+                                        "roleARN": {
+                                          "type": "string"
+                                        },
+                                        "secretKeySecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "default": "",
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "x-kubernetes-map-type": "atomic",
+                                          "additionalProperties": false
+                                        },
+                                        "sessionTokenSecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "default": "",
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "x-kubernetes-map-type": "atomic",
+                                          "additionalProperties": false
+                                        },
+                                        "useSDKCreds": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "subPath": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "name"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "parameters": {
+                                "items": {
+                                  "properties": {
+                                    "default": {
+                                      "type": "string"
+                                    },
+                                    "description": {
+                                      "type": "string"
+                                    },
+                                    "enum": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "globalName": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    },
+                                    "valueFrom": {
+                                      "properties": {
+                                        "configMapKeyRef": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "default": "",
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "x-kubernetes-map-type": "atomic",
+                                          "additionalProperties": false
+                                        },
+                                        "default": {
+                                          "type": "string"
+                                        },
+                                        "event": {
+                                          "type": "string"
+                                        },
+                                        "expression": {
+                                          "type": "string"
+                                        },
+                                        "jqFilter": {
+                                          "type": "string"
+                                        },
+                                        "jsonPath": {
+                                          "type": "string"
+                                        },
+                                        "parameter": {
+                                          "type": "string"
+                                        },
+                                        "path": {
+                                          "type": "string"
+                                        },
+                                        "supplied": {
+                                          "type": "object"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "required": [
+                                    "name"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "expression": {
+                            "type": "string"
+                          },
+                          "template": {
+                            "type": "string"
+                          },
+                          "templateRef": {
+                            "properties": {
+                              "clusterScope": {
+                                "type": "boolean"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "template": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "object"
+                    },
+                    "inline": {
+                      "x-kubernetes-preserve-unknown-fields": true
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "onExit": {
+                      "type": "string"
+                    },
+                    "template": {
+                      "type": "string"
+                    },
+                    "templateRef": {
+                      "properties": {
+                        "clusterScope": {
+                          "type": "boolean"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "template": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "when": {
+                      "type": "string"
+                    },
+                    "withItems": {
+                      "x-kubernetes-preserve-unknown-fields": true
+                    },
+                    "withParam": {
+                      "type": "string"
+                    },
+                    "withSequence": {
+                      "properties": {
+                        "count": {
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "string"
+                            }
+                          ],
+                          "x-kubernetes-int-or-string": true
+                        },
+                        "end": {
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "string"
+                            }
+                          ],
+                          "x-kubernetes-int-or-string": true
+                        },
+                        "format": {
+                          "type": "string"
+                        },
+                        "start": {
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "string"
+                            }
+                          ],
+                          "x-kubernetes-int-or-string": true
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
                 "type": "array"
               },
               "type": "array"
@@ -16905,6 +19079,9 @@
               "properties": {
                 "mutex": {
                   "properties": {
+                    "database": {
+                      "type": "boolean"
+                    },
                     "name": {
                       "type": "string"
                     },
@@ -16918,6 +19095,9 @@
                 "mutexes": {
                   "items": {
                     "properties": {
+                      "database": {
+                        "type": "boolean"
+                      },
                       "name": {
                         "type": "string"
                       },
@@ -16952,6 +19132,18 @@
                       "x-kubernetes-map-type": "atomic",
                       "additionalProperties": false
                     },
+                    "database": {
+                      "properties": {
+                        "key": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "key"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
                     "namespace": {
                       "type": "string"
                     }
@@ -16980,6 +19172,18 @@
                         ],
                         "type": "object",
                         "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "database": {
+                        "properties": {
+                          "key": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "key"
+                        ],
+                        "type": "object",
                         "additionalProperties": false
                       },
                       "namespace": {
@@ -17060,12 +19264,14 @@
                         "type": "string"
                       },
                       "fsType": {
+                        "default": "ext4",
                         "type": "string"
                       },
                       "kind": {
                         "type": "string"
                       },
                       "readOnly": {
+                        "default": false,
                         "type": "boolean"
                       }
                     },
@@ -17340,7 +19546,37 @@
                       "volumeClaimTemplate": {
                         "properties": {
                           "metadata": {
-                            "type": "object"
+                            "properties": {
+                              "annotations": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "type": "object"
+                              },
+                              "finalizers": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "generateName": {
+                                "type": "string"
+                              },
+                              "labels": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "type": "object"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "namespace": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
                           },
                           "spec": {
                             "properties": {
@@ -17647,6 +19883,18 @@
                     "type": "object",
                     "additionalProperties": false
                   },
+                  "image": {
+                    "properties": {
+                      "pullPolicy": {
+                        "type": "string"
+                      },
+                      "reference": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
                   "iscsi": {
                     "properties": {
                       "chapAuthDiscovery": {
@@ -17665,6 +19913,7 @@
                         "type": "string"
                       },
                       "iscsiInterface": {
+                        "default": "default",
                         "type": "string"
                       },
                       "lun": {
@@ -18057,6 +20306,7 @@
                         "type": "string"
                       },
                       "keyring": {
+                        "default": "/etc/ceph/keyring",
                         "type": "string"
                       },
                       "monitors": {
@@ -18067,6 +20317,7 @@
                         "x-kubernetes-list-type": "atomic"
                       },
                       "pool": {
+                        "default": "rbd",
                         "type": "string"
                       },
                       "readOnly": {
@@ -18084,6 +20335,7 @@
                         "additionalProperties": false
                       },
                       "user": {
+                        "default": "admin",
                         "type": "string"
                       }
                     },
@@ -18097,6 +20349,7 @@
                   "scaleIO": {
                     "properties": {
                       "fsType": {
+                        "default": "xfs",
                         "type": "string"
                       },
                       "gateway": {
@@ -18123,6 +20376,7 @@
                         "type": "boolean"
                       },
                       "storageMode": {
+                        "default": "ThinProvisioned",
                         "type": "string"
                       },
                       "storagePool": {
@@ -18933,6 +21187,12 @@
                 },
                 "type": "object",
                 "additionalProperties": false
+              },
+              "annotations": {
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "type": "object"
               },
               "archiveLocation": {
                 "properties": {
@@ -20119,6 +22379,9 @@
                         },
                         "type": "object",
                         "additionalProperties": false
+                      },
+                      "stopSignal": {
+                        "type": "string"
                       }
                     },
                     "type": "object",
@@ -20150,6 +22413,7 @@
                             "type": "integer"
                           },
                           "service": {
+                            "default": "",
                             "type": "string"
                           }
                         },
@@ -20319,6 +22583,7 @@
                             "type": "integer"
                           },
                           "service": {
+                            "default": "",
                             "type": "string"
                           }
                         },
@@ -20450,6 +22715,9 @@
                         "items": {
                           "properties": {
                             "name": {
+                              "type": "string"
+                            },
+                            "request": {
                               "type": "string"
                             }
                           },
@@ -20643,6 +22911,7 @@
                             "type": "integer"
                           },
                           "service": {
+                            "default": "",
                             "type": "string"
                           }
                         },
@@ -20828,9 +23097,6 @@
                     "type": "string"
                   }
                 },
-                "required": [
-                  "image"
-                ],
                 "type": "object",
                 "additionalProperties": false
               },
@@ -21227,6 +23493,9 @@
                               },
                               "type": "object",
                               "additionalProperties": false
+                            },
+                            "stopSignal": {
+                              "type": "string"
                             }
                           },
                           "type": "object",
@@ -21258,6 +23527,7 @@
                                   "type": "integer"
                                 },
                                 "service": {
+                                  "default": "",
                                   "type": "string"
                                 }
                               },
@@ -21427,6 +23697,7 @@
                                   "type": "integer"
                                 },
                                 "service": {
+                                  "default": "",
                                   "type": "string"
                                 }
                               },
@@ -21558,6 +23829,9 @@
                               "items": {
                                 "properties": {
                                   "name": {
+                                    "type": "string"
+                                  },
+                                  "request": {
                                     "type": "string"
                                   }
                                 },
@@ -21751,6 +24025,7 @@
                                   "type": "integer"
                                 },
                                 "service": {
+                                  "default": "",
                                   "type": "string"
                                 }
                               },
@@ -24037,7 +26312,9 @@
                           },
                           "type": "object"
                         },
-                        "inline": {},
+                        "inline": {
+                          "x-kubernetes-preserve-unknown-fields": true
+                        },
                         "name": {
                           "type": "string"
                         },
@@ -24066,10 +26343,7 @@
                           "type": "string"
                         },
                         "withItems": {
-                          "items": {
-                            "type": "object"
-                          },
-                          "type": "array"
+                          "x-kubernetes-preserve-unknown-fields": true
                         },
                         "withParam": {
                           "type": "string"
@@ -25554,6 +27828,9 @@
                           },
                           "type": "object",
                           "additionalProperties": false
+                        },
+                        "stopSignal": {
+                          "type": "string"
                         }
                       },
                       "type": "object",
@@ -25585,6 +27862,7 @@
                               "type": "integer"
                             },
                             "service": {
+                              "default": "",
                               "type": "string"
                             }
                           },
@@ -25757,6 +28035,7 @@
                               "type": "integer"
                             },
                             "service": {
+                              "default": "",
                               "type": "string"
                             }
                           },
@@ -25888,6 +28167,9 @@
                           "items": {
                             "properties": {
                               "name": {
+                                "type": "string"
+                              },
+                              "request": {
                                 "type": "string"
                               }
                             },
@@ -26081,6 +28363,7 @@
                               "type": "integer"
                             },
                             "service": {
+                              "default": "",
                               "type": "string"
                             }
                           },
@@ -28422,14 +30705,11 @@
                 "type": "integer"
               },
               "plugin": {
-                "type": "object"
+                "type": "object",
+                "x-kubernetes-preserve-unknown-fields": true
               },
               "podSpecPatch": {
                 "type": "string"
-              },
-              "priority": {
-                "format": "int32",
-                "type": "integer"
               },
               "priorityClassName": {
                 "type": "string"
@@ -29379,6 +31659,9 @@
                   },
                   "backoff": {
                     "properties": {
+                      "cap": {
+                        "type": "string"
+                      },
                       "duration": {
                         "type": "string"
                       },
@@ -29808,6 +32091,9 @@
                         },
                         "type": "object",
                         "additionalProperties": false
+                      },
+                      "stopSignal": {
+                        "type": "string"
                       }
                     },
                     "type": "object",
@@ -29839,6 +32125,7 @@
                             "type": "integer"
                           },
                           "service": {
+                            "default": "",
                             "type": "string"
                           }
                         },
@@ -30008,6 +32295,7 @@
                             "type": "integer"
                           },
                           "service": {
+                            "default": "",
                             "type": "string"
                           }
                         },
@@ -30139,6 +32427,9 @@
                         "items": {
                           "properties": {
                             "name": {
+                              "type": "string"
+                            },
+                            "request": {
                               "type": "string"
                             }
                           },
@@ -30335,6 +32626,7 @@
                             "type": "integer"
                           },
                           "service": {
+                            "default": "",
                             "type": "string"
                           }
                         },
@@ -30520,10 +32812,6 @@
                     "type": "string"
                   }
                 },
-                "required": [
-                  "image",
-                  "source"
-                ],
                 "type": "object",
                 "additionalProperties": false
               },
@@ -30561,6 +32849,9 @@
                   "runAsUser": {
                     "format": "int64",
                     "type": "integer"
+                  },
+                  "seLinuxChangePolicy": {
+                    "type": "string"
                   },
                   "seLinuxOptions": {
                     "properties": {
@@ -30602,6 +32893,9 @@
                     },
                     "type": "array",
                     "x-kubernetes-list-type": "atomic"
+                  },
+                  "supplementalGroupsPolicy": {
+                    "type": "string"
                   },
                   "sysctls": {
                     "items": {
@@ -31033,6 +33327,9 @@
                           },
                           "type": "object",
                           "additionalProperties": false
+                        },
+                        "stopSignal": {
+                          "type": "string"
                         }
                       },
                       "type": "object",
@@ -31064,6 +33361,7 @@
                               "type": "integer"
                             },
                             "service": {
+                              "default": "",
                               "type": "string"
                             }
                           },
@@ -31236,6 +33534,7 @@
                               "type": "integer"
                             },
                             "service": {
+                              "default": "",
                               "type": "string"
                             }
                           },
@@ -31367,6 +33666,9 @@
                           "items": {
                             "properties": {
                               "name": {
+                                "type": "string"
+                              },
+                              "request": {
                                 "type": "string"
                               }
                             },
@@ -31560,6 +33862,7 @@
                               "type": "integer"
                             },
                             "service": {
+                              "default": "",
                               "type": "string"
                             }
                           },
@@ -31755,6 +34058,2096 @@
               },
               "steps": {
                 "items": {
+                  "items": {
+                    "properties": {
+                      "arguments": {
+                        "properties": {
+                          "artifacts": {
+                            "items": {
+                              "properties": {
+                                "archive": {
+                                  "properties": {
+                                    "none": {
+                                      "type": "object"
+                                    },
+                                    "tar": {
+                                      "properties": {
+                                        "compressionLevel": {
+                                          "format": "int32",
+                                          "type": "integer"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "zip": {
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "archiveLogs": {
+                                  "type": "boolean"
+                                },
+                                "artifactGC": {
+                                  "properties": {
+                                    "podMetadata": {
+                                      "properties": {
+                                        "annotations": {
+                                          "additionalProperties": {
+                                            "type": "string"
+                                          },
+                                          "type": "object"
+                                        },
+                                        "labels": {
+                                          "additionalProperties": {
+                                            "type": "string"
+                                          },
+                                          "type": "object"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "serviceAccountName": {
+                                      "type": "string"
+                                    },
+                                    "strategy": {
+                                      "enum": [
+                                        "",
+                                        "OnWorkflowCompletion",
+                                        "OnWorkflowDeletion",
+                                        "Never"
+                                      ],
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "artifactory": {
+                                  "properties": {
+                                    "passwordSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "default": "",
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "x-kubernetes-map-type": "atomic",
+                                      "additionalProperties": false
+                                    },
+                                    "url": {
+                                      "type": "string"
+                                    },
+                                    "usernameSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "default": "",
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "x-kubernetes-map-type": "atomic",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "required": [
+                                    "url"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "azure": {
+                                  "properties": {
+                                    "accountKeySecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "default": "",
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "x-kubernetes-map-type": "atomic",
+                                      "additionalProperties": false
+                                    },
+                                    "blob": {
+                                      "type": "string"
+                                    },
+                                    "container": {
+                                      "type": "string"
+                                    },
+                                    "endpoint": {
+                                      "type": "string"
+                                    },
+                                    "useSDKCreds": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "blob",
+                                    "container",
+                                    "endpoint"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "deleted": {
+                                  "type": "boolean"
+                                },
+                                "from": {
+                                  "type": "string"
+                                },
+                                "fromExpression": {
+                                  "type": "string"
+                                },
+                                "gcs": {
+                                  "properties": {
+                                    "bucket": {
+                                      "type": "string"
+                                    },
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "serviceAccountKeySecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "default": "",
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "x-kubernetes-map-type": "atomic",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "git": {
+                                  "properties": {
+                                    "branch": {
+                                      "type": "string"
+                                    },
+                                    "depth": {
+                                      "format": "int64",
+                                      "type": "integer"
+                                    },
+                                    "disableSubmodules": {
+                                      "type": "boolean"
+                                    },
+                                    "fetch": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "insecureIgnoreHostKey": {
+                                      "type": "boolean"
+                                    },
+                                    "insecureSkipTLS": {
+                                      "type": "boolean"
+                                    },
+                                    "passwordSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "default": "",
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "x-kubernetes-map-type": "atomic",
+                                      "additionalProperties": false
+                                    },
+                                    "repo": {
+                                      "type": "string"
+                                    },
+                                    "revision": {
+                                      "type": "string"
+                                    },
+                                    "singleBranch": {
+                                      "type": "boolean"
+                                    },
+                                    "sshPrivateKeySecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "default": "",
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "x-kubernetes-map-type": "atomic",
+                                      "additionalProperties": false
+                                    },
+                                    "usernameSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "default": "",
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "x-kubernetes-map-type": "atomic",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "required": [
+                                    "repo"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "globalName": {
+                                  "type": "string"
+                                },
+                                "hdfs": {
+                                  "properties": {
+                                    "addresses": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "dataTransferProtection": {
+                                      "type": "string"
+                                    },
+                                    "force": {
+                                      "type": "boolean"
+                                    },
+                                    "hdfsUser": {
+                                      "type": "string"
+                                    },
+                                    "krbCCacheSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "default": "",
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "x-kubernetes-map-type": "atomic",
+                                      "additionalProperties": false
+                                    },
+                                    "krbConfigConfigMap": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "default": "",
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "x-kubernetes-map-type": "atomic",
+                                      "additionalProperties": false
+                                    },
+                                    "krbKeytabSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "default": "",
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "x-kubernetes-map-type": "atomic",
+                                      "additionalProperties": false
+                                    },
+                                    "krbRealm": {
+                                      "type": "string"
+                                    },
+                                    "krbServicePrincipalName": {
+                                      "type": "string"
+                                    },
+                                    "krbUsername": {
+                                      "type": "string"
+                                    },
+                                    "path": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "path"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "http": {
+                                  "properties": {
+                                    "auth": {
+                                      "properties": {
+                                        "basicAuth": {
+                                          "properties": {
+                                            "passwordSecret": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "name": {
+                                                  "default": "",
+                                                  "type": "string"
+                                                },
+                                                "optional": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              "required": [
+                                                "key"
+                                              ],
+                                              "type": "object",
+                                              "x-kubernetes-map-type": "atomic",
+                                              "additionalProperties": false
+                                            },
+                                            "usernameSecret": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "name": {
+                                                  "default": "",
+                                                  "type": "string"
+                                                },
+                                                "optional": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              "required": [
+                                                "key"
+                                              ],
+                                              "type": "object",
+                                              "x-kubernetes-map-type": "atomic",
+                                              "additionalProperties": false
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "clientCert": {
+                                          "properties": {
+                                            "clientCertSecret": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "name": {
+                                                  "default": "",
+                                                  "type": "string"
+                                                },
+                                                "optional": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              "required": [
+                                                "key"
+                                              ],
+                                              "type": "object",
+                                              "x-kubernetes-map-type": "atomic",
+                                              "additionalProperties": false
+                                            },
+                                            "clientKeySecret": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "name": {
+                                                  "default": "",
+                                                  "type": "string"
+                                                },
+                                                "optional": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              "required": [
+                                                "key"
+                                              ],
+                                              "type": "object",
+                                              "x-kubernetes-map-type": "atomic",
+                                              "additionalProperties": false
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "oauth2": {
+                                          "properties": {
+                                            "clientIDSecret": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "name": {
+                                                  "default": "",
+                                                  "type": "string"
+                                                },
+                                                "optional": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              "required": [
+                                                "key"
+                                              ],
+                                              "type": "object",
+                                              "x-kubernetes-map-type": "atomic",
+                                              "additionalProperties": false
+                                            },
+                                            "clientSecretSecret": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "name": {
+                                                  "default": "",
+                                                  "type": "string"
+                                                },
+                                                "optional": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              "required": [
+                                                "key"
+                                              ],
+                                              "type": "object",
+                                              "x-kubernetes-map-type": "atomic",
+                                              "additionalProperties": false
+                                            },
+                                            "endpointParams": {
+                                              "items": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "value": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "key"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
+                                            },
+                                            "scopes": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            },
+                                            "tokenURLSecret": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "name": {
+                                                  "default": "",
+                                                  "type": "string"
+                                                },
+                                                "optional": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              "required": [
+                                                "key"
+                                              ],
+                                              "type": "object",
+                                              "x-kubernetes-map-type": "atomic",
+                                              "additionalProperties": false
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "headers": {
+                                      "items": {
+                                        "properties": {
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "value": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "name",
+                                          "value"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "url": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "url"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "mode": {
+                                  "format": "int32",
+                                  "type": "integer"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                },
+                                "oss": {
+                                  "properties": {
+                                    "accessKeySecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "default": "",
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "x-kubernetes-map-type": "atomic",
+                                      "additionalProperties": false
+                                    },
+                                    "bucket": {
+                                      "type": "string"
+                                    },
+                                    "createBucketIfNotPresent": {
+                                      "type": "boolean"
+                                    },
+                                    "endpoint": {
+                                      "type": "string"
+                                    },
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "lifecycleRule": {
+                                      "properties": {
+                                        "markDeletionAfterDays": {
+                                          "format": "int32",
+                                          "type": "integer"
+                                        },
+                                        "markInfrequentAccessAfterDays": {
+                                          "format": "int32",
+                                          "type": "integer"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "secretKeySecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "default": "",
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "x-kubernetes-map-type": "atomic",
+                                      "additionalProperties": false
+                                    },
+                                    "securityToken": {
+                                      "type": "string"
+                                    },
+                                    "useSDKCreds": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "path": {
+                                  "type": "string"
+                                },
+                                "raw": {
+                                  "properties": {
+                                    "data": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "data"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "recurseMode": {
+                                  "type": "boolean"
+                                },
+                                "s3": {
+                                  "properties": {
+                                    "accessKeySecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "default": "",
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "x-kubernetes-map-type": "atomic",
+                                      "additionalProperties": false
+                                    },
+                                    "bucket": {
+                                      "type": "string"
+                                    },
+                                    "caSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "default": "",
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "x-kubernetes-map-type": "atomic",
+                                      "additionalProperties": false
+                                    },
+                                    "createBucketIfNotPresent": {
+                                      "properties": {
+                                        "objectLocking": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "encryptionOptions": {
+                                      "properties": {
+                                        "enableEncryption": {
+                                          "type": "boolean"
+                                        },
+                                        "kmsEncryptionContext": {
+                                          "type": "string"
+                                        },
+                                        "kmsKeyId": {
+                                          "type": "string"
+                                        },
+                                        "serverSideCustomerKeySecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "default": "",
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "x-kubernetes-map-type": "atomic",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "endpoint": {
+                                      "type": "string"
+                                    },
+                                    "insecure": {
+                                      "type": "boolean"
+                                    },
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "region": {
+                                      "type": "string"
+                                    },
+                                    "roleARN": {
+                                      "type": "string"
+                                    },
+                                    "secretKeySecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "default": "",
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "x-kubernetes-map-type": "atomic",
+                                      "additionalProperties": false
+                                    },
+                                    "sessionTokenSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "default": "",
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "x-kubernetes-map-type": "atomic",
+                                      "additionalProperties": false
+                                    },
+                                    "useSDKCreds": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "subPath": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "name"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "parameters": {
+                            "items": {
+                              "properties": {
+                                "default": {
+                                  "type": "string"
+                                },
+                                "description": {
+                                  "type": "string"
+                                },
+                                "enum": {
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "globalName": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "value": {
+                                  "type": "string"
+                                },
+                                "valueFrom": {
+                                  "properties": {
+                                    "configMapKeyRef": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "default": "",
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "x-kubernetes-map-type": "atomic",
+                                      "additionalProperties": false
+                                    },
+                                    "default": {
+                                      "type": "string"
+                                    },
+                                    "event": {
+                                      "type": "string"
+                                    },
+                                    "expression": {
+                                      "type": "string"
+                                    },
+                                    "jqFilter": {
+                                      "type": "string"
+                                    },
+                                    "jsonPath": {
+                                      "type": "string"
+                                    },
+                                    "parameter": {
+                                      "type": "string"
+                                    },
+                                    "path": {
+                                      "type": "string"
+                                    },
+                                    "supplied": {
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "required": [
+                                "name"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "continueOn": {
+                        "properties": {
+                          "error": {
+                            "type": "boolean"
+                          },
+                          "failed": {
+                            "type": "boolean"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "hooks": {
+                        "additionalProperties": {
+                          "properties": {
+                            "arguments": {
+                              "properties": {
+                                "artifacts": {
+                                  "items": {
+                                    "properties": {
+                                      "archive": {
+                                        "properties": {
+                                          "none": {
+                                            "type": "object"
+                                          },
+                                          "tar": {
+                                            "properties": {
+                                              "compressionLevel": {
+                                                "format": "int32",
+                                                "type": "integer"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "zip": {
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "archiveLogs": {
+                                        "type": "boolean"
+                                      },
+                                      "artifactGC": {
+                                        "properties": {
+                                          "podMetadata": {
+                                            "properties": {
+                                              "annotations": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "type": "object"
+                                              },
+                                              "labels": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "type": "object"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "serviceAccountName": {
+                                            "type": "string"
+                                          },
+                                          "strategy": {
+                                            "enum": [
+                                              "",
+                                              "OnWorkflowCompletion",
+                                              "OnWorkflowDeletion",
+                                              "Never"
+                                            ],
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "artifactory": {
+                                        "properties": {
+                                          "passwordSecret": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "default": "",
+                                                "type": "string"
+                                              },
+                                              "optional": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "required": [
+                                              "key"
+                                            ],
+                                            "type": "object",
+                                            "x-kubernetes-map-type": "atomic",
+                                            "additionalProperties": false
+                                          },
+                                          "url": {
+                                            "type": "string"
+                                          },
+                                          "usernameSecret": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "default": "",
+                                                "type": "string"
+                                              },
+                                              "optional": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "required": [
+                                              "key"
+                                            ],
+                                            "type": "object",
+                                            "x-kubernetes-map-type": "atomic",
+                                            "additionalProperties": false
+                                          }
+                                        },
+                                        "required": [
+                                          "url"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "azure": {
+                                        "properties": {
+                                          "accountKeySecret": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "default": "",
+                                                "type": "string"
+                                              },
+                                              "optional": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "required": [
+                                              "key"
+                                            ],
+                                            "type": "object",
+                                            "x-kubernetes-map-type": "atomic",
+                                            "additionalProperties": false
+                                          },
+                                          "blob": {
+                                            "type": "string"
+                                          },
+                                          "container": {
+                                            "type": "string"
+                                          },
+                                          "endpoint": {
+                                            "type": "string"
+                                          },
+                                          "useSDKCreds": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "blob",
+                                          "container",
+                                          "endpoint"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "deleted": {
+                                        "type": "boolean"
+                                      },
+                                      "from": {
+                                        "type": "string"
+                                      },
+                                      "fromExpression": {
+                                        "type": "string"
+                                      },
+                                      "gcs": {
+                                        "properties": {
+                                          "bucket": {
+                                            "type": "string"
+                                          },
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "serviceAccountKeySecret": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "default": "",
+                                                "type": "string"
+                                              },
+                                              "optional": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "required": [
+                                              "key"
+                                            ],
+                                            "type": "object",
+                                            "x-kubernetes-map-type": "atomic",
+                                            "additionalProperties": false
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "git": {
+                                        "properties": {
+                                          "branch": {
+                                            "type": "string"
+                                          },
+                                          "depth": {
+                                            "format": "int64",
+                                            "type": "integer"
+                                          },
+                                          "disableSubmodules": {
+                                            "type": "boolean"
+                                          },
+                                          "fetch": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "insecureIgnoreHostKey": {
+                                            "type": "boolean"
+                                          },
+                                          "insecureSkipTLS": {
+                                            "type": "boolean"
+                                          },
+                                          "passwordSecret": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "default": "",
+                                                "type": "string"
+                                              },
+                                              "optional": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "required": [
+                                              "key"
+                                            ],
+                                            "type": "object",
+                                            "x-kubernetes-map-type": "atomic",
+                                            "additionalProperties": false
+                                          },
+                                          "repo": {
+                                            "type": "string"
+                                          },
+                                          "revision": {
+                                            "type": "string"
+                                          },
+                                          "singleBranch": {
+                                            "type": "boolean"
+                                          },
+                                          "sshPrivateKeySecret": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "default": "",
+                                                "type": "string"
+                                              },
+                                              "optional": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "required": [
+                                              "key"
+                                            ],
+                                            "type": "object",
+                                            "x-kubernetes-map-type": "atomic",
+                                            "additionalProperties": false
+                                          },
+                                          "usernameSecret": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "default": "",
+                                                "type": "string"
+                                              },
+                                              "optional": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "required": [
+                                              "key"
+                                            ],
+                                            "type": "object",
+                                            "x-kubernetes-map-type": "atomic",
+                                            "additionalProperties": false
+                                          }
+                                        },
+                                        "required": [
+                                          "repo"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "globalName": {
+                                        "type": "string"
+                                      },
+                                      "hdfs": {
+                                        "properties": {
+                                          "addresses": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "dataTransferProtection": {
+                                            "type": "string"
+                                          },
+                                          "force": {
+                                            "type": "boolean"
+                                          },
+                                          "hdfsUser": {
+                                            "type": "string"
+                                          },
+                                          "krbCCacheSecret": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "default": "",
+                                                "type": "string"
+                                              },
+                                              "optional": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "required": [
+                                              "key"
+                                            ],
+                                            "type": "object",
+                                            "x-kubernetes-map-type": "atomic",
+                                            "additionalProperties": false
+                                          },
+                                          "krbConfigConfigMap": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "default": "",
+                                                "type": "string"
+                                              },
+                                              "optional": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "required": [
+                                              "key"
+                                            ],
+                                            "type": "object",
+                                            "x-kubernetes-map-type": "atomic",
+                                            "additionalProperties": false
+                                          },
+                                          "krbKeytabSecret": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "default": "",
+                                                "type": "string"
+                                              },
+                                              "optional": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "required": [
+                                              "key"
+                                            ],
+                                            "type": "object",
+                                            "x-kubernetes-map-type": "atomic",
+                                            "additionalProperties": false
+                                          },
+                                          "krbRealm": {
+                                            "type": "string"
+                                          },
+                                          "krbServicePrincipalName": {
+                                            "type": "string"
+                                          },
+                                          "krbUsername": {
+                                            "type": "string"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "path"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "http": {
+                                        "properties": {
+                                          "auth": {
+                                            "properties": {
+                                              "basicAuth": {
+                                                "properties": {
+                                                  "passwordSecret": {
+                                                    "properties": {
+                                                      "key": {
+                                                        "type": "string"
+                                                      },
+                                                      "name": {
+                                                        "default": "",
+                                                        "type": "string"
+                                                      },
+                                                      "optional": {
+                                                        "type": "boolean"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "key"
+                                                    ],
+                                                    "type": "object",
+                                                    "x-kubernetes-map-type": "atomic",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "usernameSecret": {
+                                                    "properties": {
+                                                      "key": {
+                                                        "type": "string"
+                                                      },
+                                                      "name": {
+                                                        "default": "",
+                                                        "type": "string"
+                                                      },
+                                                      "optional": {
+                                                        "type": "boolean"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "key"
+                                                    ],
+                                                    "type": "object",
+                                                    "x-kubernetes-map-type": "atomic",
+                                                    "additionalProperties": false
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "clientCert": {
+                                                "properties": {
+                                                  "clientCertSecret": {
+                                                    "properties": {
+                                                      "key": {
+                                                        "type": "string"
+                                                      },
+                                                      "name": {
+                                                        "default": "",
+                                                        "type": "string"
+                                                      },
+                                                      "optional": {
+                                                        "type": "boolean"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "key"
+                                                    ],
+                                                    "type": "object",
+                                                    "x-kubernetes-map-type": "atomic",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "clientKeySecret": {
+                                                    "properties": {
+                                                      "key": {
+                                                        "type": "string"
+                                                      },
+                                                      "name": {
+                                                        "default": "",
+                                                        "type": "string"
+                                                      },
+                                                      "optional": {
+                                                        "type": "boolean"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "key"
+                                                    ],
+                                                    "type": "object",
+                                                    "x-kubernetes-map-type": "atomic",
+                                                    "additionalProperties": false
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "oauth2": {
+                                                "properties": {
+                                                  "clientIDSecret": {
+                                                    "properties": {
+                                                      "key": {
+                                                        "type": "string"
+                                                      },
+                                                      "name": {
+                                                        "default": "",
+                                                        "type": "string"
+                                                      },
+                                                      "optional": {
+                                                        "type": "boolean"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "key"
+                                                    ],
+                                                    "type": "object",
+                                                    "x-kubernetes-map-type": "atomic",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "clientSecretSecret": {
+                                                    "properties": {
+                                                      "key": {
+                                                        "type": "string"
+                                                      },
+                                                      "name": {
+                                                        "default": "",
+                                                        "type": "string"
+                                                      },
+                                                      "optional": {
+                                                        "type": "boolean"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "key"
+                                                    ],
+                                                    "type": "object",
+                                                    "x-kubernetes-map-type": "atomic",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "endpointParams": {
+                                                    "items": {
+                                                      "properties": {
+                                                        "key": {
+                                                          "type": "string"
+                                                        },
+                                                        "value": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "key"
+                                                      ],
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "scopes": {
+                                                    "items": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "tokenURLSecret": {
+                                                    "properties": {
+                                                      "key": {
+                                                        "type": "string"
+                                                      },
+                                                      "name": {
+                                                        "default": "",
+                                                        "type": "string"
+                                                      },
+                                                      "optional": {
+                                                        "type": "boolean"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "key"
+                                                    ],
+                                                    "type": "object",
+                                                    "x-kubernetes-map-type": "atomic",
+                                                    "additionalProperties": false
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "headers": {
+                                            "items": {
+                                              "properties": {
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "value": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "required": [
+                                                "name",
+                                                "value"
+                                              ],
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          },
+                                          "url": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "url"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "mode": {
+                                        "format": "int32",
+                                        "type": "integer"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      },
+                                      "oss": {
+                                        "properties": {
+                                          "accessKeySecret": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "default": "",
+                                                "type": "string"
+                                              },
+                                              "optional": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "required": [
+                                              "key"
+                                            ],
+                                            "type": "object",
+                                            "x-kubernetes-map-type": "atomic",
+                                            "additionalProperties": false
+                                          },
+                                          "bucket": {
+                                            "type": "string"
+                                          },
+                                          "createBucketIfNotPresent": {
+                                            "type": "boolean"
+                                          },
+                                          "endpoint": {
+                                            "type": "string"
+                                          },
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "lifecycleRule": {
+                                            "properties": {
+                                              "markDeletionAfterDays": {
+                                                "format": "int32",
+                                                "type": "integer"
+                                              },
+                                              "markInfrequentAccessAfterDays": {
+                                                "format": "int32",
+                                                "type": "integer"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "secretKeySecret": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "default": "",
+                                                "type": "string"
+                                              },
+                                              "optional": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "required": [
+                                              "key"
+                                            ],
+                                            "type": "object",
+                                            "x-kubernetes-map-type": "atomic",
+                                            "additionalProperties": false
+                                          },
+                                          "securityToken": {
+                                            "type": "string"
+                                          },
+                                          "useSDKCreds": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "raw": {
+                                        "properties": {
+                                          "data": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "data"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "recurseMode": {
+                                        "type": "boolean"
+                                      },
+                                      "s3": {
+                                        "properties": {
+                                          "accessKeySecret": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "default": "",
+                                                "type": "string"
+                                              },
+                                              "optional": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "required": [
+                                              "key"
+                                            ],
+                                            "type": "object",
+                                            "x-kubernetes-map-type": "atomic",
+                                            "additionalProperties": false
+                                          },
+                                          "bucket": {
+                                            "type": "string"
+                                          },
+                                          "caSecret": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "default": "",
+                                                "type": "string"
+                                              },
+                                              "optional": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "required": [
+                                              "key"
+                                            ],
+                                            "type": "object",
+                                            "x-kubernetes-map-type": "atomic",
+                                            "additionalProperties": false
+                                          },
+                                          "createBucketIfNotPresent": {
+                                            "properties": {
+                                              "objectLocking": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "encryptionOptions": {
+                                            "properties": {
+                                              "enableEncryption": {
+                                                "type": "boolean"
+                                              },
+                                              "kmsEncryptionContext": {
+                                                "type": "string"
+                                              },
+                                              "kmsKeyId": {
+                                                "type": "string"
+                                              },
+                                              "serverSideCustomerKeySecret": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "default": "",
+                                                    "type": "string"
+                                                  },
+                                                  "optional": {
+                                                    "type": "boolean"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "key"
+                                                ],
+                                                "type": "object",
+                                                "x-kubernetes-map-type": "atomic",
+                                                "additionalProperties": false
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "endpoint": {
+                                            "type": "string"
+                                          },
+                                          "insecure": {
+                                            "type": "boolean"
+                                          },
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "region": {
+                                            "type": "string"
+                                          },
+                                          "roleARN": {
+                                            "type": "string"
+                                          },
+                                          "secretKeySecret": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "default": "",
+                                                "type": "string"
+                                              },
+                                              "optional": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "required": [
+                                              "key"
+                                            ],
+                                            "type": "object",
+                                            "x-kubernetes-map-type": "atomic",
+                                            "additionalProperties": false
+                                          },
+                                          "sessionTokenSecret": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "default": "",
+                                                "type": "string"
+                                              },
+                                              "optional": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "required": [
+                                              "key"
+                                            ],
+                                            "type": "object",
+                                            "x-kubernetes-map-type": "atomic",
+                                            "additionalProperties": false
+                                          },
+                                          "useSDKCreds": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "subPath": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "name"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                },
+                                "parameters": {
+                                  "items": {
+                                    "properties": {
+                                      "default": {
+                                        "type": "string"
+                                      },
+                                      "description": {
+                                        "type": "string"
+                                      },
+                                      "enum": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "globalName": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "value": {
+                                        "type": "string"
+                                      },
+                                      "valueFrom": {
+                                        "properties": {
+                                          "configMapKeyRef": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "default": "",
+                                                "type": "string"
+                                              },
+                                              "optional": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "required": [
+                                              "key"
+                                            ],
+                                            "type": "object",
+                                            "x-kubernetes-map-type": "atomic",
+                                            "additionalProperties": false
+                                          },
+                                          "default": {
+                                            "type": "string"
+                                          },
+                                          "event": {
+                                            "type": "string"
+                                          },
+                                          "expression": {
+                                            "type": "string"
+                                          },
+                                          "jqFilter": {
+                                            "type": "string"
+                                          },
+                                          "jsonPath": {
+                                            "type": "string"
+                                          },
+                                          "parameter": {
+                                            "type": "string"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "supplied": {
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "required": [
+                                      "name"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "expression": {
+                              "type": "string"
+                            },
+                            "template": {
+                              "type": "string"
+                            },
+                            "templateRef": {
+                              "properties": {
+                                "clusterScope": {
+                                  "type": "boolean"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "template": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "object"
+                      },
+                      "inline": {
+                        "x-kubernetes-preserve-unknown-fields": true
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "onExit": {
+                        "type": "string"
+                      },
+                      "template": {
+                        "type": "string"
+                      },
+                      "templateRef": {
+                        "properties": {
+                          "clusterScope": {
+                            "type": "boolean"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "template": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "when": {
+                        "type": "string"
+                      },
+                      "withItems": {
+                        "x-kubernetes-preserve-unknown-fields": true
+                      },
+                      "withParam": {
+                        "type": "string"
+                      },
+                      "withSequence": {
+                        "properties": {
+                          "count": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "x-kubernetes-int-or-string": true
+                          },
+                          "end": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "x-kubernetes-int-or-string": true
+                          },
+                          "format": {
+                            "type": "string"
+                          },
+                          "start": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "x-kubernetes-int-or-string": true
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
                   "type": "array"
                 },
                 "type": "array"
@@ -31772,6 +36165,9 @@
                 "properties": {
                   "mutex": {
                     "properties": {
+                      "database": {
+                        "type": "boolean"
+                      },
                       "name": {
                         "type": "string"
                       },
@@ -31785,6 +36181,9 @@
                   "mutexes": {
                     "items": {
                       "properties": {
+                        "database": {
+                          "type": "boolean"
+                        },
                         "name": {
                           "type": "string"
                         },
@@ -31819,6 +36218,18 @@
                         "x-kubernetes-map-type": "atomic",
                         "additionalProperties": false
                       },
+                      "database": {
+                        "properties": {
+                          "key": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "key"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
                       "namespace": {
                         "type": "string"
                       }
@@ -31847,6 +36258,18 @@
                           ],
                           "type": "object",
                           "x-kubernetes-map-type": "atomic",
+                          "additionalProperties": false
+                        },
+                        "database": {
+                          "properties": {
+                            "key": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "key"
+                          ],
+                          "type": "object",
                           "additionalProperties": false
                         },
                         "namespace": {
@@ -31927,12 +36350,14 @@
                           "type": "string"
                         },
                         "fsType": {
+                          "default": "ext4",
                           "type": "string"
                         },
                         "kind": {
                           "type": "string"
                         },
                         "readOnly": {
+                          "default": false,
                           "type": "boolean"
                         }
                       },
@@ -32207,7 +36632,37 @@
                         "volumeClaimTemplate": {
                           "properties": {
                             "metadata": {
-                              "type": "object"
+                              "properties": {
+                                "annotations": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "type": "object"
+                                },
+                                "finalizers": {
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "generateName": {
+                                  "type": "string"
+                                },
+                                "labels": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "type": "object"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "namespace": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
                             },
                             "spec": {
                               "properties": {
@@ -32514,6 +36969,18 @@
                       "type": "object",
                       "additionalProperties": false
                     },
+                    "image": {
+                      "properties": {
+                        "pullPolicy": {
+                          "type": "string"
+                        },
+                        "reference": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
                     "iscsi": {
                       "properties": {
                         "chapAuthDiscovery": {
@@ -32532,6 +36999,7 @@
                           "type": "string"
                         },
                         "iscsiInterface": {
+                          "default": "default",
                           "type": "string"
                         },
                         "lun": {
@@ -32924,6 +37392,7 @@
                           "type": "string"
                         },
                         "keyring": {
+                          "default": "/etc/ceph/keyring",
                           "type": "string"
                         },
                         "monitors": {
@@ -32934,6 +37403,7 @@
                           "x-kubernetes-list-type": "atomic"
                         },
                         "pool": {
+                          "default": "rbd",
                           "type": "string"
                         },
                         "readOnly": {
@@ -32951,6 +37421,7 @@
                           "additionalProperties": false
                         },
                         "user": {
+                          "default": "admin",
                           "type": "string"
                         }
                       },
@@ -32964,6 +37435,7 @@
                     "scaleIO": {
                       "properties": {
                         "fsType": {
+                          "default": "xfs",
                           "type": "string"
                         },
                         "gateway": {
@@ -32990,6 +37462,7 @@
                           "type": "boolean"
                         },
                         "storageMode": {
+                          "default": "ThinProvisioned",
                           "type": "string"
                         },
                         "storagePool": {
@@ -33177,7 +37650,37 @@
                 "type": "string"
               },
               "metadata": {
-                "type": "object"
+                "properties": {
+                  "annotations": {
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "type": "object"
+                  },
+                  "finalizers": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "generateName": {
+                    "type": "string"
+                  },
+                  "labels": {
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "type": "object"
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "namespace": {
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
               },
               "spec": {
                 "properties": {
@@ -33473,12 +37976,14 @@
                     "type": "string"
                   },
                   "fsType": {
+                    "default": "ext4",
                     "type": "string"
                   },
                   "kind": {
                     "type": "string"
                   },
                   "readOnly": {
+                    "default": false,
                     "type": "boolean"
                   }
                 },
@@ -33753,7 +38258,37 @@
                   "volumeClaimTemplate": {
                     "properties": {
                       "metadata": {
-                        "type": "object"
+                        "properties": {
+                          "annotations": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "type": "object"
+                          },
+                          "finalizers": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "generateName": {
+                            "type": "string"
+                          },
+                          "labels": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "type": "object"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "namespace": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
                       },
                       "spec": {
                         "properties": {
@@ -34060,6 +38595,18 @@
                 "type": "object",
                 "additionalProperties": false
               },
+              "image": {
+                "properties": {
+                  "pullPolicy": {
+                    "type": "string"
+                  },
+                  "reference": {
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
               "iscsi": {
                 "properties": {
                   "chapAuthDiscovery": {
@@ -34078,6 +38625,7 @@
                     "type": "string"
                   },
                   "iscsiInterface": {
+                    "default": "default",
                     "type": "string"
                   },
                   "lun": {
@@ -34470,6 +39018,7 @@
                     "type": "string"
                   },
                   "keyring": {
+                    "default": "/etc/ceph/keyring",
                     "type": "string"
                   },
                   "monitors": {
@@ -34480,6 +39029,7 @@
                     "x-kubernetes-list-type": "atomic"
                   },
                   "pool": {
+                    "default": "rbd",
                     "type": "string"
                   },
                   "readOnly": {
@@ -34497,6 +39047,7 @@
                     "additionalProperties": false
                   },
                   "user": {
+                    "default": "admin",
                     "type": "string"
                   }
                 },
@@ -34510,6 +39061,7 @@
               "scaleIO": {
                 "properties": {
                   "fsType": {
+                    "default": "xfs",
                     "type": "string"
                   },
                   "gateway": {
@@ -34536,6 +39088,7 @@
                     "type": "boolean"
                   },
                   "storageMode": {
+                    "default": "ThinProvisioned",
                     "type": "string"
                   },
                   "storagePool": {

--- a/argoproj.io/cronworkflow_v1alpha1.json
+++ b/argoproj.io/cronworkflow_v1alpha1.json
@@ -57,7 +57,37 @@
           "type": "string"
         },
         "workflowMetadata": {
-          "type": "object"
+          "properties": {
+            "annotations": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            },
+            "finalizers": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "generateName": {
+              "type": "string"
+            },
+            "labels": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            },
+            "name": {
+              "type": "string"
+            },
+            "namespace": {
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
         },
         "workflowSpec": {
           "properties": {
@@ -3137,10 +3167,6 @@
               "type": "object",
               "additionalProperties": false
             },
-            "podPriority": {
-              "format": "int32",
-              "type": "integer"
-            },
             "podPriorityClassName": {
               "type": "string"
             },
@@ -3164,6 +3190,9 @@
                 },
                 "backoff": {
                   "properties": {
+                    "cap": {
+                      "type": "string"
+                    },
                     "duration": {
                       "type": "string"
                     },
@@ -3244,6 +3273,9 @@
                   "format": "int64",
                   "type": "integer"
                 },
+                "seLinuxChangePolicy": {
+                  "type": "string"
+                },
                 "seLinuxOptions": {
                   "properties": {
                     "level": {
@@ -3284,6 +3316,9 @@
                   },
                   "type": "array",
                   "x-kubernetes-list-type": "atomic"
+                },
+                "supplementalGroupsPolicy": {
+                  "type": "string"
                 },
                 "sysctls": {
                   "items": {
@@ -3340,6 +3375,9 @@
               "properties": {
                 "mutex": {
                   "properties": {
+                    "database": {
+                      "type": "boolean"
+                    },
                     "name": {
                       "type": "string"
                     },
@@ -3353,6 +3391,9 @@
                 "mutexes": {
                   "items": {
                     "properties": {
+                      "database": {
+                        "type": "boolean"
+                      },
                       "name": {
                         "type": "string"
                       },
@@ -3387,6 +3428,18 @@
                       "x-kubernetes-map-type": "atomic",
                       "additionalProperties": false
                     },
+                    "database": {
+                      "properties": {
+                        "key": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "key"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
                     "namespace": {
                       "type": "string"
                     }
@@ -3415,6 +3468,18 @@
                         ],
                         "type": "object",
                         "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "database": {
+                        "properties": {
+                          "key": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "key"
+                        ],
+                        "type": "object",
                         "additionalProperties": false
                       },
                       "namespace": {
@@ -4116,6 +4181,12 @@
                   },
                   "type": "object",
                   "additionalProperties": false
+                },
+                "annotations": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object"
                 },
                 "archiveLocation": {
                   "properties": {
@@ -5302,6 +5373,9 @@
                           },
                           "type": "object",
                           "additionalProperties": false
+                        },
+                        "stopSignal": {
+                          "type": "string"
                         }
                       },
                       "type": "object",
@@ -5333,6 +5407,7 @@
                               "type": "integer"
                             },
                             "service": {
+                              "default": "",
                               "type": "string"
                             }
                           },
@@ -5502,6 +5577,7 @@
                               "type": "integer"
                             },
                             "service": {
+                              "default": "",
                               "type": "string"
                             }
                           },
@@ -5633,6 +5709,9 @@
                           "items": {
                             "properties": {
                               "name": {
+                                "type": "string"
+                              },
+                              "request": {
                                 "type": "string"
                               }
                             },
@@ -5826,6 +5905,7 @@
                               "type": "integer"
                             },
                             "service": {
+                              "default": "",
                               "type": "string"
                             }
                           },
@@ -6011,9 +6091,6 @@
                       "type": "string"
                     }
                   },
-                  "required": [
-                    "name"
-                  ],
                   "type": "object",
                   "additionalProperties": false
                 },
@@ -6410,6 +6487,9 @@
                                 },
                                 "type": "object",
                                 "additionalProperties": false
+                              },
+                              "stopSignal": {
+                                "type": "string"
                               }
                             },
                             "type": "object",
@@ -6441,6 +6521,7 @@
                                     "type": "integer"
                                   },
                                   "service": {
+                                    "default": "",
                                     "type": "string"
                                   }
                                 },
@@ -6610,6 +6691,7 @@
                                     "type": "integer"
                                   },
                                   "service": {
+                                    "default": "",
                                     "type": "string"
                                   }
                                 },
@@ -6741,6 +6823,9 @@
                                 "items": {
                                   "properties": {
                                     "name": {
+                                      "type": "string"
+                                    },
+                                    "request": {
                                       "type": "string"
                                     }
                                   },
@@ -6934,6 +7019,7 @@
                                     "type": "integer"
                                   },
                                   "service": {
+                                    "default": "",
                                     "type": "string"
                                   }
                                 },
@@ -9220,7 +9306,9 @@
                             },
                             "type": "object"
                           },
-                          "inline": {},
+                          "inline": {
+                            "x-kubernetes-preserve-unknown-fields": true
+                          },
                           "name": {
                             "type": "string"
                           },
@@ -9249,10 +9337,7 @@
                             "type": "string"
                           },
                           "withItems": {
-                            "items": {
-                              "type": "object"
-                            },
-                            "type": "array"
+                            "x-kubernetes-preserve-unknown-fields": true
                           },
                           "withParam": {
                             "type": "string"
@@ -10737,6 +10822,9 @@
                             },
                             "type": "object",
                             "additionalProperties": false
+                          },
+                          "stopSignal": {
+                            "type": "string"
                           }
                         },
                         "type": "object",
@@ -10768,6 +10856,7 @@
                                 "type": "integer"
                               },
                               "service": {
+                                "default": "",
                                 "type": "string"
                               }
                             },
@@ -10940,6 +11029,7 @@
                                 "type": "integer"
                               },
                               "service": {
+                                "default": "",
                                 "type": "string"
                               }
                             },
@@ -11071,6 +11161,9 @@
                             "items": {
                               "properties": {
                                 "name": {
+                                  "type": "string"
+                                },
+                                "request": {
                                   "type": "string"
                                 }
                               },
@@ -11264,6 +11357,7 @@
                                 "type": "integer"
                               },
                               "service": {
+                                "default": "",
                                 "type": "string"
                               }
                             },
@@ -13605,14 +13699,11 @@
                   "type": "integer"
                 },
                 "plugin": {
-                  "type": "object"
+                  "type": "object",
+                  "x-kubernetes-preserve-unknown-fields": true
                 },
                 "podSpecPatch": {
                   "type": "string"
-                },
-                "priority": {
-                  "format": "int32",
-                  "type": "integer"
                 },
                 "priorityClassName": {
                   "type": "string"
@@ -14562,6 +14653,9 @@
                     },
                     "backoff": {
                       "properties": {
+                        "cap": {
+                          "type": "string"
+                        },
                         "duration": {
                           "type": "string"
                         },
@@ -14991,6 +15085,9 @@
                           },
                           "type": "object",
                           "additionalProperties": false
+                        },
+                        "stopSignal": {
+                          "type": "string"
                         }
                       },
                       "type": "object",
@@ -15022,6 +15119,7 @@
                               "type": "integer"
                             },
                             "service": {
+                              "default": "",
                               "type": "string"
                             }
                           },
@@ -15191,6 +15289,7 @@
                               "type": "integer"
                             },
                             "service": {
+                              "default": "",
                               "type": "string"
                             }
                           },
@@ -15322,6 +15421,9 @@
                           "items": {
                             "properties": {
                               "name": {
+                                "type": "string"
+                              },
+                              "request": {
                                 "type": "string"
                               }
                             },
@@ -15518,6 +15620,7 @@
                               "type": "integer"
                             },
                             "service": {
+                              "default": "",
                               "type": "string"
                             }
                           },
@@ -15703,10 +15806,6 @@
                       "type": "string"
                     }
                   },
-                  "required": [
-                    "name",
-                    "source"
-                  ],
                   "type": "object",
                   "additionalProperties": false
                 },
@@ -15744,6 +15843,9 @@
                     "runAsUser": {
                       "format": "int64",
                       "type": "integer"
+                    },
+                    "seLinuxChangePolicy": {
+                      "type": "string"
                     },
                     "seLinuxOptions": {
                       "properties": {
@@ -15785,6 +15887,9 @@
                       },
                       "type": "array",
                       "x-kubernetes-list-type": "atomic"
+                    },
+                    "supplementalGroupsPolicy": {
+                      "type": "string"
                     },
                     "sysctls": {
                       "items": {
@@ -16216,6 +16321,9 @@
                             },
                             "type": "object",
                             "additionalProperties": false
+                          },
+                          "stopSignal": {
+                            "type": "string"
                           }
                         },
                         "type": "object",
@@ -16247,6 +16355,7 @@
                                 "type": "integer"
                               },
                               "service": {
+                                "default": "",
                                 "type": "string"
                               }
                             },
@@ -16419,6 +16528,7 @@
                                 "type": "integer"
                               },
                               "service": {
+                                "default": "",
                                 "type": "string"
                               }
                             },
@@ -16550,6 +16660,9 @@
                             "items": {
                               "properties": {
                                 "name": {
+                                  "type": "string"
+                                },
+                                "request": {
                                   "type": "string"
                                 }
                               },
@@ -16743,6 +16856,7 @@
                                 "type": "integer"
                               },
                               "service": {
+                                "default": "",
                                 "type": "string"
                               }
                             },
@@ -16938,6 +17052,2096 @@
                 },
                 "steps": {
                   "items": {
+                    "items": {
+                      "properties": {
+                        "arguments": {
+                          "properties": {
+                            "artifacts": {
+                              "items": {
+                                "properties": {
+                                  "archive": {
+                                    "properties": {
+                                      "none": {
+                                        "type": "object"
+                                      },
+                                      "tar": {
+                                        "properties": {
+                                          "compressionLevel": {
+                                            "format": "int32",
+                                            "type": "integer"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "zip": {
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "archiveLogs": {
+                                    "type": "boolean"
+                                  },
+                                  "artifactGC": {
+                                    "properties": {
+                                      "podMetadata": {
+                                        "properties": {
+                                          "annotations": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
+                                          },
+                                          "labels": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "serviceAccountName": {
+                                        "type": "string"
+                                      },
+                                      "strategy": {
+                                        "enum": [
+                                          "",
+                                          "OnWorkflowCompletion",
+                                          "OnWorkflowDeletion",
+                                          "Never"
+                                        ],
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "artifactory": {
+                                    "properties": {
+                                      "passwordSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "default": "",
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "x-kubernetes-map-type": "atomic",
+                                        "additionalProperties": false
+                                      },
+                                      "url": {
+                                        "type": "string"
+                                      },
+                                      "usernameSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "default": "",
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "x-kubernetes-map-type": "atomic",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "required": [
+                                      "url"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "azure": {
+                                    "properties": {
+                                      "accountKeySecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "default": "",
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "x-kubernetes-map-type": "atomic",
+                                        "additionalProperties": false
+                                      },
+                                      "blob": {
+                                        "type": "string"
+                                      },
+                                      "container": {
+                                        "type": "string"
+                                      },
+                                      "endpoint": {
+                                        "type": "string"
+                                      },
+                                      "useSDKCreds": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "blob",
+                                      "container",
+                                      "endpoint"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "deleted": {
+                                    "type": "boolean"
+                                  },
+                                  "from": {
+                                    "type": "string"
+                                  },
+                                  "fromExpression": {
+                                    "type": "string"
+                                  },
+                                  "gcs": {
+                                    "properties": {
+                                      "bucket": {
+                                        "type": "string"
+                                      },
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "serviceAccountKeySecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "default": "",
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "x-kubernetes-map-type": "atomic",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "git": {
+                                    "properties": {
+                                      "branch": {
+                                        "type": "string"
+                                      },
+                                      "depth": {
+                                        "format": "int64",
+                                        "type": "integer"
+                                      },
+                                      "disableSubmodules": {
+                                        "type": "boolean"
+                                      },
+                                      "fetch": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "insecureIgnoreHostKey": {
+                                        "type": "boolean"
+                                      },
+                                      "insecureSkipTLS": {
+                                        "type": "boolean"
+                                      },
+                                      "passwordSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "default": "",
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "x-kubernetes-map-type": "atomic",
+                                        "additionalProperties": false
+                                      },
+                                      "repo": {
+                                        "type": "string"
+                                      },
+                                      "revision": {
+                                        "type": "string"
+                                      },
+                                      "singleBranch": {
+                                        "type": "boolean"
+                                      },
+                                      "sshPrivateKeySecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "default": "",
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "x-kubernetes-map-type": "atomic",
+                                        "additionalProperties": false
+                                      },
+                                      "usernameSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "default": "",
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "x-kubernetes-map-type": "atomic",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "required": [
+                                      "repo"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "globalName": {
+                                    "type": "string"
+                                  },
+                                  "hdfs": {
+                                    "properties": {
+                                      "addresses": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "dataTransferProtection": {
+                                        "type": "string"
+                                      },
+                                      "force": {
+                                        "type": "boolean"
+                                      },
+                                      "hdfsUser": {
+                                        "type": "string"
+                                      },
+                                      "krbCCacheSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "default": "",
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "x-kubernetes-map-type": "atomic",
+                                        "additionalProperties": false
+                                      },
+                                      "krbConfigConfigMap": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "default": "",
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "x-kubernetes-map-type": "atomic",
+                                        "additionalProperties": false
+                                      },
+                                      "krbKeytabSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "default": "",
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "x-kubernetes-map-type": "atomic",
+                                        "additionalProperties": false
+                                      },
+                                      "krbRealm": {
+                                        "type": "string"
+                                      },
+                                      "krbServicePrincipalName": {
+                                        "type": "string"
+                                      },
+                                      "krbUsername": {
+                                        "type": "string"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "path"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "http": {
+                                    "properties": {
+                                      "auth": {
+                                        "properties": {
+                                          "basicAuth": {
+                                            "properties": {
+                                              "passwordSecret": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "default": "",
+                                                    "type": "string"
+                                                  },
+                                                  "optional": {
+                                                    "type": "boolean"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "key"
+                                                ],
+                                                "type": "object",
+                                                "x-kubernetes-map-type": "atomic",
+                                                "additionalProperties": false
+                                              },
+                                              "usernameSecret": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "default": "",
+                                                    "type": "string"
+                                                  },
+                                                  "optional": {
+                                                    "type": "boolean"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "key"
+                                                ],
+                                                "type": "object",
+                                                "x-kubernetes-map-type": "atomic",
+                                                "additionalProperties": false
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "clientCert": {
+                                            "properties": {
+                                              "clientCertSecret": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "default": "",
+                                                    "type": "string"
+                                                  },
+                                                  "optional": {
+                                                    "type": "boolean"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "key"
+                                                ],
+                                                "type": "object",
+                                                "x-kubernetes-map-type": "atomic",
+                                                "additionalProperties": false
+                                              },
+                                              "clientKeySecret": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "default": "",
+                                                    "type": "string"
+                                                  },
+                                                  "optional": {
+                                                    "type": "boolean"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "key"
+                                                ],
+                                                "type": "object",
+                                                "x-kubernetes-map-type": "atomic",
+                                                "additionalProperties": false
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "oauth2": {
+                                            "properties": {
+                                              "clientIDSecret": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "default": "",
+                                                    "type": "string"
+                                                  },
+                                                  "optional": {
+                                                    "type": "boolean"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "key"
+                                                ],
+                                                "type": "object",
+                                                "x-kubernetes-map-type": "atomic",
+                                                "additionalProperties": false
+                                              },
+                                              "clientSecretSecret": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "default": "",
+                                                    "type": "string"
+                                                  },
+                                                  "optional": {
+                                                    "type": "boolean"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "key"
+                                                ],
+                                                "type": "object",
+                                                "x-kubernetes-map-type": "atomic",
+                                                "additionalProperties": false
+                                              },
+                                              "endpointParams": {
+                                                "items": {
+                                                  "properties": {
+                                                    "key": {
+                                                      "type": "string"
+                                                    },
+                                                    "value": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "key"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "scopes": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              },
+                                              "tokenURLSecret": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "default": "",
+                                                    "type": "string"
+                                                  },
+                                                  "optional": {
+                                                    "type": "boolean"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "key"
+                                                ],
+                                                "type": "object",
+                                                "x-kubernetes-map-type": "atomic",
+                                                "additionalProperties": false
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "headers": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "name",
+                                            "value"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "url": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "url"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "mode": {
+                                    "format": "int32",
+                                    "type": "integer"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  },
+                                  "oss": {
+                                    "properties": {
+                                      "accessKeySecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "default": "",
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "x-kubernetes-map-type": "atomic",
+                                        "additionalProperties": false
+                                      },
+                                      "bucket": {
+                                        "type": "string"
+                                      },
+                                      "createBucketIfNotPresent": {
+                                        "type": "boolean"
+                                      },
+                                      "endpoint": {
+                                        "type": "string"
+                                      },
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "lifecycleRule": {
+                                        "properties": {
+                                          "markDeletionAfterDays": {
+                                            "format": "int32",
+                                            "type": "integer"
+                                          },
+                                          "markInfrequentAccessAfterDays": {
+                                            "format": "int32",
+                                            "type": "integer"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "secretKeySecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "default": "",
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "x-kubernetes-map-type": "atomic",
+                                        "additionalProperties": false
+                                      },
+                                      "securityToken": {
+                                        "type": "string"
+                                      },
+                                      "useSDKCreds": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "raw": {
+                                    "properties": {
+                                      "data": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "data"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "recurseMode": {
+                                    "type": "boolean"
+                                  },
+                                  "s3": {
+                                    "properties": {
+                                      "accessKeySecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "default": "",
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "x-kubernetes-map-type": "atomic",
+                                        "additionalProperties": false
+                                      },
+                                      "bucket": {
+                                        "type": "string"
+                                      },
+                                      "caSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "default": "",
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "x-kubernetes-map-type": "atomic",
+                                        "additionalProperties": false
+                                      },
+                                      "createBucketIfNotPresent": {
+                                        "properties": {
+                                          "objectLocking": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "encryptionOptions": {
+                                        "properties": {
+                                          "enableEncryption": {
+                                            "type": "boolean"
+                                          },
+                                          "kmsEncryptionContext": {
+                                            "type": "string"
+                                          },
+                                          "kmsKeyId": {
+                                            "type": "string"
+                                          },
+                                          "serverSideCustomerKeySecret": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "default": "",
+                                                "type": "string"
+                                              },
+                                              "optional": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "required": [
+                                              "key"
+                                            ],
+                                            "type": "object",
+                                            "x-kubernetes-map-type": "atomic",
+                                            "additionalProperties": false
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "endpoint": {
+                                        "type": "string"
+                                      },
+                                      "insecure": {
+                                        "type": "boolean"
+                                      },
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "region": {
+                                        "type": "string"
+                                      },
+                                      "roleARN": {
+                                        "type": "string"
+                                      },
+                                      "secretKeySecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "default": "",
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "x-kubernetes-map-type": "atomic",
+                                        "additionalProperties": false
+                                      },
+                                      "sessionTokenSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "default": "",
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "x-kubernetes-map-type": "atomic",
+                                        "additionalProperties": false
+                                      },
+                                      "useSDKCreds": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "subPath": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "name"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "parameters": {
+                              "items": {
+                                "properties": {
+                                  "default": {
+                                    "type": "string"
+                                  },
+                                  "description": {
+                                    "type": "string"
+                                  },
+                                  "enum": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "globalName": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "value": {
+                                    "type": "string"
+                                  },
+                                  "valueFrom": {
+                                    "properties": {
+                                      "configMapKeyRef": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "default": "",
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "x-kubernetes-map-type": "atomic",
+                                        "additionalProperties": false
+                                      },
+                                      "default": {
+                                        "type": "string"
+                                      },
+                                      "event": {
+                                        "type": "string"
+                                      },
+                                      "expression": {
+                                        "type": "string"
+                                      },
+                                      "jqFilter": {
+                                        "type": "string"
+                                      },
+                                      "jsonPath": {
+                                        "type": "string"
+                                      },
+                                      "parameter": {
+                                        "type": "string"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "supplied": {
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "required": [
+                                  "name"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "continueOn": {
+                          "properties": {
+                            "error": {
+                              "type": "boolean"
+                            },
+                            "failed": {
+                              "type": "boolean"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "hooks": {
+                          "additionalProperties": {
+                            "properties": {
+                              "arguments": {
+                                "properties": {
+                                  "artifacts": {
+                                    "items": {
+                                      "properties": {
+                                        "archive": {
+                                          "properties": {
+                                            "none": {
+                                              "type": "object"
+                                            },
+                                            "tar": {
+                                              "properties": {
+                                                "compressionLevel": {
+                                                  "format": "int32",
+                                                  "type": "integer"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "zip": {
+                                              "type": "object"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "archiveLogs": {
+                                          "type": "boolean"
+                                        },
+                                        "artifactGC": {
+                                          "properties": {
+                                            "podMetadata": {
+                                              "properties": {
+                                                "annotations": {
+                                                  "additionalProperties": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "object"
+                                                },
+                                                "labels": {
+                                                  "additionalProperties": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "object"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "serviceAccountName": {
+                                              "type": "string"
+                                            },
+                                            "strategy": {
+                                              "enum": [
+                                                "",
+                                                "OnWorkflowCompletion",
+                                                "OnWorkflowDeletion",
+                                                "Never"
+                                              ],
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "artifactory": {
+                                          "properties": {
+                                            "passwordSecret": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "name": {
+                                                  "default": "",
+                                                  "type": "string"
+                                                },
+                                                "optional": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              "required": [
+                                                "key"
+                                              ],
+                                              "type": "object",
+                                              "x-kubernetes-map-type": "atomic",
+                                              "additionalProperties": false
+                                            },
+                                            "url": {
+                                              "type": "string"
+                                            },
+                                            "usernameSecret": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "name": {
+                                                  "default": "",
+                                                  "type": "string"
+                                                },
+                                                "optional": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              "required": [
+                                                "key"
+                                              ],
+                                              "type": "object",
+                                              "x-kubernetes-map-type": "atomic",
+                                              "additionalProperties": false
+                                            }
+                                          },
+                                          "required": [
+                                            "url"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "azure": {
+                                          "properties": {
+                                            "accountKeySecret": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "name": {
+                                                  "default": "",
+                                                  "type": "string"
+                                                },
+                                                "optional": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              "required": [
+                                                "key"
+                                              ],
+                                              "type": "object",
+                                              "x-kubernetes-map-type": "atomic",
+                                              "additionalProperties": false
+                                            },
+                                            "blob": {
+                                              "type": "string"
+                                            },
+                                            "container": {
+                                              "type": "string"
+                                            },
+                                            "endpoint": {
+                                              "type": "string"
+                                            },
+                                            "useSDKCreds": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "blob",
+                                            "container",
+                                            "endpoint"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "deleted": {
+                                          "type": "boolean"
+                                        },
+                                        "from": {
+                                          "type": "string"
+                                        },
+                                        "fromExpression": {
+                                          "type": "string"
+                                        },
+                                        "gcs": {
+                                          "properties": {
+                                            "bucket": {
+                                              "type": "string"
+                                            },
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "serviceAccountKeySecret": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "name": {
+                                                  "default": "",
+                                                  "type": "string"
+                                                },
+                                                "optional": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              "required": [
+                                                "key"
+                                              ],
+                                              "type": "object",
+                                              "x-kubernetes-map-type": "atomic",
+                                              "additionalProperties": false
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "git": {
+                                          "properties": {
+                                            "branch": {
+                                              "type": "string"
+                                            },
+                                            "depth": {
+                                              "format": "int64",
+                                              "type": "integer"
+                                            },
+                                            "disableSubmodules": {
+                                              "type": "boolean"
+                                            },
+                                            "fetch": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            },
+                                            "insecureIgnoreHostKey": {
+                                              "type": "boolean"
+                                            },
+                                            "insecureSkipTLS": {
+                                              "type": "boolean"
+                                            },
+                                            "passwordSecret": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "name": {
+                                                  "default": "",
+                                                  "type": "string"
+                                                },
+                                                "optional": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              "required": [
+                                                "key"
+                                              ],
+                                              "type": "object",
+                                              "x-kubernetes-map-type": "atomic",
+                                              "additionalProperties": false
+                                            },
+                                            "repo": {
+                                              "type": "string"
+                                            },
+                                            "revision": {
+                                              "type": "string"
+                                            },
+                                            "singleBranch": {
+                                              "type": "boolean"
+                                            },
+                                            "sshPrivateKeySecret": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "name": {
+                                                  "default": "",
+                                                  "type": "string"
+                                                },
+                                                "optional": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              "required": [
+                                                "key"
+                                              ],
+                                              "type": "object",
+                                              "x-kubernetes-map-type": "atomic",
+                                              "additionalProperties": false
+                                            },
+                                            "usernameSecret": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "name": {
+                                                  "default": "",
+                                                  "type": "string"
+                                                },
+                                                "optional": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              "required": [
+                                                "key"
+                                              ],
+                                              "type": "object",
+                                              "x-kubernetes-map-type": "atomic",
+                                              "additionalProperties": false
+                                            }
+                                          },
+                                          "required": [
+                                            "repo"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "globalName": {
+                                          "type": "string"
+                                        },
+                                        "hdfs": {
+                                          "properties": {
+                                            "addresses": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            },
+                                            "dataTransferProtection": {
+                                              "type": "string"
+                                            },
+                                            "force": {
+                                              "type": "boolean"
+                                            },
+                                            "hdfsUser": {
+                                              "type": "string"
+                                            },
+                                            "krbCCacheSecret": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "name": {
+                                                  "default": "",
+                                                  "type": "string"
+                                                },
+                                                "optional": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              "required": [
+                                                "key"
+                                              ],
+                                              "type": "object",
+                                              "x-kubernetes-map-type": "atomic",
+                                              "additionalProperties": false
+                                            },
+                                            "krbConfigConfigMap": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "name": {
+                                                  "default": "",
+                                                  "type": "string"
+                                                },
+                                                "optional": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              "required": [
+                                                "key"
+                                              ],
+                                              "type": "object",
+                                              "x-kubernetes-map-type": "atomic",
+                                              "additionalProperties": false
+                                            },
+                                            "krbKeytabSecret": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "name": {
+                                                  "default": "",
+                                                  "type": "string"
+                                                },
+                                                "optional": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              "required": [
+                                                "key"
+                                              ],
+                                              "type": "object",
+                                              "x-kubernetes-map-type": "atomic",
+                                              "additionalProperties": false
+                                            },
+                                            "krbRealm": {
+                                              "type": "string"
+                                            },
+                                            "krbServicePrincipalName": {
+                                              "type": "string"
+                                            },
+                                            "krbUsername": {
+                                              "type": "string"
+                                            },
+                                            "path": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "path"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "http": {
+                                          "properties": {
+                                            "auth": {
+                                              "properties": {
+                                                "basicAuth": {
+                                                  "properties": {
+                                                    "passwordSecret": {
+                                                      "properties": {
+                                                        "key": {
+                                                          "type": "string"
+                                                        },
+                                                        "name": {
+                                                          "default": "",
+                                                          "type": "string"
+                                                        },
+                                                        "optional": {
+                                                          "type": "boolean"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "key"
+                                                      ],
+                                                      "type": "object",
+                                                      "x-kubernetes-map-type": "atomic",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "usernameSecret": {
+                                                      "properties": {
+                                                        "key": {
+                                                          "type": "string"
+                                                        },
+                                                        "name": {
+                                                          "default": "",
+                                                          "type": "string"
+                                                        },
+                                                        "optional": {
+                                                          "type": "boolean"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "key"
+                                                      ],
+                                                      "type": "object",
+                                                      "x-kubernetes-map-type": "atomic",
+                                                      "additionalProperties": false
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "clientCert": {
+                                                  "properties": {
+                                                    "clientCertSecret": {
+                                                      "properties": {
+                                                        "key": {
+                                                          "type": "string"
+                                                        },
+                                                        "name": {
+                                                          "default": "",
+                                                          "type": "string"
+                                                        },
+                                                        "optional": {
+                                                          "type": "boolean"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "key"
+                                                      ],
+                                                      "type": "object",
+                                                      "x-kubernetes-map-type": "atomic",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "clientKeySecret": {
+                                                      "properties": {
+                                                        "key": {
+                                                          "type": "string"
+                                                        },
+                                                        "name": {
+                                                          "default": "",
+                                                          "type": "string"
+                                                        },
+                                                        "optional": {
+                                                          "type": "boolean"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "key"
+                                                      ],
+                                                      "type": "object",
+                                                      "x-kubernetes-map-type": "atomic",
+                                                      "additionalProperties": false
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "oauth2": {
+                                                  "properties": {
+                                                    "clientIDSecret": {
+                                                      "properties": {
+                                                        "key": {
+                                                          "type": "string"
+                                                        },
+                                                        "name": {
+                                                          "default": "",
+                                                          "type": "string"
+                                                        },
+                                                        "optional": {
+                                                          "type": "boolean"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "key"
+                                                      ],
+                                                      "type": "object",
+                                                      "x-kubernetes-map-type": "atomic",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "clientSecretSecret": {
+                                                      "properties": {
+                                                        "key": {
+                                                          "type": "string"
+                                                        },
+                                                        "name": {
+                                                          "default": "",
+                                                          "type": "string"
+                                                        },
+                                                        "optional": {
+                                                          "type": "boolean"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "key"
+                                                      ],
+                                                      "type": "object",
+                                                      "x-kubernetes-map-type": "atomic",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "endpointParams": {
+                                                      "items": {
+                                                        "properties": {
+                                                          "key": {
+                                                            "type": "string"
+                                                          },
+                                                          "value": {
+                                                            "type": "string"
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "key"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                      },
+                                                      "type": "array"
+                                                    },
+                                                    "scopes": {
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    },
+                                                    "tokenURLSecret": {
+                                                      "properties": {
+                                                        "key": {
+                                                          "type": "string"
+                                                        },
+                                                        "name": {
+                                                          "default": "",
+                                                          "type": "string"
+                                                        },
+                                                        "optional": {
+                                                          "type": "boolean"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "key"
+                                                      ],
+                                                      "type": "object",
+                                                      "x-kubernetes-map-type": "atomic",
+                                                      "additionalProperties": false
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "headers": {
+                                              "items": {
+                                                "properties": {
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "value": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "name",
+                                                  "value"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
+                                            },
+                                            "url": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "url"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "mode": {
+                                          "format": "int32",
+                                          "type": "integer"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        },
+                                        "oss": {
+                                          "properties": {
+                                            "accessKeySecret": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "name": {
+                                                  "default": "",
+                                                  "type": "string"
+                                                },
+                                                "optional": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              "required": [
+                                                "key"
+                                              ],
+                                              "type": "object",
+                                              "x-kubernetes-map-type": "atomic",
+                                              "additionalProperties": false
+                                            },
+                                            "bucket": {
+                                              "type": "string"
+                                            },
+                                            "createBucketIfNotPresent": {
+                                              "type": "boolean"
+                                            },
+                                            "endpoint": {
+                                              "type": "string"
+                                            },
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "lifecycleRule": {
+                                              "properties": {
+                                                "markDeletionAfterDays": {
+                                                  "format": "int32",
+                                                  "type": "integer"
+                                                },
+                                                "markInfrequentAccessAfterDays": {
+                                                  "format": "int32",
+                                                  "type": "integer"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "secretKeySecret": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "name": {
+                                                  "default": "",
+                                                  "type": "string"
+                                                },
+                                                "optional": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              "required": [
+                                                "key"
+                                              ],
+                                              "type": "object",
+                                              "x-kubernetes-map-type": "atomic",
+                                              "additionalProperties": false
+                                            },
+                                            "securityToken": {
+                                              "type": "string"
+                                            },
+                                            "useSDKCreds": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "path": {
+                                          "type": "string"
+                                        },
+                                        "raw": {
+                                          "properties": {
+                                            "data": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "data"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "recurseMode": {
+                                          "type": "boolean"
+                                        },
+                                        "s3": {
+                                          "properties": {
+                                            "accessKeySecret": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "name": {
+                                                  "default": "",
+                                                  "type": "string"
+                                                },
+                                                "optional": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              "required": [
+                                                "key"
+                                              ],
+                                              "type": "object",
+                                              "x-kubernetes-map-type": "atomic",
+                                              "additionalProperties": false
+                                            },
+                                            "bucket": {
+                                              "type": "string"
+                                            },
+                                            "caSecret": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "name": {
+                                                  "default": "",
+                                                  "type": "string"
+                                                },
+                                                "optional": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              "required": [
+                                                "key"
+                                              ],
+                                              "type": "object",
+                                              "x-kubernetes-map-type": "atomic",
+                                              "additionalProperties": false
+                                            },
+                                            "createBucketIfNotPresent": {
+                                              "properties": {
+                                                "objectLocking": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "encryptionOptions": {
+                                              "properties": {
+                                                "enableEncryption": {
+                                                  "type": "boolean"
+                                                },
+                                                "kmsEncryptionContext": {
+                                                  "type": "string"
+                                                },
+                                                "kmsKeyId": {
+                                                  "type": "string"
+                                                },
+                                                "serverSideCustomerKeySecret": {
+                                                  "properties": {
+                                                    "key": {
+                                                      "type": "string"
+                                                    },
+                                                    "name": {
+                                                      "default": "",
+                                                      "type": "string"
+                                                    },
+                                                    "optional": {
+                                                      "type": "boolean"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "key"
+                                                  ],
+                                                  "type": "object",
+                                                  "x-kubernetes-map-type": "atomic",
+                                                  "additionalProperties": false
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "endpoint": {
+                                              "type": "string"
+                                            },
+                                            "insecure": {
+                                              "type": "boolean"
+                                            },
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "region": {
+                                              "type": "string"
+                                            },
+                                            "roleARN": {
+                                              "type": "string"
+                                            },
+                                            "secretKeySecret": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "name": {
+                                                  "default": "",
+                                                  "type": "string"
+                                                },
+                                                "optional": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              "required": [
+                                                "key"
+                                              ],
+                                              "type": "object",
+                                              "x-kubernetes-map-type": "atomic",
+                                              "additionalProperties": false
+                                            },
+                                            "sessionTokenSecret": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "name": {
+                                                  "default": "",
+                                                  "type": "string"
+                                                },
+                                                "optional": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              "required": [
+                                                "key"
+                                              ],
+                                              "type": "object",
+                                              "x-kubernetes-map-type": "atomic",
+                                              "additionalProperties": false
+                                            },
+                                            "useSDKCreds": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "subPath": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "name"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "parameters": {
+                                    "items": {
+                                      "properties": {
+                                        "default": {
+                                          "type": "string"
+                                        },
+                                        "description": {
+                                          "type": "string"
+                                        },
+                                        "enum": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        },
+                                        "globalName": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        },
+                                        "valueFrom": {
+                                          "properties": {
+                                            "configMapKeyRef": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "name": {
+                                                  "default": "",
+                                                  "type": "string"
+                                                },
+                                                "optional": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              "required": [
+                                                "key"
+                                              ],
+                                              "type": "object",
+                                              "x-kubernetes-map-type": "atomic",
+                                              "additionalProperties": false
+                                            },
+                                            "default": {
+                                              "type": "string"
+                                            },
+                                            "event": {
+                                              "type": "string"
+                                            },
+                                            "expression": {
+                                              "type": "string"
+                                            },
+                                            "jqFilter": {
+                                              "type": "string"
+                                            },
+                                            "jsonPath": {
+                                              "type": "string"
+                                            },
+                                            "parameter": {
+                                              "type": "string"
+                                            },
+                                            "path": {
+                                              "type": "string"
+                                            },
+                                            "supplied": {
+                                              "type": "object"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "required": [
+                                        "name"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "expression": {
+                                "type": "string"
+                              },
+                              "template": {
+                                "type": "string"
+                              },
+                              "templateRef": {
+                                "properties": {
+                                  "clusterScope": {
+                                    "type": "boolean"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "template": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "object"
+                        },
+                        "inline": {
+                          "x-kubernetes-preserve-unknown-fields": true
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "onExit": {
+                          "type": "string"
+                        },
+                        "template": {
+                          "type": "string"
+                        },
+                        "templateRef": {
+                          "properties": {
+                            "clusterScope": {
+                              "type": "boolean"
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "template": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "when": {
+                          "type": "string"
+                        },
+                        "withItems": {
+                          "x-kubernetes-preserve-unknown-fields": true
+                        },
+                        "withParam": {
+                          "type": "string"
+                        },
+                        "withSequence": {
+                          "properties": {
+                            "count": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "end": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "format": {
+                              "type": "string"
+                            },
+                            "start": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "x-kubernetes-int-or-string": true
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
                     "type": "array"
                   },
                   "type": "array"
@@ -16955,6 +19159,9 @@
                   "properties": {
                     "mutex": {
                       "properties": {
+                        "database": {
+                          "type": "boolean"
+                        },
                         "name": {
                           "type": "string"
                         },
@@ -16968,6 +19175,9 @@
                     "mutexes": {
                       "items": {
                         "properties": {
+                          "database": {
+                            "type": "boolean"
+                          },
                           "name": {
                             "type": "string"
                           },
@@ -17002,6 +19212,18 @@
                           "x-kubernetes-map-type": "atomic",
                           "additionalProperties": false
                         },
+                        "database": {
+                          "properties": {
+                            "key": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "key"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
                         "namespace": {
                           "type": "string"
                         }
@@ -17030,6 +19252,18 @@
                             ],
                             "type": "object",
                             "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "database": {
+                            "properties": {
+                              "key": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "key"
+                            ],
+                            "type": "object",
                             "additionalProperties": false
                           },
                           "namespace": {
@@ -17110,12 +19344,14 @@
                             "type": "string"
                           },
                           "fsType": {
+                            "default": "ext4",
                             "type": "string"
                           },
                           "kind": {
                             "type": "string"
                           },
                           "readOnly": {
+                            "default": false,
                             "type": "boolean"
                           }
                         },
@@ -17390,7 +19626,37 @@
                           "volumeClaimTemplate": {
                             "properties": {
                               "metadata": {
-                                "type": "object"
+                                "properties": {
+                                  "annotations": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  },
+                                  "finalizers": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "generateName": {
+                                    "type": "string"
+                                  },
+                                  "labels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "namespace": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
                               },
                               "spec": {
                                 "properties": {
@@ -17697,6 +19963,18 @@
                         "type": "object",
                         "additionalProperties": false
                       },
+                      "image": {
+                        "properties": {
+                          "pullPolicy": {
+                            "type": "string"
+                          },
+                          "reference": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
                       "iscsi": {
                         "properties": {
                           "chapAuthDiscovery": {
@@ -17715,6 +19993,7 @@
                             "type": "string"
                           },
                           "iscsiInterface": {
+                            "default": "default",
                             "type": "string"
                           },
                           "lun": {
@@ -18107,6 +20386,7 @@
                             "type": "string"
                           },
                           "keyring": {
+                            "default": "/etc/ceph/keyring",
                             "type": "string"
                           },
                           "monitors": {
@@ -18117,6 +20397,7 @@
                             "x-kubernetes-list-type": "atomic"
                           },
                           "pool": {
+                            "default": "rbd",
                             "type": "string"
                           },
                           "readOnly": {
@@ -18134,6 +20415,7 @@
                             "additionalProperties": false
                           },
                           "user": {
+                            "default": "admin",
                             "type": "string"
                           }
                         },
@@ -18147,6 +20429,7 @@
                       "scaleIO": {
                         "properties": {
                           "fsType": {
+                            "default": "xfs",
                             "type": "string"
                           },
                           "gateway": {
@@ -18173,6 +20456,7 @@
                             "type": "boolean"
                           },
                           "storageMode": {
+                            "default": "ThinProvisioned",
                             "type": "string"
                           },
                           "storagePool": {
@@ -18983,6 +21267,12 @@
                     },
                     "type": "object",
                     "additionalProperties": false
+                  },
+                  "annotations": {
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "type": "object"
                   },
                   "archiveLocation": {
                     "properties": {
@@ -20169,6 +22459,9 @@
                             },
                             "type": "object",
                             "additionalProperties": false
+                          },
+                          "stopSignal": {
+                            "type": "string"
                           }
                         },
                         "type": "object",
@@ -20200,6 +22493,7 @@
                                 "type": "integer"
                               },
                               "service": {
+                                "default": "",
                                 "type": "string"
                               }
                             },
@@ -20369,6 +22663,7 @@
                                 "type": "integer"
                               },
                               "service": {
+                                "default": "",
                                 "type": "string"
                               }
                             },
@@ -20500,6 +22795,9 @@
                             "items": {
                               "properties": {
                                 "name": {
+                                  "type": "string"
+                                },
+                                "request": {
                                   "type": "string"
                                 }
                               },
@@ -20693,6 +22991,7 @@
                                 "type": "integer"
                               },
                               "service": {
+                                "default": "",
                                 "type": "string"
                               }
                             },
@@ -20878,9 +23177,6 @@
                         "type": "string"
                       }
                     },
-                    "required": [
-                      "image"
-                    ],
                     "type": "object",
                     "additionalProperties": false
                   },
@@ -21277,6 +23573,9 @@
                                   },
                                   "type": "object",
                                   "additionalProperties": false
+                                },
+                                "stopSignal": {
+                                  "type": "string"
                                 }
                               },
                               "type": "object",
@@ -21308,6 +23607,7 @@
                                       "type": "integer"
                                     },
                                     "service": {
+                                      "default": "",
                                       "type": "string"
                                     }
                                   },
@@ -21477,6 +23777,7 @@
                                       "type": "integer"
                                     },
                                     "service": {
+                                      "default": "",
                                       "type": "string"
                                     }
                                   },
@@ -21608,6 +23909,9 @@
                                   "items": {
                                     "properties": {
                                       "name": {
+                                        "type": "string"
+                                      },
+                                      "request": {
                                         "type": "string"
                                       }
                                     },
@@ -21801,6 +24105,7 @@
                                       "type": "integer"
                                     },
                                     "service": {
+                                      "default": "",
                                       "type": "string"
                                     }
                                   },
@@ -24087,7 +26392,9 @@
                               },
                               "type": "object"
                             },
-                            "inline": {},
+                            "inline": {
+                              "x-kubernetes-preserve-unknown-fields": true
+                            },
                             "name": {
                               "type": "string"
                             },
@@ -24116,10 +26423,7 @@
                               "type": "string"
                             },
                             "withItems": {
-                              "items": {
-                                "type": "object"
-                              },
-                              "type": "array"
+                              "x-kubernetes-preserve-unknown-fields": true
                             },
                             "withParam": {
                               "type": "string"
@@ -25604,6 +27908,9 @@
                               },
                               "type": "object",
                               "additionalProperties": false
+                            },
+                            "stopSignal": {
+                              "type": "string"
                             }
                           },
                           "type": "object",
@@ -25635,6 +27942,7 @@
                                   "type": "integer"
                                 },
                                 "service": {
+                                  "default": "",
                                   "type": "string"
                                 }
                               },
@@ -25807,6 +28115,7 @@
                                   "type": "integer"
                                 },
                                 "service": {
+                                  "default": "",
                                   "type": "string"
                                 }
                               },
@@ -25938,6 +28247,9 @@
                               "items": {
                                 "properties": {
                                   "name": {
+                                    "type": "string"
+                                  },
+                                  "request": {
                                     "type": "string"
                                   }
                                 },
@@ -26131,6 +28443,7 @@
                                   "type": "integer"
                                 },
                                 "service": {
+                                  "default": "",
                                   "type": "string"
                                 }
                               },
@@ -28472,14 +30785,11 @@
                     "type": "integer"
                   },
                   "plugin": {
-                    "type": "object"
+                    "type": "object",
+                    "x-kubernetes-preserve-unknown-fields": true
                   },
                   "podSpecPatch": {
                     "type": "string"
-                  },
-                  "priority": {
-                    "format": "int32",
-                    "type": "integer"
                   },
                   "priorityClassName": {
                     "type": "string"
@@ -29429,6 +31739,9 @@
                       },
                       "backoff": {
                         "properties": {
+                          "cap": {
+                            "type": "string"
+                          },
                           "duration": {
                             "type": "string"
                           },
@@ -29858,6 +32171,9 @@
                             },
                             "type": "object",
                             "additionalProperties": false
+                          },
+                          "stopSignal": {
+                            "type": "string"
                           }
                         },
                         "type": "object",
@@ -29889,6 +32205,7 @@
                                 "type": "integer"
                               },
                               "service": {
+                                "default": "",
                                 "type": "string"
                               }
                             },
@@ -30058,6 +32375,7 @@
                                 "type": "integer"
                               },
                               "service": {
+                                "default": "",
                                 "type": "string"
                               }
                             },
@@ -30189,6 +32507,9 @@
                             "items": {
                               "properties": {
                                 "name": {
+                                  "type": "string"
+                                },
+                                "request": {
                                   "type": "string"
                                 }
                               },
@@ -30385,6 +32706,7 @@
                                 "type": "integer"
                               },
                               "service": {
+                                "default": "",
                                 "type": "string"
                               }
                             },
@@ -30570,10 +32892,6 @@
                         "type": "string"
                       }
                     },
-                    "required": [
-                      "image",
-                      "source"
-                    ],
                     "type": "object",
                     "additionalProperties": false
                   },
@@ -30611,6 +32929,9 @@
                       "runAsUser": {
                         "format": "int64",
                         "type": "integer"
+                      },
+                      "seLinuxChangePolicy": {
+                        "type": "string"
                       },
                       "seLinuxOptions": {
                         "properties": {
@@ -30652,6 +32973,9 @@
                         },
                         "type": "array",
                         "x-kubernetes-list-type": "atomic"
+                      },
+                      "supplementalGroupsPolicy": {
+                        "type": "string"
                       },
                       "sysctls": {
                         "items": {
@@ -31083,6 +33407,9 @@
                               },
                               "type": "object",
                               "additionalProperties": false
+                            },
+                            "stopSignal": {
+                              "type": "string"
                             }
                           },
                           "type": "object",
@@ -31114,6 +33441,7 @@
                                   "type": "integer"
                                 },
                                 "service": {
+                                  "default": "",
                                   "type": "string"
                                 }
                               },
@@ -31286,6 +33614,7 @@
                                   "type": "integer"
                                 },
                                 "service": {
+                                  "default": "",
                                   "type": "string"
                                 }
                               },
@@ -31417,6 +33746,9 @@
                               "items": {
                                 "properties": {
                                   "name": {
+                                    "type": "string"
+                                  },
+                                  "request": {
                                     "type": "string"
                                   }
                                 },
@@ -31610,6 +33942,7 @@
                                   "type": "integer"
                                 },
                                 "service": {
+                                  "default": "",
                                   "type": "string"
                                 }
                               },
@@ -31805,6 +34138,2096 @@
                   },
                   "steps": {
                     "items": {
+                      "items": {
+                        "properties": {
+                          "arguments": {
+                            "properties": {
+                              "artifacts": {
+                                "items": {
+                                  "properties": {
+                                    "archive": {
+                                      "properties": {
+                                        "none": {
+                                          "type": "object"
+                                        },
+                                        "tar": {
+                                          "properties": {
+                                            "compressionLevel": {
+                                              "format": "int32",
+                                              "type": "integer"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "zip": {
+                                          "type": "object"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "archiveLogs": {
+                                      "type": "boolean"
+                                    },
+                                    "artifactGC": {
+                                      "properties": {
+                                        "podMetadata": {
+                                          "properties": {
+                                            "annotations": {
+                                              "additionalProperties": {
+                                                "type": "string"
+                                              },
+                                              "type": "object"
+                                            },
+                                            "labels": {
+                                              "additionalProperties": {
+                                                "type": "string"
+                                              },
+                                              "type": "object"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "serviceAccountName": {
+                                          "type": "string"
+                                        },
+                                        "strategy": {
+                                          "enum": [
+                                            "",
+                                            "OnWorkflowCompletion",
+                                            "OnWorkflowDeletion",
+                                            "Never"
+                                          ],
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "artifactory": {
+                                      "properties": {
+                                        "passwordSecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "default": "",
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "x-kubernetes-map-type": "atomic",
+                                          "additionalProperties": false
+                                        },
+                                        "url": {
+                                          "type": "string"
+                                        },
+                                        "usernameSecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "default": "",
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "x-kubernetes-map-type": "atomic",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "required": [
+                                        "url"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "azure": {
+                                      "properties": {
+                                        "accountKeySecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "default": "",
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "x-kubernetes-map-type": "atomic",
+                                          "additionalProperties": false
+                                        },
+                                        "blob": {
+                                          "type": "string"
+                                        },
+                                        "container": {
+                                          "type": "string"
+                                        },
+                                        "endpoint": {
+                                          "type": "string"
+                                        },
+                                        "useSDKCreds": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "blob",
+                                        "container",
+                                        "endpoint"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "deleted": {
+                                      "type": "boolean"
+                                    },
+                                    "from": {
+                                      "type": "string"
+                                    },
+                                    "fromExpression": {
+                                      "type": "string"
+                                    },
+                                    "gcs": {
+                                      "properties": {
+                                        "bucket": {
+                                          "type": "string"
+                                        },
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "serviceAccountKeySecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "default": "",
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "x-kubernetes-map-type": "atomic",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "git": {
+                                      "properties": {
+                                        "branch": {
+                                          "type": "string"
+                                        },
+                                        "depth": {
+                                          "format": "int64",
+                                          "type": "integer"
+                                        },
+                                        "disableSubmodules": {
+                                          "type": "boolean"
+                                        },
+                                        "fetch": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        },
+                                        "insecureIgnoreHostKey": {
+                                          "type": "boolean"
+                                        },
+                                        "insecureSkipTLS": {
+                                          "type": "boolean"
+                                        },
+                                        "passwordSecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "default": "",
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "x-kubernetes-map-type": "atomic",
+                                          "additionalProperties": false
+                                        },
+                                        "repo": {
+                                          "type": "string"
+                                        },
+                                        "revision": {
+                                          "type": "string"
+                                        },
+                                        "singleBranch": {
+                                          "type": "boolean"
+                                        },
+                                        "sshPrivateKeySecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "default": "",
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "x-kubernetes-map-type": "atomic",
+                                          "additionalProperties": false
+                                        },
+                                        "usernameSecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "default": "",
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "x-kubernetes-map-type": "atomic",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "required": [
+                                        "repo"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "globalName": {
+                                      "type": "string"
+                                    },
+                                    "hdfs": {
+                                      "properties": {
+                                        "addresses": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        },
+                                        "dataTransferProtection": {
+                                          "type": "string"
+                                        },
+                                        "force": {
+                                          "type": "boolean"
+                                        },
+                                        "hdfsUser": {
+                                          "type": "string"
+                                        },
+                                        "krbCCacheSecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "default": "",
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "x-kubernetes-map-type": "atomic",
+                                          "additionalProperties": false
+                                        },
+                                        "krbConfigConfigMap": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "default": "",
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "x-kubernetes-map-type": "atomic",
+                                          "additionalProperties": false
+                                        },
+                                        "krbKeytabSecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "default": "",
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "x-kubernetes-map-type": "atomic",
+                                          "additionalProperties": false
+                                        },
+                                        "krbRealm": {
+                                          "type": "string"
+                                        },
+                                        "krbServicePrincipalName": {
+                                          "type": "string"
+                                        },
+                                        "krbUsername": {
+                                          "type": "string"
+                                        },
+                                        "path": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "path"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "http": {
+                                      "properties": {
+                                        "auth": {
+                                          "properties": {
+                                            "basicAuth": {
+                                              "properties": {
+                                                "passwordSecret": {
+                                                  "properties": {
+                                                    "key": {
+                                                      "type": "string"
+                                                    },
+                                                    "name": {
+                                                      "default": "",
+                                                      "type": "string"
+                                                    },
+                                                    "optional": {
+                                                      "type": "boolean"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "key"
+                                                  ],
+                                                  "type": "object",
+                                                  "x-kubernetes-map-type": "atomic",
+                                                  "additionalProperties": false
+                                                },
+                                                "usernameSecret": {
+                                                  "properties": {
+                                                    "key": {
+                                                      "type": "string"
+                                                    },
+                                                    "name": {
+                                                      "default": "",
+                                                      "type": "string"
+                                                    },
+                                                    "optional": {
+                                                      "type": "boolean"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "key"
+                                                  ],
+                                                  "type": "object",
+                                                  "x-kubernetes-map-type": "atomic",
+                                                  "additionalProperties": false
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "clientCert": {
+                                              "properties": {
+                                                "clientCertSecret": {
+                                                  "properties": {
+                                                    "key": {
+                                                      "type": "string"
+                                                    },
+                                                    "name": {
+                                                      "default": "",
+                                                      "type": "string"
+                                                    },
+                                                    "optional": {
+                                                      "type": "boolean"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "key"
+                                                  ],
+                                                  "type": "object",
+                                                  "x-kubernetes-map-type": "atomic",
+                                                  "additionalProperties": false
+                                                },
+                                                "clientKeySecret": {
+                                                  "properties": {
+                                                    "key": {
+                                                      "type": "string"
+                                                    },
+                                                    "name": {
+                                                      "default": "",
+                                                      "type": "string"
+                                                    },
+                                                    "optional": {
+                                                      "type": "boolean"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "key"
+                                                  ],
+                                                  "type": "object",
+                                                  "x-kubernetes-map-type": "atomic",
+                                                  "additionalProperties": false
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "oauth2": {
+                                              "properties": {
+                                                "clientIDSecret": {
+                                                  "properties": {
+                                                    "key": {
+                                                      "type": "string"
+                                                    },
+                                                    "name": {
+                                                      "default": "",
+                                                      "type": "string"
+                                                    },
+                                                    "optional": {
+                                                      "type": "boolean"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "key"
+                                                  ],
+                                                  "type": "object",
+                                                  "x-kubernetes-map-type": "atomic",
+                                                  "additionalProperties": false
+                                                },
+                                                "clientSecretSecret": {
+                                                  "properties": {
+                                                    "key": {
+                                                      "type": "string"
+                                                    },
+                                                    "name": {
+                                                      "default": "",
+                                                      "type": "string"
+                                                    },
+                                                    "optional": {
+                                                      "type": "boolean"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "key"
+                                                  ],
+                                                  "type": "object",
+                                                  "x-kubernetes-map-type": "atomic",
+                                                  "additionalProperties": false
+                                                },
+                                                "endpointParams": {
+                                                  "items": {
+                                                    "properties": {
+                                                      "key": {
+                                                        "type": "string"
+                                                      },
+                                                      "value": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "key"
+                                                    ],
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "type": "array"
+                                                },
+                                                "scopes": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                },
+                                                "tokenURLSecret": {
+                                                  "properties": {
+                                                    "key": {
+                                                      "type": "string"
+                                                    },
+                                                    "name": {
+                                                      "default": "",
+                                                      "type": "string"
+                                                    },
+                                                    "optional": {
+                                                      "type": "boolean"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "key"
+                                                  ],
+                                                  "type": "object",
+                                                  "x-kubernetes-map-type": "atomic",
+                                                  "additionalProperties": false
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "headers": {
+                                          "items": {
+                                            "properties": {
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "value": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name",
+                                              "value"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "array"
+                                        },
+                                        "url": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "url"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "mode": {
+                                      "format": "int32",
+                                      "type": "integer"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    },
+                                    "oss": {
+                                      "properties": {
+                                        "accessKeySecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "default": "",
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "x-kubernetes-map-type": "atomic",
+                                          "additionalProperties": false
+                                        },
+                                        "bucket": {
+                                          "type": "string"
+                                        },
+                                        "createBucketIfNotPresent": {
+                                          "type": "boolean"
+                                        },
+                                        "endpoint": {
+                                          "type": "string"
+                                        },
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "lifecycleRule": {
+                                          "properties": {
+                                            "markDeletionAfterDays": {
+                                              "format": "int32",
+                                              "type": "integer"
+                                            },
+                                            "markInfrequentAccessAfterDays": {
+                                              "format": "int32",
+                                              "type": "integer"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "secretKeySecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "default": "",
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "x-kubernetes-map-type": "atomic",
+                                          "additionalProperties": false
+                                        },
+                                        "securityToken": {
+                                          "type": "string"
+                                        },
+                                        "useSDKCreds": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "path": {
+                                      "type": "string"
+                                    },
+                                    "raw": {
+                                      "properties": {
+                                        "data": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "data"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "recurseMode": {
+                                      "type": "boolean"
+                                    },
+                                    "s3": {
+                                      "properties": {
+                                        "accessKeySecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "default": "",
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "x-kubernetes-map-type": "atomic",
+                                          "additionalProperties": false
+                                        },
+                                        "bucket": {
+                                          "type": "string"
+                                        },
+                                        "caSecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "default": "",
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "x-kubernetes-map-type": "atomic",
+                                          "additionalProperties": false
+                                        },
+                                        "createBucketIfNotPresent": {
+                                          "properties": {
+                                            "objectLocking": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "encryptionOptions": {
+                                          "properties": {
+                                            "enableEncryption": {
+                                              "type": "boolean"
+                                            },
+                                            "kmsEncryptionContext": {
+                                              "type": "string"
+                                            },
+                                            "kmsKeyId": {
+                                              "type": "string"
+                                            },
+                                            "serverSideCustomerKeySecret": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "name": {
+                                                  "default": "",
+                                                  "type": "string"
+                                                },
+                                                "optional": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              "required": [
+                                                "key"
+                                              ],
+                                              "type": "object",
+                                              "x-kubernetes-map-type": "atomic",
+                                              "additionalProperties": false
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "endpoint": {
+                                          "type": "string"
+                                        },
+                                        "insecure": {
+                                          "type": "boolean"
+                                        },
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "region": {
+                                          "type": "string"
+                                        },
+                                        "roleARN": {
+                                          "type": "string"
+                                        },
+                                        "secretKeySecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "default": "",
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "x-kubernetes-map-type": "atomic",
+                                          "additionalProperties": false
+                                        },
+                                        "sessionTokenSecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "default": "",
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "x-kubernetes-map-type": "atomic",
+                                          "additionalProperties": false
+                                        },
+                                        "useSDKCreds": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "subPath": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "name"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "parameters": {
+                                "items": {
+                                  "properties": {
+                                    "default": {
+                                      "type": "string"
+                                    },
+                                    "description": {
+                                      "type": "string"
+                                    },
+                                    "enum": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "globalName": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    },
+                                    "valueFrom": {
+                                      "properties": {
+                                        "configMapKeyRef": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "default": "",
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "x-kubernetes-map-type": "atomic",
+                                          "additionalProperties": false
+                                        },
+                                        "default": {
+                                          "type": "string"
+                                        },
+                                        "event": {
+                                          "type": "string"
+                                        },
+                                        "expression": {
+                                          "type": "string"
+                                        },
+                                        "jqFilter": {
+                                          "type": "string"
+                                        },
+                                        "jsonPath": {
+                                          "type": "string"
+                                        },
+                                        "parameter": {
+                                          "type": "string"
+                                        },
+                                        "path": {
+                                          "type": "string"
+                                        },
+                                        "supplied": {
+                                          "type": "object"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "required": [
+                                    "name"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "continueOn": {
+                            "properties": {
+                              "error": {
+                                "type": "boolean"
+                              },
+                              "failed": {
+                                "type": "boolean"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "hooks": {
+                            "additionalProperties": {
+                              "properties": {
+                                "arguments": {
+                                  "properties": {
+                                    "artifacts": {
+                                      "items": {
+                                        "properties": {
+                                          "archive": {
+                                            "properties": {
+                                              "none": {
+                                                "type": "object"
+                                              },
+                                              "tar": {
+                                                "properties": {
+                                                  "compressionLevel": {
+                                                    "format": "int32",
+                                                    "type": "integer"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "zip": {
+                                                "type": "object"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "archiveLogs": {
+                                            "type": "boolean"
+                                          },
+                                          "artifactGC": {
+                                            "properties": {
+                                              "podMetadata": {
+                                                "properties": {
+                                                  "annotations": {
+                                                    "additionalProperties": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "object"
+                                                  },
+                                                  "labels": {
+                                                    "additionalProperties": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "object"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "serviceAccountName": {
+                                                "type": "string"
+                                              },
+                                              "strategy": {
+                                                "enum": [
+                                                  "",
+                                                  "OnWorkflowCompletion",
+                                                  "OnWorkflowDeletion",
+                                                  "Never"
+                                                ],
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "artifactory": {
+                                            "properties": {
+                                              "passwordSecret": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "default": "",
+                                                    "type": "string"
+                                                  },
+                                                  "optional": {
+                                                    "type": "boolean"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "key"
+                                                ],
+                                                "type": "object",
+                                                "x-kubernetes-map-type": "atomic",
+                                                "additionalProperties": false
+                                              },
+                                              "url": {
+                                                "type": "string"
+                                              },
+                                              "usernameSecret": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "default": "",
+                                                    "type": "string"
+                                                  },
+                                                  "optional": {
+                                                    "type": "boolean"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "key"
+                                                ],
+                                                "type": "object",
+                                                "x-kubernetes-map-type": "atomic",
+                                                "additionalProperties": false
+                                              }
+                                            },
+                                            "required": [
+                                              "url"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "azure": {
+                                            "properties": {
+                                              "accountKeySecret": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "default": "",
+                                                    "type": "string"
+                                                  },
+                                                  "optional": {
+                                                    "type": "boolean"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "key"
+                                                ],
+                                                "type": "object",
+                                                "x-kubernetes-map-type": "atomic",
+                                                "additionalProperties": false
+                                              },
+                                              "blob": {
+                                                "type": "string"
+                                              },
+                                              "container": {
+                                                "type": "string"
+                                              },
+                                              "endpoint": {
+                                                "type": "string"
+                                              },
+                                              "useSDKCreds": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "required": [
+                                              "blob",
+                                              "container",
+                                              "endpoint"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "deleted": {
+                                            "type": "boolean"
+                                          },
+                                          "from": {
+                                            "type": "string"
+                                          },
+                                          "fromExpression": {
+                                            "type": "string"
+                                          },
+                                          "gcs": {
+                                            "properties": {
+                                              "bucket": {
+                                                "type": "string"
+                                              },
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "serviceAccountKeySecret": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "default": "",
+                                                    "type": "string"
+                                                  },
+                                                  "optional": {
+                                                    "type": "boolean"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "key"
+                                                ],
+                                                "type": "object",
+                                                "x-kubernetes-map-type": "atomic",
+                                                "additionalProperties": false
+                                              }
+                                            },
+                                            "required": [
+                                              "key"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "git": {
+                                            "properties": {
+                                              "branch": {
+                                                "type": "string"
+                                              },
+                                              "depth": {
+                                                "format": "int64",
+                                                "type": "integer"
+                                              },
+                                              "disableSubmodules": {
+                                                "type": "boolean"
+                                              },
+                                              "fetch": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              },
+                                              "insecureIgnoreHostKey": {
+                                                "type": "boolean"
+                                              },
+                                              "insecureSkipTLS": {
+                                                "type": "boolean"
+                                              },
+                                              "passwordSecret": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "default": "",
+                                                    "type": "string"
+                                                  },
+                                                  "optional": {
+                                                    "type": "boolean"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "key"
+                                                ],
+                                                "type": "object",
+                                                "x-kubernetes-map-type": "atomic",
+                                                "additionalProperties": false
+                                              },
+                                              "repo": {
+                                                "type": "string"
+                                              },
+                                              "revision": {
+                                                "type": "string"
+                                              },
+                                              "singleBranch": {
+                                                "type": "boolean"
+                                              },
+                                              "sshPrivateKeySecret": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "default": "",
+                                                    "type": "string"
+                                                  },
+                                                  "optional": {
+                                                    "type": "boolean"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "key"
+                                                ],
+                                                "type": "object",
+                                                "x-kubernetes-map-type": "atomic",
+                                                "additionalProperties": false
+                                              },
+                                              "usernameSecret": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "default": "",
+                                                    "type": "string"
+                                                  },
+                                                  "optional": {
+                                                    "type": "boolean"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "key"
+                                                ],
+                                                "type": "object",
+                                                "x-kubernetes-map-type": "atomic",
+                                                "additionalProperties": false
+                                              }
+                                            },
+                                            "required": [
+                                              "repo"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "globalName": {
+                                            "type": "string"
+                                          },
+                                          "hdfs": {
+                                            "properties": {
+                                              "addresses": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              },
+                                              "dataTransferProtection": {
+                                                "type": "string"
+                                              },
+                                              "force": {
+                                                "type": "boolean"
+                                              },
+                                              "hdfsUser": {
+                                                "type": "string"
+                                              },
+                                              "krbCCacheSecret": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "default": "",
+                                                    "type": "string"
+                                                  },
+                                                  "optional": {
+                                                    "type": "boolean"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "key"
+                                                ],
+                                                "type": "object",
+                                                "x-kubernetes-map-type": "atomic",
+                                                "additionalProperties": false
+                                              },
+                                              "krbConfigConfigMap": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "default": "",
+                                                    "type": "string"
+                                                  },
+                                                  "optional": {
+                                                    "type": "boolean"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "key"
+                                                ],
+                                                "type": "object",
+                                                "x-kubernetes-map-type": "atomic",
+                                                "additionalProperties": false
+                                              },
+                                              "krbKeytabSecret": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "default": "",
+                                                    "type": "string"
+                                                  },
+                                                  "optional": {
+                                                    "type": "boolean"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "key"
+                                                ],
+                                                "type": "object",
+                                                "x-kubernetes-map-type": "atomic",
+                                                "additionalProperties": false
+                                              },
+                                              "krbRealm": {
+                                                "type": "string"
+                                              },
+                                              "krbServicePrincipalName": {
+                                                "type": "string"
+                                              },
+                                              "krbUsername": {
+                                                "type": "string"
+                                              },
+                                              "path": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "path"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "http": {
+                                            "properties": {
+                                              "auth": {
+                                                "properties": {
+                                                  "basicAuth": {
+                                                    "properties": {
+                                                      "passwordSecret": {
+                                                        "properties": {
+                                                          "key": {
+                                                            "type": "string"
+                                                          },
+                                                          "name": {
+                                                            "default": "",
+                                                            "type": "string"
+                                                          },
+                                                          "optional": {
+                                                            "type": "boolean"
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "key"
+                                                        ],
+                                                        "type": "object",
+                                                        "x-kubernetes-map-type": "atomic",
+                                                        "additionalProperties": false
+                                                      },
+                                                      "usernameSecret": {
+                                                        "properties": {
+                                                          "key": {
+                                                            "type": "string"
+                                                          },
+                                                          "name": {
+                                                            "default": "",
+                                                            "type": "string"
+                                                          },
+                                                          "optional": {
+                                                            "type": "boolean"
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "key"
+                                                        ],
+                                                        "type": "object",
+                                                        "x-kubernetes-map-type": "atomic",
+                                                        "additionalProperties": false
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "clientCert": {
+                                                    "properties": {
+                                                      "clientCertSecret": {
+                                                        "properties": {
+                                                          "key": {
+                                                            "type": "string"
+                                                          },
+                                                          "name": {
+                                                            "default": "",
+                                                            "type": "string"
+                                                          },
+                                                          "optional": {
+                                                            "type": "boolean"
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "key"
+                                                        ],
+                                                        "type": "object",
+                                                        "x-kubernetes-map-type": "atomic",
+                                                        "additionalProperties": false
+                                                      },
+                                                      "clientKeySecret": {
+                                                        "properties": {
+                                                          "key": {
+                                                            "type": "string"
+                                                          },
+                                                          "name": {
+                                                            "default": "",
+                                                            "type": "string"
+                                                          },
+                                                          "optional": {
+                                                            "type": "boolean"
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "key"
+                                                        ],
+                                                        "type": "object",
+                                                        "x-kubernetes-map-type": "atomic",
+                                                        "additionalProperties": false
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "oauth2": {
+                                                    "properties": {
+                                                      "clientIDSecret": {
+                                                        "properties": {
+                                                          "key": {
+                                                            "type": "string"
+                                                          },
+                                                          "name": {
+                                                            "default": "",
+                                                            "type": "string"
+                                                          },
+                                                          "optional": {
+                                                            "type": "boolean"
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "key"
+                                                        ],
+                                                        "type": "object",
+                                                        "x-kubernetes-map-type": "atomic",
+                                                        "additionalProperties": false
+                                                      },
+                                                      "clientSecretSecret": {
+                                                        "properties": {
+                                                          "key": {
+                                                            "type": "string"
+                                                          },
+                                                          "name": {
+                                                            "default": "",
+                                                            "type": "string"
+                                                          },
+                                                          "optional": {
+                                                            "type": "boolean"
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "key"
+                                                        ],
+                                                        "type": "object",
+                                                        "x-kubernetes-map-type": "atomic",
+                                                        "additionalProperties": false
+                                                      },
+                                                      "endpointParams": {
+                                                        "items": {
+                                                          "properties": {
+                                                            "key": {
+                                                              "type": "string"
+                                                            },
+                                                            "value": {
+                                                              "type": "string"
+                                                            }
+                                                          },
+                                                          "required": [
+                                                            "key"
+                                                          ],
+                                                          "type": "object",
+                                                          "additionalProperties": false
+                                                        },
+                                                        "type": "array"
+                                                      },
+                                                      "scopes": {
+                                                        "items": {
+                                                          "type": "string"
+                                                        },
+                                                        "type": "array"
+                                                      },
+                                                      "tokenURLSecret": {
+                                                        "properties": {
+                                                          "key": {
+                                                            "type": "string"
+                                                          },
+                                                          "name": {
+                                                            "default": "",
+                                                            "type": "string"
+                                                          },
+                                                          "optional": {
+                                                            "type": "boolean"
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "key"
+                                                        ],
+                                                        "type": "object",
+                                                        "x-kubernetes-map-type": "atomic",
+                                                        "additionalProperties": false
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "headers": {
+                                                "items": {
+                                                  "properties": {
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "value": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "name",
+                                                    "value"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "url": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "url"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "mode": {
+                                            "format": "int32",
+                                            "type": "integer"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          },
+                                          "oss": {
+                                            "properties": {
+                                              "accessKeySecret": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "default": "",
+                                                    "type": "string"
+                                                  },
+                                                  "optional": {
+                                                    "type": "boolean"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "key"
+                                                ],
+                                                "type": "object",
+                                                "x-kubernetes-map-type": "atomic",
+                                                "additionalProperties": false
+                                              },
+                                              "bucket": {
+                                                "type": "string"
+                                              },
+                                              "createBucketIfNotPresent": {
+                                                "type": "boolean"
+                                              },
+                                              "endpoint": {
+                                                "type": "string"
+                                              },
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "lifecycleRule": {
+                                                "properties": {
+                                                  "markDeletionAfterDays": {
+                                                    "format": "int32",
+                                                    "type": "integer"
+                                                  },
+                                                  "markInfrequentAccessAfterDays": {
+                                                    "format": "int32",
+                                                    "type": "integer"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "secretKeySecret": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "default": "",
+                                                    "type": "string"
+                                                  },
+                                                  "optional": {
+                                                    "type": "boolean"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "key"
+                                                ],
+                                                "type": "object",
+                                                "x-kubernetes-map-type": "atomic",
+                                                "additionalProperties": false
+                                              },
+                                              "securityToken": {
+                                                "type": "string"
+                                              },
+                                              "useSDKCreds": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "required": [
+                                              "key"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "raw": {
+                                            "properties": {
+                                              "data": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "data"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "recurseMode": {
+                                            "type": "boolean"
+                                          },
+                                          "s3": {
+                                            "properties": {
+                                              "accessKeySecret": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "default": "",
+                                                    "type": "string"
+                                                  },
+                                                  "optional": {
+                                                    "type": "boolean"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "key"
+                                                ],
+                                                "type": "object",
+                                                "x-kubernetes-map-type": "atomic",
+                                                "additionalProperties": false
+                                              },
+                                              "bucket": {
+                                                "type": "string"
+                                              },
+                                              "caSecret": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "default": "",
+                                                    "type": "string"
+                                                  },
+                                                  "optional": {
+                                                    "type": "boolean"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "key"
+                                                ],
+                                                "type": "object",
+                                                "x-kubernetes-map-type": "atomic",
+                                                "additionalProperties": false
+                                              },
+                                              "createBucketIfNotPresent": {
+                                                "properties": {
+                                                  "objectLocking": {
+                                                    "type": "boolean"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "encryptionOptions": {
+                                                "properties": {
+                                                  "enableEncryption": {
+                                                    "type": "boolean"
+                                                  },
+                                                  "kmsEncryptionContext": {
+                                                    "type": "string"
+                                                  },
+                                                  "kmsKeyId": {
+                                                    "type": "string"
+                                                  },
+                                                  "serverSideCustomerKeySecret": {
+                                                    "properties": {
+                                                      "key": {
+                                                        "type": "string"
+                                                      },
+                                                      "name": {
+                                                        "default": "",
+                                                        "type": "string"
+                                                      },
+                                                      "optional": {
+                                                        "type": "boolean"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "key"
+                                                    ],
+                                                    "type": "object",
+                                                    "x-kubernetes-map-type": "atomic",
+                                                    "additionalProperties": false
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "endpoint": {
+                                                "type": "string"
+                                              },
+                                              "insecure": {
+                                                "type": "boolean"
+                                              },
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "region": {
+                                                "type": "string"
+                                              },
+                                              "roleARN": {
+                                                "type": "string"
+                                              },
+                                              "secretKeySecret": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "default": "",
+                                                    "type": "string"
+                                                  },
+                                                  "optional": {
+                                                    "type": "boolean"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "key"
+                                                ],
+                                                "type": "object",
+                                                "x-kubernetes-map-type": "atomic",
+                                                "additionalProperties": false
+                                              },
+                                              "sessionTokenSecret": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "default": "",
+                                                    "type": "string"
+                                                  },
+                                                  "optional": {
+                                                    "type": "boolean"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "key"
+                                                ],
+                                                "type": "object",
+                                                "x-kubernetes-map-type": "atomic",
+                                                "additionalProperties": false
+                                              },
+                                              "useSDKCreds": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "subPath": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "name"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "parameters": {
+                                      "items": {
+                                        "properties": {
+                                          "default": {
+                                            "type": "string"
+                                          },
+                                          "description": {
+                                            "type": "string"
+                                          },
+                                          "enum": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "globalName": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "value": {
+                                            "type": "string"
+                                          },
+                                          "valueFrom": {
+                                            "properties": {
+                                              "configMapKeyRef": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "default": "",
+                                                    "type": "string"
+                                                  },
+                                                  "optional": {
+                                                    "type": "boolean"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "key"
+                                                ],
+                                                "type": "object",
+                                                "x-kubernetes-map-type": "atomic",
+                                                "additionalProperties": false
+                                              },
+                                              "default": {
+                                                "type": "string"
+                                              },
+                                              "event": {
+                                                "type": "string"
+                                              },
+                                              "expression": {
+                                                "type": "string"
+                                              },
+                                              "jqFilter": {
+                                                "type": "string"
+                                              },
+                                              "jsonPath": {
+                                                "type": "string"
+                                              },
+                                              "parameter": {
+                                                "type": "string"
+                                              },
+                                              "path": {
+                                                "type": "string"
+                                              },
+                                              "supplied": {
+                                                "type": "object"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          }
+                                        },
+                                        "required": [
+                                          "name"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "expression": {
+                                  "type": "string"
+                                },
+                                "template": {
+                                  "type": "string"
+                                },
+                                "templateRef": {
+                                  "properties": {
+                                    "clusterScope": {
+                                      "type": "boolean"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "template": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "object"
+                          },
+                          "inline": {
+                            "x-kubernetes-preserve-unknown-fields": true
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "onExit": {
+                            "type": "string"
+                          },
+                          "template": {
+                            "type": "string"
+                          },
+                          "templateRef": {
+                            "properties": {
+                              "clusterScope": {
+                                "type": "boolean"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "template": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "when": {
+                            "type": "string"
+                          },
+                          "withItems": {
+                            "x-kubernetes-preserve-unknown-fields": true
+                          },
+                          "withParam": {
+                            "type": "string"
+                          },
+                          "withSequence": {
+                            "properties": {
+                              "count": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "end": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "format": {
+                                "type": "string"
+                              },
+                              "start": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
                       "type": "array"
                     },
                     "type": "array"
@@ -31822,6 +36245,9 @@
                     "properties": {
                       "mutex": {
                         "properties": {
+                          "database": {
+                            "type": "boolean"
+                          },
                           "name": {
                             "type": "string"
                           },
@@ -31835,6 +36261,9 @@
                       "mutexes": {
                         "items": {
                           "properties": {
+                            "database": {
+                              "type": "boolean"
+                            },
                             "name": {
                               "type": "string"
                             },
@@ -31869,6 +36298,18 @@
                             "x-kubernetes-map-type": "atomic",
                             "additionalProperties": false
                           },
+                          "database": {
+                            "properties": {
+                              "key": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "key"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
                           "namespace": {
                             "type": "string"
                           }
@@ -31897,6 +36338,18 @@
                               ],
                               "type": "object",
                               "x-kubernetes-map-type": "atomic",
+                              "additionalProperties": false
+                            },
+                            "database": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
                               "additionalProperties": false
                             },
                             "namespace": {
@@ -31977,12 +36430,14 @@
                               "type": "string"
                             },
                             "fsType": {
+                              "default": "ext4",
                               "type": "string"
                             },
                             "kind": {
                               "type": "string"
                             },
                             "readOnly": {
+                              "default": false,
                               "type": "boolean"
                             }
                           },
@@ -32257,7 +36712,37 @@
                             "volumeClaimTemplate": {
                               "properties": {
                                 "metadata": {
-                                  "type": "object"
+                                  "properties": {
+                                    "annotations": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "type": "object"
+                                    },
+                                    "finalizers": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "generateName": {
+                                      "type": "string"
+                                    },
+                                    "labels": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "type": "object"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "namespace": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
                                 },
                                 "spec": {
                                   "properties": {
@@ -32564,6 +37049,18 @@
                           "type": "object",
                           "additionalProperties": false
                         },
+                        "image": {
+                          "properties": {
+                            "pullPolicy": {
+                              "type": "string"
+                            },
+                            "reference": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
                         "iscsi": {
                           "properties": {
                             "chapAuthDiscovery": {
@@ -32582,6 +37079,7 @@
                               "type": "string"
                             },
                             "iscsiInterface": {
+                              "default": "default",
                               "type": "string"
                             },
                             "lun": {
@@ -32974,6 +37472,7 @@
                               "type": "string"
                             },
                             "keyring": {
+                              "default": "/etc/ceph/keyring",
                               "type": "string"
                             },
                             "monitors": {
@@ -32984,6 +37483,7 @@
                               "x-kubernetes-list-type": "atomic"
                             },
                             "pool": {
+                              "default": "rbd",
                               "type": "string"
                             },
                             "readOnly": {
@@ -33001,6 +37501,7 @@
                               "additionalProperties": false
                             },
                             "user": {
+                              "default": "admin",
                               "type": "string"
                             }
                           },
@@ -33014,6 +37515,7 @@
                         "scaleIO": {
                           "properties": {
                             "fsType": {
+                              "default": "xfs",
                               "type": "string"
                             },
                             "gateway": {
@@ -33040,6 +37542,7 @@
                               "type": "boolean"
                             },
                             "storageMode": {
+                              "default": "ThinProvisioned",
                               "type": "string"
                             },
                             "storagePool": {
@@ -33227,7 +37730,37 @@
                     "type": "string"
                   },
                   "metadata": {
-                    "type": "object"
+                    "properties": {
+                      "annotations": {
+                        "additionalProperties": {
+                          "type": "string"
+                        },
+                        "type": "object"
+                      },
+                      "finalizers": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "generateName": {
+                        "type": "string"
+                      },
+                      "labels": {
+                        "additionalProperties": {
+                          "type": "string"
+                        },
+                        "type": "object"
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "namespace": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
                   },
                   "spec": {
                     "properties": {
@@ -33523,12 +38056,14 @@
                         "type": "string"
                       },
                       "fsType": {
+                        "default": "ext4",
                         "type": "string"
                       },
                       "kind": {
                         "type": "string"
                       },
                       "readOnly": {
+                        "default": false,
                         "type": "boolean"
                       }
                     },
@@ -33803,7 +38338,37 @@
                       "volumeClaimTemplate": {
                         "properties": {
                           "metadata": {
-                            "type": "object"
+                            "properties": {
+                              "annotations": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "type": "object"
+                              },
+                              "finalizers": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "generateName": {
+                                "type": "string"
+                              },
+                              "labels": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "type": "object"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "namespace": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
                           },
                           "spec": {
                             "properties": {
@@ -34110,6 +38675,18 @@
                     "type": "object",
                     "additionalProperties": false
                   },
+                  "image": {
+                    "properties": {
+                      "pullPolicy": {
+                        "type": "string"
+                      },
+                      "reference": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
                   "iscsi": {
                     "properties": {
                       "chapAuthDiscovery": {
@@ -34128,6 +38705,7 @@
                         "type": "string"
                       },
                       "iscsiInterface": {
+                        "default": "default",
                         "type": "string"
                       },
                       "lun": {
@@ -34520,6 +39098,7 @@
                         "type": "string"
                       },
                       "keyring": {
+                        "default": "/etc/ceph/keyring",
                         "type": "string"
                       },
                       "monitors": {
@@ -34530,6 +39109,7 @@
                         "x-kubernetes-list-type": "atomic"
                       },
                       "pool": {
+                        "default": "rbd",
                         "type": "string"
                       },
                       "readOnly": {
@@ -34547,6 +39127,7 @@
                         "additionalProperties": false
                       },
                       "user": {
+                        "default": "admin",
                         "type": "string"
                       }
                     },
@@ -34560,6 +39141,7 @@
                   "scaleIO": {
                     "properties": {
                       "fsType": {
+                        "default": "xfs",
                         "type": "string"
                       },
                       "gateway": {
@@ -34586,6 +39168,7 @@
                         "type": "boolean"
                       },
                       "storageMode": {
+                        "default": "ThinProvisioned",
                         "type": "string"
                       },
                       "storagePool": {
@@ -34828,14 +39411,6 @@
           "type": "integer"
         }
       },
-      "required": [
-        "active",
-        "conditions",
-        "failed",
-        "lastScheduledTime",
-        "phase",
-        "succeeded"
-      ],
       "type": "object",
       "additionalProperties": false
     }

--- a/argoproj.io/workflowtemplate_v1alpha1.json
+++ b/argoproj.io/workflowtemplate_v1alpha1.json
@@ -3087,10 +3087,6 @@
           "type": "object",
           "additionalProperties": false
         },
-        "podPriority": {
-          "format": "int32",
-          "type": "integer"
-        },
         "podPriorityClassName": {
           "type": "string"
         },
@@ -3114,6 +3110,9 @@
             },
             "backoff": {
               "properties": {
+                "cap": {
+                  "type": "string"
+                },
                 "duration": {
                   "type": "string"
                 },
@@ -3194,6 +3193,9 @@
               "format": "int64",
               "type": "integer"
             },
+            "seLinuxChangePolicy": {
+              "type": "string"
+            },
             "seLinuxOptions": {
               "properties": {
                 "level": {
@@ -3234,6 +3236,9 @@
               },
               "type": "array",
               "x-kubernetes-list-type": "atomic"
+            },
+            "supplementalGroupsPolicy": {
+              "type": "string"
             },
             "sysctls": {
               "items": {
@@ -3290,6 +3295,9 @@
           "properties": {
             "mutex": {
               "properties": {
+                "database": {
+                  "type": "boolean"
+                },
                 "name": {
                   "type": "string"
                 },
@@ -3303,6 +3311,9 @@
             "mutexes": {
               "items": {
                 "properties": {
+                  "database": {
+                    "type": "boolean"
+                  },
                   "name": {
                     "type": "string"
                   },
@@ -3337,6 +3348,18 @@
                   "x-kubernetes-map-type": "atomic",
                   "additionalProperties": false
                 },
+                "database": {
+                  "properties": {
+                    "key": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "key"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
                 "namespace": {
                   "type": "string"
                 }
@@ -3365,6 +3388,18 @@
                     ],
                     "type": "object",
                     "x-kubernetes-map-type": "atomic",
+                    "additionalProperties": false
+                  },
+                  "database": {
+                    "properties": {
+                      "key": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "key"
+                    ],
+                    "type": "object",
                     "additionalProperties": false
                   },
                   "namespace": {
@@ -4066,6 +4101,12 @@
               },
               "type": "object",
               "additionalProperties": false
+            },
+            "annotations": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
             },
             "archiveLocation": {
               "properties": {
@@ -5252,6 +5293,9 @@
                       },
                       "type": "object",
                       "additionalProperties": false
+                    },
+                    "stopSignal": {
+                      "type": "string"
                     }
                   },
                   "type": "object",
@@ -5283,6 +5327,7 @@
                           "type": "integer"
                         },
                         "service": {
+                          "default": "",
                           "type": "string"
                         }
                       },
@@ -5452,6 +5497,7 @@
                           "type": "integer"
                         },
                         "service": {
+                          "default": "",
                           "type": "string"
                         }
                       },
@@ -5583,6 +5629,9 @@
                       "items": {
                         "properties": {
                           "name": {
+                            "type": "string"
+                          },
+                          "request": {
                             "type": "string"
                           }
                         },
@@ -5776,6 +5825,7 @@
                           "type": "integer"
                         },
                         "service": {
+                          "default": "",
                           "type": "string"
                         }
                       },
@@ -5961,9 +6011,6 @@
                   "type": "string"
                 }
               },
-              "required": [
-                "name"
-              ],
               "type": "object",
               "additionalProperties": false
             },
@@ -6360,6 +6407,9 @@
                             },
                             "type": "object",
                             "additionalProperties": false
+                          },
+                          "stopSignal": {
+                            "type": "string"
                           }
                         },
                         "type": "object",
@@ -6391,6 +6441,7 @@
                                 "type": "integer"
                               },
                               "service": {
+                                "default": "",
                                 "type": "string"
                               }
                             },
@@ -6560,6 +6611,7 @@
                                 "type": "integer"
                               },
                               "service": {
+                                "default": "",
                                 "type": "string"
                               }
                             },
@@ -6691,6 +6743,9 @@
                             "items": {
                               "properties": {
                                 "name": {
+                                  "type": "string"
+                                },
+                                "request": {
                                   "type": "string"
                                 }
                               },
@@ -6884,6 +6939,7 @@
                                 "type": "integer"
                               },
                               "service": {
+                                "default": "",
                                 "type": "string"
                               }
                             },
@@ -9170,7 +9226,9 @@
                         },
                         "type": "object"
                       },
-                      "inline": {},
+                      "inline": {
+                        "x-kubernetes-preserve-unknown-fields": true
+                      },
                       "name": {
                         "type": "string"
                       },
@@ -9199,10 +9257,7 @@
                         "type": "string"
                       },
                       "withItems": {
-                        "items": {
-                          "type": "object"
-                        },
-                        "type": "array"
+                        "x-kubernetes-preserve-unknown-fields": true
                       },
                       "withParam": {
                         "type": "string"
@@ -10687,6 +10742,9 @@
                         },
                         "type": "object",
                         "additionalProperties": false
+                      },
+                      "stopSignal": {
+                        "type": "string"
                       }
                     },
                     "type": "object",
@@ -10718,6 +10776,7 @@
                             "type": "integer"
                           },
                           "service": {
+                            "default": "",
                             "type": "string"
                           }
                         },
@@ -10890,6 +10949,7 @@
                             "type": "integer"
                           },
                           "service": {
+                            "default": "",
                             "type": "string"
                           }
                         },
@@ -11021,6 +11081,9 @@
                         "items": {
                           "properties": {
                             "name": {
+                              "type": "string"
+                            },
+                            "request": {
                               "type": "string"
                             }
                           },
@@ -11214,6 +11277,7 @@
                             "type": "integer"
                           },
                           "service": {
+                            "default": "",
                             "type": "string"
                           }
                         },
@@ -13555,14 +13619,11 @@
               "type": "integer"
             },
             "plugin": {
-              "type": "object"
+              "type": "object",
+              "x-kubernetes-preserve-unknown-fields": true
             },
             "podSpecPatch": {
               "type": "string"
-            },
-            "priority": {
-              "format": "int32",
-              "type": "integer"
             },
             "priorityClassName": {
               "type": "string"
@@ -14512,6 +14573,9 @@
                 },
                 "backoff": {
                   "properties": {
+                    "cap": {
+                      "type": "string"
+                    },
                     "duration": {
                       "type": "string"
                     },
@@ -14941,6 +15005,9 @@
                       },
                       "type": "object",
                       "additionalProperties": false
+                    },
+                    "stopSignal": {
+                      "type": "string"
                     }
                   },
                   "type": "object",
@@ -14972,6 +15039,7 @@
                           "type": "integer"
                         },
                         "service": {
+                          "default": "",
                           "type": "string"
                         }
                       },
@@ -15141,6 +15209,7 @@
                           "type": "integer"
                         },
                         "service": {
+                          "default": "",
                           "type": "string"
                         }
                       },
@@ -15272,6 +15341,9 @@
                       "items": {
                         "properties": {
                           "name": {
+                            "type": "string"
+                          },
+                          "request": {
                             "type": "string"
                           }
                         },
@@ -15468,6 +15540,7 @@
                           "type": "integer"
                         },
                         "service": {
+                          "default": "",
                           "type": "string"
                         }
                       },
@@ -15653,10 +15726,6 @@
                   "type": "string"
                 }
               },
-              "required": [
-                "name",
-                "source"
-              ],
               "type": "object",
               "additionalProperties": false
             },
@@ -15694,6 +15763,9 @@
                 "runAsUser": {
                   "format": "int64",
                   "type": "integer"
+                },
+                "seLinuxChangePolicy": {
+                  "type": "string"
                 },
                 "seLinuxOptions": {
                   "properties": {
@@ -15735,6 +15807,9 @@
                   },
                   "type": "array",
                   "x-kubernetes-list-type": "atomic"
+                },
+                "supplementalGroupsPolicy": {
+                  "type": "string"
                 },
                 "sysctls": {
                   "items": {
@@ -16166,6 +16241,9 @@
                         },
                         "type": "object",
                         "additionalProperties": false
+                      },
+                      "stopSignal": {
+                        "type": "string"
                       }
                     },
                     "type": "object",
@@ -16197,6 +16275,7 @@
                             "type": "integer"
                           },
                           "service": {
+                            "default": "",
                             "type": "string"
                           }
                         },
@@ -16369,6 +16448,7 @@
                             "type": "integer"
                           },
                           "service": {
+                            "default": "",
                             "type": "string"
                           }
                         },
@@ -16500,6 +16580,9 @@
                         "items": {
                           "properties": {
                             "name": {
+                              "type": "string"
+                            },
+                            "request": {
                               "type": "string"
                             }
                           },
@@ -16693,6 +16776,7 @@
                             "type": "integer"
                           },
                           "service": {
+                            "default": "",
                             "type": "string"
                           }
                         },
@@ -16888,6 +16972,2096 @@
             },
             "steps": {
               "items": {
+                "items": {
+                  "properties": {
+                    "arguments": {
+                      "properties": {
+                        "artifacts": {
+                          "items": {
+                            "properties": {
+                              "archive": {
+                                "properties": {
+                                  "none": {
+                                    "type": "object"
+                                  },
+                                  "tar": {
+                                    "properties": {
+                                      "compressionLevel": {
+                                        "format": "int32",
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "zip": {
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "archiveLogs": {
+                                "type": "boolean"
+                              },
+                              "artifactGC": {
+                                "properties": {
+                                  "podMetadata": {
+                                    "properties": {
+                                      "annotations": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
+                                      },
+                                      "labels": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "serviceAccountName": {
+                                    "type": "string"
+                                  },
+                                  "strategy": {
+                                    "enum": [
+                                      "",
+                                      "OnWorkflowCompletion",
+                                      "OnWorkflowDeletion",
+                                      "Never"
+                                    ],
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "artifactory": {
+                                "properties": {
+                                  "passwordSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "default": "",
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "x-kubernetes-map-type": "atomic",
+                                    "additionalProperties": false
+                                  },
+                                  "url": {
+                                    "type": "string"
+                                  },
+                                  "usernameSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "default": "",
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "x-kubernetes-map-type": "atomic",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "required": [
+                                  "url"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "azure": {
+                                "properties": {
+                                  "accountKeySecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "default": "",
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "x-kubernetes-map-type": "atomic",
+                                    "additionalProperties": false
+                                  },
+                                  "blob": {
+                                    "type": "string"
+                                  },
+                                  "container": {
+                                    "type": "string"
+                                  },
+                                  "endpoint": {
+                                    "type": "string"
+                                  },
+                                  "useSDKCreds": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "blob",
+                                  "container",
+                                  "endpoint"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "deleted": {
+                                "type": "boolean"
+                              },
+                              "from": {
+                                "type": "string"
+                              },
+                              "fromExpression": {
+                                "type": "string"
+                              },
+                              "gcs": {
+                                "properties": {
+                                  "bucket": {
+                                    "type": "string"
+                                  },
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "serviceAccountKeySecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "default": "",
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "x-kubernetes-map-type": "atomic",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "git": {
+                                "properties": {
+                                  "branch": {
+                                    "type": "string"
+                                  },
+                                  "depth": {
+                                    "format": "int64",
+                                    "type": "integer"
+                                  },
+                                  "disableSubmodules": {
+                                    "type": "boolean"
+                                  },
+                                  "fetch": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "insecureIgnoreHostKey": {
+                                    "type": "boolean"
+                                  },
+                                  "insecureSkipTLS": {
+                                    "type": "boolean"
+                                  },
+                                  "passwordSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "default": "",
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "x-kubernetes-map-type": "atomic",
+                                    "additionalProperties": false
+                                  },
+                                  "repo": {
+                                    "type": "string"
+                                  },
+                                  "revision": {
+                                    "type": "string"
+                                  },
+                                  "singleBranch": {
+                                    "type": "boolean"
+                                  },
+                                  "sshPrivateKeySecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "default": "",
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "x-kubernetes-map-type": "atomic",
+                                    "additionalProperties": false
+                                  },
+                                  "usernameSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "default": "",
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "x-kubernetes-map-type": "atomic",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "required": [
+                                  "repo"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "globalName": {
+                                "type": "string"
+                              },
+                              "hdfs": {
+                                "properties": {
+                                  "addresses": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "dataTransferProtection": {
+                                    "type": "string"
+                                  },
+                                  "force": {
+                                    "type": "boolean"
+                                  },
+                                  "hdfsUser": {
+                                    "type": "string"
+                                  },
+                                  "krbCCacheSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "default": "",
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "x-kubernetes-map-type": "atomic",
+                                    "additionalProperties": false
+                                  },
+                                  "krbConfigConfigMap": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "default": "",
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "x-kubernetes-map-type": "atomic",
+                                    "additionalProperties": false
+                                  },
+                                  "krbKeytabSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "default": "",
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "x-kubernetes-map-type": "atomic",
+                                    "additionalProperties": false
+                                  },
+                                  "krbRealm": {
+                                    "type": "string"
+                                  },
+                                  "krbServicePrincipalName": {
+                                    "type": "string"
+                                  },
+                                  "krbUsername": {
+                                    "type": "string"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "path"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "http": {
+                                "properties": {
+                                  "auth": {
+                                    "properties": {
+                                      "basicAuth": {
+                                        "properties": {
+                                          "passwordSecret": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "default": "",
+                                                "type": "string"
+                                              },
+                                              "optional": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "required": [
+                                              "key"
+                                            ],
+                                            "type": "object",
+                                            "x-kubernetes-map-type": "atomic",
+                                            "additionalProperties": false
+                                          },
+                                          "usernameSecret": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "default": "",
+                                                "type": "string"
+                                              },
+                                              "optional": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "required": [
+                                              "key"
+                                            ],
+                                            "type": "object",
+                                            "x-kubernetes-map-type": "atomic",
+                                            "additionalProperties": false
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "clientCert": {
+                                        "properties": {
+                                          "clientCertSecret": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "default": "",
+                                                "type": "string"
+                                              },
+                                              "optional": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "required": [
+                                              "key"
+                                            ],
+                                            "type": "object",
+                                            "x-kubernetes-map-type": "atomic",
+                                            "additionalProperties": false
+                                          },
+                                          "clientKeySecret": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "default": "",
+                                                "type": "string"
+                                              },
+                                              "optional": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "required": [
+                                              "key"
+                                            ],
+                                            "type": "object",
+                                            "x-kubernetes-map-type": "atomic",
+                                            "additionalProperties": false
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "oauth2": {
+                                        "properties": {
+                                          "clientIDSecret": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "default": "",
+                                                "type": "string"
+                                              },
+                                              "optional": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "required": [
+                                              "key"
+                                            ],
+                                            "type": "object",
+                                            "x-kubernetes-map-type": "atomic",
+                                            "additionalProperties": false
+                                          },
+                                          "clientSecretSecret": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "default": "",
+                                                "type": "string"
+                                              },
+                                              "optional": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "required": [
+                                              "key"
+                                            ],
+                                            "type": "object",
+                                            "x-kubernetes-map-type": "atomic",
+                                            "additionalProperties": false
+                                          },
+                                          "endpointParams": {
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "value": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "required": [
+                                                "key"
+                                              ],
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          },
+                                          "scopes": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "tokenURLSecret": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "default": "",
+                                                "type": "string"
+                                              },
+                                              "optional": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "required": [
+                                              "key"
+                                            ],
+                                            "type": "object",
+                                            "x-kubernetes-map-type": "atomic",
+                                            "additionalProperties": false
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "headers": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "name",
+                                        "value"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "url": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "url"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "mode": {
+                                "format": "int32",
+                                "type": "integer"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "optional": {
+                                "type": "boolean"
+                              },
+                              "oss": {
+                                "properties": {
+                                  "accessKeySecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "default": "",
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "x-kubernetes-map-type": "atomic",
+                                    "additionalProperties": false
+                                  },
+                                  "bucket": {
+                                    "type": "string"
+                                  },
+                                  "createBucketIfNotPresent": {
+                                    "type": "boolean"
+                                  },
+                                  "endpoint": {
+                                    "type": "string"
+                                  },
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "lifecycleRule": {
+                                    "properties": {
+                                      "markDeletionAfterDays": {
+                                        "format": "int32",
+                                        "type": "integer"
+                                      },
+                                      "markInfrequentAccessAfterDays": {
+                                        "format": "int32",
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "secretKeySecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "default": "",
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "x-kubernetes-map-type": "atomic",
+                                    "additionalProperties": false
+                                  },
+                                  "securityToken": {
+                                    "type": "string"
+                                  },
+                                  "useSDKCreds": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "path": {
+                                "type": "string"
+                              },
+                              "raw": {
+                                "properties": {
+                                  "data": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "data"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "recurseMode": {
+                                "type": "boolean"
+                              },
+                              "s3": {
+                                "properties": {
+                                  "accessKeySecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "default": "",
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "x-kubernetes-map-type": "atomic",
+                                    "additionalProperties": false
+                                  },
+                                  "bucket": {
+                                    "type": "string"
+                                  },
+                                  "caSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "default": "",
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "x-kubernetes-map-type": "atomic",
+                                    "additionalProperties": false
+                                  },
+                                  "createBucketIfNotPresent": {
+                                    "properties": {
+                                      "objectLocking": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "encryptionOptions": {
+                                    "properties": {
+                                      "enableEncryption": {
+                                        "type": "boolean"
+                                      },
+                                      "kmsEncryptionContext": {
+                                        "type": "string"
+                                      },
+                                      "kmsKeyId": {
+                                        "type": "string"
+                                      },
+                                      "serverSideCustomerKeySecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "default": "",
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "x-kubernetes-map-type": "atomic",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "endpoint": {
+                                    "type": "string"
+                                  },
+                                  "insecure": {
+                                    "type": "boolean"
+                                  },
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "region": {
+                                    "type": "string"
+                                  },
+                                  "roleARN": {
+                                    "type": "string"
+                                  },
+                                  "secretKeySecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "default": "",
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "x-kubernetes-map-type": "atomic",
+                                    "additionalProperties": false
+                                  },
+                                  "sessionTokenSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "default": "",
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "x-kubernetes-map-type": "atomic",
+                                    "additionalProperties": false
+                                  },
+                                  "useSDKCreds": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "subPath": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "name"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "parameters": {
+                          "items": {
+                            "properties": {
+                              "default": {
+                                "type": "string"
+                              },
+                              "description": {
+                                "type": "string"
+                              },
+                              "enum": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "globalName": {
+                                "type": "string"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "value": {
+                                "type": "string"
+                              },
+                              "valueFrom": {
+                                "properties": {
+                                  "configMapKeyRef": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "default": "",
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "x-kubernetes-map-type": "atomic",
+                                    "additionalProperties": false
+                                  },
+                                  "default": {
+                                    "type": "string"
+                                  },
+                                  "event": {
+                                    "type": "string"
+                                  },
+                                  "expression": {
+                                    "type": "string"
+                                  },
+                                  "jqFilter": {
+                                    "type": "string"
+                                  },
+                                  "jsonPath": {
+                                    "type": "string"
+                                  },
+                                  "parameter": {
+                                    "type": "string"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "supplied": {
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "required": [
+                              "name"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "continueOn": {
+                      "properties": {
+                        "error": {
+                          "type": "boolean"
+                        },
+                        "failed": {
+                          "type": "boolean"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "hooks": {
+                      "additionalProperties": {
+                        "properties": {
+                          "arguments": {
+                            "properties": {
+                              "artifacts": {
+                                "items": {
+                                  "properties": {
+                                    "archive": {
+                                      "properties": {
+                                        "none": {
+                                          "type": "object"
+                                        },
+                                        "tar": {
+                                          "properties": {
+                                            "compressionLevel": {
+                                              "format": "int32",
+                                              "type": "integer"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "zip": {
+                                          "type": "object"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "archiveLogs": {
+                                      "type": "boolean"
+                                    },
+                                    "artifactGC": {
+                                      "properties": {
+                                        "podMetadata": {
+                                          "properties": {
+                                            "annotations": {
+                                              "additionalProperties": {
+                                                "type": "string"
+                                              },
+                                              "type": "object"
+                                            },
+                                            "labels": {
+                                              "additionalProperties": {
+                                                "type": "string"
+                                              },
+                                              "type": "object"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "serviceAccountName": {
+                                          "type": "string"
+                                        },
+                                        "strategy": {
+                                          "enum": [
+                                            "",
+                                            "OnWorkflowCompletion",
+                                            "OnWorkflowDeletion",
+                                            "Never"
+                                          ],
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "artifactory": {
+                                      "properties": {
+                                        "passwordSecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "default": "",
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "x-kubernetes-map-type": "atomic",
+                                          "additionalProperties": false
+                                        },
+                                        "url": {
+                                          "type": "string"
+                                        },
+                                        "usernameSecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "default": "",
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "x-kubernetes-map-type": "atomic",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "required": [
+                                        "url"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "azure": {
+                                      "properties": {
+                                        "accountKeySecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "default": "",
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "x-kubernetes-map-type": "atomic",
+                                          "additionalProperties": false
+                                        },
+                                        "blob": {
+                                          "type": "string"
+                                        },
+                                        "container": {
+                                          "type": "string"
+                                        },
+                                        "endpoint": {
+                                          "type": "string"
+                                        },
+                                        "useSDKCreds": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "blob",
+                                        "container",
+                                        "endpoint"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "deleted": {
+                                      "type": "boolean"
+                                    },
+                                    "from": {
+                                      "type": "string"
+                                    },
+                                    "fromExpression": {
+                                      "type": "string"
+                                    },
+                                    "gcs": {
+                                      "properties": {
+                                        "bucket": {
+                                          "type": "string"
+                                        },
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "serviceAccountKeySecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "default": "",
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "x-kubernetes-map-type": "atomic",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "git": {
+                                      "properties": {
+                                        "branch": {
+                                          "type": "string"
+                                        },
+                                        "depth": {
+                                          "format": "int64",
+                                          "type": "integer"
+                                        },
+                                        "disableSubmodules": {
+                                          "type": "boolean"
+                                        },
+                                        "fetch": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        },
+                                        "insecureIgnoreHostKey": {
+                                          "type": "boolean"
+                                        },
+                                        "insecureSkipTLS": {
+                                          "type": "boolean"
+                                        },
+                                        "passwordSecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "default": "",
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "x-kubernetes-map-type": "atomic",
+                                          "additionalProperties": false
+                                        },
+                                        "repo": {
+                                          "type": "string"
+                                        },
+                                        "revision": {
+                                          "type": "string"
+                                        },
+                                        "singleBranch": {
+                                          "type": "boolean"
+                                        },
+                                        "sshPrivateKeySecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "default": "",
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "x-kubernetes-map-type": "atomic",
+                                          "additionalProperties": false
+                                        },
+                                        "usernameSecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "default": "",
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "x-kubernetes-map-type": "atomic",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "required": [
+                                        "repo"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "globalName": {
+                                      "type": "string"
+                                    },
+                                    "hdfs": {
+                                      "properties": {
+                                        "addresses": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        },
+                                        "dataTransferProtection": {
+                                          "type": "string"
+                                        },
+                                        "force": {
+                                          "type": "boolean"
+                                        },
+                                        "hdfsUser": {
+                                          "type": "string"
+                                        },
+                                        "krbCCacheSecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "default": "",
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "x-kubernetes-map-type": "atomic",
+                                          "additionalProperties": false
+                                        },
+                                        "krbConfigConfigMap": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "default": "",
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "x-kubernetes-map-type": "atomic",
+                                          "additionalProperties": false
+                                        },
+                                        "krbKeytabSecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "default": "",
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "x-kubernetes-map-type": "atomic",
+                                          "additionalProperties": false
+                                        },
+                                        "krbRealm": {
+                                          "type": "string"
+                                        },
+                                        "krbServicePrincipalName": {
+                                          "type": "string"
+                                        },
+                                        "krbUsername": {
+                                          "type": "string"
+                                        },
+                                        "path": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "path"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "http": {
+                                      "properties": {
+                                        "auth": {
+                                          "properties": {
+                                            "basicAuth": {
+                                              "properties": {
+                                                "passwordSecret": {
+                                                  "properties": {
+                                                    "key": {
+                                                      "type": "string"
+                                                    },
+                                                    "name": {
+                                                      "default": "",
+                                                      "type": "string"
+                                                    },
+                                                    "optional": {
+                                                      "type": "boolean"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "key"
+                                                  ],
+                                                  "type": "object",
+                                                  "x-kubernetes-map-type": "atomic",
+                                                  "additionalProperties": false
+                                                },
+                                                "usernameSecret": {
+                                                  "properties": {
+                                                    "key": {
+                                                      "type": "string"
+                                                    },
+                                                    "name": {
+                                                      "default": "",
+                                                      "type": "string"
+                                                    },
+                                                    "optional": {
+                                                      "type": "boolean"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "key"
+                                                  ],
+                                                  "type": "object",
+                                                  "x-kubernetes-map-type": "atomic",
+                                                  "additionalProperties": false
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "clientCert": {
+                                              "properties": {
+                                                "clientCertSecret": {
+                                                  "properties": {
+                                                    "key": {
+                                                      "type": "string"
+                                                    },
+                                                    "name": {
+                                                      "default": "",
+                                                      "type": "string"
+                                                    },
+                                                    "optional": {
+                                                      "type": "boolean"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "key"
+                                                  ],
+                                                  "type": "object",
+                                                  "x-kubernetes-map-type": "atomic",
+                                                  "additionalProperties": false
+                                                },
+                                                "clientKeySecret": {
+                                                  "properties": {
+                                                    "key": {
+                                                      "type": "string"
+                                                    },
+                                                    "name": {
+                                                      "default": "",
+                                                      "type": "string"
+                                                    },
+                                                    "optional": {
+                                                      "type": "boolean"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "key"
+                                                  ],
+                                                  "type": "object",
+                                                  "x-kubernetes-map-type": "atomic",
+                                                  "additionalProperties": false
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "oauth2": {
+                                              "properties": {
+                                                "clientIDSecret": {
+                                                  "properties": {
+                                                    "key": {
+                                                      "type": "string"
+                                                    },
+                                                    "name": {
+                                                      "default": "",
+                                                      "type": "string"
+                                                    },
+                                                    "optional": {
+                                                      "type": "boolean"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "key"
+                                                  ],
+                                                  "type": "object",
+                                                  "x-kubernetes-map-type": "atomic",
+                                                  "additionalProperties": false
+                                                },
+                                                "clientSecretSecret": {
+                                                  "properties": {
+                                                    "key": {
+                                                      "type": "string"
+                                                    },
+                                                    "name": {
+                                                      "default": "",
+                                                      "type": "string"
+                                                    },
+                                                    "optional": {
+                                                      "type": "boolean"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "key"
+                                                  ],
+                                                  "type": "object",
+                                                  "x-kubernetes-map-type": "atomic",
+                                                  "additionalProperties": false
+                                                },
+                                                "endpointParams": {
+                                                  "items": {
+                                                    "properties": {
+                                                      "key": {
+                                                        "type": "string"
+                                                      },
+                                                      "value": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "key"
+                                                    ],
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "type": "array"
+                                                },
+                                                "scopes": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                },
+                                                "tokenURLSecret": {
+                                                  "properties": {
+                                                    "key": {
+                                                      "type": "string"
+                                                    },
+                                                    "name": {
+                                                      "default": "",
+                                                      "type": "string"
+                                                    },
+                                                    "optional": {
+                                                      "type": "boolean"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "key"
+                                                  ],
+                                                  "type": "object",
+                                                  "x-kubernetes-map-type": "atomic",
+                                                  "additionalProperties": false
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "headers": {
+                                          "items": {
+                                            "properties": {
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "value": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name",
+                                              "value"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "array"
+                                        },
+                                        "url": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "url"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "mode": {
+                                      "format": "int32",
+                                      "type": "integer"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    },
+                                    "oss": {
+                                      "properties": {
+                                        "accessKeySecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "default": "",
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "x-kubernetes-map-type": "atomic",
+                                          "additionalProperties": false
+                                        },
+                                        "bucket": {
+                                          "type": "string"
+                                        },
+                                        "createBucketIfNotPresent": {
+                                          "type": "boolean"
+                                        },
+                                        "endpoint": {
+                                          "type": "string"
+                                        },
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "lifecycleRule": {
+                                          "properties": {
+                                            "markDeletionAfterDays": {
+                                              "format": "int32",
+                                              "type": "integer"
+                                            },
+                                            "markInfrequentAccessAfterDays": {
+                                              "format": "int32",
+                                              "type": "integer"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "secretKeySecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "default": "",
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "x-kubernetes-map-type": "atomic",
+                                          "additionalProperties": false
+                                        },
+                                        "securityToken": {
+                                          "type": "string"
+                                        },
+                                        "useSDKCreds": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "path": {
+                                      "type": "string"
+                                    },
+                                    "raw": {
+                                      "properties": {
+                                        "data": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "data"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "recurseMode": {
+                                      "type": "boolean"
+                                    },
+                                    "s3": {
+                                      "properties": {
+                                        "accessKeySecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "default": "",
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "x-kubernetes-map-type": "atomic",
+                                          "additionalProperties": false
+                                        },
+                                        "bucket": {
+                                          "type": "string"
+                                        },
+                                        "caSecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "default": "",
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "x-kubernetes-map-type": "atomic",
+                                          "additionalProperties": false
+                                        },
+                                        "createBucketIfNotPresent": {
+                                          "properties": {
+                                            "objectLocking": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "encryptionOptions": {
+                                          "properties": {
+                                            "enableEncryption": {
+                                              "type": "boolean"
+                                            },
+                                            "kmsEncryptionContext": {
+                                              "type": "string"
+                                            },
+                                            "kmsKeyId": {
+                                              "type": "string"
+                                            },
+                                            "serverSideCustomerKeySecret": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "name": {
+                                                  "default": "",
+                                                  "type": "string"
+                                                },
+                                                "optional": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              "required": [
+                                                "key"
+                                              ],
+                                              "type": "object",
+                                              "x-kubernetes-map-type": "atomic",
+                                              "additionalProperties": false
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "endpoint": {
+                                          "type": "string"
+                                        },
+                                        "insecure": {
+                                          "type": "boolean"
+                                        },
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "region": {
+                                          "type": "string"
+                                        },
+                                        "roleARN": {
+                                          "type": "string"
+                                        },
+                                        "secretKeySecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "default": "",
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "x-kubernetes-map-type": "atomic",
+                                          "additionalProperties": false
+                                        },
+                                        "sessionTokenSecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "default": "",
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "x-kubernetes-map-type": "atomic",
+                                          "additionalProperties": false
+                                        },
+                                        "useSDKCreds": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "subPath": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "name"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "parameters": {
+                                "items": {
+                                  "properties": {
+                                    "default": {
+                                      "type": "string"
+                                    },
+                                    "description": {
+                                      "type": "string"
+                                    },
+                                    "enum": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "globalName": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    },
+                                    "valueFrom": {
+                                      "properties": {
+                                        "configMapKeyRef": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "default": "",
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "x-kubernetes-map-type": "atomic",
+                                          "additionalProperties": false
+                                        },
+                                        "default": {
+                                          "type": "string"
+                                        },
+                                        "event": {
+                                          "type": "string"
+                                        },
+                                        "expression": {
+                                          "type": "string"
+                                        },
+                                        "jqFilter": {
+                                          "type": "string"
+                                        },
+                                        "jsonPath": {
+                                          "type": "string"
+                                        },
+                                        "parameter": {
+                                          "type": "string"
+                                        },
+                                        "path": {
+                                          "type": "string"
+                                        },
+                                        "supplied": {
+                                          "type": "object"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "required": [
+                                    "name"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "expression": {
+                            "type": "string"
+                          },
+                          "template": {
+                            "type": "string"
+                          },
+                          "templateRef": {
+                            "properties": {
+                              "clusterScope": {
+                                "type": "boolean"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "template": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "object"
+                    },
+                    "inline": {
+                      "x-kubernetes-preserve-unknown-fields": true
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "onExit": {
+                      "type": "string"
+                    },
+                    "template": {
+                      "type": "string"
+                    },
+                    "templateRef": {
+                      "properties": {
+                        "clusterScope": {
+                          "type": "boolean"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "template": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "when": {
+                      "type": "string"
+                    },
+                    "withItems": {
+                      "x-kubernetes-preserve-unknown-fields": true
+                    },
+                    "withParam": {
+                      "type": "string"
+                    },
+                    "withSequence": {
+                      "properties": {
+                        "count": {
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "string"
+                            }
+                          ],
+                          "x-kubernetes-int-or-string": true
+                        },
+                        "end": {
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "string"
+                            }
+                          ],
+                          "x-kubernetes-int-or-string": true
+                        },
+                        "format": {
+                          "type": "string"
+                        },
+                        "start": {
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "string"
+                            }
+                          ],
+                          "x-kubernetes-int-or-string": true
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
                 "type": "array"
               },
               "type": "array"
@@ -16905,6 +19079,9 @@
               "properties": {
                 "mutex": {
                   "properties": {
+                    "database": {
+                      "type": "boolean"
+                    },
                     "name": {
                       "type": "string"
                     },
@@ -16918,6 +19095,9 @@
                 "mutexes": {
                   "items": {
                     "properties": {
+                      "database": {
+                        "type": "boolean"
+                      },
                       "name": {
                         "type": "string"
                       },
@@ -16952,6 +19132,18 @@
                       "x-kubernetes-map-type": "atomic",
                       "additionalProperties": false
                     },
+                    "database": {
+                      "properties": {
+                        "key": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "key"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
                     "namespace": {
                       "type": "string"
                     }
@@ -16980,6 +19172,18 @@
                         ],
                         "type": "object",
                         "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "database": {
+                        "properties": {
+                          "key": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "key"
+                        ],
+                        "type": "object",
                         "additionalProperties": false
                       },
                       "namespace": {
@@ -17060,12 +19264,14 @@
                         "type": "string"
                       },
                       "fsType": {
+                        "default": "ext4",
                         "type": "string"
                       },
                       "kind": {
                         "type": "string"
                       },
                       "readOnly": {
+                        "default": false,
                         "type": "boolean"
                       }
                     },
@@ -17340,7 +19546,37 @@
                       "volumeClaimTemplate": {
                         "properties": {
                           "metadata": {
-                            "type": "object"
+                            "properties": {
+                              "annotations": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "type": "object"
+                              },
+                              "finalizers": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "generateName": {
+                                "type": "string"
+                              },
+                              "labels": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "type": "object"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "namespace": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
                           },
                           "spec": {
                             "properties": {
@@ -17647,6 +19883,18 @@
                     "type": "object",
                     "additionalProperties": false
                   },
+                  "image": {
+                    "properties": {
+                      "pullPolicy": {
+                        "type": "string"
+                      },
+                      "reference": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
                   "iscsi": {
                     "properties": {
                       "chapAuthDiscovery": {
@@ -17665,6 +19913,7 @@
                         "type": "string"
                       },
                       "iscsiInterface": {
+                        "default": "default",
                         "type": "string"
                       },
                       "lun": {
@@ -18057,6 +20306,7 @@
                         "type": "string"
                       },
                       "keyring": {
+                        "default": "/etc/ceph/keyring",
                         "type": "string"
                       },
                       "monitors": {
@@ -18067,6 +20317,7 @@
                         "x-kubernetes-list-type": "atomic"
                       },
                       "pool": {
+                        "default": "rbd",
                         "type": "string"
                       },
                       "readOnly": {
@@ -18084,6 +20335,7 @@
                         "additionalProperties": false
                       },
                       "user": {
+                        "default": "admin",
                         "type": "string"
                       }
                     },
@@ -18097,6 +20349,7 @@
                   "scaleIO": {
                     "properties": {
                       "fsType": {
+                        "default": "xfs",
                         "type": "string"
                       },
                       "gateway": {
@@ -18123,6 +20376,7 @@
                         "type": "boolean"
                       },
                       "storageMode": {
+                        "default": "ThinProvisioned",
                         "type": "string"
                       },
                       "storagePool": {
@@ -18933,6 +21187,12 @@
                 },
                 "type": "object",
                 "additionalProperties": false
+              },
+              "annotations": {
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "type": "object"
               },
               "archiveLocation": {
                 "properties": {
@@ -20119,6 +22379,9 @@
                         },
                         "type": "object",
                         "additionalProperties": false
+                      },
+                      "stopSignal": {
+                        "type": "string"
                       }
                     },
                     "type": "object",
@@ -20150,6 +22413,7 @@
                             "type": "integer"
                           },
                           "service": {
+                            "default": "",
                             "type": "string"
                           }
                         },
@@ -20319,6 +22583,7 @@
                             "type": "integer"
                           },
                           "service": {
+                            "default": "",
                             "type": "string"
                           }
                         },
@@ -20450,6 +22715,9 @@
                         "items": {
                           "properties": {
                             "name": {
+                              "type": "string"
+                            },
+                            "request": {
                               "type": "string"
                             }
                           },
@@ -20643,6 +22911,7 @@
                             "type": "integer"
                           },
                           "service": {
+                            "default": "",
                             "type": "string"
                           }
                         },
@@ -20828,9 +23097,6 @@
                     "type": "string"
                   }
                 },
-                "required": [
-                  "image"
-                ],
                 "type": "object",
                 "additionalProperties": false
               },
@@ -21227,6 +23493,9 @@
                               },
                               "type": "object",
                               "additionalProperties": false
+                            },
+                            "stopSignal": {
+                              "type": "string"
                             }
                           },
                           "type": "object",
@@ -21258,6 +23527,7 @@
                                   "type": "integer"
                                 },
                                 "service": {
+                                  "default": "",
                                   "type": "string"
                                 }
                               },
@@ -21427,6 +23697,7 @@
                                   "type": "integer"
                                 },
                                 "service": {
+                                  "default": "",
                                   "type": "string"
                                 }
                               },
@@ -21558,6 +23829,9 @@
                               "items": {
                                 "properties": {
                                   "name": {
+                                    "type": "string"
+                                  },
+                                  "request": {
                                     "type": "string"
                                   }
                                 },
@@ -21751,6 +24025,7 @@
                                   "type": "integer"
                                 },
                                 "service": {
+                                  "default": "",
                                   "type": "string"
                                 }
                               },
@@ -24037,7 +26312,9 @@
                           },
                           "type": "object"
                         },
-                        "inline": {},
+                        "inline": {
+                          "x-kubernetes-preserve-unknown-fields": true
+                        },
                         "name": {
                           "type": "string"
                         },
@@ -24066,10 +26343,7 @@
                           "type": "string"
                         },
                         "withItems": {
-                          "items": {
-                            "type": "object"
-                          },
-                          "type": "array"
+                          "x-kubernetes-preserve-unknown-fields": true
                         },
                         "withParam": {
                           "type": "string"
@@ -25554,6 +27828,9 @@
                           },
                           "type": "object",
                           "additionalProperties": false
+                        },
+                        "stopSignal": {
+                          "type": "string"
                         }
                       },
                       "type": "object",
@@ -25585,6 +27862,7 @@
                               "type": "integer"
                             },
                             "service": {
+                              "default": "",
                               "type": "string"
                             }
                           },
@@ -25757,6 +28035,7 @@
                               "type": "integer"
                             },
                             "service": {
+                              "default": "",
                               "type": "string"
                             }
                           },
@@ -25888,6 +28167,9 @@
                           "items": {
                             "properties": {
                               "name": {
+                                "type": "string"
+                              },
+                              "request": {
                                 "type": "string"
                               }
                             },
@@ -26081,6 +28363,7 @@
                               "type": "integer"
                             },
                             "service": {
+                              "default": "",
                               "type": "string"
                             }
                           },
@@ -28422,14 +30705,11 @@
                 "type": "integer"
               },
               "plugin": {
-                "type": "object"
+                "type": "object",
+                "x-kubernetes-preserve-unknown-fields": true
               },
               "podSpecPatch": {
                 "type": "string"
-              },
-              "priority": {
-                "format": "int32",
-                "type": "integer"
               },
               "priorityClassName": {
                 "type": "string"
@@ -29379,6 +31659,9 @@
                   },
                   "backoff": {
                     "properties": {
+                      "cap": {
+                        "type": "string"
+                      },
                       "duration": {
                         "type": "string"
                       },
@@ -29808,6 +32091,9 @@
                         },
                         "type": "object",
                         "additionalProperties": false
+                      },
+                      "stopSignal": {
+                        "type": "string"
                       }
                     },
                     "type": "object",
@@ -29839,6 +32125,7 @@
                             "type": "integer"
                           },
                           "service": {
+                            "default": "",
                             "type": "string"
                           }
                         },
@@ -30008,6 +32295,7 @@
                             "type": "integer"
                           },
                           "service": {
+                            "default": "",
                             "type": "string"
                           }
                         },
@@ -30139,6 +32427,9 @@
                         "items": {
                           "properties": {
                             "name": {
+                              "type": "string"
+                            },
+                            "request": {
                               "type": "string"
                             }
                           },
@@ -30335,6 +32626,7 @@
                             "type": "integer"
                           },
                           "service": {
+                            "default": "",
                             "type": "string"
                           }
                         },
@@ -30520,10 +32812,6 @@
                     "type": "string"
                   }
                 },
-                "required": [
-                  "image",
-                  "source"
-                ],
                 "type": "object",
                 "additionalProperties": false
               },
@@ -30561,6 +32849,9 @@
                   "runAsUser": {
                     "format": "int64",
                     "type": "integer"
+                  },
+                  "seLinuxChangePolicy": {
+                    "type": "string"
                   },
                   "seLinuxOptions": {
                     "properties": {
@@ -30602,6 +32893,9 @@
                     },
                     "type": "array",
                     "x-kubernetes-list-type": "atomic"
+                  },
+                  "supplementalGroupsPolicy": {
+                    "type": "string"
                   },
                   "sysctls": {
                     "items": {
@@ -31033,6 +33327,9 @@
                           },
                           "type": "object",
                           "additionalProperties": false
+                        },
+                        "stopSignal": {
+                          "type": "string"
                         }
                       },
                       "type": "object",
@@ -31064,6 +33361,7 @@
                               "type": "integer"
                             },
                             "service": {
+                              "default": "",
                               "type": "string"
                             }
                           },
@@ -31236,6 +33534,7 @@
                               "type": "integer"
                             },
                             "service": {
+                              "default": "",
                               "type": "string"
                             }
                           },
@@ -31367,6 +33666,9 @@
                           "items": {
                             "properties": {
                               "name": {
+                                "type": "string"
+                              },
+                              "request": {
                                 "type": "string"
                               }
                             },
@@ -31560,6 +33862,7 @@
                               "type": "integer"
                             },
                             "service": {
+                              "default": "",
                               "type": "string"
                             }
                           },
@@ -31755,6 +34058,2096 @@
               },
               "steps": {
                 "items": {
+                  "items": {
+                    "properties": {
+                      "arguments": {
+                        "properties": {
+                          "artifacts": {
+                            "items": {
+                              "properties": {
+                                "archive": {
+                                  "properties": {
+                                    "none": {
+                                      "type": "object"
+                                    },
+                                    "tar": {
+                                      "properties": {
+                                        "compressionLevel": {
+                                          "format": "int32",
+                                          "type": "integer"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "zip": {
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "archiveLogs": {
+                                  "type": "boolean"
+                                },
+                                "artifactGC": {
+                                  "properties": {
+                                    "podMetadata": {
+                                      "properties": {
+                                        "annotations": {
+                                          "additionalProperties": {
+                                            "type": "string"
+                                          },
+                                          "type": "object"
+                                        },
+                                        "labels": {
+                                          "additionalProperties": {
+                                            "type": "string"
+                                          },
+                                          "type": "object"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "serviceAccountName": {
+                                      "type": "string"
+                                    },
+                                    "strategy": {
+                                      "enum": [
+                                        "",
+                                        "OnWorkflowCompletion",
+                                        "OnWorkflowDeletion",
+                                        "Never"
+                                      ],
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "artifactory": {
+                                  "properties": {
+                                    "passwordSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "default": "",
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "x-kubernetes-map-type": "atomic",
+                                      "additionalProperties": false
+                                    },
+                                    "url": {
+                                      "type": "string"
+                                    },
+                                    "usernameSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "default": "",
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "x-kubernetes-map-type": "atomic",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "required": [
+                                    "url"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "azure": {
+                                  "properties": {
+                                    "accountKeySecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "default": "",
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "x-kubernetes-map-type": "atomic",
+                                      "additionalProperties": false
+                                    },
+                                    "blob": {
+                                      "type": "string"
+                                    },
+                                    "container": {
+                                      "type": "string"
+                                    },
+                                    "endpoint": {
+                                      "type": "string"
+                                    },
+                                    "useSDKCreds": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "blob",
+                                    "container",
+                                    "endpoint"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "deleted": {
+                                  "type": "boolean"
+                                },
+                                "from": {
+                                  "type": "string"
+                                },
+                                "fromExpression": {
+                                  "type": "string"
+                                },
+                                "gcs": {
+                                  "properties": {
+                                    "bucket": {
+                                      "type": "string"
+                                    },
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "serviceAccountKeySecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "default": "",
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "x-kubernetes-map-type": "atomic",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "git": {
+                                  "properties": {
+                                    "branch": {
+                                      "type": "string"
+                                    },
+                                    "depth": {
+                                      "format": "int64",
+                                      "type": "integer"
+                                    },
+                                    "disableSubmodules": {
+                                      "type": "boolean"
+                                    },
+                                    "fetch": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "insecureIgnoreHostKey": {
+                                      "type": "boolean"
+                                    },
+                                    "insecureSkipTLS": {
+                                      "type": "boolean"
+                                    },
+                                    "passwordSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "default": "",
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "x-kubernetes-map-type": "atomic",
+                                      "additionalProperties": false
+                                    },
+                                    "repo": {
+                                      "type": "string"
+                                    },
+                                    "revision": {
+                                      "type": "string"
+                                    },
+                                    "singleBranch": {
+                                      "type": "boolean"
+                                    },
+                                    "sshPrivateKeySecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "default": "",
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "x-kubernetes-map-type": "atomic",
+                                      "additionalProperties": false
+                                    },
+                                    "usernameSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "default": "",
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "x-kubernetes-map-type": "atomic",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "required": [
+                                    "repo"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "globalName": {
+                                  "type": "string"
+                                },
+                                "hdfs": {
+                                  "properties": {
+                                    "addresses": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "dataTransferProtection": {
+                                      "type": "string"
+                                    },
+                                    "force": {
+                                      "type": "boolean"
+                                    },
+                                    "hdfsUser": {
+                                      "type": "string"
+                                    },
+                                    "krbCCacheSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "default": "",
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "x-kubernetes-map-type": "atomic",
+                                      "additionalProperties": false
+                                    },
+                                    "krbConfigConfigMap": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "default": "",
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "x-kubernetes-map-type": "atomic",
+                                      "additionalProperties": false
+                                    },
+                                    "krbKeytabSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "default": "",
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "x-kubernetes-map-type": "atomic",
+                                      "additionalProperties": false
+                                    },
+                                    "krbRealm": {
+                                      "type": "string"
+                                    },
+                                    "krbServicePrincipalName": {
+                                      "type": "string"
+                                    },
+                                    "krbUsername": {
+                                      "type": "string"
+                                    },
+                                    "path": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "path"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "http": {
+                                  "properties": {
+                                    "auth": {
+                                      "properties": {
+                                        "basicAuth": {
+                                          "properties": {
+                                            "passwordSecret": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "name": {
+                                                  "default": "",
+                                                  "type": "string"
+                                                },
+                                                "optional": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              "required": [
+                                                "key"
+                                              ],
+                                              "type": "object",
+                                              "x-kubernetes-map-type": "atomic",
+                                              "additionalProperties": false
+                                            },
+                                            "usernameSecret": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "name": {
+                                                  "default": "",
+                                                  "type": "string"
+                                                },
+                                                "optional": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              "required": [
+                                                "key"
+                                              ],
+                                              "type": "object",
+                                              "x-kubernetes-map-type": "atomic",
+                                              "additionalProperties": false
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "clientCert": {
+                                          "properties": {
+                                            "clientCertSecret": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "name": {
+                                                  "default": "",
+                                                  "type": "string"
+                                                },
+                                                "optional": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              "required": [
+                                                "key"
+                                              ],
+                                              "type": "object",
+                                              "x-kubernetes-map-type": "atomic",
+                                              "additionalProperties": false
+                                            },
+                                            "clientKeySecret": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "name": {
+                                                  "default": "",
+                                                  "type": "string"
+                                                },
+                                                "optional": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              "required": [
+                                                "key"
+                                              ],
+                                              "type": "object",
+                                              "x-kubernetes-map-type": "atomic",
+                                              "additionalProperties": false
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "oauth2": {
+                                          "properties": {
+                                            "clientIDSecret": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "name": {
+                                                  "default": "",
+                                                  "type": "string"
+                                                },
+                                                "optional": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              "required": [
+                                                "key"
+                                              ],
+                                              "type": "object",
+                                              "x-kubernetes-map-type": "atomic",
+                                              "additionalProperties": false
+                                            },
+                                            "clientSecretSecret": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "name": {
+                                                  "default": "",
+                                                  "type": "string"
+                                                },
+                                                "optional": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              "required": [
+                                                "key"
+                                              ],
+                                              "type": "object",
+                                              "x-kubernetes-map-type": "atomic",
+                                              "additionalProperties": false
+                                            },
+                                            "endpointParams": {
+                                              "items": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "value": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "key"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
+                                            },
+                                            "scopes": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            },
+                                            "tokenURLSecret": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "name": {
+                                                  "default": "",
+                                                  "type": "string"
+                                                },
+                                                "optional": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              "required": [
+                                                "key"
+                                              ],
+                                              "type": "object",
+                                              "x-kubernetes-map-type": "atomic",
+                                              "additionalProperties": false
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "headers": {
+                                      "items": {
+                                        "properties": {
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "value": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "name",
+                                          "value"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "url": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "url"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "mode": {
+                                  "format": "int32",
+                                  "type": "integer"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                },
+                                "oss": {
+                                  "properties": {
+                                    "accessKeySecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "default": "",
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "x-kubernetes-map-type": "atomic",
+                                      "additionalProperties": false
+                                    },
+                                    "bucket": {
+                                      "type": "string"
+                                    },
+                                    "createBucketIfNotPresent": {
+                                      "type": "boolean"
+                                    },
+                                    "endpoint": {
+                                      "type": "string"
+                                    },
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "lifecycleRule": {
+                                      "properties": {
+                                        "markDeletionAfterDays": {
+                                          "format": "int32",
+                                          "type": "integer"
+                                        },
+                                        "markInfrequentAccessAfterDays": {
+                                          "format": "int32",
+                                          "type": "integer"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "secretKeySecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "default": "",
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "x-kubernetes-map-type": "atomic",
+                                      "additionalProperties": false
+                                    },
+                                    "securityToken": {
+                                      "type": "string"
+                                    },
+                                    "useSDKCreds": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "path": {
+                                  "type": "string"
+                                },
+                                "raw": {
+                                  "properties": {
+                                    "data": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "data"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "recurseMode": {
+                                  "type": "boolean"
+                                },
+                                "s3": {
+                                  "properties": {
+                                    "accessKeySecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "default": "",
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "x-kubernetes-map-type": "atomic",
+                                      "additionalProperties": false
+                                    },
+                                    "bucket": {
+                                      "type": "string"
+                                    },
+                                    "caSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "default": "",
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "x-kubernetes-map-type": "atomic",
+                                      "additionalProperties": false
+                                    },
+                                    "createBucketIfNotPresent": {
+                                      "properties": {
+                                        "objectLocking": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "encryptionOptions": {
+                                      "properties": {
+                                        "enableEncryption": {
+                                          "type": "boolean"
+                                        },
+                                        "kmsEncryptionContext": {
+                                          "type": "string"
+                                        },
+                                        "kmsKeyId": {
+                                          "type": "string"
+                                        },
+                                        "serverSideCustomerKeySecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "default": "",
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "x-kubernetes-map-type": "atomic",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "endpoint": {
+                                      "type": "string"
+                                    },
+                                    "insecure": {
+                                      "type": "boolean"
+                                    },
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "region": {
+                                      "type": "string"
+                                    },
+                                    "roleARN": {
+                                      "type": "string"
+                                    },
+                                    "secretKeySecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "default": "",
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "x-kubernetes-map-type": "atomic",
+                                      "additionalProperties": false
+                                    },
+                                    "sessionTokenSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "default": "",
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "x-kubernetes-map-type": "atomic",
+                                      "additionalProperties": false
+                                    },
+                                    "useSDKCreds": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "subPath": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "name"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "parameters": {
+                            "items": {
+                              "properties": {
+                                "default": {
+                                  "type": "string"
+                                },
+                                "description": {
+                                  "type": "string"
+                                },
+                                "enum": {
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "globalName": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "value": {
+                                  "type": "string"
+                                },
+                                "valueFrom": {
+                                  "properties": {
+                                    "configMapKeyRef": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "default": "",
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "x-kubernetes-map-type": "atomic",
+                                      "additionalProperties": false
+                                    },
+                                    "default": {
+                                      "type": "string"
+                                    },
+                                    "event": {
+                                      "type": "string"
+                                    },
+                                    "expression": {
+                                      "type": "string"
+                                    },
+                                    "jqFilter": {
+                                      "type": "string"
+                                    },
+                                    "jsonPath": {
+                                      "type": "string"
+                                    },
+                                    "parameter": {
+                                      "type": "string"
+                                    },
+                                    "path": {
+                                      "type": "string"
+                                    },
+                                    "supplied": {
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "required": [
+                                "name"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "continueOn": {
+                        "properties": {
+                          "error": {
+                            "type": "boolean"
+                          },
+                          "failed": {
+                            "type": "boolean"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "hooks": {
+                        "additionalProperties": {
+                          "properties": {
+                            "arguments": {
+                              "properties": {
+                                "artifacts": {
+                                  "items": {
+                                    "properties": {
+                                      "archive": {
+                                        "properties": {
+                                          "none": {
+                                            "type": "object"
+                                          },
+                                          "tar": {
+                                            "properties": {
+                                              "compressionLevel": {
+                                                "format": "int32",
+                                                "type": "integer"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "zip": {
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "archiveLogs": {
+                                        "type": "boolean"
+                                      },
+                                      "artifactGC": {
+                                        "properties": {
+                                          "podMetadata": {
+                                            "properties": {
+                                              "annotations": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "type": "object"
+                                              },
+                                              "labels": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "type": "object"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "serviceAccountName": {
+                                            "type": "string"
+                                          },
+                                          "strategy": {
+                                            "enum": [
+                                              "",
+                                              "OnWorkflowCompletion",
+                                              "OnWorkflowDeletion",
+                                              "Never"
+                                            ],
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "artifactory": {
+                                        "properties": {
+                                          "passwordSecret": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "default": "",
+                                                "type": "string"
+                                              },
+                                              "optional": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "required": [
+                                              "key"
+                                            ],
+                                            "type": "object",
+                                            "x-kubernetes-map-type": "atomic",
+                                            "additionalProperties": false
+                                          },
+                                          "url": {
+                                            "type": "string"
+                                          },
+                                          "usernameSecret": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "default": "",
+                                                "type": "string"
+                                              },
+                                              "optional": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "required": [
+                                              "key"
+                                            ],
+                                            "type": "object",
+                                            "x-kubernetes-map-type": "atomic",
+                                            "additionalProperties": false
+                                          }
+                                        },
+                                        "required": [
+                                          "url"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "azure": {
+                                        "properties": {
+                                          "accountKeySecret": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "default": "",
+                                                "type": "string"
+                                              },
+                                              "optional": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "required": [
+                                              "key"
+                                            ],
+                                            "type": "object",
+                                            "x-kubernetes-map-type": "atomic",
+                                            "additionalProperties": false
+                                          },
+                                          "blob": {
+                                            "type": "string"
+                                          },
+                                          "container": {
+                                            "type": "string"
+                                          },
+                                          "endpoint": {
+                                            "type": "string"
+                                          },
+                                          "useSDKCreds": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "blob",
+                                          "container",
+                                          "endpoint"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "deleted": {
+                                        "type": "boolean"
+                                      },
+                                      "from": {
+                                        "type": "string"
+                                      },
+                                      "fromExpression": {
+                                        "type": "string"
+                                      },
+                                      "gcs": {
+                                        "properties": {
+                                          "bucket": {
+                                            "type": "string"
+                                          },
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "serviceAccountKeySecret": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "default": "",
+                                                "type": "string"
+                                              },
+                                              "optional": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "required": [
+                                              "key"
+                                            ],
+                                            "type": "object",
+                                            "x-kubernetes-map-type": "atomic",
+                                            "additionalProperties": false
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "git": {
+                                        "properties": {
+                                          "branch": {
+                                            "type": "string"
+                                          },
+                                          "depth": {
+                                            "format": "int64",
+                                            "type": "integer"
+                                          },
+                                          "disableSubmodules": {
+                                            "type": "boolean"
+                                          },
+                                          "fetch": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "insecureIgnoreHostKey": {
+                                            "type": "boolean"
+                                          },
+                                          "insecureSkipTLS": {
+                                            "type": "boolean"
+                                          },
+                                          "passwordSecret": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "default": "",
+                                                "type": "string"
+                                              },
+                                              "optional": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "required": [
+                                              "key"
+                                            ],
+                                            "type": "object",
+                                            "x-kubernetes-map-type": "atomic",
+                                            "additionalProperties": false
+                                          },
+                                          "repo": {
+                                            "type": "string"
+                                          },
+                                          "revision": {
+                                            "type": "string"
+                                          },
+                                          "singleBranch": {
+                                            "type": "boolean"
+                                          },
+                                          "sshPrivateKeySecret": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "default": "",
+                                                "type": "string"
+                                              },
+                                              "optional": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "required": [
+                                              "key"
+                                            ],
+                                            "type": "object",
+                                            "x-kubernetes-map-type": "atomic",
+                                            "additionalProperties": false
+                                          },
+                                          "usernameSecret": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "default": "",
+                                                "type": "string"
+                                              },
+                                              "optional": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "required": [
+                                              "key"
+                                            ],
+                                            "type": "object",
+                                            "x-kubernetes-map-type": "atomic",
+                                            "additionalProperties": false
+                                          }
+                                        },
+                                        "required": [
+                                          "repo"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "globalName": {
+                                        "type": "string"
+                                      },
+                                      "hdfs": {
+                                        "properties": {
+                                          "addresses": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "dataTransferProtection": {
+                                            "type": "string"
+                                          },
+                                          "force": {
+                                            "type": "boolean"
+                                          },
+                                          "hdfsUser": {
+                                            "type": "string"
+                                          },
+                                          "krbCCacheSecret": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "default": "",
+                                                "type": "string"
+                                              },
+                                              "optional": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "required": [
+                                              "key"
+                                            ],
+                                            "type": "object",
+                                            "x-kubernetes-map-type": "atomic",
+                                            "additionalProperties": false
+                                          },
+                                          "krbConfigConfigMap": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "default": "",
+                                                "type": "string"
+                                              },
+                                              "optional": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "required": [
+                                              "key"
+                                            ],
+                                            "type": "object",
+                                            "x-kubernetes-map-type": "atomic",
+                                            "additionalProperties": false
+                                          },
+                                          "krbKeytabSecret": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "default": "",
+                                                "type": "string"
+                                              },
+                                              "optional": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "required": [
+                                              "key"
+                                            ],
+                                            "type": "object",
+                                            "x-kubernetes-map-type": "atomic",
+                                            "additionalProperties": false
+                                          },
+                                          "krbRealm": {
+                                            "type": "string"
+                                          },
+                                          "krbServicePrincipalName": {
+                                            "type": "string"
+                                          },
+                                          "krbUsername": {
+                                            "type": "string"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "path"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "http": {
+                                        "properties": {
+                                          "auth": {
+                                            "properties": {
+                                              "basicAuth": {
+                                                "properties": {
+                                                  "passwordSecret": {
+                                                    "properties": {
+                                                      "key": {
+                                                        "type": "string"
+                                                      },
+                                                      "name": {
+                                                        "default": "",
+                                                        "type": "string"
+                                                      },
+                                                      "optional": {
+                                                        "type": "boolean"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "key"
+                                                    ],
+                                                    "type": "object",
+                                                    "x-kubernetes-map-type": "atomic",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "usernameSecret": {
+                                                    "properties": {
+                                                      "key": {
+                                                        "type": "string"
+                                                      },
+                                                      "name": {
+                                                        "default": "",
+                                                        "type": "string"
+                                                      },
+                                                      "optional": {
+                                                        "type": "boolean"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "key"
+                                                    ],
+                                                    "type": "object",
+                                                    "x-kubernetes-map-type": "atomic",
+                                                    "additionalProperties": false
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "clientCert": {
+                                                "properties": {
+                                                  "clientCertSecret": {
+                                                    "properties": {
+                                                      "key": {
+                                                        "type": "string"
+                                                      },
+                                                      "name": {
+                                                        "default": "",
+                                                        "type": "string"
+                                                      },
+                                                      "optional": {
+                                                        "type": "boolean"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "key"
+                                                    ],
+                                                    "type": "object",
+                                                    "x-kubernetes-map-type": "atomic",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "clientKeySecret": {
+                                                    "properties": {
+                                                      "key": {
+                                                        "type": "string"
+                                                      },
+                                                      "name": {
+                                                        "default": "",
+                                                        "type": "string"
+                                                      },
+                                                      "optional": {
+                                                        "type": "boolean"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "key"
+                                                    ],
+                                                    "type": "object",
+                                                    "x-kubernetes-map-type": "atomic",
+                                                    "additionalProperties": false
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "oauth2": {
+                                                "properties": {
+                                                  "clientIDSecret": {
+                                                    "properties": {
+                                                      "key": {
+                                                        "type": "string"
+                                                      },
+                                                      "name": {
+                                                        "default": "",
+                                                        "type": "string"
+                                                      },
+                                                      "optional": {
+                                                        "type": "boolean"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "key"
+                                                    ],
+                                                    "type": "object",
+                                                    "x-kubernetes-map-type": "atomic",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "clientSecretSecret": {
+                                                    "properties": {
+                                                      "key": {
+                                                        "type": "string"
+                                                      },
+                                                      "name": {
+                                                        "default": "",
+                                                        "type": "string"
+                                                      },
+                                                      "optional": {
+                                                        "type": "boolean"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "key"
+                                                    ],
+                                                    "type": "object",
+                                                    "x-kubernetes-map-type": "atomic",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "endpointParams": {
+                                                    "items": {
+                                                      "properties": {
+                                                        "key": {
+                                                          "type": "string"
+                                                        },
+                                                        "value": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "key"
+                                                      ],
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "scopes": {
+                                                    "items": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "tokenURLSecret": {
+                                                    "properties": {
+                                                      "key": {
+                                                        "type": "string"
+                                                      },
+                                                      "name": {
+                                                        "default": "",
+                                                        "type": "string"
+                                                      },
+                                                      "optional": {
+                                                        "type": "boolean"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "key"
+                                                    ],
+                                                    "type": "object",
+                                                    "x-kubernetes-map-type": "atomic",
+                                                    "additionalProperties": false
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "headers": {
+                                            "items": {
+                                              "properties": {
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "value": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "required": [
+                                                "name",
+                                                "value"
+                                              ],
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          },
+                                          "url": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "url"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "mode": {
+                                        "format": "int32",
+                                        "type": "integer"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      },
+                                      "oss": {
+                                        "properties": {
+                                          "accessKeySecret": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "default": "",
+                                                "type": "string"
+                                              },
+                                              "optional": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "required": [
+                                              "key"
+                                            ],
+                                            "type": "object",
+                                            "x-kubernetes-map-type": "atomic",
+                                            "additionalProperties": false
+                                          },
+                                          "bucket": {
+                                            "type": "string"
+                                          },
+                                          "createBucketIfNotPresent": {
+                                            "type": "boolean"
+                                          },
+                                          "endpoint": {
+                                            "type": "string"
+                                          },
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "lifecycleRule": {
+                                            "properties": {
+                                              "markDeletionAfterDays": {
+                                                "format": "int32",
+                                                "type": "integer"
+                                              },
+                                              "markInfrequentAccessAfterDays": {
+                                                "format": "int32",
+                                                "type": "integer"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "secretKeySecret": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "default": "",
+                                                "type": "string"
+                                              },
+                                              "optional": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "required": [
+                                              "key"
+                                            ],
+                                            "type": "object",
+                                            "x-kubernetes-map-type": "atomic",
+                                            "additionalProperties": false
+                                          },
+                                          "securityToken": {
+                                            "type": "string"
+                                          },
+                                          "useSDKCreds": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "raw": {
+                                        "properties": {
+                                          "data": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "data"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "recurseMode": {
+                                        "type": "boolean"
+                                      },
+                                      "s3": {
+                                        "properties": {
+                                          "accessKeySecret": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "default": "",
+                                                "type": "string"
+                                              },
+                                              "optional": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "required": [
+                                              "key"
+                                            ],
+                                            "type": "object",
+                                            "x-kubernetes-map-type": "atomic",
+                                            "additionalProperties": false
+                                          },
+                                          "bucket": {
+                                            "type": "string"
+                                          },
+                                          "caSecret": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "default": "",
+                                                "type": "string"
+                                              },
+                                              "optional": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "required": [
+                                              "key"
+                                            ],
+                                            "type": "object",
+                                            "x-kubernetes-map-type": "atomic",
+                                            "additionalProperties": false
+                                          },
+                                          "createBucketIfNotPresent": {
+                                            "properties": {
+                                              "objectLocking": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "encryptionOptions": {
+                                            "properties": {
+                                              "enableEncryption": {
+                                                "type": "boolean"
+                                              },
+                                              "kmsEncryptionContext": {
+                                                "type": "string"
+                                              },
+                                              "kmsKeyId": {
+                                                "type": "string"
+                                              },
+                                              "serverSideCustomerKeySecret": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "default": "",
+                                                    "type": "string"
+                                                  },
+                                                  "optional": {
+                                                    "type": "boolean"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "key"
+                                                ],
+                                                "type": "object",
+                                                "x-kubernetes-map-type": "atomic",
+                                                "additionalProperties": false
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "endpoint": {
+                                            "type": "string"
+                                          },
+                                          "insecure": {
+                                            "type": "boolean"
+                                          },
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "region": {
+                                            "type": "string"
+                                          },
+                                          "roleARN": {
+                                            "type": "string"
+                                          },
+                                          "secretKeySecret": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "default": "",
+                                                "type": "string"
+                                              },
+                                              "optional": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "required": [
+                                              "key"
+                                            ],
+                                            "type": "object",
+                                            "x-kubernetes-map-type": "atomic",
+                                            "additionalProperties": false
+                                          },
+                                          "sessionTokenSecret": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "default": "",
+                                                "type": "string"
+                                              },
+                                              "optional": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "required": [
+                                              "key"
+                                            ],
+                                            "type": "object",
+                                            "x-kubernetes-map-type": "atomic",
+                                            "additionalProperties": false
+                                          },
+                                          "useSDKCreds": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "subPath": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "name"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                },
+                                "parameters": {
+                                  "items": {
+                                    "properties": {
+                                      "default": {
+                                        "type": "string"
+                                      },
+                                      "description": {
+                                        "type": "string"
+                                      },
+                                      "enum": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "globalName": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "value": {
+                                        "type": "string"
+                                      },
+                                      "valueFrom": {
+                                        "properties": {
+                                          "configMapKeyRef": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "default": "",
+                                                "type": "string"
+                                              },
+                                              "optional": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "required": [
+                                              "key"
+                                            ],
+                                            "type": "object",
+                                            "x-kubernetes-map-type": "atomic",
+                                            "additionalProperties": false
+                                          },
+                                          "default": {
+                                            "type": "string"
+                                          },
+                                          "event": {
+                                            "type": "string"
+                                          },
+                                          "expression": {
+                                            "type": "string"
+                                          },
+                                          "jqFilter": {
+                                            "type": "string"
+                                          },
+                                          "jsonPath": {
+                                            "type": "string"
+                                          },
+                                          "parameter": {
+                                            "type": "string"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "supplied": {
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "required": [
+                                      "name"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "expression": {
+                              "type": "string"
+                            },
+                            "template": {
+                              "type": "string"
+                            },
+                            "templateRef": {
+                              "properties": {
+                                "clusterScope": {
+                                  "type": "boolean"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "template": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "object"
+                      },
+                      "inline": {
+                        "x-kubernetes-preserve-unknown-fields": true
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "onExit": {
+                        "type": "string"
+                      },
+                      "template": {
+                        "type": "string"
+                      },
+                      "templateRef": {
+                        "properties": {
+                          "clusterScope": {
+                            "type": "boolean"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "template": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "when": {
+                        "type": "string"
+                      },
+                      "withItems": {
+                        "x-kubernetes-preserve-unknown-fields": true
+                      },
+                      "withParam": {
+                        "type": "string"
+                      },
+                      "withSequence": {
+                        "properties": {
+                          "count": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "x-kubernetes-int-or-string": true
+                          },
+                          "end": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "x-kubernetes-int-or-string": true
+                          },
+                          "format": {
+                            "type": "string"
+                          },
+                          "start": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "x-kubernetes-int-or-string": true
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
                   "type": "array"
                 },
                 "type": "array"
@@ -31772,6 +36165,9 @@
                 "properties": {
                   "mutex": {
                     "properties": {
+                      "database": {
+                        "type": "boolean"
+                      },
                       "name": {
                         "type": "string"
                       },
@@ -31785,6 +36181,9 @@
                   "mutexes": {
                     "items": {
                       "properties": {
+                        "database": {
+                          "type": "boolean"
+                        },
                         "name": {
                           "type": "string"
                         },
@@ -31819,6 +36218,18 @@
                         "x-kubernetes-map-type": "atomic",
                         "additionalProperties": false
                       },
+                      "database": {
+                        "properties": {
+                          "key": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "key"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
                       "namespace": {
                         "type": "string"
                       }
@@ -31847,6 +36258,18 @@
                           ],
                           "type": "object",
                           "x-kubernetes-map-type": "atomic",
+                          "additionalProperties": false
+                        },
+                        "database": {
+                          "properties": {
+                            "key": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "key"
+                          ],
+                          "type": "object",
                           "additionalProperties": false
                         },
                         "namespace": {
@@ -31927,12 +36350,14 @@
                           "type": "string"
                         },
                         "fsType": {
+                          "default": "ext4",
                           "type": "string"
                         },
                         "kind": {
                           "type": "string"
                         },
                         "readOnly": {
+                          "default": false,
                           "type": "boolean"
                         }
                       },
@@ -32207,7 +36632,37 @@
                         "volumeClaimTemplate": {
                           "properties": {
                             "metadata": {
-                              "type": "object"
+                              "properties": {
+                                "annotations": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "type": "object"
+                                },
+                                "finalizers": {
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "generateName": {
+                                  "type": "string"
+                                },
+                                "labels": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "type": "object"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "namespace": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
                             },
                             "spec": {
                               "properties": {
@@ -32514,6 +36969,18 @@
                       "type": "object",
                       "additionalProperties": false
                     },
+                    "image": {
+                      "properties": {
+                        "pullPolicy": {
+                          "type": "string"
+                        },
+                        "reference": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
                     "iscsi": {
                       "properties": {
                         "chapAuthDiscovery": {
@@ -32532,6 +36999,7 @@
                           "type": "string"
                         },
                         "iscsiInterface": {
+                          "default": "default",
                           "type": "string"
                         },
                         "lun": {
@@ -32924,6 +37392,7 @@
                           "type": "string"
                         },
                         "keyring": {
+                          "default": "/etc/ceph/keyring",
                           "type": "string"
                         },
                         "monitors": {
@@ -32934,6 +37403,7 @@
                           "x-kubernetes-list-type": "atomic"
                         },
                         "pool": {
+                          "default": "rbd",
                           "type": "string"
                         },
                         "readOnly": {
@@ -32951,6 +37421,7 @@
                           "additionalProperties": false
                         },
                         "user": {
+                          "default": "admin",
                           "type": "string"
                         }
                       },
@@ -32964,6 +37435,7 @@
                     "scaleIO": {
                       "properties": {
                         "fsType": {
+                          "default": "xfs",
                           "type": "string"
                         },
                         "gateway": {
@@ -32990,6 +37462,7 @@
                           "type": "boolean"
                         },
                         "storageMode": {
+                          "default": "ThinProvisioned",
                           "type": "string"
                         },
                         "storagePool": {
@@ -33177,7 +37650,37 @@
                 "type": "string"
               },
               "metadata": {
-                "type": "object"
+                "properties": {
+                  "annotations": {
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "type": "object"
+                  },
+                  "finalizers": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "generateName": {
+                    "type": "string"
+                  },
+                  "labels": {
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "type": "object"
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "namespace": {
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
               },
               "spec": {
                 "properties": {
@@ -33473,12 +37976,14 @@
                     "type": "string"
                   },
                   "fsType": {
+                    "default": "ext4",
                     "type": "string"
                   },
                   "kind": {
                     "type": "string"
                   },
                   "readOnly": {
+                    "default": false,
                     "type": "boolean"
                   }
                 },
@@ -33753,7 +38258,37 @@
                   "volumeClaimTemplate": {
                     "properties": {
                       "metadata": {
-                        "type": "object"
+                        "properties": {
+                          "annotations": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "type": "object"
+                          },
+                          "finalizers": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "generateName": {
+                            "type": "string"
+                          },
+                          "labels": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "type": "object"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "namespace": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
                       },
                       "spec": {
                         "properties": {
@@ -34060,6 +38595,18 @@
                 "type": "object",
                 "additionalProperties": false
               },
+              "image": {
+                "properties": {
+                  "pullPolicy": {
+                    "type": "string"
+                  },
+                  "reference": {
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
               "iscsi": {
                 "properties": {
                   "chapAuthDiscovery": {
@@ -34078,6 +38625,7 @@
                     "type": "string"
                   },
                   "iscsiInterface": {
+                    "default": "default",
                     "type": "string"
                   },
                   "lun": {
@@ -34470,6 +39018,7 @@
                     "type": "string"
                   },
                   "keyring": {
+                    "default": "/etc/ceph/keyring",
                     "type": "string"
                   },
                   "monitors": {
@@ -34480,6 +39029,7 @@
                     "x-kubernetes-list-type": "atomic"
                   },
                   "pool": {
+                    "default": "rbd",
                     "type": "string"
                   },
                   "readOnly": {
@@ -34497,6 +39047,7 @@
                     "additionalProperties": false
                   },
                   "user": {
+                    "default": "admin",
                     "type": "string"
                   }
                 },
@@ -34510,6 +39061,7 @@
               "scaleIO": {
                 "properties": {
                   "fsType": {
+                    "default": "xfs",
                     "type": "string"
                   },
                   "gateway": {
@@ -34536,6 +39088,7 @@
                     "type": "boolean"
                   },
                   "storageMode": {
+                    "default": "ThinProvisioned",
                     "type": "string"
                   },
                   "storagePool": {


### PR DESCRIPTION
## Summary
- Regenerates JSON schemas for Argo Workflows CRDs from the **v3.7.7** release
- Covers `Workflow`, `WorkflowTemplate`, `ClusterWorkflowTemplate`, and `CronWorkflow` (`v1alpha1`)
- Key addition: the template-level `annotations` field on `WorkflowSpec.templates[]`, introduced in v3.7 to support `workflows.argoproj.io/display-name` and similar annotations
- The previous schemas (based on an older CRD snapshot) lacked this field and caused `kubeconform -strict` to reject valid templates

## Files changed
- `argoproj.io/workflow_v1alpha1.json`
- `argoproj.io/workflowtemplate_v1alpha1.json`
- `argoproj.io/clusterworkflowtemplate_v1alpha1.json`
- `argoproj.io/cronworkflow_v1alpha1.json`
