### PR TITLE
feat: update keda CRD to new field serviceAccountName

### DIFF
--- a/keda.sh/triggerauthentication_v1alpha1.json
+++ b/keda.sh/triggerauthentication_v1alpha1.json
@@ -561,6 +561,9 @@
                 "serviceAccount": {
                   "type": "string"
                 },
+                "serviceAccountName": {
+                  "type": "string"
+                },
                 "token": {
                   "type": "string"
                 }


### PR DESCRIPTION
Adds the missing `serviceAccountName` field to the `credential` object under `hashiCorpVault` in the `TriggerAuthentication` CRD schema (`keda.sh/triggerauthentication_v1alpha1.json`).

This field is present in the upstream KEDA CRD but was missing from this catalog entry.