### PR TITLE
Update NginxProxy v1alpha2 accessLog schema

### DIFF
--- a/gateway.nginx.org/nginxproxy_v1alpha2.json
+++ b/gateway.nginx.org/nginxproxy_v1alpha2.json
@@ -6810,6 +6810,29 @@
                 "emerg"
               ],
               "type": "string"
+            },
+            "accessLog": {
+              "description": "AccessLog defines the access log settings, including format itself and disabling option.\nFor now only path /dev/stdout can be used.",
+              "properties": {
+                "disable": {
+                  "description": "Disable turns off access logging when set to true.",
+                  "type": "boolean"
+                },
+                "escape": {
+                  "description": "Escape specifies how to escape characters in variables for access log.\nPossible values are: default, json, none.\nIf not specified, 'default' escaping is used.\nSee https://nginx.org/en/docs/http/ngx_http_log_module.html#log_format",
+                  "enum": [
+                    "default",
+                    "json",
+                    "none"
+                  ],
+                  "type": "string"
+                },
+                "format": {
+                  "description": "Format specifies the custom log format string.\nIf not specified, NGINX default 'combined' format is used.\nFor now only path /dev/stdout can be used.\nSee https://nginx.org/en/docs/http/ngx_http_log_module.html#log_format",
+                  "type": "string"
+                }
+              },
+              "type": "object"
             }
           },
           "type": "object",


### PR DESCRIPTION
## Summary
- Add the `spec.logging.accessLog` schema for `gateway.nginx.org/v1alpha2` `NginxProxy`
- Match the NGINX Gateway Fabric v2.4.0 CRD shape for access log configuration

## Context
NGINX Gateway Fabric added `NginxProxy.spec.logging.accessLog` by v2.3.0, and it is present in v2.4.0. Kubeconform users validating manifests rendered from NGF v2.4.0 currently hit a false positive because this catalog schema rejects `accessLog` as an additional property.

## Verification
Validated a sample `NginxProxy` containing `spec.logging.accessLog.format` with kubeconform v0.6.7 using this local catalog schema.
