### PR TITLE
chore(nauth.io): update to v0.7.1

### DIFF
--- a/nauth.io/account_v1alpha1.json
+++ b/nauth.io/account_v1alpha1.json
@@ -1,5 +1,5 @@
 {
-  "description": "Account is the Schema for the accounts API.",
+  "description": "Account is the composite resource for the accounts API.",
   "properties": {
     "apiVersion": {
       "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
@@ -44,6 +44,10 @@
           },
           "type": "object",
           "additionalProperties": false
+        },
+        "displayName": {
+          "description": "DisplayName is an optional name for the NATS resource representing the account. May be derived if absent.",
+          "type": "string"
         },
         "exports": {
           "items": {
@@ -176,6 +180,10 @@
           },
           "type": "array"
         },
+        "jetStreamEnabled": {
+          "description": "JetStreamEnabled indicates whether JetStream should be explicitly enabled or disabled.\nIf absent, JetStream will be implicitly enabled/disabled based on the effective JetStreamLimits.",
+          "type": "boolean"
+        },
         "jetStreamLimits": {
           "properties": {
             "consumer": {
@@ -221,6 +229,24 @@
           "type": "object",
           "additionalProperties": false
         },
+        "natsClusterRef": {
+          "description": "NatsClusterRef references the NatsCluster to use for this account.\nIf not specified, the controller uses the operator-level NATS_CLUSTER_REF when configured.\nOtherwise, reconciliation fails because the target NatsCluster cannot be resolved.",
+          "properties": {
+            "name": {
+              "description": "Name of the NatsCluster",
+              "type": "string"
+            },
+            "namespace": {
+              "description": "Namespace of the NatsCluster",
+              "type": "string"
+            }
+          },
+          "required": [
+            "name"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
         "natsLimits": {
           "properties": {
             "data": {
@@ -249,6 +275,151 @@
     "status": {
       "description": "AccountStatus defines the observed state of Account.",
       "properties": {
+        "adoptions": {
+          "description": "AccountAdoptions defines the status of child resources that have been adopted or are candidates for adoption by this account.",
+          "properties": {
+            "exports": {
+              "description": "Exports defines adoptions of type `AccountExport` that are bound to the account.",
+              "items": {
+                "properties": {
+                  "name": {
+                    "description": "Name the child resource name",
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "observedGeneration": {
+                    "description": "ObservedGeneration refers to the observed generation of the child resource.",
+                    "format": "int64",
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "status": {
+                    "description": "Status of the adoption",
+                    "properties": {
+                      "desiredClaimObservedGeneration": {
+                        "description": "DesiredClaimObservedGeneration refers to the observed generation of the child resource desired claim.",
+                        "format": "int64",
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "message": {
+                        "description": "Message is a human-readable message indicating details about the adoption.",
+                        "maxLength": 32768,
+                        "type": "string"
+                      },
+                      "reason": {
+                        "description": "Reason contains a programmatic identifier indicating the reason for the adoption's last transition.\nThe value should be a CamelCase string.\nThis field may not be empty.",
+                        "maxLength": 1024,
+                        "minLength": 1,
+                        "pattern": "^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$",
+                        "type": "string"
+                      },
+                      "status": {
+                        "description": "Status of the adoption, one of True, False, Unknown.",
+                        "enum": [
+                          "True",
+                          "False",
+                          "Unknown"
+                        ],
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "reason",
+                      "status"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "uid": {
+                    "description": "UID of the child resource UID",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name",
+                  "observedGeneration",
+                  "status",
+                  "uid"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "imports": {
+              "description": "Imports defines adoptions of type `AccountImport` that are bound to the account.",
+              "items": {
+                "properties": {
+                  "name": {
+                    "description": "Name the child resource name",
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "observedGeneration": {
+                    "description": "ObservedGeneration refers to the observed generation of the child resource.",
+                    "format": "int64",
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "status": {
+                    "description": "Status of the adoption",
+                    "properties": {
+                      "desiredClaimObservedGeneration": {
+                        "description": "DesiredClaimObservedGeneration refers to the observed generation of the child resource desired claim.",
+                        "format": "int64",
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "message": {
+                        "description": "Message is a human-readable message indicating details about the adoption.",
+                        "maxLength": 32768,
+                        "type": "string"
+                      },
+                      "reason": {
+                        "description": "Reason contains a programmatic identifier indicating the reason for the adoption's last transition.\nThe value should be a CamelCase string.\nThis field may not be empty.",
+                        "maxLength": 1024,
+                        "minLength": 1,
+                        "pattern": "^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$",
+                        "type": "string"
+                      },
+                      "status": {
+                        "description": "Status of the adoption, one of True, False, Unknown.",
+                        "enum": [
+                          "True",
+                          "False",
+                          "Unknown"
+                        ],
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "reason",
+                      "status"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "uid": {
+                    "description": "UID of the child resource UID",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name",
+                  "observedGeneration",
+                  "status",
+                  "uid"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
         "claims": {
           "properties": {
             "accountLimits": {
@@ -280,6 +451,9 @@
               },
               "type": "object",
               "additionalProperties": false
+            },
+            "displayName": {
+              "type": "string"
             },
             "exports": {
               "items": {
@@ -412,6 +586,9 @@
               },
               "type": "array"
             },
+            "jetStreamEnabled": {
+              "type": "boolean"
+            },
             "jetStreamLimits": {
               "properties": {
                 "consumer": {
@@ -477,10 +654,26 @@
               },
               "type": "object",
               "additionalProperties": false
+            },
+            "signingKeys": {
+              "items": {
+                "properties": {
+                  "key": {
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
             }
           },
           "type": "object",
           "additionalProperties": false
+        },
+        "claimsHash": {
+          "description": "ClaimsHash is a hash of the Account JWT claims, used to determine if the claims have changed and a new JWT needs to be generated.",
+          "type": "string"
         },
         "conditions": {
           "items": {
@@ -551,23 +744,6 @@
         "reconcileTimestamp": {
           "format": "date-time",
           "type": "string"
-        },
-        "signingKey": {
-          "properties": {
-            "creationDate": {
-              "format": "date-time",
-              "type": "string"
-            },
-            "expirationDate": {
-              "format": "date-time",
-              "type": "string"
-            },
-            "name": {
-              "type": "string"
-            }
-          },
-          "type": "object",
-          "additionalProperties": false
         }
       },
       "type": "object",

--- a/nauth.io/accountexport_v1alpha1.json
+++ b/nauth.io/accountexport_v1alpha1.json
@@ -1,0 +1,268 @@
+{
+  "description": "AccountExport is a component resource for exports in the accounts API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "AccountExportSpec defines the desired state of AccountExport.",
+      "properties": {
+        "accountName": {
+          "description": "AccountName refers to the Account in the same namespace to which this export applies.",
+          "type": "string"
+        },
+        "rules": {
+          "description": "Rules defines the export rules for this account export. Must have at least one rule.",
+          "items": {
+            "properties": {
+              "accountTokenPosition": {
+                "type": "integer"
+              },
+              "advertise": {
+                "type": "boolean"
+              },
+              "allowTrace": {
+                "type": "boolean"
+              },
+              "name": {
+                "type": "string"
+              },
+              "responseThreshold": {
+                "description": "A Duration represents the elapsed time between two instants\nas an int64 nanosecond count. The representation limits the\nlargest representable duration to approximately 290 years.",
+                "format": "int64",
+                "type": "integer"
+              },
+              "responseType": {
+                "description": "ResponseType is used to store an export response type",
+                "enum": [
+                  "Singleton",
+                  "Stream",
+                  "Chunked"
+                ],
+                "type": "string"
+              },
+              "serviceLatency": {
+                "properties": {
+                  "results": {
+                    "description": "Subject is a string that represents a NATS subject",
+                    "type": "string"
+                  },
+                  "sampling": {
+                    "type": "integer"
+                  }
+                },
+                "required": [
+                  "results",
+                  "sampling"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "subject": {
+                "description": "Subject is a string that represents a NATS subject",
+                "type": "string"
+              },
+              "type": {
+                "description": "ExportType defines the type of import/export.",
+                "enum": [
+                  "stream",
+                  "service"
+                ],
+                "type": "string"
+              }
+            },
+            "required": [
+              "subject",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "minItems": 1,
+          "type": "array"
+        }
+      },
+      "required": [
+        "accountName",
+        "rules"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "AccountExportStatus defines the observed state of AccountExport.",
+      "properties": {
+        "accountID": {
+          "description": "AccountID is the ID of the account that this export is bound to.",
+          "type": "string"
+        },
+        "conditions": {
+          "items": {
+            "description": "Condition contains details for one aspect of the current state of this API Resource.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "lastTransitionTime is the last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "message is a human readable message indicating details about the transition.\nThis may be an empty string.",
+                "maxLength": 32768,
+                "type": "string"
+              },
+              "observedGeneration": {
+                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon.\nFor instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date\nwith respect to the current state of the instance.",
+                "format": "int64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "reason": {
+                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition.\nProducers of specific condition types may define expected values and meanings for this field,\nand whether the values are considered a guaranteed API.\nThe value should be a CamelCase string.\nThis field may not be empty.",
+                "maxLength": 1024,
+                "minLength": 1,
+                "pattern": "^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$",
+                "type": "string"
+              },
+              "status": {
+                "description": "status of the condition, one of True, False, Unknown.",
+                "enum": [
+                  "True",
+                  "False",
+                  "Unknown"
+                ],
+                "type": "string"
+              },
+              "type": {
+                "description": "type of condition in CamelCase or in foo.example.com/CamelCase.",
+                "maxLength": 316,
+                "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$",
+                "type": "string"
+              }
+            },
+            "required": [
+              "lastTransitionTime",
+              "message",
+              "reason",
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array",
+          "x-kubernetes-list-map-keys": [
+            "type"
+          ],
+          "x-kubernetes-list-type": "map"
+        },
+        "desiredClaim": {
+          "description": "Normalized claim for account to use",
+          "properties": {
+            "observedGeneration": {
+              "format": "int64",
+              "type": "integer"
+            },
+            "rules": {
+              "description": "Rules contains export rules that have been validated and are ready to be used by Account",
+              "items": {
+                "properties": {
+                  "accountTokenPosition": {
+                    "type": "integer"
+                  },
+                  "advertise": {
+                    "type": "boolean"
+                  },
+                  "allowTrace": {
+                    "type": "boolean"
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "responseThreshold": {
+                    "description": "A Duration represents the elapsed time between two instants\nas an int64 nanosecond count. The representation limits the\nlargest representable duration to approximately 290 years.",
+                    "format": "int64",
+                    "type": "integer"
+                  },
+                  "responseType": {
+                    "description": "ResponseType is used to store an export response type",
+                    "enum": [
+                      "Singleton",
+                      "Stream",
+                      "Chunked"
+                    ],
+                    "type": "string"
+                  },
+                  "serviceLatency": {
+                    "properties": {
+                      "results": {
+                        "description": "Subject is a string that represents a NATS subject",
+                        "type": "string"
+                      },
+                      "sampling": {
+                        "type": "integer"
+                      }
+                    },
+                    "required": [
+                      "results",
+                      "sampling"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "subject": {
+                    "description": "Subject is a string that represents a NATS subject",
+                    "type": "string"
+                  },
+                  "type": {
+                    "description": "ExportType defines the type of import/export.",
+                    "enum": [
+                      "stream",
+                      "service"
+                    ],
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "subject",
+                  "type"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "minItems": 1,
+              "type": "array"
+            }
+          },
+          "required": [
+            "observedGeneration",
+            "rules"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "observedGeneration": {
+          "format": "int64",
+          "type": "integer"
+        },
+        "operatorVersion": {
+          "type": "string"
+        },
+        "reconcileTimestamp": {
+          "format": "date-time",
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/nauth.io/accountimport_v1alpha1.json
+++ b/nauth.io/accountimport_v1alpha1.json
@@ -1,0 +1,235 @@
+{
+  "description": "AccountImport is a component resource for imports in the accounts API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "AccountImportSpec defines the desired state of AccountImport.",
+      "properties": {
+        "accountName": {
+          "description": "AccountName refers to the Account in the same namespace to which this import applies.",
+          "type": "string"
+        },
+        "exportAccountRef": {
+          "description": "ExportAccountRef refers to the Account from which the exports are imported.\nThis reference may point to an Account in another namespace.",
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "namespace": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "name",
+            "namespace"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "rules": {
+          "description": "Rules defines the import rules for this AccountImport.",
+          "items": {
+            "properties": {
+              "allowTrace": {
+                "type": "boolean"
+              },
+              "localSubject": {
+                "description": "LocalSubject remaps the imported subject locally in the importing account.",
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "share": {
+                "type": "boolean"
+              },
+              "subject": {
+                "description": "Subject is the exported subject to import.\nIt must be identical to or a subset of the exported subject.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type defines whether the import is a stream or service import.",
+                "enum": [
+                  "stream",
+                  "service"
+                ],
+                "type": "string"
+              }
+            },
+            "required": [
+              "subject",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "minItems": 1,
+          "type": "array"
+        }
+      },
+      "required": [
+        "accountName",
+        "exportAccountRef",
+        "rules"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "AccountImportStatus defines the observed state of AccountImport.",
+      "properties": {
+        "accountID": {
+          "description": "AccountID is the resolved ID of the Account referenced by spec.accountName.",
+          "type": "string"
+        },
+        "conditions": {
+          "items": {
+            "description": "Condition contains details for one aspect of the current state of this API Resource.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "lastTransitionTime is the last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "message is a human readable message indicating details about the transition.\nThis may be an empty string.",
+                "maxLength": 32768,
+                "type": "string"
+              },
+              "observedGeneration": {
+                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon.\nFor instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date\nwith respect to the current state of the instance.",
+                "format": "int64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "reason": {
+                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition.\nProducers of specific condition types may define expected values and meanings for this field,\nand whether the values are considered a guaranteed API.\nThe value should be a CamelCase string.\nThis field may not be empty.",
+                "maxLength": 1024,
+                "minLength": 1,
+                "pattern": "^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$",
+                "type": "string"
+              },
+              "status": {
+                "description": "status of the condition, one of True, False, Unknown.",
+                "enum": [
+                  "True",
+                  "False",
+                  "Unknown"
+                ],
+                "type": "string"
+              },
+              "type": {
+                "description": "type of condition in CamelCase or in foo.example.com/CamelCase.",
+                "maxLength": 316,
+                "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$",
+                "type": "string"
+              }
+            },
+            "required": [
+              "lastTransitionTime",
+              "message",
+              "reason",
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array",
+          "x-kubernetes-list-map-keys": [
+            "type"
+          ],
+          "x-kubernetes-list-type": "map"
+        },
+        "desiredClaim": {
+          "description": "DesiredClaim is the normalized claim for Account to use.",
+          "properties": {
+            "observedGeneration": {
+              "format": "int64",
+              "type": "integer"
+            },
+            "rules": {
+              "description": "Rules contains import rules that have been validated and are ready to be used by Account.",
+              "items": {
+                "properties": {
+                  "account": {
+                    "description": "Account is the resolved export account ID used for this import rule.",
+                    "type": "string"
+                  },
+                  "allowTrace": {
+                    "type": "boolean"
+                  },
+                  "localSubject": {
+                    "description": "LocalSubject remaps the imported subject locally in the importing account.",
+                    "type": "string"
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "share": {
+                    "type": "boolean"
+                  },
+                  "subject": {
+                    "description": "Subject is the exported subject to import.\nIt must be identical to or a subset of the exported subject.",
+                    "type": "string"
+                  },
+                  "type": {
+                    "description": "Type defines whether the import is a stream or service import.",
+                    "enum": [
+                      "stream",
+                      "service"
+                    ],
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "account",
+                  "subject",
+                  "type"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "minItems": 1,
+              "type": "array"
+            }
+          },
+          "required": [
+            "observedGeneration",
+            "rules"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "exportAccountID": {
+          "description": "ExportAccountID is the resolved ID of the Account referenced by spec.exportAccountRef.",
+          "type": "string"
+        },
+        "observedGeneration": {
+          "format": "int64",
+          "type": "integer"
+        },
+        "operatorVersion": {
+          "type": "string"
+        },
+        "reconcileTimestamp": {
+          "format": "date-time",
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/nauth.io/natscluster_v1alpha1.json
+++ b/nauth.io/natscluster_v1alpha1.json
@@ -1,0 +1,183 @@
+{
+  "description": "NatsCluster is the Schema for the natsclusters API",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "NatsClusterSpec defines the desired state of NatsCluster",
+      "properties": {
+        "operatorSigningKeySecretRef": {
+          "description": "SecretKeyReference contains information to locate a secret in the same namespace",
+          "properties": {
+            "key": {
+              "description": "Key in the Secret, when not specified an implementation-specific default key is used.",
+              "type": "string"
+            },
+            "name": {
+              "description": "Name of the Secret.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "name"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "systemAccountUserCredsSecretRef": {
+          "description": "SecretKeyReference contains information to locate a secret in the same namespace",
+          "properties": {
+            "key": {
+              "description": "Key in the Secret, when not specified an implementation-specific default key is used.",
+              "type": "string"
+            },
+            "name": {
+              "description": "Name of the Secret.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "name"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "url": {
+          "description": "URL is the NATS server URL for this cluster. Mutually exclusive with urlFrom.",
+          "type": "string"
+        },
+        "urlFrom": {
+          "description": "URLFrom loads the NATS URL from a ConfigMap or Secret. Mutually exclusive with url.",
+          "properties": {
+            "key": {
+              "description": "Key in the ConfigMap or Secret whose value is the NATS URL.",
+              "type": "string"
+            },
+            "kind": {
+              "description": "Kind is the type of resource to load from: ConfigMap or Secret.",
+              "enum": [
+                "ConfigMap",
+                "Secret"
+              ],
+              "type": "string"
+            },
+            "name": {
+              "description": "Name of the ConfigMap or Secret.",
+              "type": "string"
+            },
+            "namespace": {
+              "description": "Namespace of the resource. When empty, defaults to the NatsCluster's namespace.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "key",
+            "kind",
+            "name"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "operatorSigningKeySecretRef",
+        "systemAccountUserCredsSecretRef"
+      ],
+      "type": "object",
+      "x-kubernetes-validations": [
+        {
+          "message": "exactly one of url or urlFrom must be specified",
+          "rule": "has(self.url) != has(self.urlFrom)"
+        }
+      ],
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "NatsClusterStatus defines the observed state of NatsCluster.",
+      "properties": {
+        "conditions": {
+          "items": {
+            "description": "Condition contains details for one aspect of the current state of this API Resource.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "lastTransitionTime is the last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "message is a human readable message indicating details about the transition.\nThis may be an empty string.",
+                "maxLength": 32768,
+                "type": "string"
+              },
+              "observedGeneration": {
+                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon.\nFor instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date\nwith respect to the current state of the instance.",
+                "format": "int64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "reason": {
+                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition.\nProducers of specific condition types may define expected values and meanings for this field,\nand whether the values are considered a guaranteed API.\nThe value should be a CamelCase string.\nThis field may not be empty.",
+                "maxLength": 1024,
+                "minLength": 1,
+                "pattern": "^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$",
+                "type": "string"
+              },
+              "status": {
+                "description": "status of the condition, one of True, False, Unknown.",
+                "enum": [
+                  "True",
+                  "False",
+                  "Unknown"
+                ],
+                "type": "string"
+              },
+              "type": {
+                "description": "type of condition in CamelCase or in foo.example.com/CamelCase.",
+                "maxLength": 316,
+                "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$",
+                "type": "string"
+              }
+            },
+            "required": [
+              "lastTransitionTime",
+              "message",
+              "reason",
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array",
+          "x-kubernetes-list-map-keys": [
+            "type"
+          ],
+          "x-kubernetes-list-type": "map"
+        },
+        "observedGeneration": {
+          "format": "int64",
+          "type": "integer"
+        },
+        "operatorVersion": {
+          "type": "string"
+        },
+        "reconcileTimestamp": {
+          "format": "date-time",
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/nauth.io/user_v1alpha1.json
+++ b/nauth.io/user_v1alpha1.json
@@ -19,6 +19,15 @@
           "description": "AccountName references the account used to create the user.",
           "type": "string"
         },
+        "displayName": {
+          "description": "DisplayName is an optional name for the NATS resource representing the user. May be derived if absent.",
+          "type": "string"
+        },
+        "expiresAt": {
+          "description": "ExpiresAt is an optional absolute time when the generated user JWT expires.",
+          "format": "date-time",
+          "type": "string"
+        },
         "natsLimits": {
           "properties": {
             "data": {
@@ -149,6 +158,16 @@
         "claims": {
           "properties": {
             "accountName": {
+              "description": "Deprecated. Will be removed in a future release (>v0.5.0). Ref: https://github.com/WirelessCar/nauth/issues/102",
+              "type": "string"
+            },
+            "displayName": {
+              "description": "DisplayName is an optional name for the NATS resource representing the user.",
+              "type": "string"
+            },
+            "expiresAt": {
+              "description": "ExpiresAt is the absolute time when the generated user JWT expires.",
+              "format": "date-time",
               "type": "string"
             },
             "natsLimits": {


### PR DESCRIPTION
## Update schemas for [nauth.io v0.7.1](https://github.com/WirelessCar/nauth/releases/tag/v0.7.1)

https://github.com/WirelessCar/nauth

```   
nauth.io/account_v1alpha1.json       |  UPDATED
nauth.io/accountexport_v1alpha1.json |  NEW
nauth.io/accountimport_v1alpha1.json |  NEW
nauth.io/natscluster_v1alpha1.json   |  NEW
nauth.io/user_v1alpha1.json          |  UPDATED
```

Generated from `charts/nauth-crds/crds/*.yaml` using `/Utilities/openapi2jsonschema.py`.

## PR Checklist

- [x] I generated these CRs using the [CRD Extractor tool](https://github.com/datreeio/CRDs-catalog?tab=readme-ov-file#crd-extractor). If I used a different method, I have described the method in this PR.
- [x] I am updating existing schemas and have specified the updated schema version.
- [x] I am adding new schemas and included a link to the GitHub repository that contains the source of these schemas.
