### PR TITLE
update schemas for gateway.kgateway.dev

### DIFF
--- a/gateway.kgateway.dev/backend_v1alpha1.json
+++ b/gateway.kgateway.dev/backend_v1alpha1.json
@@ -15,7 +15,7 @@
       "description": "BackendSpec defines the desired state of Backend.",
       "properties": {
         "aws": {
-          "description": "Aws is the AWS backend configuration.\nThe Aws backend type is only supported with envoy-based gateways, it is not supported in agentgateway.",
+          "description": "Aws is the AWS backend configuration.",
           "properties": {
             "accountId": {
               "description": "AccountId is the AWS account ID to use for the backend.",
@@ -136,6 +136,26 @@
           "type": "object",
           "additionalProperties": false
         },
+        "gcp": {
+          "description": "Gcp is the GCP backend configuration.",
+          "properties": {
+            "audience": {
+              "description": "Audience is the GCP service account audience URL.\nWhen omitted, defaults to \"https://{host}\".\nThis is used by the GCP authn filter to request the appropriate token.",
+              "minLength": 1,
+              "type": "string"
+            },
+            "host": {
+              "description": "Host is the hostname of the GCP service to connect to.\nThis will be used for SNI and as the target address.",
+              "minLength": 1,
+              "type": "string"
+            }
+          },
+          "required": [
+            "host"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
         "static": {
           "description": "Static is the static backend configuration.",
           "properties": {
@@ -188,7 +208,8 @@
           "enum": [
             "AWS",
             "Static",
-            "DynamicForwardProxy"
+            "DynamicForwardProxy",
+            "GCP"
           ],
           "type": "string"
         }
@@ -208,8 +229,12 @@
           "rule": "self.type == 'DynamicForwardProxy' ? has(self.dynamicForwardProxy) : true"
         },
         {
-          "message": "exactly one of the fields in [aws static dynamicForwardProxy] must be set",
-          "rule": "[has(self.aws),has(self.static),has(self.dynamicForwardProxy)].filter(x,x==true).size() == 1"
+          "message": "gcp backend must be specified when type is 'GCP'",
+          "rule": "self.type == 'GCP' ? has(self.gcp) : true"
+        },
+        {
+          "message": "exactly one of the fields in [aws static dynamicForwardProxy gcp] must be set",
+          "rule": "[has(self.aws),has(self.static),has(self.dynamicForwardProxy),has(self.gcp)].filter(x,x==true).size() == 1"
         }
       ],
       "additionalProperties": false

--- a/gateway.kgateway.dev/backendconfigpolicy_v1alpha1.json
+++ b/gateway.kgateway.dev/backendconfigpolicy_v1alpha1.json
@@ -40,6 +40,10 @@
               "format": "int32",
               "minimum": 0,
               "type": "integer"
+            },
+            "trackRemaining": {
+              "description": "TrackRemaining controls whether Envoy tracks the remaining resource\ngauges for this circuit breaker threshold group. When enabled, the\nremaining_cx, remaining_pending, remaining_rq, and remaining_retries\nstatistics are populated. Enabling this has a performance cost.\nIf not specified, defaults to false.",
+              "type": "boolean"
             }
           },
           "type": "object",
@@ -99,6 +103,47 @@
               "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
             }
           ]
+        },
+        "dns": {
+          "description": "DNS contains DNS configuration. Note that this only applies to backends that resolve to Envoy DNS clusters, i.e.,\nBackends of type Static, AWS, or GCP.",
+          "properties": {
+            "jitter": {
+              "description": "Jitter adds a random delay of up to this duration before each DNS refresh,\nspreading query load over time and helping prevent thundering-herd spikes.\nMust be less than or equal to refreshRate when both are set.",
+              "type": "string",
+              "x-kubernetes-validations": [
+                {
+                  "message": "invalid duration value",
+                  "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                }
+              ]
+            },
+            "refreshRate": {
+              "description": "RefreshRate controls how frequently Envoy polls DNS for this backend's hostnames.\n\nMinimum value is 1ms. If unset, Envoy's default of 5s is used.\nWhen Envoy respects DNS TTLs, lower TTL values effectively override this setting,\nso RefreshRate acts as the maximum polling interval.\nRecommended value for large-scale deployments is 60s or higher.",
+              "type": "string",
+              "x-kubernetes-validations": [
+                {
+                  "message": "invalid duration value",
+                  "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                },
+                {
+                  "message": "refreshRate must be at least 1ms",
+                  "rule": "duration(self) >= duration('1ms')"
+                }
+              ]
+            },
+            "respectTTL": {
+              "description": "RespectTTL instructs Envoy to honor TTL values returned by DNS responses.\nWhen enabled, TTLs lower than RefreshRate effectively become the refresh interval.",
+              "type": "boolean"
+            }
+          },
+          "type": "object",
+          "x-kubernetes-validations": [
+            {
+              "message": "jitter must be less than or equal to refreshRate",
+              "rule": "!(has(self.jitter) && has(self.refreshRate)) || duration(self.jitter) <= duration(self.refreshRate)"
+            }
+          ],
+          "additionalProperties": false
         },
         "healthCheck": {
           "description": "HealthCheck contains the options necessary to configure the health check.",
@@ -259,9 +304,10 @@
               ]
             },
             "maxConcurrentStreams": {
-              "description": "The maximum number of concurrent streams that the connection can have.",
+              "description": "The maximum number of concurrent streams that the connection can have.\nEnvoy defaults to 1024.",
               "format": "int32",
-              "minimum": 0,
+              "maximum": 2147483647,
+              "minimum": 1,
               "type": "integer"
             },
             "overrideStreamErrorOnInvalidHttpMessage": {
@@ -912,9 +958,9 @@
             },
             "wellKnownCACertificates": {
               "description": "WellKnownCACertificates specifies whether to use a well-known set of CA\ncertificates for validating the backend's certificate chain. Currently,\nonly the system certificate pool is supported via SDS.",
-              "enum": [
-                "System"
-              ],
+              "maxLength": 253,
+              "minLength": 1,
+              "pattern": "^(System|([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/([A-Za-z0-9][-A-Za-z0-9_.]{0,61})?[A-Za-z0-9]))$",
               "type": "string"
             }
           },
@@ -925,6 +971,32 @@
               "rule": "[has(self.secretRef),has(self.files),has(self.insecureSkipVerify),has(self.wellKnownCACertificates)].filter(x,x==true).size() == 1"
             }
           ],
+          "additionalProperties": false
+        },
+        "upstreamProxyProtocol": {
+          "description": "UpstreamProxyProtocol configures the PROXY protocol for upstream connections to the backend.\nWhen enabled, the proxy protocol header is prepended to upstream connections,\nallowing backend services to see the original client connection information.\nSee [Envoy documentation](https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/transport_sockets/proxy_protocol/v3/upstream_proxy_protocol.proto) for more details.",
+          "properties": {
+            "version": {
+              "allOf": [
+                {
+                  "enum": [
+                    "V1",
+                    "V2"
+                  ]
+                },
+                {
+                  "enum": [
+                    "V1",
+                    "V2"
+                  ]
+                }
+              ],
+              "default": "V1",
+              "description": "Version is the PROXY protocol version to use.",
+              "type": "string"
+            }
+          },
+          "type": "object",
           "additionalProperties": false
         }
       },

--- a/gateway.kgateway.dev/directresponse_v1alpha1.json
+++ b/gateway.kgateway.dev/directresponse_v1alpha1.json
@@ -16,10 +16,38 @@
       "description": "DirectResponseSpec describes the desired state of a DirectResponse.",
       "properties": {
         "body": {
-          "description": "Body defines the content to be returned in the HTTP response body.\nThe maximum length of the body is restricted to prevent excessively large responses.\nIf this field is omitted, no body is included in the response.",
+          "description": "Body defines the content to be returned in the HTTP response body.\nThe maximum length of the body is restricted to prevent excessively large responses.\nIf this field and BodyFormat are both omitted, no body is included in the response.\nMutually exclusive with BodyFormat.",
           "maxLength": 4096,
           "minLength": 1,
           "type": "string"
+        },
+        "bodyFormat": {
+          "description": "BodyFormat defines the content to be returned in the HTTP response body as an Envoy format string.\nIf this field and Body are both omitted, no body is included in the response.\nMutually exclusive with Body.\nSee https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/route/v3/route_components.proto#envoy-v3-api-field-config-route-v3-directresponseaction-body-format for details.",
+          "properties": {
+            "contentType": {
+              "description": "ContentType defines the HTTP Content-Type header to be sent with the response.\nBy default, `text/plain` is used for the Text format and `application/json` for the JSON format.\nNote: This setting does not currently take effect due to a bug in Envoy, a fix for which is pending release.\nThe option is included for completeness and will become effective with a future version of Envoy.",
+              "type": "string"
+            },
+            "json": {
+              "description": "JSON is a format object by which Envoy will produce a JSON response body.\nMutually exclusive with Text.\nSee https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/substitution_format_string.proto#envoy-v3-api-field-config-core-v3-substitutionformatstring-json-format for details.\n\nSetting a field to `null` in the JSON object requires the use of\n`kubectl apply --server-side` or equivalent. With the default client-side\n`kubectl apply`, null values are stripped by kubectl before reaching\nthe API server.",
+              "type": "object",
+              "x-kubernetes-preserve-unknown-fields": true
+            },
+            "text": {
+              "description": "Text is a format string by which Envoy will format the response body.\nMutually exclusive with JSON.\nSee https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/substitution_format_string.proto#envoy-v3-api-field-config-core-v3-substitutionformatstring-text-format for details.",
+              "maxLength": 4096,
+              "minLength": 1,
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "x-kubernetes-validations": [
+            {
+              "message": "exactly one of the fields in [json text] must be set",
+              "rule": "[has(self.json),has(self.text)].filter(x,x==true).size() == 1"
+            }
+          ],
+          "additionalProperties": false
         },
         "status": {
           "description": "StatusCode defines the HTTP status code to return for this route.",
@@ -33,11 +61,162 @@
         "status"
       ],
       "type": "object",
+      "x-kubernetes-validations": [
+        {
+          "message": "at most one of the fields in [body bodyFormat] may be set",
+          "rule": "[has(self.body),has(self.bodyFormat)].filter(x,x==true).size() <= 1"
+        }
+      ],
       "additionalProperties": false
     },
     "status": {
-      "description": "DirectResponseStatus defines the observed state of a DirectResponse.",
-      "type": "object"
+      "description": "PolicyStatus defines the common attributes that all Policies should include within\ntheir status.",
+      "properties": {
+        "ancestors": {
+          "description": "Ancestors is a list of ancestor resources (usually Gateways) that are\nassociated with the policy, and the status of the policy with respect to\neach ancestor. When this policy attaches to a parent, the controller that\nmanages the parent and the ancestors MUST add an entry to this list when\nthe controller first sees the policy and SHOULD update the entry as\nappropriate when the relevant ancestor is modified.\n\nNote that choosing the relevant ancestor is left to the Policy designers;\nan important part of Policy design is designing the right object level at\nwhich to namespace this status.\n\nNote also that implementations MUST ONLY populate ancestor status for\nthe Ancestor resources they are responsible for. Implementations MUST\nuse the ControllerName field to uniquely identify the entries in this list\nthat they are responsible for.\n\nNote that to achieve this, the list of PolicyAncestorStatus structs\nMUST be treated as a map with a composite key, made up of the AncestorRef\nand ControllerName fields combined.\n\nA maximum of 16 ancestors will be represented in this list. An empty list\nmeans the Policy is not relevant for any ancestors.\n\nIf this slice is full, implementations MUST NOT add further entries.\nInstead they MUST consider the policy unimplementable and signal that\non any related resources such as the ancestor that would be referenced\nhere. For example, if this list was full on BackendTLSPolicy, no\nadditional Gateways would be able to reference the Service targeted by\nthe BackendTLSPolicy.",
+          "items": {
+            "description": "PolicyAncestorStatus describes the status of a route with respect to an\nassociated Ancestor.\n\nAncestors refer to objects that are either the Target of a policy or above it\nin terms of object hierarchy. For example, if a policy targets a Service, the\nPolicy's Ancestors are, in order, the Service, the HTTPRoute, the Gateway, and\nthe GatewayClass. Almost always, in this hierarchy, the Gateway will be the most\nuseful object to place Policy status on, so we recommend that implementations\nSHOULD use Gateway as the PolicyAncestorStatus object unless the designers\nhave a _very_ good reason otherwise.\n\nIn the context of policy attachment, the Ancestor is used to distinguish which\nresource results in a distinct application of this policy. For example, if a policy\ntargets a Service, it may have a distinct result per attached Gateway.\n\nPolicies targeting the same resource may have different effects depending on the\nancestors of those resources. For example, different Gateways targeting the same\nService may have different capabilities, especially if they have different underlying\nimplementations.\n\nFor example, in BackendTLSPolicy, the Policy attaches to a Service that is\nused as a backend in a HTTPRoute that is itself attached to a Gateway.\nIn this case, the relevant object for status is the Gateway, and that is the\nancestor object referred to in this status.\n\nNote that a parent is also an ancestor, so for objects where the parent is the\nrelevant object for status, this struct SHOULD still be used.\n\nThis struct is intended to be used in a slice that's effectively a map,\nwith a composite key made up of the AncestorRef and the ControllerName.",
+            "properties": {
+              "ancestorRef": {
+                "description": "AncestorRef corresponds with a ParentRef in the spec that this\nPolicyAncestorStatus struct describes the status of.",
+                "properties": {
+                  "group": {
+                    "default": "gateway.networking.k8s.io",
+                    "description": "Group is the group of the referent.\nWhen unspecified, \"gateway.networking.k8s.io\" is inferred.\nTo set the core API group (such as for a \"Service\" kind referent),\nGroup must be explicitly set to \"\" (empty string).\n\nSupport: Core",
+                    "maxLength": 253,
+                    "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                    "type": "string"
+                  },
+                  "kind": {
+                    "default": "Gateway",
+                    "description": "Kind is kind of the referent.\n\nThere are two kinds of parent resources with \"Core\" support:\n\n* Gateway (Gateway conformance profile)\n* Service (Mesh conformance profile, ClusterIP Services only)\n\nSupport for other resources is Implementation-Specific.",
+                    "maxLength": 63,
+                    "minLength": 1,
+                    "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
+                    "type": "string"
+                  },
+                  "name": {
+                    "description": "Name is the name of the referent.\n\nSupport: Core",
+                    "maxLength": 253,
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "namespace": {
+                    "description": "Namespace is the namespace of the referent. When unspecified, this refers\nto the local namespace of the Route.\n\nNote that there are specific rules for ParentRefs which cross namespace\nboundaries. Cross-namespace references are only valid if they are explicitly\nallowed by something in the namespace they are referring to. For example:\nGateway has the AllowedRoutes field, and ReferenceGrant provides a\ngeneric way to enable any other kind of cross-namespace reference.\n\n<gateway:experimental:description>\nParentRefs from a Route to a Service in the same namespace are \"producer\"\nroutes, which apply default routing rules to inbound connections from\nany namespace to the Service.\n\nParentRefs from a Route to a Service in a different namespace are\n\"consumer\" routes, and these routing rules are only applied to outbound\nconnections originating from the same namespace as the Route, for which\nthe intended destination of the connections are a Service targeted as a\nParentRef of the Route.\n</gateway:experimental:description>\n\nSupport: Core",
+                    "maxLength": 63,
+                    "minLength": 1,
+                    "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                    "type": "string"
+                  },
+                  "port": {
+                    "description": "Port is the network port this Route targets. It can be interpreted\ndifferently based on the type of parent resource.\n\nWhen the parent resource is a Gateway, this targets all listeners\nlistening on the specified port that also support this kind of Route(and\nselect this Route). It's not recommended to set `Port` unless the\nnetworking behaviors specified in a Route must apply to a specific port\nas opposed to a listener(s) whose port(s) may be changed. When both Port\nand SectionName are specified, the name and port of the selected listener\nmust match both specified values.\n\n<gateway:experimental:description>\nWhen the parent resource is a Service, this targets a specific port in the\nService spec. When both Port (experimental) and SectionName are specified,\nthe name and port of the selected port must match both specified values.\n</gateway:experimental:description>\n\nImplementations MAY choose to support other parent resources.\nImplementations supporting other types of parent resources MUST clearly\ndocument how/if Port is interpreted.\n\nFor the purpose of status, an attachment is considered successful as\nlong as the parent resource accepts it partially. For example, Gateway\nlisteners can restrict which Routes can attach to them by Route kind,\nnamespace, or hostname. If 1 of 2 Gateway listeners accept attachment\nfrom the referencing Route, the Route MUST be considered successfully\nattached. If no Gateway listeners accept attachment from this Route,\nthe Route MUST be considered detached from the Gateway.\n\nSupport: Extended",
+                    "format": "int32",
+                    "maximum": 65535,
+                    "minimum": 1,
+                    "type": "integer"
+                  },
+                  "sectionName": {
+                    "description": "SectionName is the name of a section within the target resource. In the\nfollowing resources, SectionName is interpreted as the following:\n\n* Gateway: Listener name. When both Port (experimental) and SectionName\nare specified, the name and port of the selected listener must match\nboth specified values.\n* Service: Port name. When both Port (experimental) and SectionName\nare specified, the name and port of the selected listener must match\nboth specified values.\n\nImplementations MAY choose to support attaching Routes to other resources.\nIf that is the case, they MUST clearly document how SectionName is\ninterpreted.\n\nWhen unspecified (empty string), this will reference the entire resource.\nFor the purpose of status, an attachment is considered successful if at\nleast one section in the parent resource accepts it. For example, Gateway\nlisteners can restrict which Routes can attach to them by Route kind,\nnamespace, or hostname. If 1 of 2 Gateway listeners accept attachment from\nthe referencing Route, the Route MUST be considered successfully\nattached. If no Gateway listeners accept attachment from this Route, the\nRoute MUST be considered detached from the Gateway.\n\nSupport: Core",
+                    "maxLength": 253,
+                    "minLength": 1,
+                    "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "conditions": {
+                "description": "Conditions describes the status of the Policy with respect to the given Ancestor.\n\n<gateway:util:excludeFromCRD>\n\nNotes for implementors:\n\nConditions are a listType `map`, which means that they function like a\nmap with a key of the `type` field _in the k8s apiserver_.\n\nThis means that implementations must obey some rules when updating this\nsection.\n\n* Implementations MUST perform a read-modify-write cycle on this field\n  before modifying it. That is, when modifying this field, implementations\n  must be confident they have fetched the most recent version of this field,\n  and ensure that changes they make are on that recent version.\n* Implementations MUST NOT remove or reorder Conditions that they are not\n  directly responsible for. For example, if an implementation sees a Condition\n  with type `special.io/SomeField`, it MUST NOT remove, change or update that\n  Condition.\n* Implementations MUST always _merge_ changes into Conditions of the same Type,\n  rather than creating more than one Condition of the same Type.\n* Implementations MUST always update the `observedGeneration` field of the\n  Condition to the `metadata.generation` of the Gateway at the time of update creation.\n* If the `observedGeneration` of a Condition is _greater than_ the value the\n  implementation knows about, then it MUST NOT perform the update on that Condition,\n  but must wait for a future reconciliation and status update. (The assumption is that\n  the implementation's copy of the object is stale and an update will be re-triggered\n  if relevant.)\n\n</gateway:util:excludeFromCRD>",
+                "items": {
+                  "description": "Condition contains details for one aspect of the current state of this API Resource.",
+                  "properties": {
+                    "lastTransitionTime": {
+                      "description": "lastTransitionTime is the last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
+                      "format": "date-time",
+                      "type": "string"
+                    },
+                    "message": {
+                      "description": "message is a human readable message indicating details about the transition.\nThis may be an empty string.",
+                      "maxLength": 32768,
+                      "type": "string"
+                    },
+                    "observedGeneration": {
+                      "description": "observedGeneration represents the .metadata.generation that the condition was set based upon.\nFor instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date\nwith respect to the current state of the instance.",
+                      "format": "int64",
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "reason": {
+                      "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition.\nProducers of specific condition types may define expected values and meanings for this field,\nand whether the values are considered a guaranteed API.\nThe value should be a CamelCase string.\nThis field may not be empty.",
+                      "maxLength": 1024,
+                      "minLength": 1,
+                      "pattern": "^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$",
+                      "type": "string"
+                    },
+                    "status": {
+                      "description": "status of the condition, one of True, False, Unknown.",
+                      "enum": [
+                        "True",
+                        "False",
+                        "Unknown"
+                      ],
+                      "type": "string"
+                    },
+                    "type": {
+                      "description": "type of condition in CamelCase or in foo.example.com/CamelCase.",
+                      "maxLength": 316,
+                      "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "lastTransitionTime",
+                    "message",
+                    "reason",
+                    "status",
+                    "type"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "maxItems": 8,
+                "minItems": 1,
+                "type": "array",
+                "x-kubernetes-list-map-keys": [
+                  "type"
+                ],
+                "x-kubernetes-list-type": "map"
+              },
+              "controllerName": {
+                "description": "ControllerName is a domain/path string that indicates the name of the\ncontroller that wrote this status. This corresponds with the\ncontrollerName field on GatewayClass.\n\nExample: \"example.net/gateway-controller\".\n\nThe format of this field is DOMAIN \"/\" PATH, where DOMAIN and PATH are\nvalid Kubernetes names\n(https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names).\n\nControllers MUST populate this field when writing status. Controllers should ensure that\nentries to status populated with their ControllerName are cleaned up when they are no\nlonger necessary.",
+                "maxLength": 253,
+                "minLength": 1,
+                "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\\/[A-Za-z0-9\\/\\-._~%!$&'()*+,;=:]+$",
+                "type": "string"
+              }
+            },
+            "required": [
+              "ancestorRef",
+              "conditions",
+              "controllerName"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "maxItems": 16,
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        }
+      },
+      "required": [
+        "ancestors"
+      ],
+      "type": "object",
+      "additionalProperties": false
     }
   },
   "required": [

--- a/gateway.kgateway.dev/gatewayextension_v1alpha1.json
+++ b/gateway.kgateway.dev/gatewayextension_v1alpha1.json
@@ -396,6 +396,86 @@
         "extProc": {
           "description": "ExtProc configuration for ExtProc extension type.",
           "properties": {
+            "allowProcessingModeOverride": {
+              "default": false,
+              "description": "AllowProcessingModeOverride determines if the processing mode can be overridden.\nDefaults to false, meaning the processing mode cannot be overridden.",
+              "type": "boolean"
+            },
+            "allowedProcessingModeOverrides": {
+              "description": "AllowedProcessingModeOverrides specifies which processing modes are allowed to override the default.\nEmpty or unspecified means all overrides are allowed (if AllowProcessingModeOverride is true).\nThis is an allowlist; any processing mode in this list will allow the override to the specified mode.\nIf AllowProcessingModeOverride is false, this field is ignored.\nSee: https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/http/ext_proc/v3/ext_proc.proto#envoy-v3-api-field-extensions-filters-http-ext-proc-v3-externalprocessor-allowed-override-modes",
+              "items": {
+                "description": "ProcessingMode defines how the filter should interact with the request/response streams",
+                "properties": {
+                  "requestBodyMode": {
+                    "default": "NONE",
+                    "description": "RequestBodyMode determines how to handle the request body",
+                    "enum": [
+                      "NONE",
+                      "STREAMED",
+                      "BUFFERED",
+                      "BUFFERED_PARTIAL",
+                      "FULL_DUPLEX_STREAMED"
+                    ],
+                    "type": "string"
+                  },
+                  "requestHeaderMode": {
+                    "default": "SEND",
+                    "description": "RequestHeaderMode determines how to handle the request headers",
+                    "enum": [
+                      "DEFAULT",
+                      "SEND",
+                      "SKIP"
+                    ],
+                    "type": "string"
+                  },
+                  "requestTrailerMode": {
+                    "default": "SKIP",
+                    "description": "RequestTrailerMode determines how to handle the request trailers",
+                    "enum": [
+                      "DEFAULT",
+                      "SEND",
+                      "SKIP"
+                    ],
+                    "type": "string"
+                  },
+                  "responseBodyMode": {
+                    "default": "NONE",
+                    "description": "ResponseBodyMode determines how to handle the response body",
+                    "enum": [
+                      "NONE",
+                      "STREAMED",
+                      "BUFFERED",
+                      "BUFFERED_PARTIAL",
+                      "FULL_DUPLEX_STREAMED"
+                    ],
+                    "type": "string"
+                  },
+                  "responseHeaderMode": {
+                    "default": "SEND",
+                    "description": "ResponseHeaderMode determines how to handle the response headers",
+                    "enum": [
+                      "DEFAULT",
+                      "SEND",
+                      "SKIP"
+                    ],
+                    "type": "string"
+                  },
+                  "responseTrailerMode": {
+                    "default": "SKIP",
+                    "description": "ResponseTrailerMode determines how to handle the response trailers",
+                    "enum": [
+                      "DEFAULT",
+                      "SEND",
+                      "SKIP"
+                    ],
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
             "failOpen": {
               "default": true,
               "description": "FailOpen determines if requests are allowed when the ext proc service is unavailable.\nDefaults to true, meaning requests are allowed upstream even if the ext proc service is unavailable.",
@@ -949,7 +1029,7 @@
           "description": "OAuth2 configuration for OAuth2 extension type.",
           "properties": {
             "authorizationEndpoint": {
-              "description": "AuthorizationEndpoint specifies the endpoint to redirect to for authorization in response to unauthorized requests.\nRefer to https://datatracker.ietf.org/doc/html/rfc6749#section-3.1 for more details.",
+              "description": "AuthorizationEndpoint specifies the endpoint to redirect to for authorization in response to unauthorized requests.\nIf both IssuerURI and this value are specified, the value discovered from the issuer will *not* be used and this takes precedence.\nRefer to https://datatracker.ietf.org/doc/html/rfc6749#section-3.1 for more details.",
               "pattern": "^https://([a-zA-Z0-9]([a-zA-Z0-9\\-]{0,61}[a-zA-Z0-9])?\\.)*[a-zA-Z0-9]([a-zA-Z0-9\\-]{0,61}[a-zA-Z0-9])?(:[0-9]{1,5})?(/[a-zA-Z0-9\\-._~!$&'()*+,;=:@%]*)*/?(\\?[a-zA-Z0-9\\-._~!$&'()*+,;=:@%/?]*)?$",
               "type": "string"
             },
@@ -1015,6 +1095,18 @@
             "cookies": {
               "description": "Cookies specifies the configuration for the OAuth2 cookies.",
               "properties": {
+                "disableAccessTokenSetCookie": {
+                  "description": "DisableAccessTokenSetCookie specifies whether to disable setting the access token cookie.\nThis can be used when the access token is too large to fit in a cookie. When true, the\nset-cookie response header for the access token will be omitted.",
+                  "type": "boolean"
+                },
+                "disableIDTokenSetCookie": {
+                  "description": "DisableIDTokenSetCookie specifies whether to disable setting the ID token cookie.\nThis can be used when the ID token is too large to fit in a cookie. When true, the\nset-cookie response header for the ID token will be omitted.",
+                  "type": "boolean"
+                },
+                "disableRefreshTokenSetCookie": {
+                  "description": "DisableRefreshTokenSetCookie specifies whether to disable setting the refresh token cookie.\nThis can be used when the refresh token is too large to fit in a cookie. When true, the\nset-cookie response header for the refresh token will be omitted.",
+                  "type": "boolean"
+                },
                 "domain": {
                   "description": "CookieDomain specifies the domain to set on the access and ID token cookies.\nIf set, the cookies will be set for the specified domain and all its subdomains. This is useful when requests\nto subdomains are not required to be re-authenticated after the user has logged into the parent domain.\nIf not set, the cookies will default to the host of the request, not including the subdomains.",
                   "maxLength": 253,
@@ -1106,7 +1198,7 @@
                         "type": "string"
                       },
                       "value": {
-                        "description": "Value is the value of HTTP Header to be matched.",
+                        "description": "Value is the value of HTTP Header to be matched.\n<gateway:experimental:description>\nMust consist of printable US-ASCII characters, optionally separated\nby single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2\n</gateway:experimental:description>\n\n<gateway:experimental:validation:Pattern=`^[!-~]+([\\t ]?[!-~]+)*$`>",
                         "maxLength": 4096,
                         "minLength": 1,
                         "type": "string"
@@ -1128,7 +1220,7 @@
               "additionalProperties": false
             },
             "endSessionEndpoint": {
-              "description": "EndSessionEndpoint specifies the URL that redirects a user's browser to in order to initiate a single logout\nacross all applications and the OpenID provider. Users are directed to this endpoint when they access the logout path.\nThis should only be set when the OpenID provider supports RP-Initiated Logout and \"openid\" is included in the list of scopes.\nRefer to https://openid.net/specs/openid-connect-rpinitiated-1_0.html#RPLogout for more details.",
+              "description": "EndSessionEndpoint specifies the URL that redirects a user's browser to in order to initiate a single logout\nacross all applications and the OpenID provider. Users are directed to this endpoint when they access the logout path.\nThis should only be set when the OpenID provider supports RP-Initiated Logout and \"openid\" is included in the list of scopes.\nIf both IssuerURI and this value are specified, the value discovered from the issuer will *not* be used and this takes precedence.\nRefer to https://openid.net/specs/openid-connect-rpinitiated-1_0.html#RPLogout for more details.",
               "pattern": "^https://([a-zA-Z0-9]([a-zA-Z0-9\\-]{0,61}[a-zA-Z0-9])?\\.)*[a-zA-Z0-9]([a-zA-Z0-9\\-]{0,61}[a-zA-Z0-9])?(:[0-9]{1,5})?(/[a-zA-Z0-9\\-._~!$&'()*+,;=:@%]*)*/?(\\?[a-zA-Z0-9\\-._~!$&'()*+,;=:@%/?]*)?$",
               "type": "string"
             },
@@ -1137,9 +1229,111 @@
               "type": "boolean"
             },
             "issuerURI": {
-              "description": "IssuerURI specifies the OpenID provider's issuer URL to discover the OpenID provider's configuration.\nThe Issuer must be a URI RFC 3986 [RFC3986] with a scheme component that must be https, a host component,\nand optionally, port and path components and no query or fragment components.\nIt discovers the authorizationEndpoint, tokenEndpoint, and endSessionEndpoint if specified in the discovery response.\nRefer to https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfig for more details.\nNote that the OpenID provider configuration is cached and only refreshed periodically when the GatewayExtension object\nis reprocessed.",
+              "description": "IssuerURI specifies the OpenID provider's issuer URL to discover the OpenID provider's configuration.\nThe Issuer must be a URI RFC 3986 [RFC3986] with a scheme component that must be https, a host component,\nand optionally, port and path components and no query or fragment components.\nIt discovers the authorizationEndpoint, tokenEndpoint, endSessionEndpoint, and jwksURI if specified in the discovery response.\nExplicit configuration of these options will take precedence over the discovered values.\nRefer to https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfig for more details.\nNote that the OpenID provider configuration is cached and only refreshed periodically when the GatewayExtension object\nis reprocessed.",
               "pattern": "^https://([a-zA-Z0-9]([a-zA-Z0-9\\-]{0,61}[a-zA-Z0-9])?\\.)*[a-zA-Z0-9]([a-zA-Z0-9\\-]{0,61}[a-zA-Z0-9])?(:[0-9]{1,5})?(/[a-zA-Z0-9\\-._~!$&'()*+,;=:@%]*)*/?$",
               "type": "string"
+            },
+            "jwt": {
+              "description": "JWT specifies the configuration for whether and how to process the retrieved access and ID tokens as JSON Web Token.",
+              "properties": {
+                "accessToken": {
+                  "description": "AccessToken specifies how to process the retrieved access token.\nThis requires the access token cookie to be enabled. Requests missing the token will be rejected.\nThe token will be verified against the provided JWKS.\nSuccessfully processed tokens have their payload made available as the 'accessToken' dynamic metadata in the 'envoy.filters.http.jwt_authn' namespace.\nIf omitted, the token will not be attempted to be parsed and verified at all.",
+                  "properties": {
+                    "audiences": {
+                      "description": "Audiences is the list of audiences to be used for the processed token.\nIf specified the token must have an 'aud' claim, and it must be in this list.\nIf not specified, the audiences will not be checked in the token.",
+                      "items": {
+                        "type": "string"
+                      },
+                      "maxItems": 32,
+                      "minItems": 1,
+                      "type": "array"
+                    },
+                    "claimsToHeaders": {
+                      "description": "ClaimsToHeaders is a list of claims from the token that should be forwarded upstream as a header.\nOptionally set the claims from the JWT payload that you want to extract and add as headers\nto the request before the request is forwarded to the upstream destination.\nNote: if ClaimsToHeaders is set, the Envoy route cache will be cleared.\nThis allows the JWT filter to correctly affect routing decisions.",
+                      "items": {
+                        "description": "JWTClaimToHeader allows copying verified claims to headers sent upstream",
+                        "properties": {
+                          "header": {
+                            "description": "Header is the header the claim will be copied to, for example, \"x-sub\".",
+                            "maxLength": 2048,
+                            "minLength": 1,
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "Name is the JWT claim name, for example, \"sub\".",
+                            "maxLength": 2048,
+                            "minLength": 1,
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "header",
+                          "name"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "maxItems": 32,
+                      "minItems": 1,
+                      "type": "array"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "idToken": {
+                  "description": "IDToken specifies how to process the retrieved ID token.\nThis requires the ID token cookie to be enabled. Requests missing the token will be rejected.\nThe token will be verified against the provided JWKS.\nSuccessfully processed tokens have their payload made available as the 'idToken' dynamic metadata in the 'envoy.filters.http.jwt_authn' namespace.\nIf omitted, the token will not be attempted to be parsed and verified at all.",
+                  "properties": {
+                    "audiences": {
+                      "description": "Audiences is the list of audiences to be used for the processed token.\nIf specified the token must have an 'aud' claim, and it must be in this list.\nIf not specified, the audiences will not be checked in the token.",
+                      "items": {
+                        "type": "string"
+                      },
+                      "maxItems": 32,
+                      "minItems": 1,
+                      "type": "array"
+                    },
+                    "claimsToHeaders": {
+                      "description": "ClaimsToHeaders is a list of claims from the token that should be forwarded upstream as a header.\nOptionally set the claims from the JWT payload that you want to extract and add as headers\nto the request before the request is forwarded to the upstream destination.\nNote: if ClaimsToHeaders is set, the Envoy route cache will be cleared.\nThis allows the JWT filter to correctly affect routing decisions.",
+                      "items": {
+                        "description": "JWTClaimToHeader allows copying verified claims to headers sent upstream",
+                        "properties": {
+                          "header": {
+                            "description": "Header is the header the claim will be copied to, for example, \"x-sub\".",
+                            "maxLength": 2048,
+                            "minLength": 1,
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "Name is the JWT claim name, for example, \"sub\".",
+                            "maxLength": 2048,
+                            "minLength": 1,
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "header",
+                          "name"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "maxItems": 32,
+                      "minItems": 1,
+                      "type": "array"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "jwksURI": {
+                  "description": "JWKSURI specifies the URL that public keys for validating JWTs should be retrieved from.\nThis must be set if the retrieved access or ID token need to be parsed and IssuerURI is not set for discovery.\nIf both IssuerURI and this value are specified, the value discovered from the issuer will *not* be used and this takes precedence.\nThe URL must point to a valid JWKS definition.\nRefer to https://datatracker.ietf.org/doc/html/rfc7517#section-5 for more details.",
+                  "pattern": "^https://([a-zA-Z0-9]([a-zA-Z0-9\\-]{0,61}[a-zA-Z0-9])?\\.)*[a-zA-Z0-9]([a-zA-Z0-9\\-]{0,61}[a-zA-Z0-9])?(:[0-9]{1,5})?(/[a-zA-Z0-9\\-._~!$&'()*+,;=:@%]*)*/?(\\?[a-zA-Z0-9\\-._~!$&'()*+,;=:@%/?]*)?$",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
             },
             "logoutPath": {
               "default": "/logout",
@@ -1159,7 +1353,7 @@
               "type": "array"
             },
             "tokenEndpoint": {
-              "description": "TokenEndpoint specifies the endpoint on the authorization server to retrieve the access token from.\nRefer to https://datatracker.ietf.org/doc/html/rfc6749#section-3.2 for more details.",
+              "description": "TokenEndpoint specifies the endpoint on the authorization server to retrieve the access token from.\nIf both IssuerURI and this value are specified, the value discovered from the issuer will *not* be used and this takes precedence.\nRefer to https://datatracker.ietf.org/doc/html/rfc6749#section-3.2 for more details.",
               "pattern": "^https://([a-zA-Z0-9]([a-zA-Z0-9\\-]{0,61}[a-zA-Z0-9])?\\.)*[a-zA-Z0-9]([a-zA-Z0-9\\-]{0,61}[a-zA-Z0-9])?(:[0-9]{1,5})?(/[a-zA-Z0-9\\-._~!$&'()*+,;=:@%]*)*/?(\\?[a-zA-Z0-9\\-._~!$&'()*+,;=:@%/?]*)?$",
               "type": "string"
             }
@@ -1173,6 +1367,18 @@
             {
               "message": "Either issuerURI, or both authorizationEndpoint and tokenEndpoint must be specified",
               "rule": "has(self.issuerURI) || (has(self.authorizationEndpoint) && has(self.tokenEndpoint))"
+            },
+            {
+              "message": "Either issuerURI or jwksURI must be specified for JWT parsing",
+              "rule": "!(has(self.?jwt.accessToken) || has(self.?jwt.idToken)) || (has(self.issuerURI) || has(self.?jwt.jwksURI))"
+            },
+            {
+              "message": "Access token cookie must not be disabled when the token should be parsed",
+              "rule": "!has(self.?jwt.accessToken) || !self.?cookies.?disableAccessTokenSetCookie.orValue(false)"
+            },
+            {
+              "message": "ID token cookie must not be disabled when the token should be parsed",
+              "rule": "!has(self.?jwt.idToken) || !self.?cookies.?disableIDTokenSetCookie.orValue(false)"
             }
           ],
           "additionalProperties": false

--- a/gateway.kgateway.dev/gatewayparameters_v1alpha1.json
+++ b/gateway.kgateway.dev/gatewayparameters_v1alpha1.json
@@ -1,5 +1,5 @@
 {
-  "description": "A GatewayParameters contains configuration that is used to dynamically\nprovision kgateway's data plane (Envoy or agentgateway proxy instance), based on a\nKubernetes Gateway.",
+  "description": "A GatewayParameters contains configuration that is used to dynamically\nprovision kgateway's data plane (Envoy proxy instance), based on a\nKubernetes Gateway.",
   "properties": {
     "apiVersion": {
       "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
@@ -16,460 +16,8 @@
       "description": "A GatewayParametersSpec describes the type of environment/platform in which\nthe proxy will be provisioned.",
       "properties": {
         "kube": {
-          "description": "The proxy will be deployed on Kubernetes.",
+          "description": "The proxy will be deployed on Kubernetes. Overlays (fields named with\nthe suffix 'Overlay') are applied after non-overlay configurations\n(\"configs\"). Configs on a GatewayClass (inside of GatewayParameters) are\napplied before configs on a Gateway (inside of GatewayParameters), which\nmerge together. Overlays on a GatewayClass are then applied, and\nfinally, overlays on a Gateway. It is recommended to use an overlay only\nif necessary (no config exists that can achieve the same goal) for\nsmoother upgrades, readability, and earlier and improved validation.",
           "properties": {
-            "agentgateway": {
-              "description": "Obsolete: This field is no longer used. Agentgateway configuration is now\ndetermined automatically based on the GatewayClass controllerName\n(agentgateway.dev/agentgateway). Use the AgentgatewayParameters API to\nconfigure agentgateway deployments. Any values specified here are ignored.",
-              "properties": {
-                "enabled": {
-                  "description": "Obsolete: This field is no longer used. The agentgateway dataplane is\nautomatically enabled when the Gateway references a GatewayClass with\ncontrollerName: agentgateway.dev/agentgateway. Use the AgentgatewayParameters\nAPI to configure agentgateway deployments. Any values specified here are ignored.",
-                  "type": "boolean"
-                },
-                "env": {
-                  "description": "The container environment variables.",
-                  "items": {
-                    "description": "EnvVar represents an environment variable present in a Container.",
-                    "properties": {
-                      "name": {
-                        "description": "Name of the environment variable.\nMay consist of any printable ASCII characters except '='.",
-                        "type": "string"
-                      },
-                      "value": {
-                        "description": "Variable references $(VAR_NAME) are expanded\nusing the previously defined environment variables in the container and\nany service environment variables. If a variable cannot be resolved,\nthe reference in the input string will be unchanged. Double $$ are reduced\nto a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.\n\"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\".\nEscaped references will never be expanded, regardless of whether the variable\nexists or not.\nDefaults to \"\".",
-                        "type": "string"
-                      },
-                      "valueFrom": {
-                        "description": "Source for the environment variable's value. Cannot be used if value is not empty.",
-                        "properties": {
-                          "configMapKeyRef": {
-                            "description": "Selects a key of a ConfigMap.",
-                            "properties": {
-                              "key": {
-                                "description": "The key to select.",
-                                "type": "string"
-                              },
-                              "name": {
-                                "default": "",
-                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
-                                "type": "string"
-                              },
-                              "optional": {
-                                "description": "Specify whether the ConfigMap or its key must be defined",
-                                "type": "boolean"
-                              }
-                            },
-                            "required": [
-                              "key"
-                            ],
-                            "type": "object",
-                            "x-kubernetes-map-type": "atomic",
-                            "additionalProperties": false
-                          },
-                          "fieldRef": {
-                            "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,\nspec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.",
-                            "properties": {
-                              "apiVersion": {
-                                "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
-                                "type": "string"
-                              },
-                              "fieldPath": {
-                                "description": "Path of the field to select in the specified API version.",
-                                "type": "string"
-                              }
-                            },
-                            "required": [
-                              "fieldPath"
-                            ],
-                            "type": "object",
-                            "x-kubernetes-map-type": "atomic",
-                            "additionalProperties": false
-                          },
-                          "fileKeyRef": {
-                            "description": "FileKeyRef selects a key of the env file.\nRequires the EnvFiles feature gate to be enabled.",
-                            "properties": {
-                              "key": {
-                                "description": "The key within the env file. An invalid key will prevent the pod from starting.\nThe keys defined within a source may consist of any printable ASCII characters except '='.\nDuring Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.",
-                                "type": "string"
-                              },
-                              "optional": {
-                                "default": false,
-                                "description": "Specify whether the file or its key must be defined. If the file or key\ndoes not exist, then the env var is not published.\nIf optional is set to true and the specified key does not exist,\nthe environment variable will not be set in the Pod's containers.\n\nIf optional is set to false and the specified key does not exist,\nan error will be returned during Pod creation.",
-                                "type": "boolean"
-                              },
-                              "path": {
-                                "description": "The path within the volume from which to select the file.\nMust be relative and may not contain the '..' path or start with '..'.",
-                                "type": "string"
-                              },
-                              "volumeName": {
-                                "description": "The name of the volume mount containing the env file.",
-                                "type": "string"
-                              }
-                            },
-                            "required": [
-                              "key",
-                              "path",
-                              "volumeName"
-                            ],
-                            "type": "object",
-                            "x-kubernetes-map-type": "atomic",
-                            "additionalProperties": false
-                          },
-                          "resourceFieldRef": {
-                            "description": "Selects a resource of the container: only resources limits and requests\n(limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.",
-                            "properties": {
-                              "containerName": {
-                                "description": "Container name: required for volumes, optional for env vars",
-                                "type": "string"
-                              },
-                              "divisor": {
-                                "anyOf": [
-                                  {
-                                    "type": "integer"
-                                  },
-                                  {
-                                    "type": "string"
-                                  }
-                                ],
-                                "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
-                                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
-                                "x-kubernetes-int-or-string": true
-                              },
-                              "resource": {
-                                "description": "Required: resource to select",
-                                "type": "string"
-                              }
-                            },
-                            "required": [
-                              "resource"
-                            ],
-                            "type": "object",
-                            "x-kubernetes-map-type": "atomic",
-                            "additionalProperties": false
-                          },
-                          "secretKeyRef": {
-                            "description": "Selects a key of a secret in the pod's namespace",
-                            "properties": {
-                              "key": {
-                                "description": "The key of the secret to select from.  Must be a valid secret key.",
-                                "type": "string"
-                              },
-                              "name": {
-                                "default": "",
-                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
-                                "type": "string"
-                              },
-                              "optional": {
-                                "description": "Specify whether the Secret or its key must be defined",
-                                "type": "boolean"
-                              }
-                            },
-                            "required": [
-                              "key"
-                            ],
-                            "type": "object",
-                            "x-kubernetes-map-type": "atomic",
-                            "additionalProperties": false
-                          }
-                        },
-                        "type": "object",
-                        "additionalProperties": false
-                      }
-                    },
-                    "required": [
-                      "name"
-                    ],
-                    "type": "object",
-                    "additionalProperties": false
-                  },
-                  "type": "array"
-                },
-                "extraVolumeMounts": {
-                  "description": "Additional volume mounts to add to the container. See\nhttps://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#volumemount-v1-core\nfor details.",
-                  "items": {
-                    "description": "VolumeMount describes a mounting of a Volume within a container.",
-                    "properties": {
-                      "mountPath": {
-                        "description": "Path within the container at which the volume should be mounted.  Must\nnot contain ':'.",
-                        "type": "string"
-                      },
-                      "mountPropagation": {
-                        "description": "mountPropagation determines how mounts are propagated from the host\nto container and the other way around.\nWhen not set, MountPropagationNone is used.\nThis field is beta in 1.10.\nWhen RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified\n(which defaults to None).",
-                        "type": "string"
-                      },
-                      "name": {
-                        "description": "This must match the Name of a Volume.",
-                        "type": "string"
-                      },
-                      "readOnly": {
-                        "description": "Mounted read-only if true, read-write otherwise (false or unspecified).\nDefaults to false.",
-                        "type": "boolean"
-                      },
-                      "recursiveReadOnly": {
-                        "description": "RecursiveReadOnly specifies whether read-only mounts should be handled\nrecursively.\n\nIf ReadOnly is false, this field has no meaning and must be unspecified.\n\nIf ReadOnly is true, and this field is set to Disabled, the mount is not made\nrecursively read-only.  If this field is set to IfPossible, the mount is made\nrecursively read-only, if it is supported by the container runtime.  If this\nfield is set to Enabled, the mount is made recursively read-only if it is\nsupported by the container runtime, otherwise the pod will not be started and\nan error will be generated to indicate the reason.\n\nIf this field is set to IfPossible or Enabled, MountPropagation must be set to\nNone (or be unspecified, which defaults to None).\n\nIf this field is not specified, it is treated as an equivalent of Disabled.",
-                        "type": "string"
-                      },
-                      "subPath": {
-                        "description": "Path within the volume from which the container's volume should be mounted.\nDefaults to \"\" (volume's root).",
-                        "type": "string"
-                      },
-                      "subPathExpr": {
-                        "description": "Expanded path within the volume from which the container's volume should be mounted.\nBehaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.\nDefaults to \"\" (volume's root).\nSubPathExpr and SubPath are mutually exclusive.",
-                        "type": "string"
-                      }
-                    },
-                    "required": [
-                      "mountPath",
-                      "name"
-                    ],
-                    "type": "object",
-                    "additionalProperties": false
-                  },
-                  "type": "array"
-                },
-                "image": {
-                  "description": "The agentgateway container image. See\nhttps://kubernetes.io/docs/concepts/containers/images\nfor details.\n\nDefault values, which may be overridden individually:\n\n\tregistry: cr.agentgateway.dev\n\trepository: agentgateway\n\ttag: <agentgateway version>\n\tpullPolicy: IfNotPresent",
-                  "properties": {
-                    "digest": {
-                      "description": "The hash digest of the image, e.g. `sha256:12345...`",
-                      "type": "string"
-                    },
-                    "pullPolicy": {
-                      "description": "The image pull policy for the container. See\nhttps://kubernetes.io/docs/concepts/containers/images/#image-pull-policy\nfor details.",
-                      "type": "string"
-                    },
-                    "registry": {
-                      "description": "The image registry.",
-                      "type": "string"
-                    },
-                    "repository": {
-                      "description": "The image repository (name).",
-                      "type": "string"
-                    },
-                    "tag": {
-                      "description": "The image tag.",
-                      "type": "string"
-                    }
-                  },
-                  "type": "object",
-                  "additionalProperties": false
-                },
-                "logLevel": {
-                  "description": "Log level for the agentgateway. Defaults to info.\nLevels include \"trace\", \"debug\", \"info\", \"error\", \"warn\". See: https://docs.rs/tracing/latest/tracing/struct.Level.html",
-                  "type": "string"
-                },
-                "resources": {
-                  "description": "The compute resources required by this container. See\nhttps://kubernetes.io/docs/concepts/configuration/manage-resources-containers/\nfor details.",
-                  "properties": {
-                    "claims": {
-                      "description": "Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.\n\nThis field depends on the\nDynamicResourceAllocation feature gate.\n\nThis field is immutable. It can only be set for containers.",
-                      "items": {
-                        "description": "ResourceClaim references one entry in PodSpec.ResourceClaims.",
-                        "properties": {
-                          "name": {
-                            "description": "Name must match the name of one entry in pod.spec.resourceClaims of\nthe Pod where this field is used. It makes that resource available\ninside a container.",
-                            "type": "string"
-                          },
-                          "request": {
-                            "description": "Request is the name chosen for a request in the referenced claim.\nIf empty, everything from the claim is made available, otherwise\nonly the result of this request.",
-                            "type": "string"
-                          }
-                        },
-                        "required": [
-                          "name"
-                        ],
-                        "type": "object",
-                        "additionalProperties": false
-                      },
-                      "type": "array",
-                      "x-kubernetes-list-map-keys": [
-                        "name"
-                      ],
-                      "x-kubernetes-list-type": "map"
-                    },
-                    "limits": {
-                      "additionalProperties": {
-                        "anyOf": [
-                          {
-                            "type": "integer"
-                          },
-                          {
-                            "type": "string"
-                          }
-                        ],
-                        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
-                        "x-kubernetes-int-or-string": true
-                      },
-                      "description": "Limits describes the maximum amount of compute resources allowed.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
-                      "type": "object"
-                    },
-                    "requests": {
-                      "additionalProperties": {
-                        "anyOf": [
-                          {
-                            "type": "integer"
-                          },
-                          {
-                            "type": "string"
-                          }
-                        ],
-                        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
-                        "x-kubernetes-int-or-string": true
-                      },
-                      "description": "Requests describes the minimum amount of compute resources required.\nIf Requests is omitted for a container, it defaults to Limits if that is explicitly specified,\notherwise to an implementation-defined value. Requests cannot exceed Limits.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
-                      "type": "object"
-                    }
-                  },
-                  "type": "object",
-                  "additionalProperties": false
-                },
-                "securityContext": {
-                  "description": "The security context for this container. See\nhttps://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#securitycontext-v1-core\nfor details.",
-                  "properties": {
-                    "allowPrivilegeEscalation": {
-                      "description": "AllowPrivilegeEscalation controls whether a process can gain more\nprivileges than its parent process. This bool directly controls if\nthe no_new_privs flag will be set on the container process.\nAllowPrivilegeEscalation is true always when the container is:\n1) run as Privileged\n2) has CAP_SYS_ADMIN\nNote that this field cannot be set when spec.os.name is windows.",
-                      "type": "boolean"
-                    },
-                    "appArmorProfile": {
-                      "description": "appArmorProfile is the AppArmor options to use by this container. If set, this profile\noverrides the pod's appArmorProfile.\nNote that this field cannot be set when spec.os.name is windows.",
-                      "properties": {
-                        "localhostProfile": {
-                          "description": "localhostProfile indicates a profile loaded on the node that should be used.\nThe profile must be preconfigured on the node to work.\nMust match the loaded name of the profile.\nMust be set if and only if type is \"Localhost\".",
-                          "type": "string"
-                        },
-                        "type": {
-                          "description": "type indicates which kind of AppArmor profile will be applied.\nValid options are:\n  Localhost - a profile pre-loaded on the node.\n  RuntimeDefault - the container runtime's default profile.\n  Unconfined - no AppArmor enforcement.",
-                          "type": "string"
-                        }
-                      },
-                      "required": [
-                        "type"
-                      ],
-                      "type": "object",
-                      "additionalProperties": false
-                    },
-                    "capabilities": {
-                      "description": "The capabilities to add/drop when running containers.\nDefaults to the default set of capabilities granted by the container runtime.\nNote that this field cannot be set when spec.os.name is windows.",
-                      "properties": {
-                        "add": {
-                          "description": "Added capabilities",
-                          "items": {
-                            "description": "Capability represent POSIX capabilities type",
-                            "type": "string"
-                          },
-                          "type": "array",
-                          "x-kubernetes-list-type": "atomic"
-                        },
-                        "drop": {
-                          "description": "Removed capabilities",
-                          "items": {
-                            "description": "Capability represent POSIX capabilities type",
-                            "type": "string"
-                          },
-                          "type": "array",
-                          "x-kubernetes-list-type": "atomic"
-                        }
-                      },
-                      "type": "object",
-                      "additionalProperties": false
-                    },
-                    "privileged": {
-                      "description": "Run container in privileged mode.\nProcesses in privileged containers are essentially equivalent to root on the host.\nDefaults to false.\nNote that this field cannot be set when spec.os.name is windows.",
-                      "type": "boolean"
-                    },
-                    "procMount": {
-                      "description": "procMount denotes the type of proc mount to use for the containers.\nThe default value is Default which uses the container runtime defaults for\nreadonly paths and masked paths.\nThis requires the ProcMountType feature flag to be enabled.\nNote that this field cannot be set when spec.os.name is windows.",
-                      "type": "string"
-                    },
-                    "readOnlyRootFilesystem": {
-                      "description": "Whether this container has a read-only root filesystem.\nDefault is false.\nNote that this field cannot be set when spec.os.name is windows.",
-                      "type": "boolean"
-                    },
-                    "runAsGroup": {
-                      "description": "The GID to run the entrypoint of the container process.\nUses runtime default if unset.\nMay also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is windows.",
-                      "format": "int64",
-                      "type": "integer"
-                    },
-                    "runAsNonRoot": {
-                      "description": "Indicates that the container must run as a non-root user.\nIf true, the Kubelet will validate the image at runtime to ensure that it\ndoes not run as UID 0 (root) and fail to start the container if it does.\nIf unset or false, no such validation will be performed.\nMay also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.",
-                      "type": "boolean"
-                    },
-                    "runAsUser": {
-                      "description": "The UID to run the entrypoint of the container process.\nDefaults to user specified in image metadata if unspecified.\nMay also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is windows.",
-                      "format": "int64",
-                      "type": "integer"
-                    },
-                    "seLinuxOptions": {
-                      "description": "The SELinux context to be applied to the container.\nIf unspecified, the container runtime will allocate a random SELinux context for each\ncontainer.  May also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is windows.",
-                      "properties": {
-                        "level": {
-                          "description": "Level is SELinux level label that applies to the container.",
-                          "type": "string"
-                        },
-                        "role": {
-                          "description": "Role is a SELinux role label that applies to the container.",
-                          "type": "string"
-                        },
-                        "type": {
-                          "description": "Type is a SELinux type label that applies to the container.",
-                          "type": "string"
-                        },
-                        "user": {
-                          "description": "User is a SELinux user label that applies to the container.",
-                          "type": "string"
-                        }
-                      },
-                      "type": "object",
-                      "additionalProperties": false
-                    },
-                    "seccompProfile": {
-                      "description": "The seccomp options to use by this container. If seccomp options are\nprovided at both the pod & container level, the container options\noverride the pod options.\nNote that this field cannot be set when spec.os.name is windows.",
-                      "properties": {
-                        "localhostProfile": {
-                          "description": "localhostProfile indicates a profile defined in a file on the node should be used.\nThe profile must be preconfigured on the node to work.\nMust be a descending path, relative to the kubelet's configured seccomp profile location.\nMust be set if type is \"Localhost\". Must NOT be set for any other type.",
-                          "type": "string"
-                        },
-                        "type": {
-                          "description": "type indicates which kind of seccomp profile will be applied.\nValid options are:\n\nLocalhost - a profile defined in a file on the node should be used.\nRuntimeDefault - the container runtime default profile should be used.\nUnconfined - no profile should be applied.",
-                          "type": "string"
-                        }
-                      },
-                      "required": [
-                        "type"
-                      ],
-                      "type": "object",
-                      "additionalProperties": false
-                    },
-                    "windowsOptions": {
-                      "description": "The Windows specific settings applied to all containers.\nIf unspecified, the options from the PodSecurityContext will be used.\nIf set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is linux.",
-                      "properties": {
-                        "gmsaCredentialSpec": {
-                          "description": "GMSACredentialSpec is where the GMSA admission webhook\n(https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the\nGMSA credential spec named by the GMSACredentialSpecName field.",
-                          "type": "string"
-                        },
-                        "gmsaCredentialSpecName": {
-                          "description": "GMSACredentialSpecName is the name of the GMSA credential spec to use.",
-                          "type": "string"
-                        },
-                        "hostProcess": {
-                          "description": "HostProcess determines if a container should be run as a 'Host Process' container.\nAll of a Pod's containers must have the same effective HostProcess value\n(it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).\nIn addition, if HostProcess is true then HostNetwork must also be set to true.",
-                          "type": "boolean"
-                        },
-                        "runAsUserName": {
-                          "description": "The UserName in Windows to run the entrypoint of the container process.\nDefaults to the user specified in image metadata if unspecified.\nMay also be set in PodSecurityContext. If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.",
-                          "type": "string"
-                        }
-                      },
-                      "type": "object",
-                      "additionalProperties": false
-                    }
-                  },
-                  "type": "object",
-                  "additionalProperties": false
-                }
-              },
-              "type": "object",
-              "additionalProperties": false
-            },
             "deployment": {
               "description": "Use a Kubernetes deployment as the proxy workload type. Currently, this is the only\nsupported workload type.",
               "properties": {
@@ -525,6 +73,39 @@
               "type": "object",
               "additionalProperties": false
             },
+            "deploymentOverlay": {
+              "description": "deploymentOverlay allows specifying overrides for the generated Deployment resource.",
+              "properties": {
+                "metadata": {
+                  "description": "metadata defines a subset of object metadata to be customized.\nLabels and annotations are merged with existing values. If both GatewayClass\nand Gateway parameters define the same label or annotation key, the Gateway\nvalue takes precedence (applied second).",
+                  "properties": {
+                    "annotations": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "Annotations is an unstructured key value map stored with a resource that may be\nset by external tools to store and retrieve arbitrary metadata. They are not\nqueryable and should be preserved when modifying objects.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations",
+                      "type": "object"
+                    },
+                    "labels": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "Map of string keys and values that can be used to organize and categorize\n(scope and select) objects. May match selectors of replication controllers\nand services.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels",
+                      "type": "object"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "spec": {
+                  "description": "Spec provides an opaque mechanism to configure the resource Spec.\nThis field accepts a complete or partial Kubernetes resource spec (e.g., PodSpec, ServiceSpec)\nand will be merged with the generated configuration using **Strategic Merge Patch** semantics.\n\n# Application Order\n\nOverlays are applied after all typed configuration fields from both levels.\nThe full merge order is:\n\n 1. GatewayClass typed configuration fields\n 2. Gateway typed configuration fields\n 3. GatewayClass overlays\n 4. Gateway overlays (can override all previous values)\n\n# Strategic Merge Patch & Deletion Guide\n\nThis merge strategy allows you to override individual fields, merge lists, or delete items\nwithout needing to provide the entire resource definition.\n\n**1. Replacing Values (Scalars):**\nSimple fields (strings, integers, booleans) in your config will overwrite the generated defaults.\n\n**2. Merging Lists (Append/Merge):**\nLists with \"merge keys\" (like `containers` which merges on `name`, or `tolerations` which merges on `key`)\nwill append your items to the generated list, or update existing items if keys match.\n\n**3. Deleting Fields or List Items ($patch: delete):**\nTo remove a field or list item from the generated resource, use the\n`$patch: delete` directive. This works for both map fields and list items,\nand is the recommended approach because it works with both client-side\nand server-side apply.\n\n\tspec:\n\t  template:\n\t    spec:\n\t      # Delete pod-level securityContext\n\t      securityContext:\n\t        $patch: delete\n\t      # Delete nodeSelector\n\t      nodeSelector:\n\t        $patch: delete\n\t      containers:\n\t        # Be sure to use the correct proxy name here or you will add a container instead of modifying a container:\n\t        - name: proxy-name\n\t          # Delete container-level securityContext\n\t          securityContext:\n\t            $patch: delete\n\n**4. Null Values (server-side apply only):**\nSetting a field to `null` can also remove it, but this ONLY works with\n`kubectl apply --server-side` or equivalent. With regular client-side\n`kubectl apply`, null values are stripped by kubectl before reaching\nthe API server, so the deletion won't occur. Prefer `$patch: delete`\nfor consistent behavior across both apply modes.\n\n\tspec:\n\t  template:\n\t    spec:\n\t      nodeSelector: null  # Removes nodeSelector (server-side apply only!)\n\n**5. Replacing Maps Entirely ($patch: replace):**\nTo replace an entire map with your values (instead of merging), use `$patch: replace`.\nThis removes all existing keys and replaces them with only your specified keys.\n\n\tspec:\n\t  template:\n\t    spec:\n\t      nodeSelector:\n\t        $patch: replace\n\t        custom-key: custom-value\n\n**6. Replacing Lists Entirely ($patch: replace):**\nIf you want to strictly define a list and ignore all generated defaults, use `$patch: replace`.\n\n\tservice:\n\t  spec:\n\t    ports:\n\t      - $patch: replace\n\t      - name: http\n\t        port: 80\n\t        targetPort: 8080\n\t        protocol: TCP\n\t      - name: https\n\t        port: 443\n\t        targetPort: 8443\n\t        protocol: TCP",
+                  "type": "object",
+                  "x-kubernetes-preserve-unknown-fields": true
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
             "envoyContainer": {
               "description": "Configuration for the container running Envoy.",
               "properties": {
@@ -537,6 +118,41 @@
                       },
                       "description": "Envoy log levels for specific components. The keys are component names and\nthe values are one of \"trace\", \"debug\", \"info\", \"warn\", \"error\",\n\"critical\", or \"off\", e.g.\n\n\t```yaml\n\tcomponentLogLevels:\n\t  upstream: debug\n\t  connection: trace\n\t```\n\nThese will be converted to the `--component-log-level` Envoy argument\nvalue. See\nhttps://www.envoyproxy.io/docs/envoy/latest/start/quick-start/run-envoy#debugging-envoy\nfor more information.\n\nNote: the keys and values cannot be empty, but they are not otherwise validated.",
                       "type": "object"
+                    },
+                    "dnsResolver": {
+                      "description": "DNS resolver configuration for Envoy's CARES DNS resolver.\nThis configuration applies to all clusters and affects DNS query behavior.\nSee https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/network/dns_resolver/cares/v3/cares_dns_resolver.proto\nfor more information.",
+                      "properties": {
+                        "udpMaxQueries": {
+                          "description": "Maximum number of UDP queries to be issued on a single UDP channel.\nThis helps prevent DNS query pinning to a single resolver, addressing\nthe issue described in https://github.com/istio/istio/issues/53577.\nDefaults to 100 if not specified. Set to 0 to disable this limit.\nSee https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/network/dns_resolver/cares/v3/cares_dns_resolver.proto#extensions-network-dns-resolver-cares-v3-caresdnsresolverconfig",
+                          "format": "int32",
+                          "minimum": 0,
+                          "type": "integer"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "logFormat": {
+                      "description": "Envoy application log format. Does *not* affect access logs. Can be JSON or custom text format.\nDefaults to text with default format string as defined in Envoy documentation.\nSee https://www.envoyproxy.io/docs/envoy/latest/operations/cli#cmdoption-log-format for format flag options.",
+                      "properties": {
+                        "json": {
+                          "description": "The format object by which Envoy will emit logs in a structured way.\nMutually exclusive with Text.\nSee https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/application_logging#printing-logs-in-json-format.",
+                          "type": "object",
+                          "x-kubernetes-preserve-unknown-fields": true
+                        },
+                        "text": {
+                          "description": "The format string by which Envoy will format log lines.\nMutually exclusive with JSON.\nSee https://www.envoyproxy.io/docs/envoy/latest/operations/cli#cmdoption-log-format.",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "x-kubernetes-validations": [
+                        {
+                          "message": "exactly one of the fields in [json text] must be set",
+                          "rule": "[has(self.json),has(self.text)].filter(x,x==true).size() == 1"
+                        }
+                      ],
+                      "additionalProperties": false
                     },
                     "logLevel": {
                       "description": "Envoy log level. Options include \"trace\", \"debug\", \"info\", \"warn\", \"error\",\n\"critical\" and \"off\". Defaults to \"info\". See\nhttps://www.envoyproxy.io/docs/envoy/latest/start/quick-start/run-envoy#debugging-envoy\nfor more information.",
@@ -702,6 +318,17 @@
                     "type": "object",
                     "additionalProperties": false
                   },
+                  "type": "array"
+                },
+                "extraArgs": {
+                  "description": "Additional arguments to pass to the Envoy binary.\n\nSimilar to Kubernetes container args, variable references $(VAR_NAME) are\nexpanded using the container's environment. If a variable cannot be\nresolved, the reference is left unchanged. Double $$ are reduced to a\nsingle $, which allows escaping the $(VAR_NAME) syntax.\n\nThe following Envoy flags are already managed by kgateway and must not be\nset here: `--disable-hot-restart`, `--service-node`, `--log-level`, and\n`--component-log-level`. Consider using a DeploymentOverlay to override these values if desired.",
+                  "items": {
+                    "maxLength": 256,
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "maxItems": 32,
+                  "minItems": 1,
                   "type": "array"
                 },
                 "extraVolumeMounts": {
@@ -987,11 +614,44 @@
               "type": "object",
               "additionalProperties": false
             },
+            "horizontalPodAutoscaler": {
+              "description": "horizontalPodAutoscaler allows creating a HorizontalPodAutoscaler for the proxy.\nIf absent, no HPA is created. If present, an HPA is created with its scaleTargetRef\nautomatically configured to target the proxy Deployment.\nThe metadata and spec fields from this overlay are applied to the generated HPA.",
+              "properties": {
+                "metadata": {
+                  "description": "metadata defines a subset of object metadata to be customized.\nLabels and annotations are merged with existing values. If both GatewayClass\nand Gateway parameters define the same label or annotation key, the Gateway\nvalue takes precedence (applied second).",
+                  "properties": {
+                    "annotations": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "Annotations is an unstructured key value map stored with a resource that may be\nset by external tools to store and retrieve arbitrary metadata. They are not\nqueryable and should be preserved when modifying objects.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations",
+                      "type": "object"
+                    },
+                    "labels": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "Map of string keys and values that can be used to organize and categorize\n(scope and select) objects. May match selectors of replication controllers\nand services.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels",
+                      "type": "object"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "spec": {
+                  "description": "Spec provides an opaque mechanism to configure the resource Spec.\nThis field accepts a complete or partial Kubernetes resource spec (e.g., PodSpec, ServiceSpec)\nand will be merged with the generated configuration using **Strategic Merge Patch** semantics.\n\n# Application Order\n\nOverlays are applied after all typed configuration fields from both levels.\nThe full merge order is:\n\n 1. GatewayClass typed configuration fields\n 2. Gateway typed configuration fields\n 3. GatewayClass overlays\n 4. Gateway overlays (can override all previous values)\n\n# Strategic Merge Patch & Deletion Guide\n\nThis merge strategy allows you to override individual fields, merge lists, or delete items\nwithout needing to provide the entire resource definition.\n\n**1. Replacing Values (Scalars):**\nSimple fields (strings, integers, booleans) in your config will overwrite the generated defaults.\n\n**2. Merging Lists (Append/Merge):**\nLists with \"merge keys\" (like `containers` which merges on `name`, or `tolerations` which merges on `key`)\nwill append your items to the generated list, or update existing items if keys match.\n\n**3. Deleting Fields or List Items ($patch: delete):**\nTo remove a field or list item from the generated resource, use the\n`$patch: delete` directive. This works for both map fields and list items,\nand is the recommended approach because it works with both client-side\nand server-side apply.\n\n\tspec:\n\t  template:\n\t    spec:\n\t      # Delete pod-level securityContext\n\t      securityContext:\n\t        $patch: delete\n\t      # Delete nodeSelector\n\t      nodeSelector:\n\t        $patch: delete\n\t      containers:\n\t        # Be sure to use the correct proxy name here or you will add a container instead of modifying a container:\n\t        - name: proxy-name\n\t          # Delete container-level securityContext\n\t          securityContext:\n\t            $patch: delete\n\n**4. Null Values (server-side apply only):**\nSetting a field to `null` can also remove it, but this ONLY works with\n`kubectl apply --server-side` or equivalent. With regular client-side\n`kubectl apply`, null values are stripped by kubectl before reaching\nthe API server, so the deletion won't occur. Prefer `$patch: delete`\nfor consistent behavior across both apply modes.\n\n\tspec:\n\t  template:\n\t    spec:\n\t      nodeSelector: null  # Removes nodeSelector (server-side apply only!)\n\n**5. Replacing Maps Entirely ($patch: replace):**\nTo replace an entire map with your values (instead of merging), use `$patch: replace`.\nThis removes all existing keys and replaces them with only your specified keys.\n\n\tspec:\n\t  template:\n\t    spec:\n\t      nodeSelector:\n\t        $patch: replace\n\t        custom-key: custom-value\n\n**6. Replacing Lists Entirely ($patch: replace):**\nIf you want to strictly define a list and ignore all generated defaults, use `$patch: replace`.\n\n\tservice:\n\t  spec:\n\t    ports:\n\t      - $patch: replace\n\t      - name: http\n\t        port: 80\n\t        targetPort: 8080\n\t        protocol: TCP\n\t      - name: https\n\t        port: 443\n\t        targetPort: 8443\n\t        protocol: TCP",
+                  "type": "object",
+                  "x-kubernetes-preserve-unknown-fields": true
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
             "istio": {
               "description": "Configuration for the Istio integration.",
               "properties": {
                 "customSidecars": {
-                  "description": "do not use slice of pointers: https://github.com/kubernetes/code-generator/issues/166\nOverride the default Istio sidecar in gateway-proxy with a custom container.",
+                  "description": "Deprecated: This field was never implemented in v2 and will be deleted.\nIf you need custom TLS certificate handling, use the built-in SDS (Secret Discovery\nService) container via the sdsContainer field instead. For other sidecar needs,\nuse a deployment overlay. Example overlay that adds a sidecar:\n\n\tspec:\n\t  kube:\n\t    deploymentOverlay:\n\t      spec:\n\t        template:\n\t          spec:\n\t            containers:\n\t              - name: my-sidecar\n\t                image: my-sidecar:latest",
                   "items": {
                     "description": "A single application container that you want to run within a pod.",
                     "properties": {
@@ -1843,7 +1503,7 @@
                         "additionalProperties": false
                       },
                       "resizePolicy": {
-                        "description": "Resources resize policy for the container.",
+                        "description": "Resources resize policy for the container.\nThis field cannot be set on ephemeral containers.",
                         "items": {
                           "description": "ContainerResizePolicy represents resource resize policy for the container.",
                           "properties": {
@@ -2650,6 +2310,39 @@
             "omitDefaultSecurityContext": {
               "description": "OmitDefaultSecurityContext is used to control whether or not\n`securityContext` fields should be rendered for the various generated\nDeployments/Containers that are dynamically provisioned by the deployer.\n\nWhen set to true, no `securityContexts` will be provided and will left\nto the user/platform to be provided.\n\nThis should be enabled on platforms such as Red Hat OpenShift where the\n`securityContext` will be dynamically added to enforce the appropriate\nlevel of security.",
               "type": "boolean"
+            },
+            "podDisruptionBudget": {
+              "description": "podDisruptionBudget allows creating a PodDisruptionBudget for the proxy.\nIf absent, no PDB is created. If present, a PDB is created with its selector\nautomatically configured to target the proxy Deployment.\nThe metadata and spec fields from this overlay are applied to the generated PDB.",
+              "properties": {
+                "metadata": {
+                  "description": "metadata defines a subset of object metadata to be customized.\nLabels and annotations are merged with existing values. If both GatewayClass\nand Gateway parameters define the same label or annotation key, the Gateway\nvalue takes precedence (applied second).",
+                  "properties": {
+                    "annotations": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "Annotations is an unstructured key value map stored with a resource that may be\nset by external tools to store and retrieve arbitrary metadata. They are not\nqueryable and should be preserved when modifying objects.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations",
+                      "type": "object"
+                    },
+                    "labels": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "Map of string keys and values that can be used to organize and categorize\n(scope and select) objects. May match selectors of replication controllers\nand services.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels",
+                      "type": "object"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "spec": {
+                  "description": "Spec provides an opaque mechanism to configure the resource Spec.\nThis field accepts a complete or partial Kubernetes resource spec (e.g., PodSpec, ServiceSpec)\nand will be merged with the generated configuration using **Strategic Merge Patch** semantics.\n\n# Application Order\n\nOverlays are applied after all typed configuration fields from both levels.\nThe full merge order is:\n\n 1. GatewayClass typed configuration fields\n 2. Gateway typed configuration fields\n 3. GatewayClass overlays\n 4. Gateway overlays (can override all previous values)\n\n# Strategic Merge Patch & Deletion Guide\n\nThis merge strategy allows you to override individual fields, merge lists, or delete items\nwithout needing to provide the entire resource definition.\n\n**1. Replacing Values (Scalars):**\nSimple fields (strings, integers, booleans) in your config will overwrite the generated defaults.\n\n**2. Merging Lists (Append/Merge):**\nLists with \"merge keys\" (like `containers` which merges on `name`, or `tolerations` which merges on `key`)\nwill append your items to the generated list, or update existing items if keys match.\n\n**3. Deleting Fields or List Items ($patch: delete):**\nTo remove a field or list item from the generated resource, use the\n`$patch: delete` directive. This works for both map fields and list items,\nand is the recommended approach because it works with both client-side\nand server-side apply.\n\n\tspec:\n\t  template:\n\t    spec:\n\t      # Delete pod-level securityContext\n\t      securityContext:\n\t        $patch: delete\n\t      # Delete nodeSelector\n\t      nodeSelector:\n\t        $patch: delete\n\t      containers:\n\t        # Be sure to use the correct proxy name here or you will add a container instead of modifying a container:\n\t        - name: proxy-name\n\t          # Delete container-level securityContext\n\t          securityContext:\n\t            $patch: delete\n\n**4. Null Values (server-side apply only):**\nSetting a field to `null` can also remove it, but this ONLY works with\n`kubectl apply --server-side` or equivalent. With regular client-side\n`kubectl apply`, null values are stripped by kubectl before reaching\nthe API server, so the deletion won't occur. Prefer `$patch: delete`\nfor consistent behavior across both apply modes.\n\n\tspec:\n\t  template:\n\t    spec:\n\t      nodeSelector: null  # Removes nodeSelector (server-side apply only!)\n\n**5. Replacing Maps Entirely ($patch: replace):**\nTo replace an entire map with your values (instead of merging), use `$patch: replace`.\nThis removes all existing keys and replaces them with only your specified keys.\n\n\tspec:\n\t  template:\n\t    spec:\n\t      nodeSelector:\n\t        $patch: replace\n\t        custom-key: custom-value\n\n**6. Replacing Lists Entirely ($patch: replace):**\nIf you want to strictly define a list and ignore all generated defaults, use `$patch: replace`.\n\n\tservice:\n\t  spec:\n\t    ports:\n\t      - $patch: replace\n\t      - name: http\n\t        port: 80\n\t        targetPort: 8080\n\t        protocol: TCP\n\t      - name: https\n\t        port: 443\n\t        targetPort: 8443\n\t        protocol: TCP",
+                  "type": "object",
+                  "x-kubernetes-preserve-unknown-fields": true
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
             },
             "podTemplate": {
               "description": "Configuration for the pods that will be created.",
@@ -3908,7 +3601,7 @@
                                     "additionalProperties": false
                                   },
                                   "resources": {
-                                    "description": "resources represents the minimum resources the volume should have.\nIf RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements\nthat are lower than previous value but must still be higher than capacity recorded in the\nstatus field of the claim.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources",
+                                    "description": "resources represents the minimum resources the volume should have.\nUsers are allowed to specify resource requirements\nthat are lower than previous value but must still be higher than capacity recorded in the\nstatus field of the claim.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources",
                                     "properties": {
                                       "limits": {
                                         "additionalProperties": {
@@ -4619,6 +4312,13 @@
                                     "signerName": {
                                       "description": "Kubelet's generated CSRs will be addressed to this signer.",
                                       "type": "string"
+                                    },
+                                    "userAnnotations": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "description": "userAnnotations allow pod authors to pass additional information to\nthe signer implementation.  Kubernetes does not restrict or validate this\nmetadata in any way.\n\nThese values are copied verbatim into the `spec.unverifiedUserAnnotations` field of\nthe PodCertificateRequest objects that Kubelet creates.\n\nEntries are subject to the same validation as object metadata annotations,\nwith the addition that all keys must be domain-prefixed. No restrictions\nare placed on values, except an overall size limitation on the entire field.\n\nSigners should document the keys and values they support. Signers should\ndeny requests that contain keys they do not recognize.",
+                                      "type": "object"
                                     }
                                   },
                                   "required": [
@@ -4989,7 +4689,7 @@
                   "description": "If specified, the pod's graceful shutdown spec.",
                   "properties": {
                     "enabled": {
-                      "description": "Enable grace period before shutdown to finish current requests while Envoy health checks fail to e.g. notify external load balancers. *NOTE:* This will not have any effect if you have not defined health checks via the health check filter",
+                      "description": "Enable grace period before shutdown to finish current requests.  When\nenabled, a preStop hook calls /healthcheck/fail on Envoy's admin port,\nwhich causes the /ready endpoint to return 503 (DRAINING). This makes\nthe Kubernetes readiness probe fail, removing the pod from Service\nendpoints so new traffic stops arriving (unless all endpoints are\ndraining -- see KEP-1669: Proxy Terminating Endpoints). The hook then\nsleeps for SleepTimeSeconds to allow in-flight requests to complete.",
                       "type": "boolean"
                     },
                     "sleepTimeSeconds": {
@@ -5673,7 +5373,7 @@
                         "type": "string"
                       },
                       "operator": {
-                        "description": "Operator represents a key's relationship to the value.\nValid operators are Exists and Equal. Defaults to Equal.\nExists is equivalent to wildcard for value, so that a pod can\ntolerate all taints of a particular category.",
+                        "description": "Operator represents a key's relationship to the value.\nValid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.\nExists is equivalent to wildcard for value, so that a pod can\ntolerate all taints of a particular category.\nLt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).",
                         "type": "string"
                       },
                       "tolerationSeconds": {
@@ -6071,6 +5771,18 @@
                   "description": "Additional labels to add to the Service object metadata.\nIf the same label is present on `Gateway.spec.infrastructure.labels`, the `Gateway` takes precedence.",
                   "type": "object"
                 },
+                "loadBalancerClass": {
+                  "description": "LoadBalancerClass is the class of the load balancer implementation this Service belongs to.\nIf specified, the value of this field must be a label-style identifier, with an optional prefix.\nThis field can only be set when the Service type is 'LoadBalancer'. If not set, the default\nload balancer implementation is used. See\nhttps://kubernetes.io/docs/concepts/services-networking/service/#load-balancer-class",
+                  "type": "string"
+                },
+                "loadBalancerSourceRanges": {
+                  "description": "LoadBalancerSourceRanges restricts traffic through the cloud-provider load-balancer\nto the specified client IPs. This field will be ignored if the cloud-provider does\nnot support the feature.\nMore info: https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
+                },
                 "ports": {
                   "description": "Additional configuration for the service ports.\nThe actual port numbers are specified in the Gateway resource.",
                   "items": {
@@ -6128,6 +5840,72 @@
                   },
                   "description": "Additional labels to add to the ServiceAccount object metadata.",
                   "type": "object"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "serviceAccountOverlay": {
+              "description": "serviceAccountOverlay allows specifying overrides for the generated ServiceAccount resource.",
+              "properties": {
+                "metadata": {
+                  "description": "metadata defines a subset of object metadata to be customized.\nLabels and annotations are merged with existing values. If both GatewayClass\nand Gateway parameters define the same label or annotation key, the Gateway\nvalue takes precedence (applied second).",
+                  "properties": {
+                    "annotations": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "Annotations is an unstructured key value map stored with a resource that may be\nset by external tools to store and retrieve arbitrary metadata. They are not\nqueryable and should be preserved when modifying objects.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations",
+                      "type": "object"
+                    },
+                    "labels": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "Map of string keys and values that can be used to organize and categorize\n(scope and select) objects. May match selectors of replication controllers\nand services.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels",
+                      "type": "object"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "spec": {
+                  "description": "Spec provides an opaque mechanism to configure the resource Spec.\nThis field accepts a complete or partial Kubernetes resource spec (e.g., PodSpec, ServiceSpec)\nand will be merged with the generated configuration using **Strategic Merge Patch** semantics.\n\n# Application Order\n\nOverlays are applied after all typed configuration fields from both levels.\nThe full merge order is:\n\n 1. GatewayClass typed configuration fields\n 2. Gateway typed configuration fields\n 3. GatewayClass overlays\n 4. Gateway overlays (can override all previous values)\n\n# Strategic Merge Patch & Deletion Guide\n\nThis merge strategy allows you to override individual fields, merge lists, or delete items\nwithout needing to provide the entire resource definition.\n\n**1. Replacing Values (Scalars):**\nSimple fields (strings, integers, booleans) in your config will overwrite the generated defaults.\n\n**2. Merging Lists (Append/Merge):**\nLists with \"merge keys\" (like `containers` which merges on `name`, or `tolerations` which merges on `key`)\nwill append your items to the generated list, or update existing items if keys match.\n\n**3. Deleting Fields or List Items ($patch: delete):**\nTo remove a field or list item from the generated resource, use the\n`$patch: delete` directive. This works for both map fields and list items,\nand is the recommended approach because it works with both client-side\nand server-side apply.\n\n\tspec:\n\t  template:\n\t    spec:\n\t      # Delete pod-level securityContext\n\t      securityContext:\n\t        $patch: delete\n\t      # Delete nodeSelector\n\t      nodeSelector:\n\t        $patch: delete\n\t      containers:\n\t        # Be sure to use the correct proxy name here or you will add a container instead of modifying a container:\n\t        - name: proxy-name\n\t          # Delete container-level securityContext\n\t          securityContext:\n\t            $patch: delete\n\n**4. Null Values (server-side apply only):**\nSetting a field to `null` can also remove it, but this ONLY works with\n`kubectl apply --server-side` or equivalent. With regular client-side\n`kubectl apply`, null values are stripped by kubectl before reaching\nthe API server, so the deletion won't occur. Prefer `$patch: delete`\nfor consistent behavior across both apply modes.\n\n\tspec:\n\t  template:\n\t    spec:\n\t      nodeSelector: null  # Removes nodeSelector (server-side apply only!)\n\n**5. Replacing Maps Entirely ($patch: replace):**\nTo replace an entire map with your values (instead of merging), use `$patch: replace`.\nThis removes all existing keys and replaces them with only your specified keys.\n\n\tspec:\n\t  template:\n\t    spec:\n\t      nodeSelector:\n\t        $patch: replace\n\t        custom-key: custom-value\n\n**6. Replacing Lists Entirely ($patch: replace):**\nIf you want to strictly define a list and ignore all generated defaults, use `$patch: replace`.\n\n\tservice:\n\t  spec:\n\t    ports:\n\t      - $patch: replace\n\t      - name: http\n\t        port: 80\n\t        targetPort: 8080\n\t        protocol: TCP\n\t      - name: https\n\t        port: 443\n\t        targetPort: 8443\n\t        protocol: TCP",
+                  "type": "object",
+                  "x-kubernetes-preserve-unknown-fields": true
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "serviceOverlay": {
+              "description": "serviceOverlay allows specifying overrides for the generated Service resource.",
+              "properties": {
+                "metadata": {
+                  "description": "metadata defines a subset of object metadata to be customized.\nLabels and annotations are merged with existing values. If both GatewayClass\nand Gateway parameters define the same label or annotation key, the Gateway\nvalue takes precedence (applied second).",
+                  "properties": {
+                    "annotations": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "Annotations is an unstructured key value map stored with a resource that may be\nset by external tools to store and retrieve arbitrary metadata. They are not\nqueryable and should be preserved when modifying objects.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations",
+                      "type": "object"
+                    },
+                    "labels": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "Map of string keys and values that can be used to organize and categorize\n(scope and select) objects. May match selectors of replication controllers\nand services.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels",
+                      "type": "object"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "spec": {
+                  "description": "Spec provides an opaque mechanism to configure the resource Spec.\nThis field accepts a complete or partial Kubernetes resource spec (e.g., PodSpec, ServiceSpec)\nand will be merged with the generated configuration using **Strategic Merge Patch** semantics.\n\n# Application Order\n\nOverlays are applied after all typed configuration fields from both levels.\nThe full merge order is:\n\n 1. GatewayClass typed configuration fields\n 2. Gateway typed configuration fields\n 3. GatewayClass overlays\n 4. Gateway overlays (can override all previous values)\n\n# Strategic Merge Patch & Deletion Guide\n\nThis merge strategy allows you to override individual fields, merge lists, or delete items\nwithout needing to provide the entire resource definition.\n\n**1. Replacing Values (Scalars):**\nSimple fields (strings, integers, booleans) in your config will overwrite the generated defaults.\n\n**2. Merging Lists (Append/Merge):**\nLists with \"merge keys\" (like `containers` which merges on `name`, or `tolerations` which merges on `key`)\nwill append your items to the generated list, or update existing items if keys match.\n\n**3. Deleting Fields or List Items ($patch: delete):**\nTo remove a field or list item from the generated resource, use the\n`$patch: delete` directive. This works for both map fields and list items,\nand is the recommended approach because it works with both client-side\nand server-side apply.\n\n\tspec:\n\t  template:\n\t    spec:\n\t      # Delete pod-level securityContext\n\t      securityContext:\n\t        $patch: delete\n\t      # Delete nodeSelector\n\t      nodeSelector:\n\t        $patch: delete\n\t      containers:\n\t        # Be sure to use the correct proxy name here or you will add a container instead of modifying a container:\n\t        - name: proxy-name\n\t          # Delete container-level securityContext\n\t          securityContext:\n\t            $patch: delete\n\n**4. Null Values (server-side apply only):**\nSetting a field to `null` can also remove it, but this ONLY works with\n`kubectl apply --server-side` or equivalent. With regular client-side\n`kubectl apply`, null values are stripped by kubectl before reaching\nthe API server, so the deletion won't occur. Prefer `$patch: delete`\nfor consistent behavior across both apply modes.\n\n\tspec:\n\t  template:\n\t    spec:\n\t      nodeSelector: null  # Removes nodeSelector (server-side apply only!)\n\n**5. Replacing Maps Entirely ($patch: replace):**\nTo replace an entire map with your values (instead of merging), use `$patch: replace`.\nThis removes all existing keys and replaces them with only your specified keys.\n\n\tspec:\n\t  template:\n\t    spec:\n\t      nodeSelector:\n\t        $patch: replace\n\t        custom-key: custom-value\n\n**6. Replacing Lists Entirely ($patch: replace):**\nIf you want to strictly define a list and ignore all generated defaults, use `$patch: replace`.\n\n\tservice:\n\t  spec:\n\t    ports:\n\t      - $patch: replace\n\t      - name: http\n\t        port: 80\n\t        targetPort: 8080\n\t        protocol: TCP\n\t      - name: https\n\t        port: 443\n\t        targetPort: 8443\n\t        protocol: TCP",
+                  "type": "object",
+                  "x-kubernetes-preserve-unknown-fields": true
                 }
               },
               "type": "object",
@@ -6244,6 +6022,39 @@
                 "statsRoutePrefixRewrite": {
                   "description": "The Envoy stats endpoint with general metrics for the additional stats route",
                   "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "verticalPodAutoscaler": {
+              "description": "verticalPodAutoscaler allows creating a VerticalPodAutoscaler for the proxy.\nIf absent, no VPA is created. If present, a VPA is created with its targetRef\nautomatically configured to target the proxy Deployment.\nThe metadata and spec fields from this overlay are applied to the generated VPA.",
+              "properties": {
+                "metadata": {
+                  "description": "metadata defines a subset of object metadata to be customized.\nLabels and annotations are merged with existing values. If both GatewayClass\nand Gateway parameters define the same label or annotation key, the Gateway\nvalue takes precedence (applied second).",
+                  "properties": {
+                    "annotations": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "Annotations is an unstructured key value map stored with a resource that may be\nset by external tools to store and retrieve arbitrary metadata. They are not\nqueryable and should be preserved when modifying objects.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations",
+                      "type": "object"
+                    },
+                    "labels": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "Map of string keys and values that can be used to organize and categorize\n(scope and select) objects. May match selectors of replication controllers\nand services.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels",
+                      "type": "object"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "spec": {
+                  "description": "Spec provides an opaque mechanism to configure the resource Spec.\nThis field accepts a complete or partial Kubernetes resource spec (e.g., PodSpec, ServiceSpec)\nand will be merged with the generated configuration using **Strategic Merge Patch** semantics.\n\n# Application Order\n\nOverlays are applied after all typed configuration fields from both levels.\nThe full merge order is:\n\n 1. GatewayClass typed configuration fields\n 2. Gateway typed configuration fields\n 3. GatewayClass overlays\n 4. Gateway overlays (can override all previous values)\n\n# Strategic Merge Patch & Deletion Guide\n\nThis merge strategy allows you to override individual fields, merge lists, or delete items\nwithout needing to provide the entire resource definition.\n\n**1. Replacing Values (Scalars):**\nSimple fields (strings, integers, booleans) in your config will overwrite the generated defaults.\n\n**2. Merging Lists (Append/Merge):**\nLists with \"merge keys\" (like `containers` which merges on `name`, or `tolerations` which merges on `key`)\nwill append your items to the generated list, or update existing items if keys match.\n\n**3. Deleting Fields or List Items ($patch: delete):**\nTo remove a field or list item from the generated resource, use the\n`$patch: delete` directive. This works for both map fields and list items,\nand is the recommended approach because it works with both client-side\nand server-side apply.\n\n\tspec:\n\t  template:\n\t    spec:\n\t      # Delete pod-level securityContext\n\t      securityContext:\n\t        $patch: delete\n\t      # Delete nodeSelector\n\t      nodeSelector:\n\t        $patch: delete\n\t      containers:\n\t        # Be sure to use the correct proxy name here or you will add a container instead of modifying a container:\n\t        - name: proxy-name\n\t          # Delete container-level securityContext\n\t          securityContext:\n\t            $patch: delete\n\n**4. Null Values (server-side apply only):**\nSetting a field to `null` can also remove it, but this ONLY works with\n`kubectl apply --server-side` or equivalent. With regular client-side\n`kubectl apply`, null values are stripped by kubectl before reaching\nthe API server, so the deletion won't occur. Prefer `$patch: delete`\nfor consistent behavior across both apply modes.\n\n\tspec:\n\t  template:\n\t    spec:\n\t      nodeSelector: null  # Removes nodeSelector (server-side apply only!)\n\n**5. Replacing Maps Entirely ($patch: replace):**\nTo replace an entire map with your values (instead of merging), use `$patch: replace`.\nThis removes all existing keys and replaces them with only your specified keys.\n\n\tspec:\n\t  template:\n\t    spec:\n\t      nodeSelector:\n\t        $patch: replace\n\t        custom-key: custom-value\n\n**6. Replacing Lists Entirely ($patch: replace):**\nIf you want to strictly define a list and ignore all generated defaults, use `$patch: replace`.\n\n\tservice:\n\t  spec:\n\t    ports:\n\t      - $patch: replace\n\t      - name: http\n\t        port: 80\n\t        targetPort: 8080\n\t        protocol: TCP\n\t      - name: https\n\t        port: 443\n\t        targetPort: 8443\n\t        protocol: TCP",
+                  "type": "object",
+                  "x-kubernetes-preserve-unknown-fields": true
                 }
               },
               "type": "object",

--- a/gateway.kgateway.dev/httplistenerpolicy_v1alpha1.json
+++ b/gateway.kgateway.dev/httplistenerpolicy_v1alpha1.json
@@ -174,7 +174,7 @@
                                   "type": "string"
                                 },
                                 "value": {
-                                  "description": "Value is the value of HTTP Header to be matched.",
+                                  "description": "Value is the value of HTTP Header to be matched.\n<gateway:experimental:description>\nMust consist of printable US-ASCII characters, optionally separated\nby single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2\n</gateway:experimental:description>\n\n<gateway:experimental:validation:Pattern=`^[!-~]+([\\t ]?[!-~]+)*$`>",
                                   "maxLength": 4096,
                                   "minLength": 1,
                                   "type": "string"
@@ -211,6 +211,50 @@
                           },
                           "required": [
                             "flags"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "runtimeFilter": {
+                          "description": "Filters for random sampling of access logs.\nBased on: https://www.envoyproxy.io/docs/envoy/v1.33.0/api-v3/config/accesslog/v3/accesslog.proto#config-accesslog-v3-runtimefilter",
+                          "properties": {
+                            "percentSampled": {
+                              "description": "By default, the runtime filter will log on every request when the runtime key is set.\nIf this field is set, it additionally applies a fractional percent check so that only a\nfraction of requests are logged.",
+                              "properties": {
+                                "denominator": {
+                                  "description": "Specifies the denominator. If the denominator specified is less than the numerator,\nthe final fractional percentage is capped at 1 (100%).\nDefaults to HUNDRED.",
+                                  "enum": [
+                                    "HUNDRED",
+                                    "TEN_THOUSAND",
+                                    "MILLION"
+                                  ],
+                                  "type": "string"
+                                },
+                                "numerator": {
+                                  "description": "Specifies the numerator. Defaults to 0.",
+                                  "format": "int32",
+                                  "minimum": 0,
+                                  "type": "integer"
+                                }
+                              },
+                              "required": [
+                                "numerator"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "runtimeKey": {
+                              "description": "The runtime key to look up in the runtime implementation. This key determines whether\nthe access log is enabled. When the runtime key value is set, the filter checks this key\nat runtime to decide whether to log each request.",
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "useIndependentRandomness": {
+                              "description": "If set to true, the filter uses Envoy's independent randomness source.\nWhen false (the default), the filter uses the runtime key lookup.",
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "runtimeKey"
                           ],
                           "type": "object",
                           "additionalProperties": false
@@ -354,7 +398,7 @@
                             "type": "string"
                           },
                           "value": {
-                            "description": "Value is the value of HTTP Header to be matched.",
+                            "description": "Value is the value of HTTP Header to be matched.\n<gateway:experimental:description>\nMust consist of printable US-ASCII characters, optionally separated\nby single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2\n</gateway:experimental:description>\n\n<gateway:experimental:validation:Pattern=`^[!-~]+([\\t ]?[!-~]+)*$`>",
                             "maxLength": 4096,
                             "minLength": 1,
                             "type": "string"
@@ -486,7 +530,7 @@
                                   "type": "string"
                                 },
                                 "value": {
-                                  "description": "Value is the value of HTTP Header to be matched.",
+                                  "description": "Value is the value of HTTP Header to be matched.\n<gateway:experimental:description>\nMust consist of printable US-ASCII characters, optionally separated\nby single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2\n</gateway:experimental:description>\n\n<gateway:experimental:validation:Pattern=`^[!-~]+([\\t ]?[!-~]+)*$`>",
                                   "maxLength": 4096,
                                   "minLength": 1,
                                   "type": "string"
@@ -523,6 +567,50 @@
                           },
                           "required": [
                             "flags"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "runtimeFilter": {
+                          "description": "Filters for random sampling of access logs.\nBased on: https://www.envoyproxy.io/docs/envoy/v1.33.0/api-v3/config/accesslog/v3/accesslog.proto#config-accesslog-v3-runtimefilter",
+                          "properties": {
+                            "percentSampled": {
+                              "description": "By default, the runtime filter will log on every request when the runtime key is set.\nIf this field is set, it additionally applies a fractional percent check so that only a\nfraction of requests are logged.",
+                              "properties": {
+                                "denominator": {
+                                  "description": "Specifies the denominator. If the denominator specified is less than the numerator,\nthe final fractional percentage is capped at 1 (100%).\nDefaults to HUNDRED.",
+                                  "enum": [
+                                    "HUNDRED",
+                                    "TEN_THOUSAND",
+                                    "MILLION"
+                                  ],
+                                  "type": "string"
+                                },
+                                "numerator": {
+                                  "description": "Specifies the numerator. Defaults to 0.",
+                                  "format": "int32",
+                                  "minimum": 0,
+                                  "type": "integer"
+                                }
+                              },
+                              "required": [
+                                "numerator"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "runtimeKey": {
+                              "description": "The runtime key to look up in the runtime implementation. This key determines whether\nthe access log is enabled. When the runtime key value is set, the filter checks this key\nat runtime to decide whether to log each request.",
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "useIndependentRandomness": {
+                              "description": "If set to true, the filter uses Envoy's independent randomness source.\nWhen false (the default), the filter uses the runtime key lookup.",
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "runtimeKey"
                           ],
                           "type": "object",
                           "additionalProperties": false
@@ -578,6 +666,50 @@
                     },
                     "required": [
                       "flags"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "runtimeFilter": {
+                    "description": "Filters for random sampling of access logs.\nBased on: https://www.envoyproxy.io/docs/envoy/v1.33.0/api-v3/config/accesslog/v3/accesslog.proto#config-accesslog-v3-runtimefilter",
+                    "properties": {
+                      "percentSampled": {
+                        "description": "By default, the runtime filter will log on every request when the runtime key is set.\nIf this field is set, it additionally applies a fractional percent check so that only a\nfraction of requests are logged.",
+                        "properties": {
+                          "denominator": {
+                            "description": "Specifies the denominator. If the denominator specified is less than the numerator,\nthe final fractional percentage is capped at 1 (100%).\nDefaults to HUNDRED.",
+                            "enum": [
+                              "HUNDRED",
+                              "TEN_THOUSAND",
+                              "MILLION"
+                            ],
+                            "type": "string"
+                          },
+                          "numerator": {
+                            "description": "Specifies the numerator. Defaults to 0.",
+                            "format": "int32",
+                            "minimum": 0,
+                            "type": "integer"
+                          }
+                        },
+                        "required": [
+                          "numerator"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "runtimeKey": {
+                        "description": "The runtime key to look up in the runtime implementation. This key determines whether\nthe access log is enabled. When the runtime key value is set, the filter checks this key\nat runtime to decide whether to log each request.",
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "useIndependentRandomness": {
+                        "description": "If set to true, the filter uses Envoy's independent randomness source.\nWhen false (the default), the filter uses the runtime key lookup.",
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "runtimeKey"
                     ],
                     "type": "object",
                     "additionalProperties": false
@@ -1108,7 +1240,7 @@
                     "type": "string"
                   },
                   "value": {
-                    "description": "Value is the value of HTTP Header to be matched.",
+                    "description": "Value is the value of HTTP Header to be matched.\n<gateway:experimental:description>\nMust consist of printable US-ASCII characters, optionally separated\nby single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2\n</gateway:experimental:description>\n\n<gateway:experimental:validation:Pattern=`^[!-~]+([\\t ]?[!-~]+)*$`>",
                     "maxLength": 4096,
                     "minLength": 1,
                     "type": "string"
@@ -1150,7 +1282,7 @@
                     "type": "string"
                   },
                   "value": {
-                    "description": "Value is the value of HTTP Header to be matched.",
+                    "description": "Value is the value of HTTP Header to be matched.\n<gateway:experimental:description>\nMust consist of printable US-ASCII characters, optionally separated\nby single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2\n</gateway:experimental:description>\n\n<gateway:experimental:validation:Pattern=`^[!-~]+([\\t ]?[!-~]+)*$`>",
                     "maxLength": 4096,
                     "minLength": 1,
                     "type": "string"
@@ -1194,6 +1326,46 @@
           "type": "object",
           "additionalProperties": false
         },
+        "http2ProtocolOptions": {
+          "description": "Http2ProtocolOptions configures downstream HTTP/2 behavior on the listener's\nHttpConnectionManager.\nSee here for more information: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/protocol.proto#config-core-v3-http2protocoloptions",
+          "properties": {
+            "initialConnectionWindowSize": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "string"
+                }
+              ],
+              "description": "InitialConnectionWindowSize is similar to InitialStreamWindowSize, but for the connection level.\nSame range and default value as InitialStreamWindowSize.\nValues can be specified with units like \"64Ki\".",
+              "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+              "x-kubernetes-int-or-string": true
+            },
+            "initialStreamWindowSize": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "string"
+                }
+              ],
+              "description": "InitialStreamWindowSize is the initial window size for the stream.\nValid values range from 65535 (2^16 - 1, HTTP/2 default) to 2147483647 (2^31 - 1, HTTP/2 maximum).\nDefaults to 268435456 (256 * 1024 * 1024).\nValues can be specified with units like \"64Ki\".",
+              "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+              "x-kubernetes-int-or-string": true
+            },
+            "maxConcurrentStreams": {
+              "description": "The maximum number of concurrent streams that the connection can have.\nEnvoy defaults to 1024.",
+              "format": "int32",
+              "maximum": 2147483647,
+              "minimum": 1,
+              "type": "integer"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
         "idleTimeout": {
           "description": "IdleTimeout is the idle timeout for connnections.\nSee here for more information: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/protocol.proto#envoy-v3-api-msg-config-core-v3-httpprotocoloptions",
           "type": "string",
@@ -1203,6 +1375,12 @@
               "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
             }
           ]
+        },
+        "maxHeadersCount": {
+          "description": "MaxHeadersCount sets the maximum number of headers allowed in a request.\nDownstream requests that exceed this limit will receive a 431 response for HTTP/1.x and a\nstream reset for HTTP/2. If unset, defaults to Envoy's built-in default of 100.\nSee here for more information: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/protocol.proto#envoy-v3-api-field-config-core-v3-httpprotocoloptions-max-headers-count",
+          "format": "int32",
+          "minimum": 1,
+          "type": "integer"
         },
         "maxRequestHeadersKb": {
           "description": "MaxRequestHeadersKb sets the maximum size of request headers that Envoy will accept.\nIf unset, the Envoy default is 60 KiB.\nSee here for more information: https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto#envoy-v3-api-field-extensions-filters-network-http-connection-manager-v3-httpconnectionmanager-max-request-headers-kb",
@@ -1228,6 +1406,10 @@
           ],
           "type": "string"
         },
+        "skipXFFAppend": {
+          "description": "SkipXffAppend specifies whether to skip adding the downstream's remote IP address to the X-Forwarded-For HTTP header.\nNote: If omitted, this effectively will default to true when UseRemoteAddress is false, such that Envoy acts as a \"transparent proxy\".\nSee here for more information: https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto#envoy-v3-api-field-extensions-filters-network-http-connection-manager-v3-httpconnectionmanager-skip-xff-append",
+          "type": "boolean"
+        },
         "streamIdleTimeout": {
           "description": "StreamIdleTimeout is the idle timeout for HTTP streams.\nSee here for more information: https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto#envoy-v3-api-field-extensions-filters-network-http-connection-manager-v3-httpconnectionmanager-stream-idle-timeout",
           "type": "string",
@@ -1237,6 +1419,14 @@
               "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
             }
           ]
+        },
+        "stripHostPortMode": {
+          "description": "StripHostPortMode determines whether, and under what conditions, Envoy will strip the port\nfrom the Host/authority header. StripMatchingHostPort strips the port only if it matches\nthe listener's own port. StripAnyHostPort strips the port unconditionally.\nSee here for more information: https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto#envoy-v3-api-field-extensions-filters-network-http-connection-manager-v3-httpconnectionmanager-strip-matching-host-port\nSee also: https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto#envoy-v3-api-field-extensions-filters-network-http-connection-manager-v3-httpconnectionmanager-strip-any-host-port",
+          "enum": [
+            "MatchingPort",
+            "AnyPort"
+          ],
+          "type": "string"
         },
         "targetRefs": {
           "description": "TargetRefs specifies the target resources by reference to attach the policy to.",
@@ -1648,8 +1838,16 @@
                         "minProperties": 1,
                         "properties": {
                           "environmentResourceDetector": {
-                            "description": "EnvironmentResourceDetectorConfig specified the EnvironmentResourceDetector",
-                            "type": "object"
+                            "description": "EnvironmentResourceDetector sets OpenTelemetry resource attributes from the OTEL_RESOURCE_ATTRIBUTES\nenvironment variable in the Envoy container.\nDefault enabled if not set. If multiple are set, the last will take precedence.",
+                            "properties": {
+                              "enable": {
+                                "default": true,
+                                "description": "Enable controls whether the EnvironmentResourceDetector is used.",
+                                "type": "boolean"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
                           }
                         },
                         "type": "object",
@@ -1723,17 +1921,53 @@
           "additionalProperties": false
         },
         "useRemoteAddress": {
-          "description": "UseRemoteAddress determines whether to use the remote address for the original client.\nNote: If this field is omitted, it will fallback to the default value of 'true', which we set for all Envoy HCMs.\nThus, setting this explicitly to true is unnecessary (but will not cause any harm).\nWhen true, Envoy will use the remote address of the connection as the client address.\nWhen false, Envoy will use the X-Forwarded-For header to determine the client address.\nSee here for more information: https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto#envoy-v3-api-field-extensions-filters-network-http-connection-manager-v3-httpconnectionmanager-use-remote-address",
+          "description": "UseRemoteAddress determines whether to use the remote address for the original client.\nNote: If this field is omitted, it will fallback to the default value of 'true', which we set for all Envoy HCMs.\nThus, setting this explicitly to true is unnecessary (but will not cause any harm).\nWhen true, Envoy will use the remote address of the connection as the client address.\nWhen false, Envoy will use the X-Forwarded-For header to determine the client address. Furthermore, SkipXffAppend will implicitly be set to true unless explicitly configured.\nSee here for more information: https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto#envoy-v3-api-field-extensions-filters-network-http-connection-manager-v3-httpconnectionmanager-use-remote-address",
           "type": "boolean"
         },
+        "uuidRequestIdConfig": {
+          "description": "UuidRequestIdConfig configures the behavior of the UUID request ID extension.\nThis extension sets the x-request-id header to a UUID value.",
+          "properties": {
+            "packTraceReason": {
+              "description": "PackTraceReason determines if the trace sampling decision is embedded into the UUID.\nDefaults to true. Set to false to prevent Envoy from mutating the Request ID,\nwhich is useful when preserving exact UUIDs from external systems.",
+              "type": "boolean"
+            },
+            "useRequestIdForTraceSampling": {
+              "description": "UseRequestIDForTraceSampling determines if the Request ID is used to calculate the\ntrace sampling decision. Defaults to true. This ensures consistent sampling decisions\nfor a given Request ID across the mesh.",
+              "type": "boolean"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
         "xffNumTrustedHops": {
-          "description": "XffNumTrustedHops is the number of additional ingress proxy hops from the right side of the X-Forwarded-For HTTP header to trust when determining the origin client's IP address.\nSee here for more information: https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto#envoy-v3-api-field-extensions-filters-network-http-connection-manager-v3-httpconnectionmanager-xff-num-trusted-hops",
+          "description": "XffNumTrustedHops is the number of additional ingress proxy hops from the right side of the X-Forwarded-For HTTP header to trust when determining the origin client's IP address.\nThis is mutually exclusive with XffTrustedCIDRs.\nSee here for more information: https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto#envoy-v3-api-field-extensions-filters-network-http-connection-manager-v3-httpconnectionmanager-xff-num-trusted-hops",
           "format": "int32",
           "minimum": 0,
           "type": "integer"
+        },
+        "xffTrustedCIDRs": {
+          "description": "XffTrustedCIDRs are ranges of IPs that may appear in the X-Forwarded-For HTTP header and are trusted when determining the origin client's IP address.\nThis is mutually exclusive with XffNumTrustedHops and requires UseRemoteAddress to be set to false.\nSee here for more information: https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/http/original_ip_detection/xff/v3/xff.proto#envoy-v3-api-field-extensions-http-original-ip-detection-xff-v3-xffconfig-xff-trusted-cidrs",
+          "items": {
+            "description": "CIDR can be used wherever an address range in CIDR notation is expected.\nNote: The regex for the IP validation patterns was taken from https://www.ditig.com/validating-ipv4-and-ipv6-addresses-with-regexp",
+            "format": "cidr",
+            "pattern": "^((25[0-5]|(2[0-4]|1\\d|[1-9]|)\\d)\\.?\\b){4}\\/([0-9]|[1-2][0-9]|3[0-2])$|^((?:[0-9A-Fa-f]{1,4}:){7}[0-9A-Fa-f]{1,4}|(?:[0-9A-Fa-f]{1,4}:){1,7}:|:(?::[0-9A-Fa-f]{1,4}){1,7}|(?:[0-9A-Fa-f]{1,4}:){1,6}:[0-9A-Fa-f]{1,4}|(?:[0-9A-Fa-f]{1,4}:){1,5}(?::[0-9A-Fa-f]{1,4}){1,2}|(?:[0-9A-Fa-f]{1,4}:){1,4}(?::[0-9A-Fa-f]{1,4}){1,3}|(?:[0-9A-Fa-f]{1,4}:){1,3}(?::[0-9A-Fa-f]{1,4}){1,4}|(?:[0-9A-Fa-f]{1,4}:){1,2}(?::[0-9A-Fa-f]{1,4}){1,5}|[0-9A-Fa-f]{1,4}:(?:(?::[0-9A-Fa-f]{1,4}){1,6})|:(?:(?::[0-9A-Fa-f]{1,4}){1,6}))\\/(12[0-8]|1[0-1][0-9]|[1-9][0-9]|[0-9])$",
+            "type": "string"
+          },
+          "minItems": 1,
+          "type": "array"
         }
       },
       "type": "object",
+      "x-kubernetes-validations": [
+        {
+          "message": "useRemoteAddress must be set to false if xffTrustedCIDRs is set",
+          "rule": "!has(self.xffTrustedCIDRs) || (has(self.useRemoteAddress) && !self.useRemoteAddress)"
+        },
+        {
+          "message": "only one of xffNumTrustedHops and xffTrustedCIDRs may be set",
+          "rule": "!has(self.xffNumTrustedHops) || !has(self.xffTrustedCIDRs)"
+        }
+      ],
       "additionalProperties": false
     },
     "status": {

--- a/gateway.kgateway.dev/listenerpolicy_v1alpha1.json
+++ b/gateway.kgateway.dev/listenerpolicy_v1alpha1.json
@@ -18,8 +18,71 @@
         "default": {
           "description": "Default specifies default listener configuration for all Listeners, unless a per-port\nconfiguration is defined.",
           "properties": {
+            "clientCertificateValidation": {
+              "description": "ClientCertificateValidation configures mutual TLS (mTLS) client certificate validation for the listener.\nThis enables per-listener configuration of CA certificates for client certificate validation,\nallowing different listeners on the same port to enforce different mTLS trust boundaries.\nWhen configured on a ListenerPolicy targeting a specific listener (via sectionName),\nit overrides any Gateway-level mTLS configuration for that listener.\n\nSecurity Note: Per-listener CA certificate validation can be bypassed in scenarios where\nwildcard listeners (e.g., *.example.com) overlap with more specific hostnames on the same port,\ndue to TLS connection coalescing. For deployments with non-overlapping hostnames per listener,\nthis security concern does not apply. See GEP-91 and GEP-3567 for more details.\nReference: https://gateway-api.sigs.k8s.io/geps/gep-91/\nReference: https://github.com/kubernetes-sigs/gateway-api/issues/3567",
+              "properties": {
+                "caCertificateRefs": {
+                  "description": "CACertificateRefs contains references to Kubernetes Secrets or ConfigMaps containing\nCA certificates. Multiple references will be combined into a single trusted CA pool for the listener.\nThe referenced Secrets/ConfigMaps must have a ca.crt key containing the PEM data",
+                  "items": {
+                    "description": "ObjectReference identifies an API object including its namespace.\n\nThe API object must be valid in the cluster; the Group and Kind must\nbe registered in the cluster for this reference to be valid.\n\nReferences to objects with invalid Group and Kind are not valid, and must\nbe rejected by the implementation, with appropriate Conditions set\non the containing object.",
+                    "properties": {
+                      "group": {
+                        "description": "Group is the group of the referent. For example, \"gateway.networking.k8s.io\".\nWhen set to the empty string, core API group is inferred.",
+                        "maxLength": 253,
+                        "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                        "type": "string"
+                      },
+                      "kind": {
+                        "description": "Kind is kind of the referent. For example \"ConfigMap\" or \"Service\".",
+                        "maxLength": 63,
+                        "minLength": 1,
+                        "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "Name is the name of the referent.",
+                        "maxLength": 253,
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "namespace": {
+                        "description": "Namespace is the namespace of the referenced object. When unspecified, the local\nnamespace is inferred.\n\nNote that when a namespace different than the local namespace is specified,\na ReferenceGrant object is required in the referent namespace to allow that\nnamespace's owner to accept the reference. See the ReferenceGrant\ndocumentation for details.\n\nSupport: Core",
+                        "maxLength": 63,
+                        "minLength": 1,
+                        "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "group",
+                      "kind",
+                      "name"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "maxItems": 8,
+                  "minItems": 1,
+                  "type": "array"
+                },
+                "mode": {
+                  "description": "Mode specifies how the listener should enforce client certificate validation.",
+                  "enum": [
+                    "Require",
+                    "Optional"
+                  ],
+                  "type": "string"
+                }
+              },
+              "required": [
+                "caCertificateRefs",
+                "mode"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
             "httpSettings": {
-              "description": "HTTPListenerPolicy is intended to be used for configuring the Envoy `HttpConnectionManager` and any other config or policy\nthat should map 1-to-1 with a given HTTP listener, such as the Envoy health check HTTP filter.",
+              "description": "HTTPSettings is intended to be used for configuring the Envoy `HttpConnectionManager` and any other config or policy\nthat should map 1-to-1 with a given HTTP listener, such as the Envoy health check HTTP filter.",
               "properties": {
                 "acceptHttp10": {
                   "description": "AcceptHTTP10 determines whether to accept incoming HTTP/1.0 and HTTP 0.9 requests.\nSee here for more information: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/protocol.proto#config-core-v3-http1protocoloptions",
@@ -180,7 +243,7 @@
                                           "type": "string"
                                         },
                                         "value": {
-                                          "description": "Value is the value of HTTP Header to be matched.",
+                                          "description": "Value is the value of HTTP Header to be matched.\n<gateway:experimental:description>\nMust consist of printable US-ASCII characters, optionally separated\nby single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2\n</gateway:experimental:description>\n\n<gateway:experimental:validation:Pattern=`^[!-~]+([\\t ]?[!-~]+)*$`>",
                                           "maxLength": 4096,
                                           "minLength": 1,
                                           "type": "string"
@@ -217,6 +280,50 @@
                                   },
                                   "required": [
                                     "flags"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "runtimeFilter": {
+                                  "description": "Filters for random sampling of access logs.\nBased on: https://www.envoyproxy.io/docs/envoy/v1.33.0/api-v3/config/accesslog/v3/accesslog.proto#config-accesslog-v3-runtimefilter",
+                                  "properties": {
+                                    "percentSampled": {
+                                      "description": "By default, the runtime filter will log on every request when the runtime key is set.\nIf this field is set, it additionally applies a fractional percent check so that only a\nfraction of requests are logged.",
+                                      "properties": {
+                                        "denominator": {
+                                          "description": "Specifies the denominator. If the denominator specified is less than the numerator,\nthe final fractional percentage is capped at 1 (100%).\nDefaults to HUNDRED.",
+                                          "enum": [
+                                            "HUNDRED",
+                                            "TEN_THOUSAND",
+                                            "MILLION"
+                                          ],
+                                          "type": "string"
+                                        },
+                                        "numerator": {
+                                          "description": "Specifies the numerator. Defaults to 0.",
+                                          "format": "int32",
+                                          "minimum": 0,
+                                          "type": "integer"
+                                        }
+                                      },
+                                      "required": [
+                                        "numerator"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "runtimeKey": {
+                                      "description": "The runtime key to look up in the runtime implementation. This key determines whether\nthe access log is enabled. When the runtime key value is set, the filter checks this key\nat runtime to decide whether to log each request.",
+                                      "minLength": 1,
+                                      "type": "string"
+                                    },
+                                    "useIndependentRandomness": {
+                                      "description": "If set to true, the filter uses Envoy's independent randomness source.\nWhen false (the default), the filter uses the runtime key lookup.",
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "runtimeKey"
                                   ],
                                   "type": "object",
                                   "additionalProperties": false
@@ -360,7 +467,7 @@
                                     "type": "string"
                                   },
                                   "value": {
-                                    "description": "Value is the value of HTTP Header to be matched.",
+                                    "description": "Value is the value of HTTP Header to be matched.\n<gateway:experimental:description>\nMust consist of printable US-ASCII characters, optionally separated\nby single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2\n</gateway:experimental:description>\n\n<gateway:experimental:validation:Pattern=`^[!-~]+([\\t ]?[!-~]+)*$`>",
                                     "maxLength": 4096,
                                     "minLength": 1,
                                     "type": "string"
@@ -492,7 +599,7 @@
                                           "type": "string"
                                         },
                                         "value": {
-                                          "description": "Value is the value of HTTP Header to be matched.",
+                                          "description": "Value is the value of HTTP Header to be matched.\n<gateway:experimental:description>\nMust consist of printable US-ASCII characters, optionally separated\nby single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2\n</gateway:experimental:description>\n\n<gateway:experimental:validation:Pattern=`^[!-~]+([\\t ]?[!-~]+)*$`>",
                                           "maxLength": 4096,
                                           "minLength": 1,
                                           "type": "string"
@@ -529,6 +636,50 @@
                                   },
                                   "required": [
                                     "flags"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "runtimeFilter": {
+                                  "description": "Filters for random sampling of access logs.\nBased on: https://www.envoyproxy.io/docs/envoy/v1.33.0/api-v3/config/accesslog/v3/accesslog.proto#config-accesslog-v3-runtimefilter",
+                                  "properties": {
+                                    "percentSampled": {
+                                      "description": "By default, the runtime filter will log on every request when the runtime key is set.\nIf this field is set, it additionally applies a fractional percent check so that only a\nfraction of requests are logged.",
+                                      "properties": {
+                                        "denominator": {
+                                          "description": "Specifies the denominator. If the denominator specified is less than the numerator,\nthe final fractional percentage is capped at 1 (100%).\nDefaults to HUNDRED.",
+                                          "enum": [
+                                            "HUNDRED",
+                                            "TEN_THOUSAND",
+                                            "MILLION"
+                                          ],
+                                          "type": "string"
+                                        },
+                                        "numerator": {
+                                          "description": "Specifies the numerator. Defaults to 0.",
+                                          "format": "int32",
+                                          "minimum": 0,
+                                          "type": "integer"
+                                        }
+                                      },
+                                      "required": [
+                                        "numerator"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "runtimeKey": {
+                                      "description": "The runtime key to look up in the runtime implementation. This key determines whether\nthe access log is enabled. When the runtime key value is set, the filter checks this key\nat runtime to decide whether to log each request.",
+                                      "minLength": 1,
+                                      "type": "string"
+                                    },
+                                    "useIndependentRandomness": {
+                                      "description": "If set to true, the filter uses Envoy's independent randomness source.\nWhen false (the default), the filter uses the runtime key lookup.",
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "runtimeKey"
                                   ],
                                   "type": "object",
                                   "additionalProperties": false
@@ -584,6 +735,50 @@
                             },
                             "required": [
                               "flags"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "runtimeFilter": {
+                            "description": "Filters for random sampling of access logs.\nBased on: https://www.envoyproxy.io/docs/envoy/v1.33.0/api-v3/config/accesslog/v3/accesslog.proto#config-accesslog-v3-runtimefilter",
+                            "properties": {
+                              "percentSampled": {
+                                "description": "By default, the runtime filter will log on every request when the runtime key is set.\nIf this field is set, it additionally applies a fractional percent check so that only a\nfraction of requests are logged.",
+                                "properties": {
+                                  "denominator": {
+                                    "description": "Specifies the denominator. If the denominator specified is less than the numerator,\nthe final fractional percentage is capped at 1 (100%).\nDefaults to HUNDRED.",
+                                    "enum": [
+                                      "HUNDRED",
+                                      "TEN_THOUSAND",
+                                      "MILLION"
+                                    ],
+                                    "type": "string"
+                                  },
+                                  "numerator": {
+                                    "description": "Specifies the numerator. Defaults to 0.",
+                                    "format": "int32",
+                                    "minimum": 0,
+                                    "type": "integer"
+                                  }
+                                },
+                                "required": [
+                                  "numerator"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "runtimeKey": {
+                                "description": "The runtime key to look up in the runtime implementation. This key determines whether\nthe access log is enabled. When the runtime key value is set, the filter checks this key\nat runtime to decide whether to log each request.",
+                                "minLength": 1,
+                                "type": "string"
+                              },
+                              "useIndependentRandomness": {
+                                "description": "If set to true, the filter uses Envoy's independent randomness source.\nWhen false (the default), the filter uses the runtime key lookup.",
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "runtimeKey"
                             ],
                             "type": "object",
                             "additionalProperties": false
@@ -1114,7 +1309,7 @@
                             "type": "string"
                           },
                           "value": {
-                            "description": "Value is the value of HTTP Header to be matched.",
+                            "description": "Value is the value of HTTP Header to be matched.\n<gateway:experimental:description>\nMust consist of printable US-ASCII characters, optionally separated\nby single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2\n</gateway:experimental:description>\n\n<gateway:experimental:validation:Pattern=`^[!-~]+([\\t ]?[!-~]+)*$`>",
                             "maxLength": 4096,
                             "minLength": 1,
                             "type": "string"
@@ -1156,7 +1351,7 @@
                             "type": "string"
                           },
                           "value": {
-                            "description": "Value is the value of HTTP Header to be matched.",
+                            "description": "Value is the value of HTTP Header to be matched.\n<gateway:experimental:description>\nMust consist of printable US-ASCII characters, optionally separated\nby single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2\n</gateway:experimental:description>\n\n<gateway:experimental:validation:Pattern=`^[!-~]+([\\t ]?[!-~]+)*$`>",
                             "maxLength": 4096,
                             "minLength": 1,
                             "type": "string"
@@ -1200,6 +1395,46 @@
                   "type": "object",
                   "additionalProperties": false
                 },
+                "http2ProtocolOptions": {
+                  "description": "Http2ProtocolOptions configures downstream HTTP/2 behavior on the listener's\nHttpConnectionManager.\nSee here for more information: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/protocol.proto#config-core-v3-http2protocoloptions",
+                  "properties": {
+                    "initialConnectionWindowSize": {
+                      "anyOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ],
+                      "description": "InitialConnectionWindowSize is similar to InitialStreamWindowSize, but for the connection level.\nSame range and default value as InitialStreamWindowSize.\nValues can be specified with units like \"64Ki\".",
+                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                      "x-kubernetes-int-or-string": true
+                    },
+                    "initialStreamWindowSize": {
+                      "anyOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ],
+                      "description": "InitialStreamWindowSize is the initial window size for the stream.\nValid values range from 65535 (2^16 - 1, HTTP/2 default) to 2147483647 (2^31 - 1, HTTP/2 maximum).\nDefaults to 268435456 (256 * 1024 * 1024).\nValues can be specified with units like \"64Ki\".",
+                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                      "x-kubernetes-int-or-string": true
+                    },
+                    "maxConcurrentStreams": {
+                      "description": "The maximum number of concurrent streams that the connection can have.\nEnvoy defaults to 1024.",
+                      "format": "int32",
+                      "maximum": 2147483647,
+                      "minimum": 1,
+                      "type": "integer"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
                 "idleTimeout": {
                   "description": "IdleTimeout is the idle timeout for connnections.\nSee here for more information: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/protocol.proto#envoy-v3-api-msg-config-core-v3-httpprotocoloptions",
                   "type": "string",
@@ -1209,6 +1444,12 @@
                       "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
                     }
                   ]
+                },
+                "maxHeadersCount": {
+                  "description": "MaxHeadersCount sets the maximum number of headers allowed in a request.\nDownstream requests that exceed this limit will receive a 431 response for HTTP/1.x and a\nstream reset for HTTP/2. If unset, defaults to Envoy's built-in default of 100.\nSee here for more information: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/protocol.proto#envoy-v3-api-field-config-core-v3-httpprotocoloptions-max-headers-count",
+                  "format": "int32",
+                  "minimum": 1,
+                  "type": "integer"
                 },
                 "maxRequestHeadersKb": {
                   "description": "MaxRequestHeadersKb sets the maximum size of request headers that Envoy will accept.\nIf unset, the Envoy default is 60 KiB.\nSee here for more information: https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto#envoy-v3-api-field-extensions-filters-network-http-connection-manager-v3-httpconnectionmanager-max-request-headers-kb",
@@ -1234,6 +1475,10 @@
                   ],
                   "type": "string"
                 },
+                "skipXFFAppend": {
+                  "description": "SkipXffAppend specifies whether to skip adding the downstream's remote IP address to the X-Forwarded-For HTTP header.\nNote: If omitted, this effectively will default to true when UseRemoteAddress is false, such that Envoy acts as a \"transparent proxy\".\nSee here for more information: https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto#envoy-v3-api-field-extensions-filters-network-http-connection-manager-v3-httpconnectionmanager-skip-xff-append",
+                  "type": "boolean"
+                },
                 "streamIdleTimeout": {
                   "description": "StreamIdleTimeout is the idle timeout for HTTP streams.\nSee here for more information: https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto#envoy-v3-api-field-extensions-filters-network-http-connection-manager-v3-httpconnectionmanager-stream-idle-timeout",
                   "type": "string",
@@ -1243,6 +1488,14 @@
                       "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
                     }
                   ]
+                },
+                "stripHostPortMode": {
+                  "description": "StripHostPortMode determines whether, and under what conditions, Envoy will strip the port\nfrom the Host/authority header. StripMatchingHostPort strips the port only if it matches\nthe listener's own port. StripAnyHostPort strips the port unconditionally.\nSee here for more information: https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto#envoy-v3-api-field-extensions-filters-network-http-connection-manager-v3-httpconnectionmanager-strip-matching-host-port\nSee also: https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto#envoy-v3-api-field-extensions-filters-network-http-connection-manager-v3-httpconnectionmanager-strip-any-host-port",
+                  "enum": [
+                    "MatchingPort",
+                    "AnyPort"
+                  ],
+                  "type": "string"
                 },
                 "tracing": {
                   "description": "Tracing contains various settings for Envoy's OpenTelemetry tracer.\nSee here for more information: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/trace/v3/opentelemetry.proto.html",
@@ -1569,8 +1822,16 @@
                                 "minProperties": 1,
                                 "properties": {
                                   "environmentResourceDetector": {
-                                    "description": "EnvironmentResourceDetectorConfig specified the EnvironmentResourceDetector",
-                                    "type": "object"
+                                    "description": "EnvironmentResourceDetector sets OpenTelemetry resource attributes from the OTEL_RESOURCE_ATTRIBUTES\nenvironment variable in the Envoy container.\nDefault enabled if not set. If multiple are set, the last will take precedence.",
+                                    "properties": {
+                                      "enable": {
+                                        "default": true,
+                                        "description": "Enable controls whether the EnvironmentResourceDetector is used.",
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
                                   }
                                 },
                                 "type": "object",
@@ -1644,17 +1905,53 @@
                   "additionalProperties": false
                 },
                 "useRemoteAddress": {
-                  "description": "UseRemoteAddress determines whether to use the remote address for the original client.\nNote: If this field is omitted, it will fallback to the default value of 'true', which we set for all Envoy HCMs.\nThus, setting this explicitly to true is unnecessary (but will not cause any harm).\nWhen true, Envoy will use the remote address of the connection as the client address.\nWhen false, Envoy will use the X-Forwarded-For header to determine the client address.\nSee here for more information: https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto#envoy-v3-api-field-extensions-filters-network-http-connection-manager-v3-httpconnectionmanager-use-remote-address",
+                  "description": "UseRemoteAddress determines whether to use the remote address for the original client.\nNote: If this field is omitted, it will fallback to the default value of 'true', which we set for all Envoy HCMs.\nThus, setting this explicitly to true is unnecessary (but will not cause any harm).\nWhen true, Envoy will use the remote address of the connection as the client address.\nWhen false, Envoy will use the X-Forwarded-For header to determine the client address. Furthermore, SkipXffAppend will implicitly be set to true unless explicitly configured.\nSee here for more information: https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto#envoy-v3-api-field-extensions-filters-network-http-connection-manager-v3-httpconnectionmanager-use-remote-address",
                   "type": "boolean"
                 },
+                "uuidRequestIdConfig": {
+                  "description": "UuidRequestIdConfig configures the behavior of the UUID request ID extension.\nThis extension sets the x-request-id header to a UUID value.",
+                  "properties": {
+                    "packTraceReason": {
+                      "description": "PackTraceReason determines if the trace sampling decision is embedded into the UUID.\nDefaults to true. Set to false to prevent Envoy from mutating the Request ID,\nwhich is useful when preserving exact UUIDs from external systems.",
+                      "type": "boolean"
+                    },
+                    "useRequestIdForTraceSampling": {
+                      "description": "UseRequestIDForTraceSampling determines if the Request ID is used to calculate the\ntrace sampling decision. Defaults to true. This ensures consistent sampling decisions\nfor a given Request ID across the mesh.",
+                      "type": "boolean"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
                 "xffNumTrustedHops": {
-                  "description": "XffNumTrustedHops is the number of additional ingress proxy hops from the right side of the X-Forwarded-For HTTP header to trust when determining the origin client's IP address.\nSee here for more information: https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto#envoy-v3-api-field-extensions-filters-network-http-connection-manager-v3-httpconnectionmanager-xff-num-trusted-hops",
+                  "description": "XffNumTrustedHops is the number of additional ingress proxy hops from the right side of the X-Forwarded-For HTTP header to trust when determining the origin client's IP address.\nThis is mutually exclusive with XffTrustedCIDRs.\nSee here for more information: https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto#envoy-v3-api-field-extensions-filters-network-http-connection-manager-v3-httpconnectionmanager-xff-num-trusted-hops",
                   "format": "int32",
                   "minimum": 0,
                   "type": "integer"
+                },
+                "xffTrustedCIDRs": {
+                  "description": "XffTrustedCIDRs are ranges of IPs that may appear in the X-Forwarded-For HTTP header and are trusted when determining the origin client's IP address.\nThis is mutually exclusive with XffNumTrustedHops and requires UseRemoteAddress to be set to false.\nSee here for more information: https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/http/original_ip_detection/xff/v3/xff.proto#envoy-v3-api-field-extensions-http-original-ip-detection-xff-v3-xffconfig-xff-trusted-cidrs",
+                  "items": {
+                    "description": "CIDR can be used wherever an address range in CIDR notation is expected.\nNote: The regex for the IP validation patterns was taken from https://www.ditig.com/validating-ipv4-and-ipv6-addresses-with-regexp",
+                    "format": "cidr",
+                    "pattern": "^((25[0-5]|(2[0-4]|1\\d|[1-9]|)\\d)\\.?\\b){4}\\/([0-9]|[1-2][0-9]|3[0-2])$|^((?:[0-9A-Fa-f]{1,4}:){7}[0-9A-Fa-f]{1,4}|(?:[0-9A-Fa-f]{1,4}:){1,7}:|:(?::[0-9A-Fa-f]{1,4}){1,7}|(?:[0-9A-Fa-f]{1,4}:){1,6}:[0-9A-Fa-f]{1,4}|(?:[0-9A-Fa-f]{1,4}:){1,5}(?::[0-9A-Fa-f]{1,4}){1,2}|(?:[0-9A-Fa-f]{1,4}:){1,4}(?::[0-9A-Fa-f]{1,4}){1,3}|(?:[0-9A-Fa-f]{1,4}:){1,3}(?::[0-9A-Fa-f]{1,4}){1,4}|(?:[0-9A-Fa-f]{1,4}:){1,2}(?::[0-9A-Fa-f]{1,4}){1,5}|[0-9A-Fa-f]{1,4}:(?:(?::[0-9A-Fa-f]{1,4}){1,6})|:(?:(?::[0-9A-Fa-f]{1,4}){1,6}))\\/(12[0-8]|1[0-1][0-9]|[1-9][0-9]|[0-9])$",
+                    "type": "string"
+                  },
+                  "minItems": 1,
+                  "type": "array"
                 }
               },
               "type": "object",
+              "x-kubernetes-validations": [
+                {
+                  "message": "useRemoteAddress must be set to false if xffTrustedCIDRs is set",
+                  "rule": "!has(self.xffTrustedCIDRs) || (has(self.useRemoteAddress) && !self.useRemoteAddress)"
+                },
+                {
+                  "message": "only one of xffNumTrustedHops and xffTrustedCIDRs may be set",
+                  "rule": "!has(self.xffNumTrustedHops) || !has(self.xffTrustedCIDRs)"
+                }
+              ],
               "additionalProperties": false
             },
             "perConnectionBufferLimitBytes": {
@@ -1664,8 +1961,56 @@
               "type": "integer"
             },
             "proxyProtocol": {
-              "description": "ProxyProtocol configures the PROXY protocol listener filter.\nWhen set, Envoy will expect connections to include the PROXY protocol header.\nThis is commonly used when kgateway is behind a load balancer that preserves client IP information.\nSee here for more information: https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/listener/proxy_protocol/v3/proxy_protocol.proto",
-              "type": "object"
+              "description": "ProxyProtocol configures the PROXY protocol listener filter.\nBy default, when set, Envoy will require connections to include the PROXY\nprotocol header. This behavior can be relaxed by setting\nallowRequestsWithoutProxyProtocol to true, which allows the listener to\nalso accept connections without the PROXY protocol header.\nThis is commonly used when kgateway is behind a load balancer that preserves client IP information.\nSee here for more information: https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/listener/proxy_protocol/v3/proxy_protocol.proto",
+              "properties": {
+                "allowRequestsWithoutProxyProtocol": {
+                  "description": "AllowRequestsWithoutProxyProtocol, when true, configures the PROXY protocol\nlistener filter to accept connections that do not include a PROXY protocol\nheader in addition to those that do. This allows a single listener to serve\nmixed traffic, e.g. PROXY-preserving load balancer traffic plus direct\nin-cluster traffic on the same port.\n\nSecurity: accepting connections without a PROXY header is non-conformant\nwith the PROXY protocol spec and allows clients to spoof the perceived\nsource address. Only enable this when every source that can reach the\nlistener is trusted. See\nhttps://www.haproxy.org/download/2.1/doc/proxy-protocol.txt.\n\nDefaults to false.",
+                  "type": "boolean"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "tcpKeepalive": {
+              "description": "TCPKeepalive configures OS-level TCP keepalive checks for downstream client connections accepted by this listener.",
+              "properties": {
+                "keepAliveInterval": {
+                  "description": "The number of seconds between keep-alive probes.",
+                  "type": "string",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "invalid duration value",
+                      "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                    },
+                    {
+                      "message": "keepAliveInterval must be at least 1 second",
+                      "rule": "duration(self) >= duration('1s')"
+                    }
+                  ]
+                },
+                "keepAliveProbes": {
+                  "description": "Maximum number of keep-alive probes to send before dropping the connection.",
+                  "format": "int32",
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "keepAliveTime": {
+                  "description": "The number of seconds a connection needs to be idle before keep-alive probes start being sent.",
+                  "type": "string",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "invalid duration value",
+                      "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                    },
+                    {
+                      "message": "keepAliveTime must be at least 1 second",
+                      "rule": "duration(self) >= duration('1s')"
+                    }
+                  ]
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
             }
           },
           "type": "object",
@@ -1679,7 +2024,7 @@
                 "description": "Listener stores the configuration that will be applied to all Listeners handling\nmatching the given port.",
                 "properties": {
                   "httpSettings": {
-                    "description": "HTTPListenerPolicy is intended to be used for configuring the Envoy `HttpConnectionManager` and any other config or policy\nthat should map 1-to-1 with a given HTTP listener, such as the Envoy health check HTTP filter.",
+                    "description": "HTTPSettings is intended to be used for configuring the Envoy `HttpConnectionManager` and any other config or policy\nthat should map 1-to-1 with a given HTTP listener, such as the Envoy health check HTTP filter.",
                     "properties": {
                       "acceptHttp10": {
                         "description": "AcceptHTTP10 determines whether to accept incoming HTTP/1.0 and HTTP 0.9 requests.\nSee here for more information: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/protocol.proto#config-core-v3-http1protocoloptions",
@@ -1840,7 +2185,7 @@
                                                 "type": "string"
                                               },
                                               "value": {
-                                                "description": "Value is the value of HTTP Header to be matched.",
+                                                "description": "Value is the value of HTTP Header to be matched.\n<gateway:experimental:description>\nMust consist of printable US-ASCII characters, optionally separated\nby single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2\n</gateway:experimental:description>\n\n<gateway:experimental:validation:Pattern=`^[!-~]+([\\t ]?[!-~]+)*$`>",
                                                 "maxLength": 4096,
                                                 "minLength": 1,
                                                 "type": "string"
@@ -1877,6 +2222,50 @@
                                         },
                                         "required": [
                                           "flags"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "runtimeFilter": {
+                                        "description": "Filters for random sampling of access logs.\nBased on: https://www.envoyproxy.io/docs/envoy/v1.33.0/api-v3/config/accesslog/v3/accesslog.proto#config-accesslog-v3-runtimefilter",
+                                        "properties": {
+                                          "percentSampled": {
+                                            "description": "By default, the runtime filter will log on every request when the runtime key is set.\nIf this field is set, it additionally applies a fractional percent check so that only a\nfraction of requests are logged.",
+                                            "properties": {
+                                              "denominator": {
+                                                "description": "Specifies the denominator. If the denominator specified is less than the numerator,\nthe final fractional percentage is capped at 1 (100%).\nDefaults to HUNDRED.",
+                                                "enum": [
+                                                  "HUNDRED",
+                                                  "TEN_THOUSAND",
+                                                  "MILLION"
+                                                ],
+                                                "type": "string"
+                                              },
+                                              "numerator": {
+                                                "description": "Specifies the numerator. Defaults to 0.",
+                                                "format": "int32",
+                                                "minimum": 0,
+                                                "type": "integer"
+                                              }
+                                            },
+                                            "required": [
+                                              "numerator"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "runtimeKey": {
+                                            "description": "The runtime key to look up in the runtime implementation. This key determines whether\nthe access log is enabled. When the runtime key value is set, the filter checks this key\nat runtime to decide whether to log each request.",
+                                            "minLength": 1,
+                                            "type": "string"
+                                          },
+                                          "useIndependentRandomness": {
+                                            "description": "If set to true, the filter uses Envoy's independent randomness source.\nWhen false (the default), the filter uses the runtime key lookup.",
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "runtimeKey"
                                         ],
                                         "type": "object",
                                         "additionalProperties": false
@@ -2020,7 +2409,7 @@
                                           "type": "string"
                                         },
                                         "value": {
-                                          "description": "Value is the value of HTTP Header to be matched.",
+                                          "description": "Value is the value of HTTP Header to be matched.\n<gateway:experimental:description>\nMust consist of printable US-ASCII characters, optionally separated\nby single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2\n</gateway:experimental:description>\n\n<gateway:experimental:validation:Pattern=`^[!-~]+([\\t ]?[!-~]+)*$`>",
                                           "maxLength": 4096,
                                           "minLength": 1,
                                           "type": "string"
@@ -2152,7 +2541,7 @@
                                                 "type": "string"
                                               },
                                               "value": {
-                                                "description": "Value is the value of HTTP Header to be matched.",
+                                                "description": "Value is the value of HTTP Header to be matched.\n<gateway:experimental:description>\nMust consist of printable US-ASCII characters, optionally separated\nby single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2\n</gateway:experimental:description>\n\n<gateway:experimental:validation:Pattern=`^[!-~]+([\\t ]?[!-~]+)*$`>",
                                                 "maxLength": 4096,
                                                 "minLength": 1,
                                                 "type": "string"
@@ -2189,6 +2578,50 @@
                                         },
                                         "required": [
                                           "flags"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "runtimeFilter": {
+                                        "description": "Filters for random sampling of access logs.\nBased on: https://www.envoyproxy.io/docs/envoy/v1.33.0/api-v3/config/accesslog/v3/accesslog.proto#config-accesslog-v3-runtimefilter",
+                                        "properties": {
+                                          "percentSampled": {
+                                            "description": "By default, the runtime filter will log on every request when the runtime key is set.\nIf this field is set, it additionally applies a fractional percent check so that only a\nfraction of requests are logged.",
+                                            "properties": {
+                                              "denominator": {
+                                                "description": "Specifies the denominator. If the denominator specified is less than the numerator,\nthe final fractional percentage is capped at 1 (100%).\nDefaults to HUNDRED.",
+                                                "enum": [
+                                                  "HUNDRED",
+                                                  "TEN_THOUSAND",
+                                                  "MILLION"
+                                                ],
+                                                "type": "string"
+                                              },
+                                              "numerator": {
+                                                "description": "Specifies the numerator. Defaults to 0.",
+                                                "format": "int32",
+                                                "minimum": 0,
+                                                "type": "integer"
+                                              }
+                                            },
+                                            "required": [
+                                              "numerator"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "runtimeKey": {
+                                            "description": "The runtime key to look up in the runtime implementation. This key determines whether\nthe access log is enabled. When the runtime key value is set, the filter checks this key\nat runtime to decide whether to log each request.",
+                                            "minLength": 1,
+                                            "type": "string"
+                                          },
+                                          "useIndependentRandomness": {
+                                            "description": "If set to true, the filter uses Envoy's independent randomness source.\nWhen false (the default), the filter uses the runtime key lookup.",
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "runtimeKey"
                                         ],
                                         "type": "object",
                                         "additionalProperties": false
@@ -2244,6 +2677,50 @@
                                   },
                                   "required": [
                                     "flags"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "runtimeFilter": {
+                                  "description": "Filters for random sampling of access logs.\nBased on: https://www.envoyproxy.io/docs/envoy/v1.33.0/api-v3/config/accesslog/v3/accesslog.proto#config-accesslog-v3-runtimefilter",
+                                  "properties": {
+                                    "percentSampled": {
+                                      "description": "By default, the runtime filter will log on every request when the runtime key is set.\nIf this field is set, it additionally applies a fractional percent check so that only a\nfraction of requests are logged.",
+                                      "properties": {
+                                        "denominator": {
+                                          "description": "Specifies the denominator. If the denominator specified is less than the numerator,\nthe final fractional percentage is capped at 1 (100%).\nDefaults to HUNDRED.",
+                                          "enum": [
+                                            "HUNDRED",
+                                            "TEN_THOUSAND",
+                                            "MILLION"
+                                          ],
+                                          "type": "string"
+                                        },
+                                        "numerator": {
+                                          "description": "Specifies the numerator. Defaults to 0.",
+                                          "format": "int32",
+                                          "minimum": 0,
+                                          "type": "integer"
+                                        }
+                                      },
+                                      "required": [
+                                        "numerator"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "runtimeKey": {
+                                      "description": "The runtime key to look up in the runtime implementation. This key determines whether\nthe access log is enabled. When the runtime key value is set, the filter checks this key\nat runtime to decide whether to log each request.",
+                                      "minLength": 1,
+                                      "type": "string"
+                                    },
+                                    "useIndependentRandomness": {
+                                      "description": "If set to true, the filter uses Envoy's independent randomness source.\nWhen false (the default), the filter uses the runtime key lookup.",
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "runtimeKey"
                                   ],
                                   "type": "object",
                                   "additionalProperties": false
@@ -2774,7 +3251,7 @@
                                   "type": "string"
                                 },
                                 "value": {
-                                  "description": "Value is the value of HTTP Header to be matched.",
+                                  "description": "Value is the value of HTTP Header to be matched.\n<gateway:experimental:description>\nMust consist of printable US-ASCII characters, optionally separated\nby single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2\n</gateway:experimental:description>\n\n<gateway:experimental:validation:Pattern=`^[!-~]+([\\t ]?[!-~]+)*$`>",
                                   "maxLength": 4096,
                                   "minLength": 1,
                                   "type": "string"
@@ -2816,7 +3293,7 @@
                                   "type": "string"
                                 },
                                 "value": {
-                                  "description": "Value is the value of HTTP Header to be matched.",
+                                  "description": "Value is the value of HTTP Header to be matched.\n<gateway:experimental:description>\nMust consist of printable US-ASCII characters, optionally separated\nby single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2\n</gateway:experimental:description>\n\n<gateway:experimental:validation:Pattern=`^[!-~]+([\\t ]?[!-~]+)*$`>",
                                   "maxLength": 4096,
                                   "minLength": 1,
                                   "type": "string"
@@ -2860,6 +3337,46 @@
                         "type": "object",
                         "additionalProperties": false
                       },
+                      "http2ProtocolOptions": {
+                        "description": "Http2ProtocolOptions configures downstream HTTP/2 behavior on the listener's\nHttpConnectionManager.\nSee here for more information: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/protocol.proto#config-core-v3-http2protocoloptions",
+                        "properties": {
+                          "initialConnectionWindowSize": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "description": "InitialConnectionWindowSize is similar to InitialStreamWindowSize, but for the connection level.\nSame range and default value as InitialStreamWindowSize.\nValues can be specified with units like \"64Ki\".",
+                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                            "x-kubernetes-int-or-string": true
+                          },
+                          "initialStreamWindowSize": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "description": "InitialStreamWindowSize is the initial window size for the stream.\nValid values range from 65535 (2^16 - 1, HTTP/2 default) to 2147483647 (2^31 - 1, HTTP/2 maximum).\nDefaults to 268435456 (256 * 1024 * 1024).\nValues can be specified with units like \"64Ki\".",
+                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                            "x-kubernetes-int-or-string": true
+                          },
+                          "maxConcurrentStreams": {
+                            "description": "The maximum number of concurrent streams that the connection can have.\nEnvoy defaults to 1024.",
+                            "format": "int32",
+                            "maximum": 2147483647,
+                            "minimum": 1,
+                            "type": "integer"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
                       "idleTimeout": {
                         "description": "IdleTimeout is the idle timeout for connnections.\nSee here for more information: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/protocol.proto#envoy-v3-api-msg-config-core-v3-httpprotocoloptions",
                         "type": "string",
@@ -2869,6 +3386,12 @@
                             "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
                           }
                         ]
+                      },
+                      "maxHeadersCount": {
+                        "description": "MaxHeadersCount sets the maximum number of headers allowed in a request.\nDownstream requests that exceed this limit will receive a 431 response for HTTP/1.x and a\nstream reset for HTTP/2. If unset, defaults to Envoy's built-in default of 100.\nSee here for more information: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/protocol.proto#envoy-v3-api-field-config-core-v3-httpprotocoloptions-max-headers-count",
+                        "format": "int32",
+                        "minimum": 1,
+                        "type": "integer"
                       },
                       "maxRequestHeadersKb": {
                         "description": "MaxRequestHeadersKb sets the maximum size of request headers that Envoy will accept.\nIf unset, the Envoy default is 60 KiB.\nSee here for more information: https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto#envoy-v3-api-field-extensions-filters-network-http-connection-manager-v3-httpconnectionmanager-max-request-headers-kb",
@@ -2894,6 +3417,10 @@
                         ],
                         "type": "string"
                       },
+                      "skipXFFAppend": {
+                        "description": "SkipXffAppend specifies whether to skip adding the downstream's remote IP address to the X-Forwarded-For HTTP header.\nNote: If omitted, this effectively will default to true when UseRemoteAddress is false, such that Envoy acts as a \"transparent proxy\".\nSee here for more information: https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto#envoy-v3-api-field-extensions-filters-network-http-connection-manager-v3-httpconnectionmanager-skip-xff-append",
+                        "type": "boolean"
+                      },
                       "streamIdleTimeout": {
                         "description": "StreamIdleTimeout is the idle timeout for HTTP streams.\nSee here for more information: https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto#envoy-v3-api-field-extensions-filters-network-http-connection-manager-v3-httpconnectionmanager-stream-idle-timeout",
                         "type": "string",
@@ -2903,6 +3430,14 @@
                             "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
                           }
                         ]
+                      },
+                      "stripHostPortMode": {
+                        "description": "StripHostPortMode determines whether, and under what conditions, Envoy will strip the port\nfrom the Host/authority header. StripMatchingHostPort strips the port only if it matches\nthe listener's own port. StripAnyHostPort strips the port unconditionally.\nSee here for more information: https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto#envoy-v3-api-field-extensions-filters-network-http-connection-manager-v3-httpconnectionmanager-strip-matching-host-port\nSee also: https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto#envoy-v3-api-field-extensions-filters-network-http-connection-manager-v3-httpconnectionmanager-strip-any-host-port",
+                        "enum": [
+                          "MatchingPort",
+                          "AnyPort"
+                        ],
+                        "type": "string"
                       },
                       "tracing": {
                         "description": "Tracing contains various settings for Envoy's OpenTelemetry tracer.\nSee here for more information: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/trace/v3/opentelemetry.proto.html",
@@ -3229,8 +3764,16 @@
                                       "minProperties": 1,
                                       "properties": {
                                         "environmentResourceDetector": {
-                                          "description": "EnvironmentResourceDetectorConfig specified the EnvironmentResourceDetector",
-                                          "type": "object"
+                                          "description": "EnvironmentResourceDetector sets OpenTelemetry resource attributes from the OTEL_RESOURCE_ATTRIBUTES\nenvironment variable in the Envoy container.\nDefault enabled if not set. If multiple are set, the last will take precedence.",
+                                          "properties": {
+                                            "enable": {
+                                              "default": true,
+                                              "description": "Enable controls whether the EnvironmentResourceDetector is used.",
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
                                         }
                                       },
                                       "type": "object",
@@ -3304,17 +3847,53 @@
                         "additionalProperties": false
                       },
                       "useRemoteAddress": {
-                        "description": "UseRemoteAddress determines whether to use the remote address for the original client.\nNote: If this field is omitted, it will fallback to the default value of 'true', which we set for all Envoy HCMs.\nThus, setting this explicitly to true is unnecessary (but will not cause any harm).\nWhen true, Envoy will use the remote address of the connection as the client address.\nWhen false, Envoy will use the X-Forwarded-For header to determine the client address.\nSee here for more information: https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto#envoy-v3-api-field-extensions-filters-network-http-connection-manager-v3-httpconnectionmanager-use-remote-address",
+                        "description": "UseRemoteAddress determines whether to use the remote address for the original client.\nNote: If this field is omitted, it will fallback to the default value of 'true', which we set for all Envoy HCMs.\nThus, setting this explicitly to true is unnecessary (but will not cause any harm).\nWhen true, Envoy will use the remote address of the connection as the client address.\nWhen false, Envoy will use the X-Forwarded-For header to determine the client address. Furthermore, SkipXffAppend will implicitly be set to true unless explicitly configured.\nSee here for more information: https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto#envoy-v3-api-field-extensions-filters-network-http-connection-manager-v3-httpconnectionmanager-use-remote-address",
                         "type": "boolean"
                       },
+                      "uuidRequestIdConfig": {
+                        "description": "UuidRequestIdConfig configures the behavior of the UUID request ID extension.\nThis extension sets the x-request-id header to a UUID value.",
+                        "properties": {
+                          "packTraceReason": {
+                            "description": "PackTraceReason determines if the trace sampling decision is embedded into the UUID.\nDefaults to true. Set to false to prevent Envoy from mutating the Request ID,\nwhich is useful when preserving exact UUIDs from external systems.",
+                            "type": "boolean"
+                          },
+                          "useRequestIdForTraceSampling": {
+                            "description": "UseRequestIDForTraceSampling determines if the Request ID is used to calculate the\ntrace sampling decision. Defaults to true. This ensures consistent sampling decisions\nfor a given Request ID across the mesh.",
+                            "type": "boolean"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
                       "xffNumTrustedHops": {
-                        "description": "XffNumTrustedHops is the number of additional ingress proxy hops from the right side of the X-Forwarded-For HTTP header to trust when determining the origin client's IP address.\nSee here for more information: https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto#envoy-v3-api-field-extensions-filters-network-http-connection-manager-v3-httpconnectionmanager-xff-num-trusted-hops",
+                        "description": "XffNumTrustedHops is the number of additional ingress proxy hops from the right side of the X-Forwarded-For HTTP header to trust when determining the origin client's IP address.\nThis is mutually exclusive with XffTrustedCIDRs.\nSee here for more information: https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto#envoy-v3-api-field-extensions-filters-network-http-connection-manager-v3-httpconnectionmanager-xff-num-trusted-hops",
                         "format": "int32",
                         "minimum": 0,
                         "type": "integer"
+                      },
+                      "xffTrustedCIDRs": {
+                        "description": "XffTrustedCIDRs are ranges of IPs that may appear in the X-Forwarded-For HTTP header and are trusted when determining the origin client's IP address.\nThis is mutually exclusive with XffNumTrustedHops and requires UseRemoteAddress to be set to false.\nSee here for more information: https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/http/original_ip_detection/xff/v3/xff.proto#envoy-v3-api-field-extensions-http-original-ip-detection-xff-v3-xffconfig-xff-trusted-cidrs",
+                        "items": {
+                          "description": "CIDR can be used wherever an address range in CIDR notation is expected.\nNote: The regex for the IP validation patterns was taken from https://www.ditig.com/validating-ipv4-and-ipv6-addresses-with-regexp",
+                          "format": "cidr",
+                          "pattern": "^((25[0-5]|(2[0-4]|1\\d|[1-9]|)\\d)\\.?\\b){4}\\/([0-9]|[1-2][0-9]|3[0-2])$|^((?:[0-9A-Fa-f]{1,4}:){7}[0-9A-Fa-f]{1,4}|(?:[0-9A-Fa-f]{1,4}:){1,7}:|:(?::[0-9A-Fa-f]{1,4}){1,7}|(?:[0-9A-Fa-f]{1,4}:){1,6}:[0-9A-Fa-f]{1,4}|(?:[0-9A-Fa-f]{1,4}:){1,5}(?::[0-9A-Fa-f]{1,4}){1,2}|(?:[0-9A-Fa-f]{1,4}:){1,4}(?::[0-9A-Fa-f]{1,4}){1,3}|(?:[0-9A-Fa-f]{1,4}:){1,3}(?::[0-9A-Fa-f]{1,4}){1,4}|(?:[0-9A-Fa-f]{1,4}:){1,2}(?::[0-9A-Fa-f]{1,4}){1,5}|[0-9A-Fa-f]{1,4}:(?:(?::[0-9A-Fa-f]{1,4}){1,6})|:(?:(?::[0-9A-Fa-f]{1,4}){1,6}))\\/(12[0-8]|1[0-1][0-9]|[1-9][0-9]|[0-9])$",
+                          "type": "string"
+                        },
+                        "minItems": 1,
+                        "type": "array"
                       }
                     },
                     "type": "object",
+                    "x-kubernetes-validations": [
+                      {
+                        "message": "useRemoteAddress must be set to false if xffTrustedCIDRs is set",
+                        "rule": "!has(self.xffTrustedCIDRs) || (has(self.useRemoteAddress) && !self.useRemoteAddress)"
+                      },
+                      {
+                        "message": "only one of xffNumTrustedHops and xffTrustedCIDRs may be set",
+                        "rule": "!has(self.xffNumTrustedHops) || !has(self.xffTrustedCIDRs)"
+                      }
+                    ],
                     "additionalProperties": false
                   },
                   "perConnectionBufferLimitBytes": {
@@ -3324,8 +3903,56 @@
                     "type": "integer"
                   },
                   "proxyProtocol": {
-                    "description": "ProxyProtocol configures the PROXY protocol listener filter.\nWhen set, Envoy will expect connections to include the PROXY protocol header.\nThis is commonly used when kgateway is behind a load balancer that preserves client IP information.\nSee here for more information: https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/listener/proxy_protocol/v3/proxy_protocol.proto",
-                    "type": "object"
+                    "description": "ProxyProtocol configures the PROXY protocol listener filter.\nBy default, when set, Envoy will require connections to include the PROXY\nprotocol header. This behavior can be relaxed by setting\nallowRequestsWithoutProxyProtocol to true, which allows the listener to\nalso accept connections without the PROXY protocol header.\nThis is commonly used when kgateway is behind a load balancer that preserves client IP information.\nSee here for more information: https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/listener/proxy_protocol/v3/proxy_protocol.proto",
+                    "properties": {
+                      "allowRequestsWithoutProxyProtocol": {
+                        "description": "AllowRequestsWithoutProxyProtocol, when true, configures the PROXY protocol\nlistener filter to accept connections that do not include a PROXY protocol\nheader in addition to those that do. This allows a single listener to serve\nmixed traffic, e.g. PROXY-preserving load balancer traffic plus direct\nin-cluster traffic on the same port.\n\nSecurity: accepting connections without a PROXY header is non-conformant\nwith the PROXY protocol spec and allows clients to spoof the perceived\nsource address. Only enable this when every source that can reach the\nlistener is trusted. See\nhttps://www.haproxy.org/download/2.1/doc/proxy-protocol.txt.\n\nDefaults to false.",
+                        "type": "boolean"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "tcpKeepalive": {
+                    "description": "TCPKeepalive configures OS-level TCP keepalive checks for downstream client connections accepted by this listener.",
+                    "properties": {
+                      "keepAliveInterval": {
+                        "description": "The number of seconds between keep-alive probes.",
+                        "type": "string",
+                        "x-kubernetes-validations": [
+                          {
+                            "message": "invalid duration value",
+                            "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                          },
+                          {
+                            "message": "keepAliveInterval must be at least 1 second",
+                            "rule": "duration(self) >= duration('1s')"
+                          }
+                        ]
+                      },
+                      "keepAliveProbes": {
+                        "description": "Maximum number of keep-alive probes to send before dropping the connection.",
+                        "format": "int32",
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "keepAliveTime": {
+                        "description": "The number of seconds a connection needs to be idle before keep-alive probes start being sent.",
+                        "type": "string",
+                        "x-kubernetes-validations": [
+                          {
+                            "message": "invalid duration value",
+                            "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                          },
+                          {
+                            "message": "keepAliveTime must be at least 1 second",
+                            "rule": "duration(self) >= duration('1s')"
+                          }
+                        ]
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
                   }
                 },
                 "type": "object",
@@ -3362,7 +3989,7 @@
         "targetRefs": {
           "description": "TargetRefs specifies the target resources by reference to attach the policy to.\nOnly supports `Gateway` resources",
           "items": {
-            "description": "Select the object to attach the policy by Group, Kind, and Name.\nThe object must be in the same namespace as the policy.\nYou can target only one object at a time.",
+            "description": "Select the object to attach the policy by Group, Kind, Name and SectionName.\nThe object must be in the same namespace as the policy.\nYou can target only one object at a time.",
             "properties": {
               "group": {
                 "description": "The API group of the target resource.\nFor Kubernetes Gateway API resources, the group is `gateway.networking.k8s.io`.",
@@ -3381,6 +4008,13 @@
                 "description": "The name of the target resource.",
                 "maxLength": 253,
                 "minLength": 1,
+                "type": "string"
+              },
+              "sectionName": {
+                "description": "The section name of the target resource.",
+                "maxLength": 253,
+                "minLength": 1,
+                "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
                 "type": "string"
               }
             },
@@ -3405,7 +4039,7 @@
         "targetSelectors": {
           "description": "TargetSelectors specifies the target selectors to select `Gateway` resources to attach the policy to.",
           "items": {
-            "description": "LocalPolicyTargetSelector selects the object to attach the policy by Group, Kind, and MatchLabels.\nThe object must be in the same namespace as the policy and match the\nspecified labels.\nDo not use targetSelectors when reconciliation times are critical, especially if you\nhave a large number of policies that target the same resource.\nInstead, use targetRefs to attach the policy.",
+            "description": "LocalPolicyTargetSelectorWithSectionName the object to attach the policy by Group, Kind, MatchLabels, and optionally SectionName.\nThe object must be in the same namespace as the policy and match the\nspecified labels.\nDo not use targetSelectors when reconciliation times are critical, especially if you\nhave a large number of policies that target the same resource.\nInstead, use targetRefs to attach the policy.",
             "properties": {
               "group": {
                 "description": "The API group of the target resource.\nFor Kubernetes Gateway API resources, the group is `gateway.networking.k8s.io`.",
@@ -3426,6 +4060,13 @@
                 },
                 "description": "Label selector to select the target resource.",
                 "type": "object"
+              },
+              "sectionName": {
+                "description": "The section name of the target resource.",
+                "maxLength": 253,
+                "minLength": 1,
+                "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                "type": "string"
               }
             },
             "required": [

--- a/gateway.kgateway.dev/trafficpolicy_v1alpha1.json
+++ b/gateway.kgateway.dev/trafficpolicy_v1alpha1.json
@@ -14,6 +14,117 @@
     "spec": {
       "description": "TrafficPolicySpec defines the desired state of a traffic policy.",
       "properties": {
+        "acl": {
+          "description": "ACL configures IP-based access control for HTTP requests.\nRules are evaluated using longest-prefix matching on the effictive client IP\nfrom envoy base on settings. See the UseRemoteAddress, XffTrustedCIDRs,\nXffNumTrustedHops settings under ListenerPolicy -> HttpSettings for details.",
+          "properties": {
+            "defaultAction": {
+              "description": "DefaultAction is the action to take when no rule matches the client IP.",
+              "enum": [
+                "allow",
+                "deny"
+              ],
+              "type": "string"
+            },
+            "denyResponse": {
+              "description": "DenyResponse customizes the HTTP response sent when a request is denied.",
+              "properties": {
+                "blockedByHeaderName": {
+                  "description": "BlockedByHeaderName, when set, adds a response header with this name on every deny.\nThe header value mirrors the blocked-by dynamic metadata: the matched rule's name,\n\"rule\" for an unnamed rule, or \"default\" for a default-action deny.",
+                  "maxLength": 256,
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "headers": {
+                  "description": "Headers are additional response headers to attach on every deny.",
+                  "items": {
+                    "description": "ACLResponseHeader defines a response header to include in deny responses.",
+                    "properties": {
+                      "name": {
+                        "description": "Name is the header name.",
+                        "maxLength": 256,
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "value": {
+                        "description": "Value is the header value.",
+                        "maxLength": 4096,
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "name",
+                      "value"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "maxItems": 16,
+                  "type": "array"
+                },
+                "statusCode": {
+                  "description": "StatusCode is the HTTP status code returned on deny. Defaults to 403.",
+                  "format": "int32",
+                  "maximum": 599,
+                  "minimum": 100,
+                  "type": "integer"
+                }
+              },
+              "type": "object",
+              "x-kubernetes-validations": [
+                {
+                  "message": "at least one of the fields in [statusCode headers blockedByHeaderName] must be set",
+                  "rule": "[has(self.statusCode),has(self.headers),has(self.blockedByHeaderName)].filter(x,x==true).size() >= 1"
+                }
+              ],
+              "additionalProperties": false
+            },
+            "rules": {
+              "description": "Rules is a list of IP/CIDR-based rules. Longest-prefix match wins regardless of rule order.",
+              "items": {
+                "description": "ACLRule defines an IP/CIDR-based ACL rule.",
+                "properties": {
+                  "action": {
+                    "description": "Action determines what to do when a client IP matches this rule.",
+                    "enum": [
+                      "allow",
+                      "deny"
+                    ],
+                    "type": "string"
+                  },
+                  "cidrs": {
+                    "description": "CIDRs is a list of IP addresses or CIDR ranges (e.g. \"10.0.0.0/8\", \"2001:db8::/32\", \"192.168.1.1\", \"::1\").\nBare IPs without a prefix are treated as /32 for IPv4 and /128 for IPv6.\nAll entries share the same name and action.",
+                    "items": {
+                      "description": "IPOrCIDR accepts either a bare IP address or an address range in CIDR notation.\nA bare IP without a prefix length is treated as /32 for IPv4 and /128 for IPv6.\nNote: The regex for the IP validation patterns was taken from https://www.ditig.com/validating-ipv4-and-ipv6-addresses-with-regexp",
+                      "pattern": "^((25[0-5]|(2[0-4]|1\\d|[1-9]|)\\d)\\.?\\b){4}(\\/([0-9]|[1-2][0-9]|3[0-2]))?$|^((?:[0-9A-Fa-f]{1,4}:){7}[0-9A-Fa-f]{1,4}|(?:[0-9A-Fa-f]{1,4}:){1,7}:|:(?::[0-9A-Fa-f]{1,4}){1,7}|(?:[0-9A-Fa-f]{1,4}:){1,6}:[0-9A-Fa-f]{1,4}|(?:[0-9A-Fa-f]{1,4}:){1,5}(?::[0-9A-Fa-f]{1,4}){1,2}|(?:[0-9A-Fa-f]{1,4}:){1,4}(?::[0-9A-Fa-f]{1,4}){1,3}|(?:[0-9A-Fa-f]{1,4}:){1,3}(?::[0-9A-Fa-f]{1,4}){1,4}|(?:[0-9A-Fa-f]{1,4}:){1,2}(?::[0-9A-Fa-f]{1,4}){1,5}|[0-9A-Fa-f]{1,4}:(?:(?::[0-9A-Fa-f]{1,4}){1,6})|:(?:(?::[0-9A-Fa-f]{1,4}){1,6}))(\\/(12[0-8]|1[0-1][0-9]|[1-9][0-9]|[0-9]))?$",
+                      "type": "string"
+                    },
+                    "maxItems": 256,
+                    "minItems": 1,
+                    "type": "array"
+                  },
+                  "name": {
+                    "description": "Name is an optional rule identifier emitted as blocked-by dynamic metadata on deny.",
+                    "maxLength": 256,
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "action",
+                  "cidrs"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "maxItems": 256,
+              "type": "array"
+            }
+          },
+          "required": [
+            "defaultAction"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
         "apiKeyAuth": {
           "description": "APIKeyAuth authenticates users based on a configured API Key.",
           "properties": {
@@ -269,7 +380,7 @@
               "type": "boolean"
             },
             "allowHeaders": {
-              "description": "AllowHeaders indicates which HTTP request headers are supported for\naccessing the requested resource.\n\nHeader names are not case sensitive.\n\nMultiple header names in the value of the `Access-Control-Allow-Headers`\nresponse header are separated by a comma (\",\").\n\nWhen the `AllowHeaders` field is configured with one or more headers, the\ngateway must return the `Access-Control-Allow-Headers` response header\nwhich value is present in the `AllowHeaders` field.\n\nIf any header name in the `Access-Control-Request-Headers` request header\nis not included in the list of header names specified by the response\nheader `Access-Control-Allow-Headers`, it will present an error on the\nclient side.\n\nIf any header name in the `Access-Control-Allow-Headers` response header\ndoes not recognize by the client, it will also occur an error on the\nclient side.\n\nA wildcard indicates that the requests with all HTTP headers are allowed.\nThe `Access-Control-Allow-Headers` response header can only use `*`\nwildcard as value when the `AllowCredentials` field is false or omitted.\n\nWhen the `AllowCredentials` field is true and `AllowHeaders` field\nspecified with the `*` wildcard, the gateway must specify one or more\nHTTP headers in the value of the `Access-Control-Allow-Headers` response\nheader. The value of the header `Access-Control-Allow-Headers` is same as\nthe `Access-Control-Request-Headers` header provided by the client. If\nthe header `Access-Control-Request-Headers` is not included in the\nrequest, the gateway will omit the `Access-Control-Allow-Headers`\nresponse header, instead of specifying the `*` wildcard. A Gateway\nimplementation may choose to add implementation-specific default headers.\n\nSupport: Extended",
+              "description": "AllowHeaders indicates which HTTP request headers are supported for\naccessing the requested resource.\n\nHeader names are not case-sensitive.\n\nMultiple header names in the value of the `Access-Control-Allow-Headers`\nresponse header are separated by a comma (\",\").\n\nWhen the `AllowHeaders` field is configured with one or more headers, the\ngateway must return the `Access-Control-Allow-Headers` response header\nwhich value is present in the `AllowHeaders` field.\n\nIf any header name in the `Access-Control-Request-Headers` request header\nis not included in the list of header names specified by the response\nheader `Access-Control-Allow-Headers`, it will present an error on the\nclient side.\n\nIf any header name in the `Access-Control-Allow-Headers` response header\ndoes not recognize by the client, it will also occur an error on the\nclient side.\n\nA wildcard indicates that the requests with all HTTP headers are allowed.\nIf config contains the wildcard \"*\" in allowHeaders and the request is\nnot credentialed, the `Access-Control-Allow-Headers` response header\ncan either use the `*` wildcard or the value of\nAccess-Control-Request-Headers from the request.\n\nWhen the request is credentialed, the gateway must not specify the `*`\nwildcard in the `Access-Control-Allow-Headers` response header. When\nalso the `AllowCredentials` field is true and `AllowHeaders` field\nis specified with the `*` wildcard, the gateway must specify one or more\nHTTP headers in the value of the `Access-Control-Allow-Headers` response\nheader. The value of the header `Access-Control-Allow-Headers` is same as\nthe `Access-Control-Request-Headers` header provided by the client. If\nthe header `Access-Control-Request-Headers` is not included in the\nrequest, the gateway will omit the `Access-Control-Allow-Headers`\nresponse header, instead of specifying the `*` wildcard.\n\nSupport: Extended",
               "items": {
                 "description": "HTTPHeaderName is the name of an HTTP header.\n\nValid values include:\n\n* \"Authorization\"\n* \"Set-Cookie\"\n\nInvalid values include:\n\n  - \":method\" - \":\" is an invalid character. This means that HTTP/2 pseudo\n    headers are not currently supported by this type.\n  - \"/invalid\" - \"/ \" is an invalid character",
                 "maxLength": 256,
@@ -279,10 +390,16 @@
               },
               "maxItems": 64,
               "type": "array",
-              "x-kubernetes-list-type": "set"
+              "x-kubernetes-list-type": "set",
+              "x-kubernetes-validations": [
+                {
+                  "message": "AllowHeaders cannot contain '*' alongside other headers",
+                  "rule": "!('*' in self && self.size() > 1)"
+                }
+              ]
             },
             "allowMethods": {
-              "description": "AllowMethods indicates which HTTP methods are supported for accessing the\nrequested resource.\n\nValid values are any method defined by RFC9110, along with the special\nvalue `*`, which represents all HTTP methods are allowed.\n\nMethod names are case sensitive, so these values are also case-sensitive.\n(See https://www.rfc-editor.org/rfc/rfc2616#section-5.1.1)\n\nMultiple method names in the value of the `Access-Control-Allow-Methods`\nresponse header are separated by a comma (\",\").\n\nA CORS-safelisted method is a method that is `GET`, `HEAD`, or `POST`.\n(See https://fetch.spec.whatwg.org/#cors-safelisted-method) The\nCORS-safelisted methods are always allowed, regardless of whether they\nare specified in the `AllowMethods` field.\n\nWhen the `AllowMethods` field is configured with one or more methods, the\ngateway must return the `Access-Control-Allow-Methods` response header\nwhich value is present in the `AllowMethods` field.\n\nIf the HTTP method of the `Access-Control-Request-Method` request header\nis not included in the list of methods specified by the response header\n`Access-Control-Allow-Methods`, it will present an error on the client\nside.\n\nThe `Access-Control-Allow-Methods` response header can only use `*`\nwildcard as value when the `AllowCredentials` field is false or omitted.\n\nWhen the `AllowCredentials` field is true and `AllowMethods` field\nspecified with the `*` wildcard, the gateway must specify one HTTP method\nin the value of the Access-Control-Allow-Methods response header. The\nvalue of the header `Access-Control-Allow-Methods` is same as the\n`Access-Control-Request-Method` header provided by the client. If the\nheader `Access-Control-Request-Method` is not included in the request,\nthe gateway will omit the `Access-Control-Allow-Methods` response header,\ninstead of specifying the `*` wildcard. A Gateway implementation may\nchoose to add implementation-specific default methods.\n\nSupport: Extended",
+              "description": "AllowMethods indicates which HTTP methods are supported for accessing the\nrequested resource.\n\nValid values are any method defined by RFC9110, along with the special\nvalue `*`, which represents all HTTP methods are allowed.\n\nMethod names are case-sensitive, so these values are also case-sensitive.\n(See https://www.rfc-editor.org/rfc/rfc2616#section-5.1.1)\n\nMultiple method names in the value of the `Access-Control-Allow-Methods`\nresponse header are separated by a comma (\",\").\n\nA CORS-safelisted method is a method that is `GET`, `HEAD`, or `POST`.\n(See https://fetch.spec.whatwg.org/#cors-safelisted-method) The\nCORS-safelisted methods are always allowed, regardless of whether they\nare specified in the `AllowMethods` field.\n\nWhen the `AllowMethods` field is configured with one or more methods, the\ngateway must return the `Access-Control-Allow-Methods` response header\nwhich value is present in the `AllowMethods` field.\n\nIf the HTTP method of the `Access-Control-Request-Method` request header\nis not included in the list of methods specified by the response header\n`Access-Control-Allow-Methods`, it will present an error on the client\nside.\n\nIf config contains the wildcard \"*\" in allowMethods and the request is\nnot credentialed, the `Access-Control-Allow-Methods` response header\ncan either use the `*` wildcard or the value of\nAccess-Control-Request-Method from the request.\n\nWhen the request is credentialed, the gateway must not specify the `*`\nwildcard in the `Access-Control-Allow-Methods` response header. When\nalso the `AllowCredentials` field is true and `AllowMethods` field\nspecified with the `*` wildcard, the gateway must specify one HTTP method\nin the value of the Access-Control-Allow-Methods response header. The\nvalue of the header `Access-Control-Allow-Methods` is same as the\n`Access-Control-Request-Method` header provided by the client. If the\nheader `Access-Control-Request-Method` is not included in the request,\nthe gateway will omit the `Access-Control-Allow-Methods` response header,\ninstead of specifying the `*` wildcard.\n\nSupport: Extended",
               "items": {
                 "enum": [
                   "GET",
@@ -309,12 +426,12 @@
               ]
             },
             "allowOrigins": {
-              "description": "AllowOrigins indicates whether the response can be shared with requested\nresource from the given `Origin`.\n\nThe `Origin` consists of a scheme and a host, with an optional port, and\ntakes the form `<scheme>://<host>(:<port>)`.\n\nValid values for scheme are: `http` and `https`.\n\nValid values for port are any integer between 1 and 65535 (the list of\navailable TCP/UDP ports). Note that, if not included, port `80` is\nassumed for `http` scheme origins, and port `443` is assumed for `https`\norigins. This may affect origin matching.\n\nThe host part of the origin may contain the wildcard character `*`. These\nwildcard characters behave as follows:\n\n* `*` is a greedy match to the _left_, including any number of\n  DNS labels to the left of its position. This also means that\n  `*` will include any number of period `.` characters to the\n  left of its position.\n* A wildcard by itself matches all hosts.\n\nAn origin value that includes _only_ the `*` character indicates requests\nfrom all `Origin`s are allowed.\n\nWhen the `AllowOrigins` field is configured with multiple origins, it\nmeans the server supports clients from multiple origins. If the request\n`Origin` matches the configured allowed origins, the gateway must return\nthe given `Origin` and sets value of the header\n`Access-Control-Allow-Origin` same as the `Origin` header provided by the\nclient.\n\nThe status code of a successful response to a \"preflight\" request is\nalways an OK status (i.e., 204 or 200).\n\nIf the request `Origin` does not match the configured allowed origins,\nthe gateway returns 204/200 response but doesn't set the relevant\ncross-origin response headers. Alternatively, the gateway responds with\n403 status to the \"preflight\" request is denied, coupled with omitting\nthe CORS headers. The cross-origin request fails on the client side.\nTherefore, the client doesn't attempt the actual cross-origin request.\n\nThe `Access-Control-Allow-Origin` response header can only use `*`\nwildcard as value when the `AllowCredentials` field is false or omitted.\n\nWhen the `AllowCredentials` field is true and `AllowOrigins` field\nspecified with the `*` wildcard, the gateway must return a single origin\nin the value of the `Access-Control-Allow-Origin` response header,\ninstead of specifying the `*` wildcard. The value of the header\n`Access-Control-Allow-Origin` is same as the `Origin` header provided by\nthe client.\n\nSupport: Extended",
+              "description": "AllowOrigins indicates whether the response can be shared with requested\nresource from the given `Origin`.\n\nThe `Origin` consists of a scheme and a host, with an optional port, and\ntakes the form `<scheme>://<host>(:<port>)`.\n\nValid values for scheme are: `http` and `https`.\n\nValid values for port are any integer between 1 and 65535 (the list of\navailable TCP/UDP ports). Note that, if not included, port `80` is\nassumed for `http` scheme origins, and port `443` is assumed for `https`\norigins. This may affect origin matching.\n\nThe host part of the origin may contain the wildcard character `*`. These\nwildcard characters behave as follows:\n\n* `*` is a greedy match to the _left_, including any number of\n  DNS labels to the left of its position. This also means that\n  `*` will include any number of period `.` characters to the\n  left of its position.\n* A wildcard by itself matches all hosts.\n\nAn origin value that includes _only_ the `*` character indicates requests\nfrom all `Origin`s are allowed.\n\nWhen the `AllowOrigins` field is configured with multiple origins, it\nmeans the server supports clients from multiple origins. If the request\n`Origin` matches the configured allowed origins, the gateway must return\nthe given `Origin` and sets value of the header\n`Access-Control-Allow-Origin` same as the `Origin` header provided by the\nclient.\n\nThe status code of a successful response to a \"preflight\" request is\nalways an OK status (i.e., 204 or 200).\n\nIf the request `Origin` does not match the configured allowed origins,\nthe gateway returns 204/200 response but doesn't set the relevant\ncross-origin response headers. Alternatively, the gateway responds with\n403 status to the \"preflight\" request is denied, coupled with omitting\nthe CORS headers. The cross-origin request fails on the client side.\nTherefore, the client doesn't attempt the actual cross-origin request.\n\nConversely, if the request `Origin` matches one of the configured\nallowed origins, the gateway sets the response header\n`Access-Control-Allow-Origin` to the same value as the `Origin`\nheader provided by the client.\n\nWhen config has the wildcard (\"*\") in allowOrigins, and the request\nis not credentialed (e.g., it is a preflight request), the\n`Access-Control-Allow-Origin` response header either contains the\nwildcard as well or the Origin from the request.\n\nWhen the request is credentialed, the gateway must not specify the `*`\nwildcard in the `Access-Control-Allow-Origin` response header. When\nalso the `AllowCredentials` field is true and `AllowOrigins` field\nspecified with the `*` wildcard, the gateway must return a single origin\nin the value of the `Access-Control-Allow-Origin` response header,\ninstead of specifying the `*` wildcard. The value of the header\n`Access-Control-Allow-Origin` is same as the `Origin` header provided by\nthe client.\n\nSupport: Extended",
               "items": {
-                "description": "The CORSOrigin MUST NOT be a relative URI, and it MUST follow the URI syntax and\nencoding rules specified in RFC3986.  The CORSOrigin MUST include both a\nscheme (e.g., \"http\" or \"spiffe\") and a scheme-specific-part, or it should be a single '*' character.\nURIs that include an authority MUST include a fully qualified domain name or\nIP address as the host.\n<gateway:util:excludeFromCRD> The below regex was generated to simplify the assertion of scheme://host:<port> being port optional </gateway:util:excludeFromCRD>",
+                "description": "The CORSOrigin MUST NOT be a relative URI, and it MUST follow the URI syntax and\nencoding rules specified in RFC3986.  The CORSOrigin MUST include both a\nscheme (\"http\" or \"https\") and a scheme-specific-part, or it should be a single '*' character.\nURIs that include an authority MUST include a fully qualified domain name or\nIP address as the host.",
                 "maxLength": 253,
                 "minLength": 1,
-                "pattern": "(^\\*$)|(^([a-zA-Z][a-zA-Z0-9+\\-.]+):\\/\\/([^:/?#]+)(:([0-9]{1,5}))?$)",
+                "pattern": "(^\\*$)|(^(http(s)?):\\/\\/(((\\*\\.)?([a-zA-Z0-9\\-]+\\.)*[a-zA-Z0-9-]+|\\*)(:([0-9]{1,5}))?)$)",
                 "type": "string"
               },
               "maxItems": 64,
@@ -332,7 +449,7 @@
               "type": "object"
             },
             "exposeHeaders": {
-              "description": "ExposeHeaders indicates which HTTP response headers can be exposed\nto client-side scripts in response to a cross-origin request.\n\nA CORS-safelisted response header is an HTTP header in a CORS response\nthat it is considered safe to expose to the client scripts.\nThe CORS-safelisted response headers include the following headers:\n`Cache-Control`\n`Content-Language`\n`Content-Length`\n`Content-Type`\n`Expires`\n`Last-Modified`\n`Pragma`\n(See https://fetch.spec.whatwg.org/#cors-safelisted-response-header-name)\nThe CORS-safelisted response headers are exposed to client by default.\n\nWhen an HTTP header name is specified using the `ExposeHeaders` field,\nthis additional header will be exposed as part of the response to the\nclient.\n\nHeader names are not case sensitive.\n\nMultiple header names in the value of the `Access-Control-Expose-Headers`\nresponse header are separated by a comma (\",\").\n\nA wildcard indicates that the responses with all HTTP headers are exposed\nto clients. The `Access-Control-Expose-Headers` response header can only\nuse `*` wildcard as value when the `AllowCredentials` field is false or omitted.\n\nSupport: Extended",
+              "description": "ExposeHeaders indicates which HTTP response headers can be exposed\nto client-side scripts in response to a cross-origin request.\n\nA CORS-safelisted response header is an HTTP header in a CORS response\nthat it is considered safe to expose to the client scripts.\nThe CORS-safelisted response headers include the following headers:\n`Cache-Control`\n`Content-Language`\n`Content-Length`\n`Content-Type`\n`Expires`\n`Last-Modified`\n`Pragma`\n(See https://fetch.spec.whatwg.org/#cors-safelisted-response-header-name)\nThe CORS-safelisted response headers are exposed to client by default.\n\nWhen an HTTP header name is specified using the `ExposeHeaders` field,\nthis additional header will be exposed as part of the response to the\nclient.\n\nHeader names are not case-sensitive.\n\nMultiple header names in the value of the `Access-Control-Expose-Headers`\nresponse header are separated by a comma (\",\").\n\nA wildcard indicates that the responses with all HTTP headers are exposed\nto clients. The `Access-Control-Expose-Headers` response header can only\nuse `*` wildcard as value when the request is not credentialed.\n\nWhen the `exposeHeaders` config field contains the \"*\" wildcard and\nthe request is credentialed, the gateway cannot use the `*` wildcard in\nthe `Access-Control-Expose-Headers` response header.\n\nSupport: Extended",
               "items": {
                 "description": "HTTPHeaderName is the name of an HTTP header.\n\nValid values include:\n\n* \"Authorization\"\n* \"Set-Cookie\"\n\nInvalid values include:\n\n  - \":method\" - \":\" is an invalid character. This means that HTTP/2 pseudo\n    headers are not currently supported by this type.\n  - \"/invalid\" - \"/ \" is an invalid character",
                 "maxLength": 256,
@@ -346,7 +463,7 @@
             },
             "maxAge": {
               "default": 5,
-              "description": "MaxAge indicates the duration (in seconds) for the client to cache the\nresults of a \"preflight\" request.\n\nThe information provided by the `Access-Control-Allow-Methods` and\n`Access-Control-Allow-Headers` response headers can be cached by the\nclient until the time specified by `Access-Control-Max-Age` elapses.\n\nThe default value of `Access-Control-Max-Age` response header is 5\n(seconds).",
+              "description": "MaxAge indicates the duration (in seconds) for the client to cache the\nresults of a \"preflight\" request.\n\nThe information provided by the `Access-Control-Allow-Methods` and\n`Access-Control-Allow-Headers` response headers can be cached by the\nclient until the time specified by `Access-Control-Max-Age` elapses.\n\nThe default value of `Access-Control-Max-Age` response header is 5\n(seconds).\n\nWhen the `MaxAge` field is unspecified, the gateway sets the response\nheader \"Access-Control-Max-Age: 5\" by default.",
               "format": "int32",
               "minimum": 1,
               "type": "integer"
@@ -609,6 +726,124 @@
           ],
           "additionalProperties": false
         },
+        "faultInjection": {
+          "description": "FaultInjection configures fault injection for chaos engineering and\nresiliency testing. Supports delay injection, abort injection,\nand response rate limiting.",
+          "properties": {
+            "abort": {
+              "description": "Abort injects HTTP or gRPC errors to terminate requests early.",
+              "properties": {
+                "grpcStatus": {
+                  "description": "GrpcStatus is the gRPC status code to return when aborting a request.",
+                  "format": "int32",
+                  "maximum": 16,
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "httpStatus": {
+                  "description": "HttpStatus is the HTTP status code to return when aborting a request.",
+                  "format": "int32",
+                  "maximum": 599,
+                  "minimum": 200,
+                  "type": "integer"
+                },
+                "percentage": {
+                  "default": 100,
+                  "description": "Percentage of requests to abort. Defaults to 100.",
+                  "format": "int32",
+                  "maximum": 100,
+                  "minimum": 0,
+                  "type": "integer"
+                }
+              },
+              "type": "object",
+              "x-kubernetes-validations": [
+                {
+                  "message": "exactly one of the fields in [httpStatus grpcStatus] must be set",
+                  "rule": "[has(self.httpStatus),has(self.grpcStatus)].filter(x,x==true).size() == 1"
+                }
+              ],
+              "additionalProperties": false
+            },
+            "delay": {
+              "description": "Delay injects latency into requests before forwarding upstream.",
+              "properties": {
+                "fixedDelay": {
+                  "description": "FixedDelay is the duration to delay before forwarding the request.",
+                  "type": "string",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "invalid duration value",
+                      "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                    },
+                    {
+                      "message": "must be at least 1ms",
+                      "rule": "duration(self) >= duration('1ms')"
+                    },
+                    {
+                      "message": "must not exceed 1h",
+                      "rule": "duration(self) <= duration('1h')"
+                    }
+                  ]
+                },
+                "percentage": {
+                  "default": 100,
+                  "description": "Percentage of requests to inject the delay on. Defaults to 100.",
+                  "format": "int32",
+                  "maximum": 100,
+                  "minimum": 0,
+                  "type": "integer"
+                }
+              },
+              "required": [
+                "fixedDelay"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "disable": {
+              "description": "Disable the fault injection filter.\nCan be used to disable fault injection policies applied at a higher level\nin the config hierarchy.",
+              "type": "object"
+            },
+            "maxActiveFaults": {
+              "description": "MaxActiveFaults limits the number of concurrent active faults.\nWhen this limit is reached, new requests will not have faults injected.\nIf not specified, defaults to unlimited.",
+              "format": "int32",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "responseRateLimit": {
+              "description": "ResponseRateLimit limits the response body data rate to simulate\nslow or degraded upstream connections.",
+              "properties": {
+                "kbitsPerSecond": {
+                  "description": "KbitsPerSecond limits the response rate to the specified kilobits per second.",
+                  "format": "int64",
+                  "minimum": 1,
+                  "type": "integer"
+                },
+                "percentage": {
+                  "default": 100,
+                  "description": "Percentage of requests to apply the rate limit on. Defaults to 100.",
+                  "format": "int32",
+                  "maximum": 100,
+                  "minimum": 0,
+                  "type": "integer"
+                }
+              },
+              "required": [
+                "kbitsPerSecond"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "x-kubernetes-validations": [
+            {
+              "message": "at least one of the fields in [delay abort responseRateLimit disable] must be set",
+              "rule": "[has(self.delay),has(self.abort),has(self.responseRateLimit),has(self.disable)].filter(x,x==true).size() >= 1"
+            }
+          ],
+          "additionalProperties": false
+        },
         "headerModifiers": {
           "description": "HeaderModifiers defines the policy to modify request and response headers.",
           "properties": {
@@ -628,7 +863,7 @@
                         "type": "string"
                       },
                       "value": {
-                        "description": "Value is the value of HTTP Header to be matched.",
+                        "description": "Value is the value of HTTP Header to be matched.\n<gateway:experimental:description>\nMust consist of printable US-ASCII characters, optionally separated\nby single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2\n</gateway:experimental:description>\n\n<gateway:experimental:validation:Pattern=`^[!-~]+([\\t ]?[!-~]+)*$`>",
                         "maxLength": 4096,
                         "minLength": 1,
                         "type": "string"
@@ -670,7 +905,7 @@
                         "type": "string"
                       },
                       "value": {
-                        "description": "Value is the value of HTTP Header to be matched.",
+                        "description": "Value is the value of HTTP Header to be matched.\n<gateway:experimental:description>\nMust consist of printable US-ASCII characters, optionally separated\nby single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2\n</gateway:experimental:description>\n\n<gateway:experimental:validation:Pattern=`^[!-~]+([\\t ]?[!-~]+)*$`>",
                         "maxLength": 4096,
                         "minLength": 1,
                         "type": "string"
@@ -710,7 +945,7 @@
                         "type": "string"
                       },
                       "value": {
-                        "description": "Value is the value of HTTP Header to be matched.",
+                        "description": "Value is the value of HTTP Header to be matched.\n<gateway:experimental:description>\nMust consist of printable US-ASCII characters, optionally separated\nby single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2\n</gateway:experimental:description>\n\n<gateway:experimental:validation:Pattern=`^[!-~]+([\\t ]?[!-~]+)*$`>",
                         "maxLength": 4096,
                         "minLength": 1,
                         "type": "string"
@@ -752,7 +987,7 @@
                         "type": "string"
                       },
                       "value": {
-                        "description": "Value is the value of HTTP Header to be matched.",
+                        "description": "Value is the value of HTTP Header to be matched.\n<gateway:experimental:description>\nMust consist of printable US-ASCII characters, optionally separated\nby single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2\n</gateway:experimental:description>\n\n<gateway:experimental:validation:Pattern=`^[!-~]+([\\t ]?[!-~]+)*$`>",
                         "maxLength": 4096,
                         "minLength": 1,
                         "type": "string"
@@ -971,6 +1206,20 @@
             "local": {
               "description": "Local defines a local rate limiting policy.",
               "properties": {
+                "percentEnabled": {
+                  "description": "PercentEnabled specifies the percentage of requests for which the rate limiter is enabled.",
+                  "format": "int32",
+                  "maximum": 100,
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "percentEnforced": {
+                  "description": "PercentEnforced specifies the percentage of requests for which the rate limiter is enforced.",
+                  "format": "int32",
+                  "maximum": 100,
+                  "minimum": 0,
+                  "type": "integer"
+                },
                 "tokenBucket": {
                   "description": "TokenBucket represents the configuration for a token bucket local rate-limiting mechanism.\nIt defines the parameters for controlling the rate at which requests are allowed.",
                   "properties": {
@@ -1059,7 +1308,7 @@
           "additionalProperties": false
         },
         "retry": {
-          "description": "Retry defines the policy for retrying requests.\nIt is applicable to HTTPRoutes, Gateway listeners and XListenerSets, and ignored for other targeted kinds.",
+          "description": "Retry defines the policy for retrying requests.\nIt is applicable to HTTPRoutes, Gateway listeners and ListenerSets, and ignored for other targeted kinds.",
           "properties": {
             "attempts": {
               "default": 1,
@@ -1126,7 +1375,7 @@
             "statusCodes": {
               "description": "StatusCodes specifies the HTTP status codes in the range 400-599 that should be retried in addition\nto the conditions specified in RetryOn.",
               "items": {
-                "description": "HTTPRouteRetryStatusCode defines an HTTP response status code for\nwhich a backend request should be retried.\n\nImplementations MUST support the following status codes as retryable:\n\n* 500\n* 502\n* 503\n* 504\n\nImplementations MAY support specifying additional discrete values in the\n500-599 range.\n\nImplementations MAY support specifying discrete values in the 400-499 range,\nwhich are often inadvisable to retry.\n\n<gateway:experimental>",
+                "description": "HTTPRouteRetryStatusCode defines an HTTP response status code for\nwhich a backend request should be retried.\n\nImplementations MUST support the following status codes as retriable:\n\n* 500\n* 502\n* 503\n* 504\n\nImplementations MAY support specifying additional discrete values in the\n500-599 range.\n\nImplementations MAY support specifying discrete values in the 400-499 range,\nwhich are often inadvisable to retry.\n\n<gateway:experimental>",
                 "maximum": 599,
                 "minimum": 400,
                 "type": "integer"
@@ -1189,8 +1438,8 @@
           "type": "array",
           "x-kubernetes-validations": [
             {
-              "message": "targetRefs may only reference Gateway, HTTPRoute, or ListenerSet resources",
-              "rule": "self.all(r, (r.kind == 'Gateway' || r.kind == 'HTTPRoute' || r.kind.endsWith('ListenerSet')))"
+              "message": "targetRefs may only reference Gateway, HTTPRoute, GRPCRoute, or ListenerSet resources",
+              "rule": "self.all(r, (r.kind == 'Gateway' || r.kind == 'HTTPRoute' || r.kind == 'GRPCRoute' || r.kind.endsWith('ListenerSet')))"
             }
           ]
         },
@@ -1238,8 +1487,8 @@
           "type": "array",
           "x-kubernetes-validations": [
             {
-              "message": "targetSelectors may only reference Gateway, HTTPRoute, or ListenerSet resources",
-              "rule": "self.all(r, (r.kind == 'Gateway' || r.kind == 'HTTPRoute' || r.kind.endsWith('ListenerSet')))"
+              "message": "targetSelectors may only reference Gateway, HTTPRoute, GRPCRoute, or ListenerSet resources",
+              "rule": "self.all(r, (r.kind == 'Gateway' || r.kind == 'HTTPRoute' || r.kind == 'GRPCRoute' || r.kind.endsWith('ListenerSet')))"
             }
           ]
         },
@@ -1270,6 +1519,173 @@
           "type": "object",
           "additionalProperties": false
         },
+        "tracing": {
+          "description": "Tracing configures per-route tracing overrides.\nThese settings override the listener-level tracing configuration\n(configured via ListenerPolicy) for matched routes.\nThe tracing provider (e.g., OpenTelemetry collector endpoint) must be\nconfigured at the listener level via ListenerPolicy. Without a listener-level\ntracing provider, route-level settings have no effect.\nNOTE: This field is only honored for HTTPRoute and GRPCRoute targets.",
+          "properties": {
+            "attributes": {
+              "description": "Additional attributes to add to active spans for this route.\nThese are merged with listener-level attributes configured via ListenerPolicy.\nOn name collision, route-level attributes take priority.",
+              "items": {
+                "description": "Describes attributes for the active span.\nRef: https://www.envoyproxy.io/docs/envoy/latest/api-v3/type/tracing/v3/custom_tag.proto#envoy-v3-api-msg-type-tracing-v3-customtag",
+                "maxProperties": 2,
+                "minProperties": 1,
+                "properties": {
+                  "environment": {
+                    "description": "An environment attribute value.",
+                    "properties": {
+                      "defaultValue": {
+                        "description": "When the environment variable is not found, the attribute value will be populated with this default value if specified,\notherwise no attribute will be populated.",
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "Environment variable name to obtain the value to populate the attribute value.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "name"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "literal": {
+                    "description": "A literal attribute value.",
+                    "properties": {
+                      "value": {
+                        "description": "Static literal value to populate the attribute value.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "value"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "metadata": {
+                    "description": "An attribute to obtain the value from the metadata.",
+                    "properties": {
+                      "defaultValue": {
+                        "description": "When no valid metadata is found, the attribute value would be populated with this default value if specified, otherwise no attribute would be populated.",
+                        "type": "string"
+                      },
+                      "kind": {
+                        "description": "Specify what kind of metadata to obtain attribute value from",
+                        "enum": [
+                          "Request",
+                          "Route",
+                          "Cluster",
+                          "Host"
+                        ],
+                        "type": "string"
+                      },
+                      "metadataKey": {
+                        "description": "Metadata key to define the path to retrieve the attribute value.",
+                        "properties": {
+                          "key": {
+                            "description": "The key name of the Metadata from which to retrieve the Struct",
+                            "type": "string"
+                          },
+                          "path": {
+                            "description": "The path used to retrieve a specific Value from the Struct. This can be either a prefix or a full path,\ndepending on the use case",
+                            "items": {
+                              "description": "Specifies a segment in a path for retrieving values from Metadata.",
+                              "properties": {
+                                "key": {
+                                  "description": "The key used to retrieve the value in the struct",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "required": [
+                          "key",
+                          "path"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "required": [
+                      "kind",
+                      "metadataKey"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "name": {
+                    "description": "The name of the attribute",
+                    "type": "string"
+                  },
+                  "requestHeader": {
+                    "description": "A request header attribute value.",
+                    "properties": {
+                      "defaultValue": {
+                        "description": "When the header does not exist, the attribute value will be populated with this default value if specified,\notherwise no attribute will be populated.",
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "Header name to obtain the value to populate the attribute value.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "name"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  }
+                },
+                "required": [
+                  "name"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "maxItems": 16,
+              "type": "array"
+            },
+            "clientSampling": {
+              "description": "Target percentage of requests that will be force traced if the\nx-client-trace-id header is set. Overrides the listener-level setting.",
+              "format": "int32",
+              "maximum": 100,
+              "minimum": 0,
+              "type": "integer"
+            },
+            "disable": {
+              "description": "Disable tracing for this route.\nCan be used to disable tracing for specific routes when listener-level\ntracing is configured via ListenerPolicy.",
+              "type": "object"
+            },
+            "overallSampling": {
+              "description": "Target percentage of requests that will be traced after all other\nsampling checks have been applied. This acts as an upper limit on\nthe total configured sampling rate. Overrides the listener-level setting.",
+              "format": "int32",
+              "maximum": 100,
+              "minimum": 0,
+              "type": "integer"
+            },
+            "randomSampling": {
+              "description": "Target percentage of requests that will be randomly selected for\ntrace generation. Overrides the listener-level setting.",
+              "format": "int32",
+              "maximum": 100,
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          "type": "object",
+          "x-kubernetes-validations": [
+            {
+              "message": "disable is mutually exclusive with other tracing fields",
+              "rule": "!has(self.disable) || (!has(self.clientSampling) && !has(self.randomSampling) && !has(self.overallSampling) && !has(self.attributes))"
+            }
+          ],
+          "additionalProperties": false
+        },
         "transformation": {
           "description": "Transformation is used to mutate and transform requests and responses\nbefore forwarding them to the destination.",
           "properties": {
@@ -1277,7 +1693,7 @@
               "description": "Request is used to modify the request path.",
               "properties": {
                 "add": {
-                  "description": "Add is a list of headers to add to the request and what that value should be set to.\nIf there is already a header with these values then append the value as an extra entry.\nAdd is not supported on arm64 build, see https://github.com/kgateway-dev/kgateway/blob/v2.2.x/docs/guides/transformation.md for details",
+                  "description": "Add is a list of headers to add to the request and what that value should be set to.\nIf there is already a header with these values then append the value as an extra entry.\nAdd is not supported on arm64 build, see docs/guides/transformation.md for details",
                   "items": {
                     "properties": {
                       "name": {
@@ -1307,20 +1723,69 @@
                   "properties": {
                     "parseAs": {
                       "default": "AsString",
-                      "description": "ParseAs defines what auto formatting should be applied to the body.\nThis can make interacting with keys within a json body much easier if AsJson is selected.",
+                      "description": "ParseAs defines what auto formatting should be applied to the body.\nThis can make interacting with keys within a json body much easier if AsJson is selected.\nWhen set to None, it will not buffer the body and will skip all body processing. In\naddition, attempt to extract json variables from the body using inja template in the header\nwill result in 400 response.",
                       "enum": [
                         "AsString",
-                        "AsJson"
+                        "AsJson",
+                        "None"
                       ],
                       "type": "string"
                     },
                     "value": {
-                      "description": "Value is the template to apply to generate the output value for the body.\nOnly Inja templates are supported.",
+                      "description": "Value is the template to apply to generate the output value for the body.\nOnly Inja templates are supported. If ParseAs field is set to None,\nthis Value field is ignored and no body transformation will be done.",
                       "type": "string"
                     }
                   },
                   "type": "object",
                   "additionalProperties": false
+                },
+                "dynamicMetadata": {
+                  "description": "DynamicMetadata is a list of dynamic metadata entries to set.\nThe values are stored in Envoy dynamic metadata and can be used in access log\ntemplates or consumed by other filters down the chain.",
+                  "items": {
+                    "description": "DynamicMetadataTransformation defines a single dynamic metadata entry to set.",
+                    "properties": {
+                      "key": {
+                        "description": "Key is the metadata key within the namespace.",
+                        "maxLength": 256,
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "namespace": {
+                        "description": "Namespace is the dynamic metadata namespace.",
+                        "maxLength": 256,
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "value": {
+                        "description": "Value is the value to set in dynamic metadata.",
+                        "properties": {
+                          "stringValue": {
+                            "description": "StringValue is an Inja template whose rendered output is stored as the metadata string value.",
+                            "minLength": 1,
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-validations": [
+                          {
+                            "message": "exactly one of the fields in [stringValue] must be set",
+                            "rule": "[has(self.stringValue)].filter(x,x==true).size() == 1"
+                          }
+                        ],
+                        "additionalProperties": false
+                      }
+                    },
+                    "required": [
+                      "key",
+                      "namespace",
+                      "value"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "maxItems": 16,
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
                 },
                 "remove": {
                   "description": "Remove is a list of header names to remove from the request/response.",
@@ -1365,7 +1830,7 @@
               "description": "Response is used to modify the response path.",
               "properties": {
                 "add": {
-                  "description": "Add is a list of headers to add to the request and what that value should be set to.\nIf there is already a header with these values then append the value as an extra entry.\nAdd is not supported on arm64 build, see https://github.com/kgateway-dev/kgateway/blob/v2.2.x/docs/guides/transformation.md for details",
+                  "description": "Add is a list of headers to add to the request and what that value should be set to.\nIf there is already a header with these values then append the value as an extra entry.\nAdd is not supported on arm64 build, see docs/guides/transformation.md for details",
                   "items": {
                     "properties": {
                       "name": {
@@ -1395,20 +1860,69 @@
                   "properties": {
                     "parseAs": {
                       "default": "AsString",
-                      "description": "ParseAs defines what auto formatting should be applied to the body.\nThis can make interacting with keys within a json body much easier if AsJson is selected.",
+                      "description": "ParseAs defines what auto formatting should be applied to the body.\nThis can make interacting with keys within a json body much easier if AsJson is selected.\nWhen set to None, it will not buffer the body and will skip all body processing. In\naddition, attempt to extract json variables from the body using inja template in the header\nwill result in 400 response.",
                       "enum": [
                         "AsString",
-                        "AsJson"
+                        "AsJson",
+                        "None"
                       ],
                       "type": "string"
                     },
                     "value": {
-                      "description": "Value is the template to apply to generate the output value for the body.\nOnly Inja templates are supported.",
+                      "description": "Value is the template to apply to generate the output value for the body.\nOnly Inja templates are supported. If ParseAs field is set to None,\nthis Value field is ignored and no body transformation will be done.",
                       "type": "string"
                     }
                   },
                   "type": "object",
                   "additionalProperties": false
+                },
+                "dynamicMetadata": {
+                  "description": "DynamicMetadata is a list of dynamic metadata entries to set.\nThe values are stored in Envoy dynamic metadata and can be used in access log\ntemplates or consumed by other filters down the chain.",
+                  "items": {
+                    "description": "DynamicMetadataTransformation defines a single dynamic metadata entry to set.",
+                    "properties": {
+                      "key": {
+                        "description": "Key is the metadata key within the namespace.",
+                        "maxLength": 256,
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "namespace": {
+                        "description": "Namespace is the dynamic metadata namespace.",
+                        "maxLength": 256,
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "value": {
+                        "description": "Value is the value to set in dynamic metadata.",
+                        "properties": {
+                          "stringValue": {
+                            "description": "StringValue is an Inja template whose rendered output is stored as the metadata string value.",
+                            "minLength": 1,
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-validations": [
+                          {
+                            "message": "exactly one of the fields in [stringValue] must be set",
+                            "rule": "[has(self.stringValue)].filter(x,x==true).size() == 1"
+                          }
+                        ],
+                        "additionalProperties": false
+                      }
+                    },
+                    "required": [
+                      "key",
+                      "namespace",
+                      "value"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "maxItems": 16,
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
                 },
                 "remove": {
                   "description": "Remove is a list of header names to remove from the request/response.",
@@ -1495,6 +2009,10 @@
         {
           "message": "autoHostRewrite can only be used when targeting HTTPRoute resources",
           "rule": "!has(self.autoHostRewrite) || ((has(self.targetRefs) && self.targetRefs.all(r, r.kind == 'HTTPRoute')) || (has(self.targetSelectors) && self.targetSelectors.all(r, r.kind == 'HTTPRoute')))"
+        },
+        {
+          "message": "tracing can only be used when targeting HTTPRoute or GRPCRoute resources",
+          "rule": "!has(self.tracing) || ((has(self.targetRefs) && self.targetRefs.all(r, r.kind == 'HTTPRoute' || r.kind == 'GRPCRoute')) || (has(self.targetSelectors) && self.targetSelectors.all(r, r.kind == 'HTTPRoute' || r.kind == 'GRPCRoute')))"
         },
         {
           "message": "retry.perTryTimeout must be less than timeouts.request",


### PR DESCRIPTION
These versions correspond to kgateway version 2.3.4 (https://github.com/kgateway-dev/kgateway/tree/v2.3.4/install/helm/kgateway-crds/templates)
## PR Checklist

- [x] I generated these CRs using the [CRD Extractor tool](https://github.com/datreeio/CRDs-catalog?tab=readme-ov-file#crd-extractor). If I used a different method, I have described the method in this PR.
- [x] I am updating existing schemas and have specified the updated schema version.
- [ ] I am adding new schemas and included a link to the GitHub repository that contains the source of these schemas.
