### PR TITLE
Add cluster-api-provider-openstack (CAPO) resources at v0.14.4

### DIFF
--- a/infrastructure.cluster.x-k8s.io/openstackcluster_v1beta1.json
+++ b/infrastructure.cluster.x-k8s.io/openstackcluster_v1beta1.json
@@ -1,0 +1,2596 @@
+{
+  "description": "OpenStackCluster is the Schema for the openstackclusters API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "OpenStackClusterSpec defines the desired state of OpenStackCluster.",
+      "properties": {
+        "apiServerFixedIP": {
+          "description": "APIServerFixedIP is the fixed IP which will be associated with the API server.\nIn the case where the API server has a floating IP but not a managed load balancer,\nthis field is not used.\nIf a managed load balancer is used and this field is not specified, a fixed IP will\nbe dynamically allocated for the load balancer.\nIf a managed load balancer is not used AND the API server floating IP is disabled,\nthis field MUST be specified and should correspond to a pre-allocated port that\nholds the fixed IP to be used as a VIP.",
+          "type": "string"
+        },
+        "apiServerFloatingIP": {
+          "description": "APIServerFloatingIP is the floatingIP which will be associated with the API server.\nThe floatingIP will be created if it does not already exist.\nIf not specified, a new floatingIP is allocated.\nThis field is not used if DisableAPIServerFloatingIP is set to true.",
+          "type": "string"
+        },
+        "apiServerLoadBalancer": {
+          "description": "APIServerLoadBalancer configures the optional LoadBalancer for the APIServer.\nIf not specified, no load balancer will be created for the API server.",
+          "properties": {
+            "additionalPorts": {
+              "description": "AdditionalPorts adds additional tcp ports to the load balancer.",
+              "items": {
+                "type": "integer"
+              },
+              "type": "array",
+              "x-kubernetes-list-type": "set"
+            },
+            "allowedCIDRs": {
+              "description": "AllowedCIDRs restrict access to all API-Server listeners to the given address CIDRs.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array",
+              "x-kubernetes-list-type": "set"
+            },
+            "availabilityZone": {
+              "description": "AvailabilityZone is the failure domain that will be used to create the APIServerLoadBalancer Spec.",
+              "type": "string"
+            },
+            "enabled": {
+              "default": true,
+              "description": "Enabled defines whether a load balancer should be created. This value\ndefaults to true if an APIServerLoadBalancer is given.\n\nThere is no reason to set this to false. To disable creation of the\nAPI server loadbalancer, omit the APIServerLoadBalancer field in the\ncluster spec instead.",
+              "type": "boolean"
+            },
+            "flavor": {
+              "description": "Flavor is the flavor name that will be used to create the APIServerLoadBalancer Spec.",
+              "type": "string"
+            },
+            "monitor": {
+              "description": "Monitor contains configuration for the load balancer health monitor.",
+              "properties": {
+                "delay": {
+                  "description": "Delay is the time in seconds between sending probes to members.",
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "maxRetries": {
+                  "description": "MaxRetries is the number of successful checks before changing the operating status of the member to ONLINE.",
+                  "maximum": 10,
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "maxRetriesDown": {
+                  "description": "MaxRetriesDown is the number of allowed check failures before changing the operating status of the member to ERROR.",
+                  "maximum": 10,
+                  "minimum": 1,
+                  "type": "integer"
+                },
+                "timeout": {
+                  "description": "Timeout is the maximum time in seconds for a monitor to wait for a connection to be established before it times out.",
+                  "minimum": 0,
+                  "type": "integer"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "network": {
+              "description": "Network defines which network should the load balancer be allocated on.",
+              "maxProperties": 1,
+              "minProperties": 1,
+              "properties": {
+                "filter": {
+                  "description": "Filter specifies a filter to select an OpenStack network. If provided, cannot be empty.",
+                  "minProperties": 1,
+                  "properties": {
+                    "description": {
+                      "type": "string"
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "notTags": {
+                      "description": "NotTags is a list of tags to filter by. If specified, resources which\ncontain all of the given tags will be excluded from the result.",
+                      "items": {
+                        "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                        "minLength": 1,
+                        "pattern": "^[^,]+$",
+                        "type": "string"
+                      },
+                      "type": "array",
+                      "x-kubernetes-list-type": "set"
+                    },
+                    "notTagsAny": {
+                      "description": "NotTagsAny is a list of tags to filter by. If specified, resources\nwhich contain any of the given tags will be excluded from the result.",
+                      "items": {
+                        "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                        "minLength": 1,
+                        "pattern": "^[^,]+$",
+                        "type": "string"
+                      },
+                      "type": "array",
+                      "x-kubernetes-list-type": "set"
+                    },
+                    "projectID": {
+                      "type": "string"
+                    },
+                    "tags": {
+                      "description": "Tags is a list of tags to filter by. If specified, the resource must\nhave all of the tags specified to be included in the result.",
+                      "items": {
+                        "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                        "minLength": 1,
+                        "pattern": "^[^,]+$",
+                        "type": "string"
+                      },
+                      "type": "array",
+                      "x-kubernetes-list-type": "set"
+                    },
+                    "tagsAny": {
+                      "description": "TagsAny is a list of tags to filter by. If specified, the resource\nmust have at least one of the tags specified to be included in the\nresult.",
+                      "items": {
+                        "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                        "minLength": 1,
+                        "pattern": "^[^,]+$",
+                        "type": "string"
+                      },
+                      "type": "array",
+                      "x-kubernetes-list-type": "set"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "id": {
+                  "description": "ID is the ID of the network to use. If ID is provided, the other filters cannot be provided. Must be in UUID format.",
+                  "format": "uuid",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "provider": {
+              "description": "Provider specifies name of a specific Octavia provider to use for the\nAPI load balancer. The Octavia default will be used if it is not\nspecified.",
+              "type": "string"
+            },
+            "subnets": {
+              "description": "Subnets define which subnets should the load balancer be allocated on.\nIt is expected that subnets are located on the network specified in this resource.\nOnly the first element is taken into account.\nkubebuilder:validation:MaxLength:=2",
+              "items": {
+                "description": "SubnetParam specifies an OpenStack subnet to use. It may be specified by either ID or filter, but not both.",
+                "maxProperties": 1,
+                "minProperties": 1,
+                "properties": {
+                  "filter": {
+                    "description": "Filter specifies a filter to select the subnet. It must match exactly one subnet.",
+                    "minProperties": 1,
+                    "properties": {
+                      "cidr": {
+                        "type": "string"
+                      },
+                      "description": {
+                        "type": "string"
+                      },
+                      "gatewayIP": {
+                        "type": "string"
+                      },
+                      "ipVersion": {
+                        "type": "integer"
+                      },
+                      "ipv6AddressMode": {
+                        "type": "string"
+                      },
+                      "ipv6RAMode": {
+                        "type": "string"
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "notTags": {
+                        "description": "NotTags is a list of tags to filter by. If specified, resources which\ncontain all of the given tags will be excluded from the result.",
+                        "items": {
+                          "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                          "minLength": 1,
+                          "pattern": "^[^,]+$",
+                          "type": "string"
+                        },
+                        "type": "array",
+                        "x-kubernetes-list-type": "set"
+                      },
+                      "notTagsAny": {
+                        "description": "NotTagsAny is a list of tags to filter by. If specified, resources\nwhich contain any of the given tags will be excluded from the result.",
+                        "items": {
+                          "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                          "minLength": 1,
+                          "pattern": "^[^,]+$",
+                          "type": "string"
+                        },
+                        "type": "array",
+                        "x-kubernetes-list-type": "set"
+                      },
+                      "projectID": {
+                        "type": "string"
+                      },
+                      "tags": {
+                        "description": "Tags is a list of tags to filter by. If specified, the resource must\nhave all of the tags specified to be included in the result.",
+                        "items": {
+                          "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                          "minLength": 1,
+                          "pattern": "^[^,]+$",
+                          "type": "string"
+                        },
+                        "type": "array",
+                        "x-kubernetes-list-type": "set"
+                      },
+                      "tagsAny": {
+                        "description": "TagsAny is a list of tags to filter by. If specified, the resource\nmust have at least one of the tags specified to be included in the\nresult.",
+                        "items": {
+                          "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                          "minLength": 1,
+                          "pattern": "^[^,]+$",
+                          "type": "string"
+                        },
+                        "type": "array",
+                        "x-kubernetes-list-type": "set"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "id": {
+                    "description": "ID is the uuid of the subnet. It will not be validated.",
+                    "format": "uuid",
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array",
+              "x-kubernetes-list-type": "atomic"
+            }
+          },
+          "required": [
+            "enabled"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "apiServerPort": {
+          "description": "APIServerPort is the port on which the listener on the APIServer\nwill be created. If specified, it must be an integer between 0 and 65535.",
+          "maximum": 65535,
+          "minimum": 0,
+          "type": "integer"
+        },
+        "bastion": {
+          "description": "Bastion is the OpenStack instance to login the nodes\n\nAs a rolling update is not ideal during a bastion host session, we\nprevent changes to a running bastion configuration. To make changes, it's required\nto first set `enabled: false` which will remove the bastion and then changes can be made.",
+          "properties": {
+            "availabilityZone": {
+              "description": "AvailabilityZone is the failure domain that will be used to create the Bastion Spec.",
+              "type": "string"
+            },
+            "enabled": {
+              "default": true,
+              "description": "Enabled means that bastion is enabled. The bastion is enabled by\ndefault if this field is not specified. Set this field to false to disable the\nbastion.\n\nIt is not currently possible to remove the bastion from the cluster\nspec without first disabling it by setting this field to false and\nwaiting until the bastion has been deleted.",
+              "type": "boolean"
+            },
+            "floatingIP": {
+              "description": "FloatingIP which will be associated to the bastion machine. It's the IP address, not UUID.\nThe floating IP should already exist and should not be associated with a port. If FIP of this address does not\nexist, CAPO will try to create it, but by default only OpenStack administrators have privileges to do so.",
+              "format": "ipv4",
+              "type": "string"
+            },
+            "spec": {
+              "description": "Spec for the bastion itself",
+              "properties": {
+                "additionalBlockDevices": {
+                  "description": "AdditionalBlockDevices is a list of specifications for additional block devices to attach to the server instance",
+                  "items": {
+                    "description": "AdditionalBlockDevice is a block device to attach to the server.",
+                    "properties": {
+                      "name": {
+                        "description": "Name of the block device in the context of a machine.\nIf the block device is a volume, the Cinder volume will be named\nas a combination of the machine name and this name.\nAlso, this name will be used for tagging the block device.\nInformation about the block device tag can be obtained from the OpenStack\nmetadata API or the config drive.\nName cannot be 'root', which is reserved for the root volume.",
+                        "type": "string"
+                      },
+                      "sizeGiB": {
+                        "description": "SizeGiB is the size of the block device in gibibytes (GiB).",
+                        "minimum": 1,
+                        "type": "integer"
+                      },
+                      "storage": {
+                        "description": "Storage specifies the storage type of the block device and\nadditional storage options.",
+                        "properties": {
+                          "type": {
+                            "description": "Type is the type of block device to create.\nThis can be either \"Volume\" or \"Local\".",
+                            "type": "string"
+                          },
+                          "volume": {
+                            "description": "Volume contains additional storage options for a volume block device.",
+                            "properties": {
+                              "availabilityZone": {
+                                "description": "AvailabilityZone is the volume availability zone to create the volume\nin. If not specified, the volume will be created without an explicit\navailability zone.",
+                                "properties": {
+                                  "from": {
+                                    "default": "Name",
+                                    "description": "From specifies where we will obtain the availability zone for the\nvolume. The options are \"Name\" and \"Machine\". If \"Name\" is specified\nthen the Name field must also be specified. If \"Machine\" is specified\nthe volume will use the value of FailureDomain, if any, from the\nassociated Machine.",
+                                    "enum": [
+                                      "Name",
+                                      "Machine"
+                                    ],
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "description": "Name is the name of a volume availability zone to use. It is required\nif From is \"Name\". The volume availability zone name may not contain\nspaces.",
+                                    "minLength": 1,
+                                    "pattern": "^[^ ]+$",
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "x-kubernetes-validations": [
+                                  {
+                                    "message": "name is required when from is 'Name' or default",
+                                    "rule": "!has(self.from) || self.from == 'Name' ? has(self.name) : !has(self.name)"
+                                  }
+                                ],
+                                "additionalProperties": false
+                              },
+                              "type": {
+                                "description": "Type is the Cinder volume type of the volume.\nIf omitted, the default Cinder volume type that is configured in the OpenStack cloud\nwill be used.",
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "required": [
+                          "type"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "required": [
+                      "name",
+                      "sizeGiB",
+                      "storage"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array",
+                  "x-kubernetes-list-map-keys": [
+                    "name"
+                  ],
+                  "x-kubernetes-list-type": "map"
+                },
+                "configDrive": {
+                  "description": "Config Drive support",
+                  "type": "boolean"
+                },
+                "flavor": {
+                  "description": "The flavor reference for the flavor for your server instance.",
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "flavorID": {
+                  "description": "FlavorID allows flavors to be specified by ID.  This field takes precedence\nover Flavor.",
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "floatingIPPoolRef": {
+                  "description": "floatingIPPoolRef is a reference to a IPPool that will be assigned\nto an IPAddressClaim. Once the IPAddressClaim is fulfilled, the FloatingIP\nwill be assigned to the OpenStackMachine.",
+                  "properties": {
+                    "apiGroup": {
+                      "description": "APIGroup is the group for the resource being referenced.\nIf APIGroup is not specified, the specified Kind must be in the core API group.\nFor any other third-party types, APIGroup is required.",
+                      "type": "string"
+                    },
+                    "kind": {
+                      "description": "Kind is the type of resource being referenced",
+                      "type": "string"
+                    },
+                    "name": {
+                      "description": "Name is the name of resource being referenced",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "kind",
+                    "name"
+                  ],
+                  "type": "object",
+                  "x-kubernetes-map-type": "atomic",
+                  "additionalProperties": false
+                },
+                "identityRef": {
+                  "description": "IdentityRef is a reference to a secret holding OpenStack credentials\nto be used when reconciling this machine. If not specified, the\ncredentials specified in the cluster will be used.",
+                  "properties": {
+                    "cloudName": {
+                      "description": "CloudName specifies the name of the entry in the clouds.yaml file to use.",
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "name": {
+                      "description": "Name is the name of a Secret (type=Secret) in the same namespace as the resource being provisioned,\nor the name of an OpenStackClusterIdentity (type=ClusterIdentity).\nThe Secret must contain a key named `clouds.yaml` which contains an OpenStack clouds.yaml file.\nThe Secret may optionally contain a key named `cacert` containing a PEM-encoded CA certificate.",
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "region": {
+                      "description": "Region specifies an OpenStack region to use. If specified, it overrides\nany value in clouds.yaml. If specified for an OpenStackMachine, its\nvalue will be included in providerID.",
+                      "type": "string"
+                    },
+                    "type": {
+                      "default": "Secret",
+                      "description": "Type specifies the identity reference type. Defaults to Secret for backward compatibility.",
+                      "enum": [
+                        "Secret",
+                        "ClusterIdentity"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "cloudName",
+                    "name",
+                    "type"
+                  ],
+                  "type": "object",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "region is immutable",
+                      "rule": "(!has(self.region) && !has(oldSelf.region)) || self.region == oldSelf.region"
+                    }
+                  ],
+                  "additionalProperties": false
+                },
+                "image": {
+                  "description": "The image to use for your server instance.\nIf the rootVolume is specified, this will be used when creating the root volume.",
+                  "maxProperties": 1,
+                  "minProperties": 1,
+                  "properties": {
+                    "filter": {
+                      "description": "Filter describes a query for an image. If specified, the combination\nof name and tags must return a single matching image or an error will\nbe raised.",
+                      "minProperties": 1,
+                      "properties": {
+                        "name": {
+                          "description": "The name of the desired image. If specified, the combination of name and tags must return a single matching image or an error will be raised.",
+                          "type": "string"
+                        },
+                        "tags": {
+                          "description": "The tags associated with the desired image. If specified, the combination of name and tags must return a single matching image or an error will be raised.",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array",
+                          "x-kubernetes-list-type": "set"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "id": {
+                      "description": "ID is the uuid of the image. ID will not be validated before use.",
+                      "format": "uuid",
+                      "type": "string"
+                    },
+                    "imageRef": {
+                      "description": "ImageRef is a reference to an ORC Image in the same namespace as the\nreferring object.",
+                      "properties": {
+                        "name": {
+                          "description": "Name is the name of the referenced resource",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "ports": {
+                  "description": "Ports to be attached to the server instance. They are created if a port with the given name does not already exist.\nIf not specified a default port will be added for the default cluster network.",
+                  "items": {
+                    "properties": {
+                      "adminStateUp": {
+                        "description": "AdminStateUp specifies whether the port should be created in the up (true) or down (false) state. The default is up.",
+                        "type": "boolean"
+                      },
+                      "allowedAddressPairs": {
+                        "description": "AllowedAddressPairs is a list of address pairs which Neutron will\nallow the port to send traffic from in addition to the port's\naddresses. If not specified, the MAC Address will be the MAC Address\nof the port. Depending on the configuration of Neutron, it may be\nsupported to specify a CIDR instead of a specific IP address.",
+                        "items": {
+                          "properties": {
+                            "ipAddress": {
+                              "description": "IPAddress is the IP address of the allowed address pair. Depending on\nthe configuration of Neutron, it may be supported to specify a CIDR\ninstead of a specific IP address.",
+                              "type": "string"
+                            },
+                            "macAddress": {
+                              "description": "MACAddress is the MAC address of the allowed address pair. If not\nspecified, the MAC address will be the MAC address of the port.",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "ipAddress"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "description": {
+                        "description": "Description is a human-readable description for the port.",
+                        "type": "string"
+                      },
+                      "disablePortSecurity": {
+                        "description": "DisablePortSecurity enables or disables the port security when set.\nWhen not set, it takes the value of the corresponding field at the network level.",
+                        "type": "boolean"
+                      },
+                      "fixedIPs": {
+                        "description": "FixedIPs is a list of pairs of subnet and/or IP address to assign to the port. If specified, these must be subnets of the port's network.",
+                        "items": {
+                          "properties": {
+                            "ipAddress": {
+                              "description": "IPAddress is a specific IP address to assign to the port. If Subnet\nis also specified, IPAddress must be a valid IP address in the\nsubnet. If Subnet is not specified, IPAddress must be a valid IP\naddress in any subnet of the port's network.",
+                              "type": "string"
+                            },
+                            "subnet": {
+                              "description": "Subnet is an openstack subnet query that will return the id of a subnet to create\nthe fixed IP of a port in. This query must not return more than one subnet.",
+                              "maxProperties": 1,
+                              "minProperties": 1,
+                              "properties": {
+                                "filter": {
+                                  "description": "Filter specifies a filter to select the subnet. It must match exactly one subnet.",
+                                  "minProperties": 1,
+                                  "properties": {
+                                    "cidr": {
+                                      "type": "string"
+                                    },
+                                    "description": {
+                                      "type": "string"
+                                    },
+                                    "gatewayIP": {
+                                      "type": "string"
+                                    },
+                                    "ipVersion": {
+                                      "type": "integer"
+                                    },
+                                    "ipv6AddressMode": {
+                                      "type": "string"
+                                    },
+                                    "ipv6RAMode": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "notTags": {
+                                      "description": "NotTags is a list of tags to filter by. If specified, resources which\ncontain all of the given tags will be excluded from the result.",
+                                      "items": {
+                                        "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                                        "minLength": 1,
+                                        "pattern": "^[^,]+$",
+                                        "type": "string"
+                                      },
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "set"
+                                    },
+                                    "notTagsAny": {
+                                      "description": "NotTagsAny is a list of tags to filter by. If specified, resources\nwhich contain any of the given tags will be excluded from the result.",
+                                      "items": {
+                                        "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                                        "minLength": 1,
+                                        "pattern": "^[^,]+$",
+                                        "type": "string"
+                                      },
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "set"
+                                    },
+                                    "projectID": {
+                                      "type": "string"
+                                    },
+                                    "tags": {
+                                      "description": "Tags is a list of tags to filter by. If specified, the resource must\nhave all of the tags specified to be included in the result.",
+                                      "items": {
+                                        "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                                        "minLength": 1,
+                                        "pattern": "^[^,]+$",
+                                        "type": "string"
+                                      },
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "set"
+                                    },
+                                    "tagsAny": {
+                                      "description": "TagsAny is a list of tags to filter by. If specified, the resource\nmust have at least one of the tags specified to be included in the\nresult.",
+                                      "items": {
+                                        "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                                        "minLength": 1,
+                                        "pattern": "^[^,]+$",
+                                        "type": "string"
+                                      },
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "set"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "id": {
+                                  "description": "ID is the uuid of the subnet. It will not be validated.",
+                                  "format": "uuid",
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
+                      },
+                      "hostID": {
+                        "description": "HostID specifies the ID of the host where the port resides.",
+                        "type": "string"
+                      },
+                      "macAddress": {
+                        "description": "MACAddress specifies the MAC address of the port. If not specified, the MAC address will be generated.",
+                        "type": "string"
+                      },
+                      "nameSuffix": {
+                        "description": "NameSuffix will be appended to the name of the port if specified. If unspecified, instead the 0-based index of the port in the list is used.",
+                        "type": "string"
+                      },
+                      "network": {
+                        "description": "Network is a query for an openstack network that the port will be created or discovered on.\nThis will fail if the query returns more than one network.",
+                        "maxProperties": 1,
+                        "minProperties": 1,
+                        "properties": {
+                          "filter": {
+                            "description": "Filter specifies a filter to select an OpenStack network. If provided, cannot be empty.",
+                            "minProperties": 1,
+                            "properties": {
+                              "description": {
+                                "type": "string"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "notTags": {
+                                "description": "NotTags is a list of tags to filter by. If specified, resources which\ncontain all of the given tags will be excluded from the result.",
+                                "items": {
+                                  "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                                  "minLength": 1,
+                                  "pattern": "^[^,]+$",
+                                  "type": "string"
+                                },
+                                "type": "array",
+                                "x-kubernetes-list-type": "set"
+                              },
+                              "notTagsAny": {
+                                "description": "NotTagsAny is a list of tags to filter by. If specified, resources\nwhich contain any of the given tags will be excluded from the result.",
+                                "items": {
+                                  "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                                  "minLength": 1,
+                                  "pattern": "^[^,]+$",
+                                  "type": "string"
+                                },
+                                "type": "array",
+                                "x-kubernetes-list-type": "set"
+                              },
+                              "projectID": {
+                                "type": "string"
+                              },
+                              "tags": {
+                                "description": "Tags is a list of tags to filter by. If specified, the resource must\nhave all of the tags specified to be included in the result.",
+                                "items": {
+                                  "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                                  "minLength": 1,
+                                  "pattern": "^[^,]+$",
+                                  "type": "string"
+                                },
+                                "type": "array",
+                                "x-kubernetes-list-type": "set"
+                              },
+                              "tagsAny": {
+                                "description": "TagsAny is a list of tags to filter by. If specified, the resource\nmust have at least one of the tags specified to be included in the\nresult.",
+                                "items": {
+                                  "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                                  "minLength": 1,
+                                  "pattern": "^[^,]+$",
+                                  "type": "string"
+                                },
+                                "type": "array",
+                                "x-kubernetes-list-type": "set"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "id": {
+                            "description": "ID is the ID of the network to use. If ID is provided, the other filters cannot be provided. Must be in UUID format.",
+                            "format": "uuid",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "profile": {
+                        "description": "Profile is a set of key-value pairs that are used for binding\ndetails. We intentionally don't expose this as a map[string]string\nbecause we only want to enable the users to set the values of the\nkeys that are known to work in OpenStack Networking API.  See\nhttps://docs.openstack.org/api-ref/network/v2/index.html?expanded=create-port-detail#create-port\nTo set profiles, your tenant needs permissions rule:create_port, and\nrule:create_port:binding:profile",
+                        "properties": {
+                          "ovsHWOffload": {
+                            "description": "OVSHWOffload enables or disables the OVS hardware offload feature.\nThis flag is not required on OpenStack clouds since Yoga as Nova will set it automatically when the port is attached.\nSee: https://bugs.launchpad.net/nova/+bug/2020813",
+                            "type": "boolean"
+                          },
+                          "trustedVF": {
+                            "description": "TrustedVF enables or disables the \u201ctrusted mode\u201d for the VF.",
+                            "type": "boolean"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "propagateUplinkStatus": {
+                        "description": "PropageteUplinkStatus enables or disables the propagate uplink status on the port.",
+                        "type": "boolean"
+                      },
+                      "securityGroups": {
+                        "description": "SecurityGroups is a list of the names, uuids, filters or any combination these of the security groups to assign to the instance.",
+                        "items": {
+                          "description": "SecurityGroupParam specifies an OpenStack security group. It may be specified by ID or filter, but not both.",
+                          "maxProperties": 1,
+                          "minProperties": 1,
+                          "properties": {
+                            "filter": {
+                              "description": "Filter specifies a query to select an OpenStack security group. If provided, cannot be empty.",
+                              "minProperties": 1,
+                              "properties": {
+                                "description": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "notTags": {
+                                  "description": "NotTags is a list of tags to filter by. If specified, resources which\ncontain all of the given tags will be excluded from the result.",
+                                  "items": {
+                                    "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                                    "minLength": 1,
+                                    "pattern": "^[^,]+$",
+                                    "type": "string"
+                                  },
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "set"
+                                },
+                                "notTagsAny": {
+                                  "description": "NotTagsAny is a list of tags to filter by. If specified, resources\nwhich contain any of the given tags will be excluded from the result.",
+                                  "items": {
+                                    "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                                    "minLength": 1,
+                                    "pattern": "^[^,]+$",
+                                    "type": "string"
+                                  },
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "set"
+                                },
+                                "projectID": {
+                                  "type": "string"
+                                },
+                                "tags": {
+                                  "description": "Tags is a list of tags to filter by. If specified, the resource must\nhave all of the tags specified to be included in the result.",
+                                  "items": {
+                                    "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                                    "minLength": 1,
+                                    "pattern": "^[^,]+$",
+                                    "type": "string"
+                                  },
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "set"
+                                },
+                                "tagsAny": {
+                                  "description": "TagsAny is a list of tags to filter by. If specified, the resource\nmust have at least one of the tags specified to be included in the\nresult.",
+                                  "items": {
+                                    "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                                    "minLength": 1,
+                                    "pattern": "^[^,]+$",
+                                    "type": "string"
+                                  },
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "set"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "id": {
+                              "description": "ID is the ID of the security group to use. If ID is provided, the other filters cannot be provided. Must be in UUID format.",
+                              "format": "uuid",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
+                      },
+                      "tags": {
+                        "description": "Tags applied to the port (and corresponding trunk, if a trunk is configured.)\nThese tags are applied in addition to the instance's tags, which will also be applied to the port.",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array",
+                        "x-kubernetes-list-type": "set"
+                      },
+                      "trunk": {
+                        "description": "Trunk specifies whether trunking is enabled at the port level. If not\nprovided the value is inherited from the machine, or false for a\nbastion host.",
+                        "type": "boolean"
+                      },
+                      "valueSpecs": {
+                        "description": "Value specs are extra parameters to include in the API request with OpenStack.\nThis is an extension point for the API, so what they do and if they are supported,\ndepends on the specific OpenStack implementation.",
+                        "items": {
+                          "description": "ValueSpec represents a single value_spec key-value pair.",
+                          "properties": {
+                            "key": {
+                              "description": "Key is the key in the key-value pair.",
+                              "type": "string"
+                            },
+                            "name": {
+                              "description": "Name is the name of the key-value pair.\nThis is just for identifying the pair and will not be sent to the OpenStack API.",
+                              "type": "string"
+                            },
+                            "value": {
+                              "description": "Value is the value in the key-value pair.",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "key",
+                            "name",
+                            "value"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array",
+                        "x-kubernetes-list-map-keys": [
+                          "name"
+                        ],
+                        "x-kubernetes-list-type": "map"
+                      },
+                      "vnicType": {
+                        "description": "VNICType specifies the type of vNIC which this port should be\nattached to. This is used to determine which mechanism driver(s) to\nbe used to bind the port. The valid values are normal, macvtap,\ndirect, baremetal, direct-physical, virtio-forwarder, smart-nic and\nremote-managed, although these values will not be validated in this\nAPI to ensure compatibility with future neutron changes or custom\nimplementations. What type of vNIC is actually available depends on\ndeployments. If not specified, the Neutron default value is used.",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "providerID": {
+                  "description": "ProviderID is the unique identifier as specified by the cloud provider.",
+                  "type": "string"
+                },
+                "rootVolume": {
+                  "description": "The volume metadata to boot from",
+                  "properties": {
+                    "availabilityZone": {
+                      "description": "AvailabilityZone is the volume availability zone to create the volume\nin. If not specified, the volume will be created without an explicit\navailability zone.",
+                      "properties": {
+                        "from": {
+                          "default": "Name",
+                          "description": "From specifies where we will obtain the availability zone for the\nvolume. The options are \"Name\" and \"Machine\". If \"Name\" is specified\nthen the Name field must also be specified. If \"Machine\" is specified\nthe volume will use the value of FailureDomain, if any, from the\nassociated Machine.",
+                          "enum": [
+                            "Name",
+                            "Machine"
+                          ],
+                          "type": "string"
+                        },
+                        "name": {
+                          "description": "Name is the name of a volume availability zone to use. It is required\nif From is \"Name\". The volume availability zone name may not contain\nspaces.",
+                          "minLength": 1,
+                          "pattern": "^[^ ]+$",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "x-kubernetes-validations": [
+                        {
+                          "message": "name is required when from is 'Name' or default",
+                          "rule": "!has(self.from) || self.from == 'Name' ? has(self.name) : !has(self.name)"
+                        }
+                      ],
+                      "additionalProperties": false
+                    },
+                    "sizeGiB": {
+                      "description": "SizeGiB is the size of the block device in gibibytes (GiB).",
+                      "minimum": 1,
+                      "type": "integer"
+                    },
+                    "type": {
+                      "description": "Type is the Cinder volume type of the volume.\nIf omitted, the default Cinder volume type that is configured in the OpenStack cloud\nwill be used.",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "sizeGiB"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "schedulerHintAdditionalProperties": {
+                  "description": "SchedulerHintAdditionalProperties are arbitrary key/value pairs that provide additional hints\nto the OpenStack scheduler. These hints can influence how instances are placed on the infrastructure,\nsuch as specifying certain host aggregates or availability zones.",
+                  "items": {
+                    "description": "SchedulerHintAdditionalProperty represents a single additional property for a scheduler hint.\nIt includes a Name to identify the property and a Value that can be of various types.",
+                    "properties": {
+                      "name": {
+                        "description": "Name is the name of the scheduler hint property.\nIt is a unique identifier for the property.",
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "value": {
+                        "description": "Value is the value of the scheduler hint property, which can be of various types\n(e.g., bool, string, int). The type is indicated by the Value.Type field.",
+                        "properties": {
+                          "bool": {
+                            "description": "Bool is the boolean value of the scheduler hint, used when Type is \"Bool\".\nThis field is required if type is 'Bool', and must not be set otherwise.",
+                            "type": "boolean"
+                          },
+                          "number": {
+                            "description": "Number is the integer value of the scheduler hint, used when Type is \"Number\".\nThis field is required if type is 'Number', and must not be set otherwise.",
+                            "type": "integer"
+                          },
+                          "string": {
+                            "description": "String is the string value of the scheduler hint, used when Type is \"String\".\nThis field is required if type is 'String', and must not be set otherwise.",
+                            "maxLength": 255,
+                            "minLength": 1,
+                            "type": "string"
+                          },
+                          "type": {
+                            "description": "Type represents the type of the value.\nValid values are Bool, String, and Number.",
+                            "enum": [
+                              "Bool",
+                              "String",
+                              "Number"
+                            ],
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "type"
+                        ],
+                        "type": "object",
+                        "x-kubernetes-validations": [
+                          {
+                            "message": "bool is required when type is Bool, and forbidden otherwise",
+                            "rule": "has(self.type) && self.type == 'Bool' ? has(self.bool) : !has(self.bool)"
+                          },
+                          {
+                            "message": "number is required when type is Number, and forbidden otherwise",
+                            "rule": "has(self.type) && self.type == 'Number' ? has(self.number) : !has(self.number)"
+                          },
+                          {
+                            "message": "string is required when type is String, and forbidden otherwise",
+                            "rule": "has(self.type) && self.type == 'String' ? has(self.string) : !has(self.string)"
+                          }
+                        ],
+                        "additionalProperties": false
+                      }
+                    },
+                    "required": [
+                      "name",
+                      "value"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array",
+                  "x-kubernetes-list-map-keys": [
+                    "name"
+                  ],
+                  "x-kubernetes-list-type": "map"
+                },
+                "securityGroups": {
+                  "description": "The names of the security groups to assign to the instance",
+                  "items": {
+                    "description": "SecurityGroupParam specifies an OpenStack security group. It may be specified by ID or filter, but not both.",
+                    "maxProperties": 1,
+                    "minProperties": 1,
+                    "properties": {
+                      "filter": {
+                        "description": "Filter specifies a query to select an OpenStack security group. If provided, cannot be empty.",
+                        "minProperties": 1,
+                        "properties": {
+                          "description": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "notTags": {
+                            "description": "NotTags is a list of tags to filter by. If specified, resources which\ncontain all of the given tags will be excluded from the result.",
+                            "items": {
+                              "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                              "minLength": 1,
+                              "pattern": "^[^,]+$",
+                              "type": "string"
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "set"
+                          },
+                          "notTagsAny": {
+                            "description": "NotTagsAny is a list of tags to filter by. If specified, resources\nwhich contain any of the given tags will be excluded from the result.",
+                            "items": {
+                              "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                              "minLength": 1,
+                              "pattern": "^[^,]+$",
+                              "type": "string"
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "set"
+                          },
+                          "projectID": {
+                            "type": "string"
+                          },
+                          "tags": {
+                            "description": "Tags is a list of tags to filter by. If specified, the resource must\nhave all of the tags specified to be included in the result.",
+                            "items": {
+                              "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                              "minLength": 1,
+                              "pattern": "^[^,]+$",
+                              "type": "string"
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "set"
+                          },
+                          "tagsAny": {
+                            "description": "TagsAny is a list of tags to filter by. If specified, the resource\nmust have at least one of the tags specified to be included in the\nresult.",
+                            "items": {
+                              "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                              "minLength": 1,
+                              "pattern": "^[^,]+$",
+                              "type": "string"
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "set"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "id": {
+                        "description": "ID is the ID of the security group to use. If ID is provided, the other filters cannot be provided. Must be in UUID format.",
+                        "format": "uuid",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "serverGroup": {
+                  "description": "The server group to assign the machine to.",
+                  "maxProperties": 1,
+                  "minProperties": 1,
+                  "properties": {
+                    "filter": {
+                      "description": "Filter specifies a query to select an OpenStack server group. If provided, it cannot be empty.",
+                      "minProperties": 1,
+                      "properties": {
+                        "name": {
+                          "description": "Name is the name of a server group to look for.",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "id": {
+                      "description": "ID is the ID of the server group to use.",
+                      "format": "uuid",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "serverMetadata": {
+                  "description": "Metadata mapping. Allows you to create a map of key value pairs to add to the server instance.",
+                  "items": {
+                    "properties": {
+                      "key": {
+                        "description": "Key is the server metadata key",
+                        "maxLength": 255,
+                        "type": "string"
+                      },
+                      "value": {
+                        "description": "Value is the server metadata value",
+                        "maxLength": 255,
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "key",
+                      "value"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array",
+                  "x-kubernetes-list-map-keys": [
+                    "key"
+                  ],
+                  "x-kubernetes-list-type": "map"
+                },
+                "sshKeyName": {
+                  "description": "The ssh key to inject in the instance",
+                  "type": "string"
+                },
+                "tags": {
+                  "description": "Tags which will be added to the machine and all dependent resources\nwhich support them. These are in addition to Tags defined on the\ncluster.\nRequires Nova api 2.52 minimum!",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array",
+                  "x-kubernetes-list-type": "set"
+                },
+                "trunk": {
+                  "description": "Whether the server instance is created on a trunk port or not.",
+                  "type": "boolean"
+                }
+              },
+              "required": [
+                "image"
+              ],
+              "type": "object",
+              "x-kubernetes-validations": [
+                {
+                  "message": "at least one of flavor or flavorID must be set",
+                  "rule": "(has(self.flavor) || has(self.flavorID))"
+                }
+              ],
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "x-kubernetes-validations": [
+            {
+              "message": "spec is required if bastion is enabled",
+              "rule": "!self.enabled || has(self.spec)"
+            }
+          ],
+          "additionalProperties": false
+        },
+        "controlPlaneAvailabilityZones": {
+          "description": "ControlPlaneAvailabilityZones is the set of availability zones which\ncontrol plane machines may be deployed to.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "set"
+        },
+        "controlPlaneEndpoint": {
+          "description": "ControlPlaneEndpoint represents the endpoint used to communicate with the control plane.\nIt is normally populated automatically by the OpenStackCluster\ncontroller during cluster provisioning. If it is set on creation the\ncontrol plane endpoint will use the values set here in preference to\nvalues set elsewhere.\nControlPlaneEndpoint cannot be modified after ControlPlaneEndpoint.Host has been set.",
+          "properties": {
+            "host": {
+              "description": "host is the hostname on which the API server is serving.",
+              "maxLength": 512,
+              "type": "string"
+            },
+            "port": {
+              "description": "port is the port on which the API server is serving.",
+              "format": "int32",
+              "type": "integer"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "controlPlaneOmitAvailabilityZone": {
+          "description": "ControlPlaneOmitAvailabilityZone causes availability zone to be\nomitted when creating control plane nodes, allowing the Nova\nscheduler to make a decision on which availability zone to use based\non other scheduling constraints",
+          "type": "boolean"
+        },
+        "disableAPIServerFloatingIP": {
+          "description": "DisableAPIServerFloatingIP determines whether or not to attempt to attach a floating\nIP to the API server. This allows for the creation of clusters when attaching a floating\nIP to the API server (and hence, in many cases, exposing the API server to the internet)\nis not possible or desirable, e.g. if using a shared VLAN for communication between\nmanagement and workload clusters or when the management cluster is inside the\nproject network.\nThis option requires that the API server use a VIP on the cluster network so that the\nunderlying machines can change without changing ControlPlaneEndpoint.Host.\nWhen using a managed load balancer, this VIP will be managed automatically.\nIf not using a managed load balancer, cluster configuration will fail without additional\nconfiguration to manage the VIP on the control plane machines, which falls outside of\nthe scope of this controller.",
+          "type": "boolean"
+        },
+        "disableExternalNetwork": {
+          "description": "DisableExternalNetwork specifies whether or not to attempt to connect the cluster\nto an external network. This allows for the creation of clusters when connecting\nto an external network is not possible or desirable, e.g. if using a provider network.",
+          "type": "boolean"
+        },
+        "disablePortSecurity": {
+          "description": "DisablePortSecurity disables the port security of the network created for the\nKubernetes cluster, which also disables SecurityGroups",
+          "type": "boolean"
+        },
+        "externalNetwork": {
+          "description": "ExternalNetwork is the OpenStack Network to be used to get public internet to the VMs.\nThis option is ignored if DisableExternalNetwork is set to true.\n\nIf ExternalNetwork is defined it must refer to exactly one external network.\n\nIf ExternalNetwork is not defined or is empty the controller will use any\nexisting external network as long as there is only one. It is an\nerror if ExternalNetwork is not defined and there are multiple\nexternal networks unless DisableExternalNetwork is also set.\n\nIf ExternalNetwork is not defined and there are no external networks\nthe controller will proceed as though DisableExternalNetwork was set.",
+          "maxProperties": 1,
+          "minProperties": 1,
+          "properties": {
+            "filter": {
+              "description": "Filter specifies a filter to select an OpenStack network. If provided, cannot be empty.",
+              "minProperties": 1,
+              "properties": {
+                "description": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "notTags": {
+                  "description": "NotTags is a list of tags to filter by. If specified, resources which\ncontain all of the given tags will be excluded from the result.",
+                  "items": {
+                    "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                    "minLength": 1,
+                    "pattern": "^[^,]+$",
+                    "type": "string"
+                  },
+                  "type": "array",
+                  "x-kubernetes-list-type": "set"
+                },
+                "notTagsAny": {
+                  "description": "NotTagsAny is a list of tags to filter by. If specified, resources\nwhich contain any of the given tags will be excluded from the result.",
+                  "items": {
+                    "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                    "minLength": 1,
+                    "pattern": "^[^,]+$",
+                    "type": "string"
+                  },
+                  "type": "array",
+                  "x-kubernetes-list-type": "set"
+                },
+                "projectID": {
+                  "type": "string"
+                },
+                "tags": {
+                  "description": "Tags is a list of tags to filter by. If specified, the resource must\nhave all of the tags specified to be included in the result.",
+                  "items": {
+                    "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                    "minLength": 1,
+                    "pattern": "^[^,]+$",
+                    "type": "string"
+                  },
+                  "type": "array",
+                  "x-kubernetes-list-type": "set"
+                },
+                "tagsAny": {
+                  "description": "TagsAny is a list of tags to filter by. If specified, the resource\nmust have at least one of the tags specified to be included in the\nresult.",
+                  "items": {
+                    "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                    "minLength": 1,
+                    "pattern": "^[^,]+$",
+                    "type": "string"
+                  },
+                  "type": "array",
+                  "x-kubernetes-list-type": "set"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "id": {
+              "description": "ID is the ID of the network to use. If ID is provided, the other filters cannot be provided. Must be in UUID format.",
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "externalRouterIPs": {
+          "description": "ExternalRouterIPs is an array of externalIPs on the respective subnets.\nThis is necessary if the router needs a fixed ip in a specific subnet.",
+          "items": {
+            "properties": {
+              "fixedIP": {
+                "description": "The FixedIP in the corresponding subnet",
+                "type": "string"
+              },
+              "subnet": {
+                "description": "The subnet in which the FixedIP is used for the Gateway of this router",
+                "maxProperties": 1,
+                "minProperties": 1,
+                "properties": {
+                  "filter": {
+                    "description": "Filter specifies a filter to select the subnet. It must match exactly one subnet.",
+                    "minProperties": 1,
+                    "properties": {
+                      "cidr": {
+                        "type": "string"
+                      },
+                      "description": {
+                        "type": "string"
+                      },
+                      "gatewayIP": {
+                        "type": "string"
+                      },
+                      "ipVersion": {
+                        "type": "integer"
+                      },
+                      "ipv6AddressMode": {
+                        "type": "string"
+                      },
+                      "ipv6RAMode": {
+                        "type": "string"
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "notTags": {
+                        "description": "NotTags is a list of tags to filter by. If specified, resources which\ncontain all of the given tags will be excluded from the result.",
+                        "items": {
+                          "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                          "minLength": 1,
+                          "pattern": "^[^,]+$",
+                          "type": "string"
+                        },
+                        "type": "array",
+                        "x-kubernetes-list-type": "set"
+                      },
+                      "notTagsAny": {
+                        "description": "NotTagsAny is a list of tags to filter by. If specified, resources\nwhich contain any of the given tags will be excluded from the result.",
+                        "items": {
+                          "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                          "minLength": 1,
+                          "pattern": "^[^,]+$",
+                          "type": "string"
+                        },
+                        "type": "array",
+                        "x-kubernetes-list-type": "set"
+                      },
+                      "projectID": {
+                        "type": "string"
+                      },
+                      "tags": {
+                        "description": "Tags is a list of tags to filter by. If specified, the resource must\nhave all of the tags specified to be included in the result.",
+                        "items": {
+                          "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                          "minLength": 1,
+                          "pattern": "^[^,]+$",
+                          "type": "string"
+                        },
+                        "type": "array",
+                        "x-kubernetes-list-type": "set"
+                      },
+                      "tagsAny": {
+                        "description": "TagsAny is a list of tags to filter by. If specified, the resource\nmust have at least one of the tags specified to be included in the\nresult.",
+                        "items": {
+                          "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                          "minLength": 1,
+                          "pattern": "^[^,]+$",
+                          "type": "string"
+                        },
+                        "type": "array",
+                        "x-kubernetes-list-type": "set"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "id": {
+                    "description": "ID is the uuid of the subnet. It will not be validated.",
+                    "format": "uuid",
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              }
+            },
+            "required": [
+              "subnet"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        },
+        "identityRef": {
+          "description": "IdentityRef is a reference to a secret holding OpenStack credentials\nto be used when reconciling this cluster. It is also to reconcile\nmachines unless overridden in the machine spec.",
+          "properties": {
+            "cloudName": {
+              "description": "CloudName specifies the name of the entry in the clouds.yaml file to use.",
+              "minLength": 1,
+              "type": "string"
+            },
+            "name": {
+              "description": "Name is the name of a Secret (type=Secret) in the same namespace as the resource being provisioned,\nor the name of an OpenStackClusterIdentity (type=ClusterIdentity).\nThe Secret must contain a key named `clouds.yaml` which contains an OpenStack clouds.yaml file.\nThe Secret may optionally contain a key named `cacert` containing a PEM-encoded CA certificate.",
+              "minLength": 1,
+              "type": "string"
+            },
+            "region": {
+              "description": "Region specifies an OpenStack region to use. If specified, it overrides\nany value in clouds.yaml. If specified for an OpenStackMachine, its\nvalue will be included in providerID.",
+              "type": "string"
+            },
+            "type": {
+              "default": "Secret",
+              "description": "Type specifies the identity reference type. Defaults to Secret for backward compatibility.",
+              "enum": [
+                "Secret",
+                "ClusterIdentity"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "cloudName",
+            "name",
+            "type"
+          ],
+          "type": "object",
+          "x-kubernetes-validations": [
+            {
+              "message": "region is immutable",
+              "rule": "(!has(self.region) && !has(oldSelf.region)) || self.region == oldSelf.region"
+            }
+          ],
+          "additionalProperties": false
+        },
+        "managedSecurityGroups": {
+          "description": "ManagedSecurityGroups determines whether OpenStack security groups for the cluster\nwill be managed by the OpenStack provider or whether pre-existing security groups will\nbe specified as part of the configuration.\nBy default, the managed security groups have rules that allow the Kubelet, etcd, and the\nKubernetes API server to function correctly.\nIt's possible to add additional rules to the managed security groups.\nWhen defined to an empty struct, the managed security groups will be created with the default rules.",
+          "properties": {
+            "allNodesSecurityGroupRules": {
+              "description": "allNodesSecurityGroupRules defines the rules that should be applied to all nodes.",
+              "items": {
+                "description": "SecurityGroupRuleSpec represent the basic information of the associated OpenStack\nSecurity Group Role.\nFor now this is only used for the allNodesSecurityGroupRules but when we add\nother security groups, we'll need to add a validation because\nRemote* fields are mutually exclusive.",
+                "properties": {
+                  "description": {
+                    "description": "description of the security group rule.",
+                    "type": "string"
+                  },
+                  "direction": {
+                    "description": "direction in which the security group rule is applied. The only values\nallowed are \"ingress\" or \"egress\". For a compute instance, an ingress\nsecurity group rule is applied to incoming (ingress) traffic for that\ninstance. An egress rule is applied to traffic leaving the instance.",
+                    "enum": [
+                      "ingress",
+                      "egress"
+                    ],
+                    "type": "string"
+                  },
+                  "etherType": {
+                    "description": "etherType must be IPv4 or IPv6, and addresses represented in CIDR must match the\ningress or egress rules.",
+                    "enum": [
+                      "IPv4",
+                      "IPv6"
+                    ],
+                    "type": "string"
+                  },
+                  "name": {
+                    "description": "name of the security group rule.\nIt's used to identify the rule so it can be patched and will not be sent to the OpenStack API.",
+                    "type": "string"
+                  },
+                  "portRangeMax": {
+                    "description": "portRangeMax is a number in the range that is matched by the security group\nrule. The portRangeMin attribute constrains the portRangeMax attribute.",
+                    "type": "integer"
+                  },
+                  "portRangeMin": {
+                    "description": "portRangeMin is a number in the range that is matched by the security group\nrule. If the protocol is TCP or UDP, this value must be less than or equal\nto the value of the portRangeMax attribute.",
+                    "type": "integer"
+                  },
+                  "protocol": {
+                    "description": "protocol is the protocol that is matched by the security group rule.",
+                    "type": "string"
+                  },
+                  "remoteGroupID": {
+                    "description": "remoteGroupID is the remote group ID to be associated with this security group rule.\nYou can specify either remoteGroupID or remoteIPPrefix or remoteManagedGroups.",
+                    "type": "string"
+                  },
+                  "remoteIPPrefix": {
+                    "description": "remoteIPPrefix is the remote IP prefix to be associated with this security group rule.\nYou can specify either remoteGroupID or remoteIPPrefix or remoteManagedGroups.",
+                    "type": "string"
+                  },
+                  "remoteManagedGroups": {
+                    "description": "remoteManagedGroups is the remote managed groups to be associated with this security group rule.\nYou can specify either remoteGroupID or remoteIPPrefix or remoteManagedGroups.",
+                    "items": {
+                      "enum": [
+                        "bastion",
+                        "controlplane",
+                        "worker"
+                      ],
+                      "type": "string"
+                    },
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "direction",
+                  "name"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array",
+              "x-kubernetes-list-map-keys": [
+                "name"
+              ],
+              "x-kubernetes-list-type": "map"
+            },
+            "allowAllInClusterTraffic": {
+              "default": false,
+              "description": "AllowAllInClusterTraffic allows all ingress and egress traffic between cluster nodes when set to true.",
+              "type": "boolean"
+            },
+            "controlPlaneNodesSecurityGroupRules": {
+              "description": "controlPlaneNodesSecurityGroupRules defines the rules that should be applied to control plane nodes.",
+              "items": {
+                "description": "SecurityGroupRuleSpec represent the basic information of the associated OpenStack\nSecurity Group Role.\nFor now this is only used for the allNodesSecurityGroupRules but when we add\nother security groups, we'll need to add a validation because\nRemote* fields are mutually exclusive.",
+                "properties": {
+                  "description": {
+                    "description": "description of the security group rule.",
+                    "type": "string"
+                  },
+                  "direction": {
+                    "description": "direction in which the security group rule is applied. The only values\nallowed are \"ingress\" or \"egress\". For a compute instance, an ingress\nsecurity group rule is applied to incoming (ingress) traffic for that\ninstance. An egress rule is applied to traffic leaving the instance.",
+                    "enum": [
+                      "ingress",
+                      "egress"
+                    ],
+                    "type": "string"
+                  },
+                  "etherType": {
+                    "description": "etherType must be IPv4 or IPv6, and addresses represented in CIDR must match the\ningress or egress rules.",
+                    "enum": [
+                      "IPv4",
+                      "IPv6"
+                    ],
+                    "type": "string"
+                  },
+                  "name": {
+                    "description": "name of the security group rule.\nIt's used to identify the rule so it can be patched and will not be sent to the OpenStack API.",
+                    "type": "string"
+                  },
+                  "portRangeMax": {
+                    "description": "portRangeMax is a number in the range that is matched by the security group\nrule. The portRangeMin attribute constrains the portRangeMax attribute.",
+                    "type": "integer"
+                  },
+                  "portRangeMin": {
+                    "description": "portRangeMin is a number in the range that is matched by the security group\nrule. If the protocol is TCP or UDP, this value must be less than or equal\nto the value of the portRangeMax attribute.",
+                    "type": "integer"
+                  },
+                  "protocol": {
+                    "description": "protocol is the protocol that is matched by the security group rule.",
+                    "type": "string"
+                  },
+                  "remoteGroupID": {
+                    "description": "remoteGroupID is the remote group ID to be associated with this security group rule.\nYou can specify either remoteGroupID or remoteIPPrefix or remoteManagedGroups.",
+                    "type": "string"
+                  },
+                  "remoteIPPrefix": {
+                    "description": "remoteIPPrefix is the remote IP prefix to be associated with this security group rule.\nYou can specify either remoteGroupID or remoteIPPrefix or remoteManagedGroups.",
+                    "type": "string"
+                  },
+                  "remoteManagedGroups": {
+                    "description": "remoteManagedGroups is the remote managed groups to be associated with this security group rule.\nYou can specify either remoteGroupID or remoteIPPrefix or remoteManagedGroups.",
+                    "items": {
+                      "enum": [
+                        "bastion",
+                        "controlplane",
+                        "worker"
+                      ],
+                      "type": "string"
+                    },
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "direction",
+                  "name"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array",
+              "x-kubernetes-list-map-keys": [
+                "name"
+              ],
+              "x-kubernetes-list-type": "map"
+            },
+            "workerNodesSecurityGroupRules": {
+              "description": "workerNodesSecurityGroupRules defines the rules that should be applied to worker nodes.",
+              "items": {
+                "description": "SecurityGroupRuleSpec represent the basic information of the associated OpenStack\nSecurity Group Role.\nFor now this is only used for the allNodesSecurityGroupRules but when we add\nother security groups, we'll need to add a validation because\nRemote* fields are mutually exclusive.",
+                "properties": {
+                  "description": {
+                    "description": "description of the security group rule.",
+                    "type": "string"
+                  },
+                  "direction": {
+                    "description": "direction in which the security group rule is applied. The only values\nallowed are \"ingress\" or \"egress\". For a compute instance, an ingress\nsecurity group rule is applied to incoming (ingress) traffic for that\ninstance. An egress rule is applied to traffic leaving the instance.",
+                    "enum": [
+                      "ingress",
+                      "egress"
+                    ],
+                    "type": "string"
+                  },
+                  "etherType": {
+                    "description": "etherType must be IPv4 or IPv6, and addresses represented in CIDR must match the\ningress or egress rules.",
+                    "enum": [
+                      "IPv4",
+                      "IPv6"
+                    ],
+                    "type": "string"
+                  },
+                  "name": {
+                    "description": "name of the security group rule.\nIt's used to identify the rule so it can be patched and will not be sent to the OpenStack API.",
+                    "type": "string"
+                  },
+                  "portRangeMax": {
+                    "description": "portRangeMax is a number in the range that is matched by the security group\nrule. The portRangeMin attribute constrains the portRangeMax attribute.",
+                    "type": "integer"
+                  },
+                  "portRangeMin": {
+                    "description": "portRangeMin is a number in the range that is matched by the security group\nrule. If the protocol is TCP or UDP, this value must be less than or equal\nto the value of the portRangeMax attribute.",
+                    "type": "integer"
+                  },
+                  "protocol": {
+                    "description": "protocol is the protocol that is matched by the security group rule.",
+                    "type": "string"
+                  },
+                  "remoteGroupID": {
+                    "description": "remoteGroupID is the remote group ID to be associated with this security group rule.\nYou can specify either remoteGroupID or remoteIPPrefix or remoteManagedGroups.",
+                    "type": "string"
+                  },
+                  "remoteIPPrefix": {
+                    "description": "remoteIPPrefix is the remote IP prefix to be associated with this security group rule.\nYou can specify either remoteGroupID or remoteIPPrefix or remoteManagedGroups.",
+                    "type": "string"
+                  },
+                  "remoteManagedGroups": {
+                    "description": "remoteManagedGroups is the remote managed groups to be associated with this security group rule.\nYou can specify either remoteGroupID or remoteIPPrefix or remoteManagedGroups.",
+                    "items": {
+                      "enum": [
+                        "bastion",
+                        "controlplane",
+                        "worker"
+                      ],
+                      "type": "string"
+                    },
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "direction",
+                  "name"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array",
+              "x-kubernetes-list-map-keys": [
+                "name"
+              ],
+              "x-kubernetes-list-type": "map"
+            }
+          },
+          "required": [
+            "allowAllInClusterTraffic"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "managedSubnets": {
+          "description": "ManagedSubnets describe OpenStack Subnets to be created. Cluster actuator will create a network,\nsubnets with the defined CIDR, and a router connected to these subnets. Currently only one IPv4\nsubnet is supported. If you leave this empty, no network will be created.",
+          "items": {
+            "properties": {
+              "allocationPools": {
+                "description": "AllocationPools is an array of AllocationPool objects that will be applied to OpenStack Subnet being created.\nIf set, OpenStack will only allocate these IPs for Machines. It will still be possible to create ports from\noutside of these ranges manually.",
+                "items": {
+                  "properties": {
+                    "end": {
+                      "description": "End represents the end of the AlloctionPool, that is the highest IP of the pool.",
+                      "type": "string"
+                    },
+                    "start": {
+                      "description": "Start represents the start of the AllocationPool, that is the lowest IP of the pool.",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "end",
+                    "start"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "array"
+              },
+              "cidr": {
+                "description": "CIDR is representing the IP address range used to create the subnet, e.g. 10.0.0.0/24.\nThis field is required when defining a subnet.",
+                "type": "string"
+              },
+              "dnsNameservers": {
+                "description": "DNSNameservers holds a list of DNS server addresses that will be provided when creating\nthe subnet. These addresses need to have the same IP version as CIDR.",
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              }
+            },
+            "required": [
+              "cidr"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "maxItems": 1,
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        },
+        "network": {
+          "description": "Network specifies an existing network to use if no ManagedSubnets\nare specified.",
+          "maxProperties": 1,
+          "minProperties": 1,
+          "properties": {
+            "filter": {
+              "description": "Filter specifies a filter to select an OpenStack network. If provided, cannot be empty.",
+              "minProperties": 1,
+              "properties": {
+                "description": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "notTags": {
+                  "description": "NotTags is a list of tags to filter by. If specified, resources which\ncontain all of the given tags will be excluded from the result.",
+                  "items": {
+                    "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                    "minLength": 1,
+                    "pattern": "^[^,]+$",
+                    "type": "string"
+                  },
+                  "type": "array",
+                  "x-kubernetes-list-type": "set"
+                },
+                "notTagsAny": {
+                  "description": "NotTagsAny is a list of tags to filter by. If specified, resources\nwhich contain any of the given tags will be excluded from the result.",
+                  "items": {
+                    "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                    "minLength": 1,
+                    "pattern": "^[^,]+$",
+                    "type": "string"
+                  },
+                  "type": "array",
+                  "x-kubernetes-list-type": "set"
+                },
+                "projectID": {
+                  "type": "string"
+                },
+                "tags": {
+                  "description": "Tags is a list of tags to filter by. If specified, the resource must\nhave all of the tags specified to be included in the result.",
+                  "items": {
+                    "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                    "minLength": 1,
+                    "pattern": "^[^,]+$",
+                    "type": "string"
+                  },
+                  "type": "array",
+                  "x-kubernetes-list-type": "set"
+                },
+                "tagsAny": {
+                  "description": "TagsAny is a list of tags to filter by. If specified, the resource\nmust have at least one of the tags specified to be included in the\nresult.",
+                  "items": {
+                    "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                    "minLength": 1,
+                    "pattern": "^[^,]+$",
+                    "type": "string"
+                  },
+                  "type": "array",
+                  "x-kubernetes-list-type": "set"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "id": {
+              "description": "ID is the ID of the network to use. If ID is provided, the other filters cannot be provided. Must be in UUID format.",
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "networkMTU": {
+          "description": "NetworkMTU sets the maximum transmission unit (MTU) value to address fragmentation for the private network ID.\nThis value will be used only if the Cluster actuator creates the network.\nIf left empty, the network will have the default MTU defined in Openstack network service.\nTo use this field, the Openstack installation requires the net-mtu neutron API extension.",
+          "type": "integer"
+        },
+        "router": {
+          "description": "Router specifies an existing router to be used if ManagedSubnets are\nspecified. If specified, no new router will be created.",
+          "maxProperties": 1,
+          "minProperties": 1,
+          "properties": {
+            "filter": {
+              "description": "Filter specifies a filter to select an OpenStack router. If provided, cannot be empty.",
+              "minProperties": 1,
+              "properties": {
+                "description": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "notTags": {
+                  "description": "NotTags is a list of tags to filter by. If specified, resources which\ncontain all of the given tags will be excluded from the result.",
+                  "items": {
+                    "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                    "minLength": 1,
+                    "pattern": "^[^,]+$",
+                    "type": "string"
+                  },
+                  "type": "array",
+                  "x-kubernetes-list-type": "set"
+                },
+                "notTagsAny": {
+                  "description": "NotTagsAny is a list of tags to filter by. If specified, resources\nwhich contain any of the given tags will be excluded from the result.",
+                  "items": {
+                    "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                    "minLength": 1,
+                    "pattern": "^[^,]+$",
+                    "type": "string"
+                  },
+                  "type": "array",
+                  "x-kubernetes-list-type": "set"
+                },
+                "projectID": {
+                  "type": "string"
+                },
+                "tags": {
+                  "description": "Tags is a list of tags to filter by. If specified, the resource must\nhave all of the tags specified to be included in the result.",
+                  "items": {
+                    "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                    "minLength": 1,
+                    "pattern": "^[^,]+$",
+                    "type": "string"
+                  },
+                  "type": "array",
+                  "x-kubernetes-list-type": "set"
+                },
+                "tagsAny": {
+                  "description": "TagsAny is a list of tags to filter by. If specified, the resource\nmust have at least one of the tags specified to be included in the\nresult.",
+                  "items": {
+                    "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                    "minLength": 1,
+                    "pattern": "^[^,]+$",
+                    "type": "string"
+                  },
+                  "type": "array",
+                  "x-kubernetes-list-type": "set"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "id": {
+              "description": "ID is the ID of the router to use. If ID is provided, the other filters cannot be provided. Must be in UUID format.",
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "subnets": {
+          "description": "Subnets specifies existing subnets to use if not ManagedSubnets are\nspecified. All subnets must be in the network specified by Network.\nThere can be zero, one, or two subnets. If no subnets are specified,\nall subnets in Network will be used. If 2 subnets are specified, one\nmust be IPv4 and the other IPv6.",
+          "items": {
+            "description": "SubnetParam specifies an OpenStack subnet to use. It may be specified by either ID or filter, but not both.",
+            "maxProperties": 1,
+            "minProperties": 1,
+            "properties": {
+              "filter": {
+                "description": "Filter specifies a filter to select the subnet. It must match exactly one subnet.",
+                "minProperties": 1,
+                "properties": {
+                  "cidr": {
+                    "type": "string"
+                  },
+                  "description": {
+                    "type": "string"
+                  },
+                  "gatewayIP": {
+                    "type": "string"
+                  },
+                  "ipVersion": {
+                    "type": "integer"
+                  },
+                  "ipv6AddressMode": {
+                    "type": "string"
+                  },
+                  "ipv6RAMode": {
+                    "type": "string"
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "notTags": {
+                    "description": "NotTags is a list of tags to filter by. If specified, resources which\ncontain all of the given tags will be excluded from the result.",
+                    "items": {
+                      "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                      "minLength": 1,
+                      "pattern": "^[^,]+$",
+                      "type": "string"
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-type": "set"
+                  },
+                  "notTagsAny": {
+                    "description": "NotTagsAny is a list of tags to filter by. If specified, resources\nwhich contain any of the given tags will be excluded from the result.",
+                    "items": {
+                      "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                      "minLength": 1,
+                      "pattern": "^[^,]+$",
+                      "type": "string"
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-type": "set"
+                  },
+                  "projectID": {
+                    "type": "string"
+                  },
+                  "tags": {
+                    "description": "Tags is a list of tags to filter by. If specified, the resource must\nhave all of the tags specified to be included in the result.",
+                    "items": {
+                      "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                      "minLength": 1,
+                      "pattern": "^[^,]+$",
+                      "type": "string"
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-type": "set"
+                  },
+                  "tagsAny": {
+                    "description": "TagsAny is a list of tags to filter by. If specified, the resource\nmust have at least one of the tags specified to be included in the\nresult.",
+                    "items": {
+                      "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                      "minLength": 1,
+                      "pattern": "^[^,]+$",
+                      "type": "string"
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-type": "set"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "id": {
+                "description": "ID is the uuid of the subnet. It will not be validated.",
+                "format": "uuid",
+                "type": "string"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "maxItems": 2,
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        },
+        "tags": {
+          "description": "Tags to set on all resources in cluster which support tags",
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "set"
+        }
+      },
+      "required": [
+        "identityRef"
+      ],
+      "type": "object",
+      "x-kubernetes-validations": [
+        {
+          "message": "bastion floating IP cannot be set when disableExternalNetwork is true",
+          "rule": "has(self.disableExternalNetwork) && self.disableExternalNetwork ? !has(self.bastion) || !has(self.bastion.floatingIP) : true"
+        },
+        {
+          "message": "disableAPIServerFloatingIP cannot be false when disableExternalNetwork is true",
+          "rule": "has(self.disableExternalNetwork) && self.disableExternalNetwork ? has(self.disableAPIServerFloatingIP) && self.disableAPIServerFloatingIP : true"
+        }
+      ],
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "OpenStackClusterStatus defines the observed state of OpenStackCluster.",
+      "properties": {
+        "apiServerLoadBalancer": {
+          "description": "APIServerLoadBalancer describes the api server load balancer if one exists",
+          "properties": {
+            "allowedCIDRs": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "id": {
+              "type": "string"
+            },
+            "internalIP": {
+              "type": "string"
+            },
+            "ip": {
+              "type": "string"
+            },
+            "loadBalancerNetwork": {
+              "description": "LoadBalancerNetwork contains information about network and/or subnets which the\nloadbalancer is allocated on.\nIf subnets are specified within the LoadBalancerNetwork currently only the first\nsubnet in the list is taken into account.",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "subnets": {
+                  "description": "Subnets is a list of subnets associated with the default cluster network. Machines which use the default cluster network will get an address from all of these subnets.",
+                  "items": {
+                    "description": "Subnet represents basic information about the associated OpenStack Neutron Subnet.",
+                    "properties": {
+                      "cidr": {
+                        "type": "string"
+                      },
+                      "id": {
+                        "type": "string"
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "tags": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "required": [
+                      "cidr",
+                      "id",
+                      "name"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "tags": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                }
+              },
+              "required": [
+                "id",
+                "name"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "name": {
+              "type": "string"
+            },
+            "tags": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "id",
+            "internalIP",
+            "ip",
+            "name"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "bastion": {
+          "description": "Bastion contains the information about the deployed bastion host",
+          "properties": {
+            "floatingIP": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "ip": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "resolved": {
+              "description": "Resolved contains parts of the bastion's machine spec with all\nexternal references fully resolved.",
+              "properties": {
+                "flavorID": {
+                  "description": "FlavorID is the ID of the flavor to use.",
+                  "type": "string"
+                },
+                "imageID": {
+                  "description": "ImageID is the ID of the image to use for the machine and is calculated based on ImageFilter.",
+                  "type": "string"
+                },
+                "ports": {
+                  "description": "Ports is the fully resolved list of ports to create for the machine.",
+                  "items": {
+                    "description": "ResolvedPortSpec is a PortOpts with all contained references fully resolved.",
+                    "properties": {
+                      "adminStateUp": {
+                        "description": "AdminStateUp specifies whether the port should be created in the up (true) or down (false) state. The default is up.",
+                        "type": "boolean"
+                      },
+                      "allowedAddressPairs": {
+                        "description": "AllowedAddressPairs is a list of address pairs which Neutron will\nallow the port to send traffic from in addition to the port's\naddresses. If not specified, the MAC Address will be the MAC Address\nof the port. Depending on the configuration of Neutron, it may be\nsupported to specify a CIDR instead of a specific IP address.",
+                        "items": {
+                          "properties": {
+                            "ipAddress": {
+                              "description": "IPAddress is the IP address of the allowed address pair. Depending on\nthe configuration of Neutron, it may be supported to specify a CIDR\ninstead of a specific IP address.",
+                              "type": "string"
+                            },
+                            "macAddress": {
+                              "description": "MACAddress is the MAC address of the allowed address pair. If not\nspecified, the MAC address will be the MAC address of the port.",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "ipAddress"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "description": {
+                        "description": "Description is a human-readable description for the port.",
+                        "type": "string"
+                      },
+                      "disablePortSecurity": {
+                        "description": "DisablePortSecurity enables or disables the port security when set.\nWhen not set, it takes the value of the corresponding field at the network level.",
+                        "type": "boolean"
+                      },
+                      "fixedIPs": {
+                        "description": "FixedIPs is a list of pairs of subnet and/or IP address to assign to the port. If specified, these must be subnets of the port's network.",
+                        "items": {
+                          "description": "ResolvedFixedIP is a FixedIP with the Subnet resolved to an ID.",
+                          "properties": {
+                            "ipAddress": {
+                              "description": "IPAddress is a specific IP address to assign to the port. If SubnetID\nis also specified, IPAddress must be a valid IP address in the\nsubnet. If Subnet is not specified, IPAddress must be a valid IP\naddress in any subnet of the port's network.",
+                              "type": "string"
+                            },
+                            "subnet": {
+                              "description": "SubnetID is the id of a subnet to create the fixed IP of a port in.",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
+                      },
+                      "hostID": {
+                        "description": "HostID specifies the ID of the host where the port resides.",
+                        "type": "string"
+                      },
+                      "macAddress": {
+                        "description": "MACAddress specifies the MAC address of the port. If not specified, the MAC address will be generated.",
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "Name is the name of the port.",
+                        "type": "string"
+                      },
+                      "networkID": {
+                        "description": "NetworkID is the ID of the network the port will be created in.",
+                        "type": "string"
+                      },
+                      "profile": {
+                        "description": "Profile is a set of key-value pairs that are used for binding\ndetails. We intentionally don't expose this as a map[string]string\nbecause we only want to enable the users to set the values of the\nkeys that are known to work in OpenStack Networking API.  See\nhttps://docs.openstack.org/api-ref/network/v2/index.html?expanded=create-port-detail#create-port\nTo set profiles, your tenant needs permissions rule:create_port, and\nrule:create_port:binding:profile",
+                        "properties": {
+                          "ovsHWOffload": {
+                            "description": "OVSHWOffload enables or disables the OVS hardware offload feature.\nThis flag is not required on OpenStack clouds since Yoga as Nova will set it automatically when the port is attached.\nSee: https://bugs.launchpad.net/nova/+bug/2020813",
+                            "type": "boolean"
+                          },
+                          "trustedVF": {
+                            "description": "TrustedVF enables or disables the \u201ctrusted mode\u201d for the VF.",
+                            "type": "boolean"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "propagateUplinkStatus": {
+                        "description": "PropageteUplinkStatus enables or disables the propagate uplink status on the port.",
+                        "type": "boolean"
+                      },
+                      "securityGroups": {
+                        "description": "SecurityGroups is a list of security group IDs to assign to the port.",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
+                      },
+                      "tags": {
+                        "description": "Tags applied to the port (and corresponding trunk, if a trunk is configured.)",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array",
+                        "x-kubernetes-list-type": "set"
+                      },
+                      "trunk": {
+                        "description": "Trunk specifies whether trunking is enabled at the port level.",
+                        "type": "boolean"
+                      },
+                      "valueSpecs": {
+                        "description": "Value specs are extra parameters to include in the API request with OpenStack.\nThis is an extension point for the API, so what they do and if they are supported,\ndepends on the specific OpenStack implementation.",
+                        "items": {
+                          "description": "ValueSpec represents a single value_spec key-value pair.",
+                          "properties": {
+                            "key": {
+                              "description": "Key is the key in the key-value pair.",
+                              "type": "string"
+                            },
+                            "name": {
+                              "description": "Name is the name of the key-value pair.\nThis is just for identifying the pair and will not be sent to the OpenStack API.",
+                              "type": "string"
+                            },
+                            "value": {
+                              "description": "Value is the value in the key-value pair.",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "key",
+                            "name",
+                            "value"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array",
+                        "x-kubernetes-list-map-keys": [
+                          "name"
+                        ],
+                        "x-kubernetes-list-type": "map"
+                      },
+                      "vnicType": {
+                        "description": "VNICType specifies the type of vNIC which this port should be\nattached to. This is used to determine which mechanism driver(s) to\nbe used to bind the port. The valid values are normal, macvtap,\ndirect, baremetal, direct-physical, virtio-forwarder, smart-nic and\nremote-managed, although these values will not be validated in this\nAPI to ensure compatibility with future neutron changes or custom\nimplementations. What type of vNIC is actually available depends on\ndeployments. If not specified, the Neutron default value is used.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "description",
+                      "name",
+                      "networkID"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "serverGroupID": {
+                  "description": "ServerGroupID is the ID of the server group the machine should be added to and is calculated based on ServerGroupFilter.",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "resources": {
+              "description": "Resources contains references to OpenStack resources created for the bastion.",
+              "properties": {
+                "ports": {
+                  "description": "Ports is the status of the ports created for the machine.",
+                  "items": {
+                    "properties": {
+                      "id": {
+                        "description": "ID is the unique identifier of the port.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "id"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "sshKeyName": {
+              "type": "string"
+            },
+            "state": {
+              "description": "InstanceState describes the state of an OpenStack instance.",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "bastionSecurityGroup": {
+          "description": "BastionSecurityGroup contains the information about the OpenStack\nSecurity Group that needs to be applied to worker nodes.",
+          "properties": {
+            "id": {
+              "description": "id of the security group",
+              "type": "string"
+            },
+            "name": {
+              "description": "name of the security group",
+              "type": "string"
+            }
+          },
+          "required": [
+            "id",
+            "name"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "conditions": {
+          "description": "Conditions defines current service state of the OpenStackCluster.\nThis field surfaces into Cluster's status.conditions[InfrastructureReady] condition.\nThe Ready condition must surface issues during the entire lifecycle of the OpenStackCluster\n(both during initial provisioning and after the initial provisioning is completed).",
+          "items": {
+            "description": "Condition defines an observation of a Cluster API resource operational state.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "lastTransitionTime is the last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed. If that is not known, then using the time when\nthe API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "message is a human readable message indicating details about the transition.\nThis field may be empty.",
+                "maxLength": 10240,
+                "minLength": 1,
+                "type": "string"
+              },
+              "reason": {
+                "description": "reason is the reason for the condition's last transition in CamelCase.\nThe specific API may choose whether or not this field is considered a guaranteed API.\nThis field may be empty.",
+                "maxLength": 256,
+                "minLength": 1,
+                "type": "string"
+              },
+              "severity": {
+                "description": "severity provides an explicit classification of Reason code, so the users or machines can immediately\nunderstand the current situation and act accordingly.\nThe Severity field MUST be set only when Status=False.",
+                "maxLength": 32,
+                "type": "string"
+              },
+              "status": {
+                "description": "status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "type of condition in CamelCase or in foo.example.com/CamelCase.\nMany .condition.type values are consistent across resources like Available, but because arbitrary conditions\ncan be useful (see .node.status.conditions), the ability to deconflict is important.",
+                "maxLength": 256,
+                "minLength": 1,
+                "type": "string"
+              }
+            },
+            "required": [
+              "lastTransitionTime",
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "controlPlaneSecurityGroup": {
+          "description": "ControlPlaneSecurityGroup contains the information about the\nOpenStack Security Group that needs to be applied to control plane\nnodes.",
+          "properties": {
+            "id": {
+              "description": "id of the security group",
+              "type": "string"
+            },
+            "name": {
+              "description": "name of the security group",
+              "type": "string"
+            }
+          },
+          "required": [
+            "id",
+            "name"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "externalNetwork": {
+          "description": "ExternalNetwork contains information about the external network used for default ingress and egress traffic.",
+          "properties": {
+            "id": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "tags": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "id",
+            "name"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "failureDomains": {
+          "additionalProperties": {
+            "description": "FailureDomainSpec is the Schema for Cluster API failure domains.\nIt allows controllers to understand how many failure domains a cluster can optionally span across.",
+            "properties": {
+              "attributes": {
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "description": "attributes is a free form map of attributes an infrastructure provider might use or require.",
+                "type": "object"
+              },
+              "controlPlane": {
+                "description": "controlPlane determines if this failure domain is suitable for use by control plane machines.",
+                "type": "boolean"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "description": "FailureDomains represent OpenStack availability zones",
+          "type": "object"
+        },
+        "failureMessage": {
+          "description": "FailureMessage will be set in the event that there is a terminal problem\nreconciling the OpenStackCluster and will contain a more verbose string suitable\nfor logging and human consumption.\n\nThis field should not be set for transitive errors that a controller\nfaces that are expected to be fixed automatically over\ntime (like service outages), but instead indicate that something is\nfundamentally wrong with the OpenStackCluster's spec or the configuration of\nthe controller, and that manual intervention is required. Examples\nof terminal errors would be invalid combinations of settings in the\nspec, values that are unsupported by the controller, or the\nresponsible controller itself being critically misconfigured.\n\nAny transient errors that occur during the reconciliation of\nOpenStackClusters can be added as events to the OpenStackCluster object\nand/or logged in the controller's output.\n\nDeprecated: This field is deprecated and will be removed in a future API version.\nUse status.conditions to report failures.",
+          "type": "string"
+        },
+        "failureReason": {
+          "description": "FailureReason will be set in the event that there is a terminal problem\nreconciling the OpenStackCluster and will contain a succinct value suitable\nfor machine interpretation.\n\nThis field should not be set for transitive errors that a controller\nfaces that are expected to be fixed automatically over\ntime (like service outages), but instead indicate that something is\nfundamentally wrong with the OpenStackCluster's spec or the configuration of\nthe controller, and that manual intervention is required. Examples\nof terminal errors would be invalid combinations of settings in the\nspec, values that are unsupported by the controller, or the\nresponsible controller itself being critically misconfigured.\n\nAny transient errors that occur during the reconciliation of\nOpenStackClusters can be added as events to the OpenStackCluster object\nand/or logged in the controller's output.\n\nDeprecated: This field is deprecated and will be removed in a future API version.\nUse status.conditions to report failures.",
+          "type": "string"
+        },
+        "initialization": {
+          "description": "Initialization contains information about the initialization status of the cluster.",
+          "properties": {
+            "provisioned": {
+              "description": "Provisioned is set to true when the initial provisioning of the cluster infrastructure is completed.\nThe value of this field is never updated after provisioning is completed.",
+              "type": "boolean"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "network": {
+          "description": "Network contains information about the created OpenStack Network.",
+          "properties": {
+            "id": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "subnets": {
+              "description": "Subnets is a list of subnets associated with the default cluster network. Machines which use the default cluster network will get an address from all of these subnets.",
+              "items": {
+                "description": "Subnet represents basic information about the associated OpenStack Neutron Subnet.",
+                "properties": {
+                  "cidr": {
+                    "type": "string"
+                  },
+                  "id": {
+                    "type": "string"
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "tags": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "cidr",
+                  "id",
+                  "name"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "tags": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "id",
+            "name"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "ready": {
+          "default": false,
+          "description": "Ready is true when the cluster infrastructure is ready.\n\nDeprecated: This field is deprecated and will be removed in a future API version.\nUse status.conditions to determine the ready state of the cluster.",
+          "type": "boolean"
+        },
+        "router": {
+          "description": "Router describes the default cluster router",
+          "properties": {
+            "id": {
+              "type": "string"
+            },
+            "ips": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "name": {
+              "type": "string"
+            },
+            "tags": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "id",
+            "name"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "workerSecurityGroup": {
+          "description": "WorkerSecurityGroup contains the information about the OpenStack\nSecurity Group that needs to be applied to worker nodes.",
+          "properties": {
+            "id": {
+              "description": "id of the security group",
+              "type": "string"
+            },
+            "name": {
+              "description": "name of the security group",
+              "type": "string"
+            }
+          },
+          "required": [
+            "id",
+            "name"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "ready"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/infrastructure.cluster.x-k8s.io/openstackclusteridentity_v1alpha1.json
+++ b/infrastructure.cluster.x-k8s.io/openstackclusteridentity_v1alpha1.json
@@ -1,0 +1,93 @@
+{
+  "description": "OpenStackClusterIdentity is a cluster-scoped identity that centralizes OpenStack credentials.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "OpenStackClusterIdentitySpec defines the desired state for an OpenStackClusterIdentity.",
+      "properties": {
+        "namespaceSelector": {
+          "description": "NamespaceSelector limits which namespaces may use this identity. If nil, all namespaces are allowed.",
+          "properties": {
+            "matchExpressions": {
+              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+              "items": {
+                "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                "properties": {
+                  "key": {
+                    "description": "key is the label key that the selector applies to.",
+                    "type": "string"
+                  },
+                  "operator": {
+                    "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                    "type": "string"
+                  },
+                  "values": {
+                    "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
+                  }
+                },
+                "required": [
+                  "key",
+                  "operator"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array",
+              "x-kubernetes-list-type": "atomic"
+            },
+            "matchLabels": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+              "type": "object"
+            }
+          },
+          "type": "object",
+          "x-kubernetes-map-type": "atomic",
+          "additionalProperties": false
+        },
+        "secretRef": {
+          "description": "SecretRef references the credentials Secret containing a `clouds.yaml` file.",
+          "properties": {
+            "name": {
+              "description": "Name of the Secret which contains a `clouds.yaml` key (and optionally `cacert`).",
+              "type": "string"
+            },
+            "namespace": {
+              "description": "Namespace where the Secret resides.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "name",
+            "namespace"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "secretRef"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/infrastructure.cluster.x-k8s.io/openstackclustertemplate_v1beta1.json
+++ b/infrastructure.cluster.x-k8s.io/openstackclustertemplate_v1beta1.json
@@ -1,0 +1,2029 @@
+{
+  "description": "OpenStackClusterTemplate is the Schema for the openstackclustertemplates API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "OpenStackClusterTemplateSpec defines the desired state of OpenStackClusterTemplate.",
+      "properties": {
+        "template": {
+          "description": "OpenStackClusterTemplateResource describes the data needed to create a OpenStackCluster from a template.",
+          "properties": {
+            "spec": {
+              "description": "OpenStackClusterSpec defines the desired state of OpenStackCluster.",
+              "properties": {
+                "apiServerFixedIP": {
+                  "description": "APIServerFixedIP is the fixed IP which will be associated with the API server.\nIn the case where the API server has a floating IP but not a managed load balancer,\nthis field is not used.\nIf a managed load balancer is used and this field is not specified, a fixed IP will\nbe dynamically allocated for the load balancer.\nIf a managed load balancer is not used AND the API server floating IP is disabled,\nthis field MUST be specified and should correspond to a pre-allocated port that\nholds the fixed IP to be used as a VIP.",
+                  "type": "string"
+                },
+                "apiServerFloatingIP": {
+                  "description": "APIServerFloatingIP is the floatingIP which will be associated with the API server.\nThe floatingIP will be created if it does not already exist.\nIf not specified, a new floatingIP is allocated.\nThis field is not used if DisableAPIServerFloatingIP is set to true.",
+                  "type": "string"
+                },
+                "apiServerLoadBalancer": {
+                  "description": "APIServerLoadBalancer configures the optional LoadBalancer for the APIServer.\nIf not specified, no load balancer will be created for the API server.",
+                  "properties": {
+                    "additionalPorts": {
+                      "description": "AdditionalPorts adds additional tcp ports to the load balancer.",
+                      "items": {
+                        "type": "integer"
+                      },
+                      "type": "array",
+                      "x-kubernetes-list-type": "set"
+                    },
+                    "allowedCIDRs": {
+                      "description": "AllowedCIDRs restrict access to all API-Server listeners to the given address CIDRs.",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array",
+                      "x-kubernetes-list-type": "set"
+                    },
+                    "availabilityZone": {
+                      "description": "AvailabilityZone is the failure domain that will be used to create the APIServerLoadBalancer Spec.",
+                      "type": "string"
+                    },
+                    "enabled": {
+                      "default": true,
+                      "description": "Enabled defines whether a load balancer should be created. This value\ndefaults to true if an APIServerLoadBalancer is given.\n\nThere is no reason to set this to false. To disable creation of the\nAPI server loadbalancer, omit the APIServerLoadBalancer field in the\ncluster spec instead.",
+                      "type": "boolean"
+                    },
+                    "flavor": {
+                      "description": "Flavor is the flavor name that will be used to create the APIServerLoadBalancer Spec.",
+                      "type": "string"
+                    },
+                    "monitor": {
+                      "description": "Monitor contains configuration for the load balancer health monitor.",
+                      "properties": {
+                        "delay": {
+                          "description": "Delay is the time in seconds between sending probes to members.",
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "maxRetries": {
+                          "description": "MaxRetries is the number of successful checks before changing the operating status of the member to ONLINE.",
+                          "maximum": 10,
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "maxRetriesDown": {
+                          "description": "MaxRetriesDown is the number of allowed check failures before changing the operating status of the member to ERROR.",
+                          "maximum": 10,
+                          "minimum": 1,
+                          "type": "integer"
+                        },
+                        "timeout": {
+                          "description": "Timeout is the maximum time in seconds for a monitor to wait for a connection to be established before it times out.",
+                          "minimum": 0,
+                          "type": "integer"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "network": {
+                      "description": "Network defines which network should the load balancer be allocated on.",
+                      "maxProperties": 1,
+                      "minProperties": 1,
+                      "properties": {
+                        "filter": {
+                          "description": "Filter specifies a filter to select an OpenStack network. If provided, cannot be empty.",
+                          "minProperties": 1,
+                          "properties": {
+                            "description": {
+                              "type": "string"
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "notTags": {
+                              "description": "NotTags is a list of tags to filter by. If specified, resources which\ncontain all of the given tags will be excluded from the result.",
+                              "items": {
+                                "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                                "minLength": 1,
+                                "pattern": "^[^,]+$",
+                                "type": "string"
+                              },
+                              "type": "array",
+                              "x-kubernetes-list-type": "set"
+                            },
+                            "notTagsAny": {
+                              "description": "NotTagsAny is a list of tags to filter by. If specified, resources\nwhich contain any of the given tags will be excluded from the result.",
+                              "items": {
+                                "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                                "minLength": 1,
+                                "pattern": "^[^,]+$",
+                                "type": "string"
+                              },
+                              "type": "array",
+                              "x-kubernetes-list-type": "set"
+                            },
+                            "projectID": {
+                              "type": "string"
+                            },
+                            "tags": {
+                              "description": "Tags is a list of tags to filter by. If specified, the resource must\nhave all of the tags specified to be included in the result.",
+                              "items": {
+                                "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                                "minLength": 1,
+                                "pattern": "^[^,]+$",
+                                "type": "string"
+                              },
+                              "type": "array",
+                              "x-kubernetes-list-type": "set"
+                            },
+                            "tagsAny": {
+                              "description": "TagsAny is a list of tags to filter by. If specified, the resource\nmust have at least one of the tags specified to be included in the\nresult.",
+                              "items": {
+                                "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                                "minLength": 1,
+                                "pattern": "^[^,]+$",
+                                "type": "string"
+                              },
+                              "type": "array",
+                              "x-kubernetes-list-type": "set"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "id": {
+                          "description": "ID is the ID of the network to use. If ID is provided, the other filters cannot be provided. Must be in UUID format.",
+                          "format": "uuid",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "provider": {
+                      "description": "Provider specifies name of a specific Octavia provider to use for the\nAPI load balancer. The Octavia default will be used if it is not\nspecified.",
+                      "type": "string"
+                    },
+                    "subnets": {
+                      "description": "Subnets define which subnets should the load balancer be allocated on.\nIt is expected that subnets are located on the network specified in this resource.\nOnly the first element is taken into account.\nkubebuilder:validation:MaxLength:=2",
+                      "items": {
+                        "description": "SubnetParam specifies an OpenStack subnet to use. It may be specified by either ID or filter, but not both.",
+                        "maxProperties": 1,
+                        "minProperties": 1,
+                        "properties": {
+                          "filter": {
+                            "description": "Filter specifies a filter to select the subnet. It must match exactly one subnet.",
+                            "minProperties": 1,
+                            "properties": {
+                              "cidr": {
+                                "type": "string"
+                              },
+                              "description": {
+                                "type": "string"
+                              },
+                              "gatewayIP": {
+                                "type": "string"
+                              },
+                              "ipVersion": {
+                                "type": "integer"
+                              },
+                              "ipv6AddressMode": {
+                                "type": "string"
+                              },
+                              "ipv6RAMode": {
+                                "type": "string"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "notTags": {
+                                "description": "NotTags is a list of tags to filter by. If specified, resources which\ncontain all of the given tags will be excluded from the result.",
+                                "items": {
+                                  "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                                  "minLength": 1,
+                                  "pattern": "^[^,]+$",
+                                  "type": "string"
+                                },
+                                "type": "array",
+                                "x-kubernetes-list-type": "set"
+                              },
+                              "notTagsAny": {
+                                "description": "NotTagsAny is a list of tags to filter by. If specified, resources\nwhich contain any of the given tags will be excluded from the result.",
+                                "items": {
+                                  "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                                  "minLength": 1,
+                                  "pattern": "^[^,]+$",
+                                  "type": "string"
+                                },
+                                "type": "array",
+                                "x-kubernetes-list-type": "set"
+                              },
+                              "projectID": {
+                                "type": "string"
+                              },
+                              "tags": {
+                                "description": "Tags is a list of tags to filter by. If specified, the resource must\nhave all of the tags specified to be included in the result.",
+                                "items": {
+                                  "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                                  "minLength": 1,
+                                  "pattern": "^[^,]+$",
+                                  "type": "string"
+                                },
+                                "type": "array",
+                                "x-kubernetes-list-type": "set"
+                              },
+                              "tagsAny": {
+                                "description": "TagsAny is a list of tags to filter by. If specified, the resource\nmust have at least one of the tags specified to be included in the\nresult.",
+                                "items": {
+                                  "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                                  "minLength": 1,
+                                  "pattern": "^[^,]+$",
+                                  "type": "string"
+                                },
+                                "type": "array",
+                                "x-kubernetes-list-type": "set"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "id": {
+                            "description": "ID is the uuid of the subnet. It will not be validated.",
+                            "format": "uuid",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array",
+                      "x-kubernetes-list-type": "atomic"
+                    }
+                  },
+                  "required": [
+                    "enabled"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "apiServerPort": {
+                  "description": "APIServerPort is the port on which the listener on the APIServer\nwill be created. If specified, it must be an integer between 0 and 65535.",
+                  "maximum": 65535,
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "bastion": {
+                  "description": "Bastion is the OpenStack instance to login the nodes\n\nAs a rolling update is not ideal during a bastion host session, we\nprevent changes to a running bastion configuration. To make changes, it's required\nto first set `enabled: false` which will remove the bastion and then changes can be made.",
+                  "properties": {
+                    "availabilityZone": {
+                      "description": "AvailabilityZone is the failure domain that will be used to create the Bastion Spec.",
+                      "type": "string"
+                    },
+                    "enabled": {
+                      "default": true,
+                      "description": "Enabled means that bastion is enabled. The bastion is enabled by\ndefault if this field is not specified. Set this field to false to disable the\nbastion.\n\nIt is not currently possible to remove the bastion from the cluster\nspec without first disabling it by setting this field to false and\nwaiting until the bastion has been deleted.",
+                      "type": "boolean"
+                    },
+                    "floatingIP": {
+                      "description": "FloatingIP which will be associated to the bastion machine. It's the IP address, not UUID.\nThe floating IP should already exist and should not be associated with a port. If FIP of this address does not\nexist, CAPO will try to create it, but by default only OpenStack administrators have privileges to do so.",
+                      "format": "ipv4",
+                      "type": "string"
+                    },
+                    "spec": {
+                      "description": "Spec for the bastion itself",
+                      "properties": {
+                        "additionalBlockDevices": {
+                          "description": "AdditionalBlockDevices is a list of specifications for additional block devices to attach to the server instance",
+                          "items": {
+                            "description": "AdditionalBlockDevice is a block device to attach to the server.",
+                            "properties": {
+                              "name": {
+                                "description": "Name of the block device in the context of a machine.\nIf the block device is a volume, the Cinder volume will be named\nas a combination of the machine name and this name.\nAlso, this name will be used for tagging the block device.\nInformation about the block device tag can be obtained from the OpenStack\nmetadata API or the config drive.\nName cannot be 'root', which is reserved for the root volume.",
+                                "type": "string"
+                              },
+                              "sizeGiB": {
+                                "description": "SizeGiB is the size of the block device in gibibytes (GiB).",
+                                "minimum": 1,
+                                "type": "integer"
+                              },
+                              "storage": {
+                                "description": "Storage specifies the storage type of the block device and\nadditional storage options.",
+                                "properties": {
+                                  "type": {
+                                    "description": "Type is the type of block device to create.\nThis can be either \"Volume\" or \"Local\".",
+                                    "type": "string"
+                                  },
+                                  "volume": {
+                                    "description": "Volume contains additional storage options for a volume block device.",
+                                    "properties": {
+                                      "availabilityZone": {
+                                        "description": "AvailabilityZone is the volume availability zone to create the volume\nin. If not specified, the volume will be created without an explicit\navailability zone.",
+                                        "properties": {
+                                          "from": {
+                                            "default": "Name",
+                                            "description": "From specifies where we will obtain the availability zone for the\nvolume. The options are \"Name\" and \"Machine\". If \"Name\" is specified\nthen the Name field must also be specified. If \"Machine\" is specified\nthe volume will use the value of FailureDomain, if any, from the\nassociated Machine.",
+                                            "enum": [
+                                              "Name",
+                                              "Machine"
+                                            ],
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "description": "Name is the name of a volume availability zone to use. It is required\nif From is \"Name\". The volume availability zone name may not contain\nspaces.",
+                                            "minLength": 1,
+                                            "pattern": "^[^ ]+$",
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "name is required when from is 'Name' or default",
+                                            "rule": "!has(self.from) || self.from == 'Name' ? has(self.name) : !has(self.name)"
+                                          }
+                                        ],
+                                        "additionalProperties": false
+                                      },
+                                      "type": {
+                                        "description": "Type is the Cinder volume type of the volume.\nIf omitted, the default Cinder volume type that is configured in the OpenStack cloud\nwill be used.",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "required": [
+                                  "type"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "required": [
+                              "name",
+                              "sizeGiB",
+                              "storage"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array",
+                          "x-kubernetes-list-map-keys": [
+                            "name"
+                          ],
+                          "x-kubernetes-list-type": "map"
+                        },
+                        "configDrive": {
+                          "description": "Config Drive support",
+                          "type": "boolean"
+                        },
+                        "flavor": {
+                          "description": "The flavor reference for the flavor for your server instance.",
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "flavorID": {
+                          "description": "FlavorID allows flavors to be specified by ID.  This field takes precedence\nover Flavor.",
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "floatingIPPoolRef": {
+                          "description": "floatingIPPoolRef is a reference to a IPPool that will be assigned\nto an IPAddressClaim. Once the IPAddressClaim is fulfilled, the FloatingIP\nwill be assigned to the OpenStackMachine.",
+                          "properties": {
+                            "apiGroup": {
+                              "description": "APIGroup is the group for the resource being referenced.\nIf APIGroup is not specified, the specified Kind must be in the core API group.\nFor any other third-party types, APIGroup is required.",
+                              "type": "string"
+                            },
+                            "kind": {
+                              "description": "Kind is the type of resource being referenced",
+                              "type": "string"
+                            },
+                            "name": {
+                              "description": "Name is the name of resource being referenced",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "kind",
+                            "name"
+                          ],
+                          "type": "object",
+                          "x-kubernetes-map-type": "atomic",
+                          "additionalProperties": false
+                        },
+                        "identityRef": {
+                          "description": "IdentityRef is a reference to a secret holding OpenStack credentials\nto be used when reconciling this machine. If not specified, the\ncredentials specified in the cluster will be used.",
+                          "properties": {
+                            "cloudName": {
+                              "description": "CloudName specifies the name of the entry in the clouds.yaml file to use.",
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "name": {
+                              "description": "Name is the name of a Secret (type=Secret) in the same namespace as the resource being provisioned,\nor the name of an OpenStackClusterIdentity (type=ClusterIdentity).\nThe Secret must contain a key named `clouds.yaml` which contains an OpenStack clouds.yaml file.\nThe Secret may optionally contain a key named `cacert` containing a PEM-encoded CA certificate.",
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "region": {
+                              "description": "Region specifies an OpenStack region to use. If specified, it overrides\nany value in clouds.yaml. If specified for an OpenStackMachine, its\nvalue will be included in providerID.",
+                              "type": "string"
+                            },
+                            "type": {
+                              "default": "Secret",
+                              "description": "Type specifies the identity reference type. Defaults to Secret for backward compatibility.",
+                              "enum": [
+                                "Secret",
+                                "ClusterIdentity"
+                              ],
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "cloudName",
+                            "name",
+                            "type"
+                          ],
+                          "type": "object",
+                          "x-kubernetes-validations": [
+                            {
+                              "message": "region is immutable",
+                              "rule": "(!has(self.region) && !has(oldSelf.region)) || self.region == oldSelf.region"
+                            }
+                          ],
+                          "additionalProperties": false
+                        },
+                        "image": {
+                          "description": "The image to use for your server instance.\nIf the rootVolume is specified, this will be used when creating the root volume.",
+                          "maxProperties": 1,
+                          "minProperties": 1,
+                          "properties": {
+                            "filter": {
+                              "description": "Filter describes a query for an image. If specified, the combination\nof name and tags must return a single matching image or an error will\nbe raised.",
+                              "minProperties": 1,
+                              "properties": {
+                                "name": {
+                                  "description": "The name of the desired image. If specified, the combination of name and tags must return a single matching image or an error will be raised.",
+                                  "type": "string"
+                                },
+                                "tags": {
+                                  "description": "The tags associated with the desired image. If specified, the combination of name and tags must return a single matching image or an error will be raised.",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "set"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "id": {
+                              "description": "ID is the uuid of the image. ID will not be validated before use.",
+                              "format": "uuid",
+                              "type": "string"
+                            },
+                            "imageRef": {
+                              "description": "ImageRef is a reference to an ORC Image in the same namespace as the\nreferring object.",
+                              "properties": {
+                                "name": {
+                                  "description": "Name is the name of the referenced resource",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "name"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "ports": {
+                          "description": "Ports to be attached to the server instance. They are created if a port with the given name does not already exist.\nIf not specified a default port will be added for the default cluster network.",
+                          "items": {
+                            "properties": {
+                              "adminStateUp": {
+                                "description": "AdminStateUp specifies whether the port should be created in the up (true) or down (false) state. The default is up.",
+                                "type": "boolean"
+                              },
+                              "allowedAddressPairs": {
+                                "description": "AllowedAddressPairs is a list of address pairs which Neutron will\nallow the port to send traffic from in addition to the port's\naddresses. If not specified, the MAC Address will be the MAC Address\nof the port. Depending on the configuration of Neutron, it may be\nsupported to specify a CIDR instead of a specific IP address.",
+                                "items": {
+                                  "properties": {
+                                    "ipAddress": {
+                                      "description": "IPAddress is the IP address of the allowed address pair. Depending on\nthe configuration of Neutron, it may be supported to specify a CIDR\ninstead of a specific IP address.",
+                                      "type": "string"
+                                    },
+                                    "macAddress": {
+                                      "description": "MACAddress is the MAC address of the allowed address pair. If not\nspecified, the MAC address will be the MAC address of the port.",
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "ipAddress"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "description": {
+                                "description": "Description is a human-readable description for the port.",
+                                "type": "string"
+                              },
+                              "disablePortSecurity": {
+                                "description": "DisablePortSecurity enables or disables the port security when set.\nWhen not set, it takes the value of the corresponding field at the network level.",
+                                "type": "boolean"
+                              },
+                              "fixedIPs": {
+                                "description": "FixedIPs is a list of pairs of subnet and/or IP address to assign to the port. If specified, these must be subnets of the port's network.",
+                                "items": {
+                                  "properties": {
+                                    "ipAddress": {
+                                      "description": "IPAddress is a specific IP address to assign to the port. If Subnet\nis also specified, IPAddress must be a valid IP address in the\nsubnet. If Subnet is not specified, IPAddress must be a valid IP\naddress in any subnet of the port's network.",
+                                      "type": "string"
+                                    },
+                                    "subnet": {
+                                      "description": "Subnet is an openstack subnet query that will return the id of a subnet to create\nthe fixed IP of a port in. This query must not return more than one subnet.",
+                                      "maxProperties": 1,
+                                      "minProperties": 1,
+                                      "properties": {
+                                        "filter": {
+                                          "description": "Filter specifies a filter to select the subnet. It must match exactly one subnet.",
+                                          "minProperties": 1,
+                                          "properties": {
+                                            "cidr": {
+                                              "type": "string"
+                                            },
+                                            "description": {
+                                              "type": "string"
+                                            },
+                                            "gatewayIP": {
+                                              "type": "string"
+                                            },
+                                            "ipVersion": {
+                                              "type": "integer"
+                                            },
+                                            "ipv6AddressMode": {
+                                              "type": "string"
+                                            },
+                                            "ipv6RAMode": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "notTags": {
+                                              "description": "NotTags is a list of tags to filter by. If specified, resources which\ncontain all of the given tags will be excluded from the result.",
+                                              "items": {
+                                                "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                                                "minLength": 1,
+                                                "pattern": "^[^,]+$",
+                                                "type": "string"
+                                              },
+                                              "type": "array",
+                                              "x-kubernetes-list-type": "set"
+                                            },
+                                            "notTagsAny": {
+                                              "description": "NotTagsAny is a list of tags to filter by. If specified, resources\nwhich contain any of the given tags will be excluded from the result.",
+                                              "items": {
+                                                "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                                                "minLength": 1,
+                                                "pattern": "^[^,]+$",
+                                                "type": "string"
+                                              },
+                                              "type": "array",
+                                              "x-kubernetes-list-type": "set"
+                                            },
+                                            "projectID": {
+                                              "type": "string"
+                                            },
+                                            "tags": {
+                                              "description": "Tags is a list of tags to filter by. If specified, the resource must\nhave all of the tags specified to be included in the result.",
+                                              "items": {
+                                                "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                                                "minLength": 1,
+                                                "pattern": "^[^,]+$",
+                                                "type": "string"
+                                              },
+                                              "type": "array",
+                                              "x-kubernetes-list-type": "set"
+                                            },
+                                            "tagsAny": {
+                                              "description": "TagsAny is a list of tags to filter by. If specified, the resource\nmust have at least one of the tags specified to be included in the\nresult.",
+                                              "items": {
+                                                "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                                                "minLength": 1,
+                                                "pattern": "^[^,]+$",
+                                                "type": "string"
+                                              },
+                                              "type": "array",
+                                              "x-kubernetes-list-type": "set"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "id": {
+                                          "description": "ID is the uuid of the subnet. It will not be validated.",
+                                          "format": "uuid",
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
+                              },
+                              "hostID": {
+                                "description": "HostID specifies the ID of the host where the port resides.",
+                                "type": "string"
+                              },
+                              "macAddress": {
+                                "description": "MACAddress specifies the MAC address of the port. If not specified, the MAC address will be generated.",
+                                "type": "string"
+                              },
+                              "nameSuffix": {
+                                "description": "NameSuffix will be appended to the name of the port if specified. If unspecified, instead the 0-based index of the port in the list is used.",
+                                "type": "string"
+                              },
+                              "network": {
+                                "description": "Network is a query for an openstack network that the port will be created or discovered on.\nThis will fail if the query returns more than one network.",
+                                "maxProperties": 1,
+                                "minProperties": 1,
+                                "properties": {
+                                  "filter": {
+                                    "description": "Filter specifies a filter to select an OpenStack network. If provided, cannot be empty.",
+                                    "minProperties": 1,
+                                    "properties": {
+                                      "description": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "notTags": {
+                                        "description": "NotTags is a list of tags to filter by. If specified, resources which\ncontain all of the given tags will be excluded from the result.",
+                                        "items": {
+                                          "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                                          "minLength": 1,
+                                          "pattern": "^[^,]+$",
+                                          "type": "string"
+                                        },
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "set"
+                                      },
+                                      "notTagsAny": {
+                                        "description": "NotTagsAny is a list of tags to filter by. If specified, resources\nwhich contain any of the given tags will be excluded from the result.",
+                                        "items": {
+                                          "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                                          "minLength": 1,
+                                          "pattern": "^[^,]+$",
+                                          "type": "string"
+                                        },
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "set"
+                                      },
+                                      "projectID": {
+                                        "type": "string"
+                                      },
+                                      "tags": {
+                                        "description": "Tags is a list of tags to filter by. If specified, the resource must\nhave all of the tags specified to be included in the result.",
+                                        "items": {
+                                          "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                                          "minLength": 1,
+                                          "pattern": "^[^,]+$",
+                                          "type": "string"
+                                        },
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "set"
+                                      },
+                                      "tagsAny": {
+                                        "description": "TagsAny is a list of tags to filter by. If specified, the resource\nmust have at least one of the tags specified to be included in the\nresult.",
+                                        "items": {
+                                          "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                                          "minLength": 1,
+                                          "pattern": "^[^,]+$",
+                                          "type": "string"
+                                        },
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "set"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "id": {
+                                    "description": "ID is the ID of the network to use. If ID is provided, the other filters cannot be provided. Must be in UUID format.",
+                                    "format": "uuid",
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "profile": {
+                                "description": "Profile is a set of key-value pairs that are used for binding\ndetails. We intentionally don't expose this as a map[string]string\nbecause we only want to enable the users to set the values of the\nkeys that are known to work in OpenStack Networking API.  See\nhttps://docs.openstack.org/api-ref/network/v2/index.html?expanded=create-port-detail#create-port\nTo set profiles, your tenant needs permissions rule:create_port, and\nrule:create_port:binding:profile",
+                                "properties": {
+                                  "ovsHWOffload": {
+                                    "description": "OVSHWOffload enables or disables the OVS hardware offload feature.\nThis flag is not required on OpenStack clouds since Yoga as Nova will set it automatically when the port is attached.\nSee: https://bugs.launchpad.net/nova/+bug/2020813",
+                                    "type": "boolean"
+                                  },
+                                  "trustedVF": {
+                                    "description": "TrustedVF enables or disables the \u201ctrusted mode\u201d for the VF.",
+                                    "type": "boolean"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "propagateUplinkStatus": {
+                                "description": "PropageteUplinkStatus enables or disables the propagate uplink status on the port.",
+                                "type": "boolean"
+                              },
+                              "securityGroups": {
+                                "description": "SecurityGroups is a list of the names, uuids, filters or any combination these of the security groups to assign to the instance.",
+                                "items": {
+                                  "description": "SecurityGroupParam specifies an OpenStack security group. It may be specified by ID or filter, but not both.",
+                                  "maxProperties": 1,
+                                  "minProperties": 1,
+                                  "properties": {
+                                    "filter": {
+                                      "description": "Filter specifies a query to select an OpenStack security group. If provided, cannot be empty.",
+                                      "minProperties": 1,
+                                      "properties": {
+                                        "description": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "notTags": {
+                                          "description": "NotTags is a list of tags to filter by. If specified, resources which\ncontain all of the given tags will be excluded from the result.",
+                                          "items": {
+                                            "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                                            "minLength": 1,
+                                            "pattern": "^[^,]+$",
+                                            "type": "string"
+                                          },
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "set"
+                                        },
+                                        "notTagsAny": {
+                                          "description": "NotTagsAny is a list of tags to filter by. If specified, resources\nwhich contain any of the given tags will be excluded from the result.",
+                                          "items": {
+                                            "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                                            "minLength": 1,
+                                            "pattern": "^[^,]+$",
+                                            "type": "string"
+                                          },
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "set"
+                                        },
+                                        "projectID": {
+                                          "type": "string"
+                                        },
+                                        "tags": {
+                                          "description": "Tags is a list of tags to filter by. If specified, the resource must\nhave all of the tags specified to be included in the result.",
+                                          "items": {
+                                            "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                                            "minLength": 1,
+                                            "pattern": "^[^,]+$",
+                                            "type": "string"
+                                          },
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "set"
+                                        },
+                                        "tagsAny": {
+                                          "description": "TagsAny is a list of tags to filter by. If specified, the resource\nmust have at least one of the tags specified to be included in the\nresult.",
+                                          "items": {
+                                            "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                                            "minLength": 1,
+                                            "pattern": "^[^,]+$",
+                                            "type": "string"
+                                          },
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "set"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "id": {
+                                      "description": "ID is the ID of the security group to use. If ID is provided, the other filters cannot be provided. Must be in UUID format.",
+                                      "format": "uuid",
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
+                              },
+                              "tags": {
+                                "description": "Tags applied to the port (and corresponding trunk, if a trunk is configured.)\nThese tags are applied in addition to the instance's tags, which will also be applied to the port.",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array",
+                                "x-kubernetes-list-type": "set"
+                              },
+                              "trunk": {
+                                "description": "Trunk specifies whether trunking is enabled at the port level. If not\nprovided the value is inherited from the machine, or false for a\nbastion host.",
+                                "type": "boolean"
+                              },
+                              "valueSpecs": {
+                                "description": "Value specs are extra parameters to include in the API request with OpenStack.\nThis is an extension point for the API, so what they do and if they are supported,\ndepends on the specific OpenStack implementation.",
+                                "items": {
+                                  "description": "ValueSpec represents a single value_spec key-value pair.",
+                                  "properties": {
+                                    "key": {
+                                      "description": "Key is the key in the key-value pair.",
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "description": "Name is the name of the key-value pair.\nThis is just for identifying the pair and will not be sent to the OpenStack API.",
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "description": "Value is the value in the key-value pair.",
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "key",
+                                    "name",
+                                    "value"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array",
+                                "x-kubernetes-list-map-keys": [
+                                  "name"
+                                ],
+                                "x-kubernetes-list-type": "map"
+                              },
+                              "vnicType": {
+                                "description": "VNICType specifies the type of vNIC which this port should be\nattached to. This is used to determine which mechanism driver(s) to\nbe used to bind the port. The valid values are normal, macvtap,\ndirect, baremetal, direct-physical, virtio-forwarder, smart-nic and\nremote-managed, although these values will not be validated in this\nAPI to ensure compatibility with future neutron changes or custom\nimplementations. What type of vNIC is actually available depends on\ndeployments. If not specified, the Neutron default value is used.",
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "providerID": {
+                          "description": "ProviderID is the unique identifier as specified by the cloud provider.",
+                          "type": "string"
+                        },
+                        "rootVolume": {
+                          "description": "The volume metadata to boot from",
+                          "properties": {
+                            "availabilityZone": {
+                              "description": "AvailabilityZone is the volume availability zone to create the volume\nin. If not specified, the volume will be created without an explicit\navailability zone.",
+                              "properties": {
+                                "from": {
+                                  "default": "Name",
+                                  "description": "From specifies where we will obtain the availability zone for the\nvolume. The options are \"Name\" and \"Machine\". If \"Name\" is specified\nthen the Name field must also be specified. If \"Machine\" is specified\nthe volume will use the value of FailureDomain, if any, from the\nassociated Machine.",
+                                  "enum": [
+                                    "Name",
+                                    "Machine"
+                                  ],
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "description": "Name is the name of a volume availability zone to use. It is required\nif From is \"Name\". The volume availability zone name may not contain\nspaces.",
+                                  "minLength": 1,
+                                  "pattern": "^[^ ]+$",
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "x-kubernetes-validations": [
+                                {
+                                  "message": "name is required when from is 'Name' or default",
+                                  "rule": "!has(self.from) || self.from == 'Name' ? has(self.name) : !has(self.name)"
+                                }
+                              ],
+                              "additionalProperties": false
+                            },
+                            "sizeGiB": {
+                              "description": "SizeGiB is the size of the block device in gibibytes (GiB).",
+                              "minimum": 1,
+                              "type": "integer"
+                            },
+                            "type": {
+                              "description": "Type is the Cinder volume type of the volume.\nIf omitted, the default Cinder volume type that is configured in the OpenStack cloud\nwill be used.",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "sizeGiB"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "schedulerHintAdditionalProperties": {
+                          "description": "SchedulerHintAdditionalProperties are arbitrary key/value pairs that provide additional hints\nto the OpenStack scheduler. These hints can influence how instances are placed on the infrastructure,\nsuch as specifying certain host aggregates or availability zones.",
+                          "items": {
+                            "description": "SchedulerHintAdditionalProperty represents a single additional property for a scheduler hint.\nIt includes a Name to identify the property and a Value that can be of various types.",
+                            "properties": {
+                              "name": {
+                                "description": "Name is the name of the scheduler hint property.\nIt is a unique identifier for the property.",
+                                "minLength": 1,
+                                "type": "string"
+                              },
+                              "value": {
+                                "description": "Value is the value of the scheduler hint property, which can be of various types\n(e.g., bool, string, int). The type is indicated by the Value.Type field.",
+                                "properties": {
+                                  "bool": {
+                                    "description": "Bool is the boolean value of the scheduler hint, used when Type is \"Bool\".\nThis field is required if type is 'Bool', and must not be set otherwise.",
+                                    "type": "boolean"
+                                  },
+                                  "number": {
+                                    "description": "Number is the integer value of the scheduler hint, used when Type is \"Number\".\nThis field is required if type is 'Number', and must not be set otherwise.",
+                                    "type": "integer"
+                                  },
+                                  "string": {
+                                    "description": "String is the string value of the scheduler hint, used when Type is \"String\".\nThis field is required if type is 'String', and must not be set otherwise.",
+                                    "maxLength": 255,
+                                    "minLength": 1,
+                                    "type": "string"
+                                  },
+                                  "type": {
+                                    "description": "Type represents the type of the value.\nValid values are Bool, String, and Number.",
+                                    "enum": [
+                                      "Bool",
+                                      "String",
+                                      "Number"
+                                    ],
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "type"
+                                ],
+                                "type": "object",
+                                "x-kubernetes-validations": [
+                                  {
+                                    "message": "bool is required when type is Bool, and forbidden otherwise",
+                                    "rule": "has(self.type) && self.type == 'Bool' ? has(self.bool) : !has(self.bool)"
+                                  },
+                                  {
+                                    "message": "number is required when type is Number, and forbidden otherwise",
+                                    "rule": "has(self.type) && self.type == 'Number' ? has(self.number) : !has(self.number)"
+                                  },
+                                  {
+                                    "message": "string is required when type is String, and forbidden otherwise",
+                                    "rule": "has(self.type) && self.type == 'String' ? has(self.string) : !has(self.string)"
+                                  }
+                                ],
+                                "additionalProperties": false
+                              }
+                            },
+                            "required": [
+                              "name",
+                              "value"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array",
+                          "x-kubernetes-list-map-keys": [
+                            "name"
+                          ],
+                          "x-kubernetes-list-type": "map"
+                        },
+                        "securityGroups": {
+                          "description": "The names of the security groups to assign to the instance",
+                          "items": {
+                            "description": "SecurityGroupParam specifies an OpenStack security group. It may be specified by ID or filter, but not both.",
+                            "maxProperties": 1,
+                            "minProperties": 1,
+                            "properties": {
+                              "filter": {
+                                "description": "Filter specifies a query to select an OpenStack security group. If provided, cannot be empty.",
+                                "minProperties": 1,
+                                "properties": {
+                                  "description": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "notTags": {
+                                    "description": "NotTags is a list of tags to filter by. If specified, resources which\ncontain all of the given tags will be excluded from the result.",
+                                    "items": {
+                                      "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                                      "minLength": 1,
+                                      "pattern": "^[^,]+$",
+                                      "type": "string"
+                                    },
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "set"
+                                  },
+                                  "notTagsAny": {
+                                    "description": "NotTagsAny is a list of tags to filter by. If specified, resources\nwhich contain any of the given tags will be excluded from the result.",
+                                    "items": {
+                                      "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                                      "minLength": 1,
+                                      "pattern": "^[^,]+$",
+                                      "type": "string"
+                                    },
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "set"
+                                  },
+                                  "projectID": {
+                                    "type": "string"
+                                  },
+                                  "tags": {
+                                    "description": "Tags is a list of tags to filter by. If specified, the resource must\nhave all of the tags specified to be included in the result.",
+                                    "items": {
+                                      "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                                      "minLength": 1,
+                                      "pattern": "^[^,]+$",
+                                      "type": "string"
+                                    },
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "set"
+                                  },
+                                  "tagsAny": {
+                                    "description": "TagsAny is a list of tags to filter by. If specified, the resource\nmust have at least one of the tags specified to be included in the\nresult.",
+                                    "items": {
+                                      "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                                      "minLength": 1,
+                                      "pattern": "^[^,]+$",
+                                      "type": "string"
+                                    },
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "set"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "id": {
+                                "description": "ID is the ID of the security group to use. If ID is provided, the other filters cannot be provided. Must be in UUID format.",
+                                "format": "uuid",
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "serverGroup": {
+                          "description": "The server group to assign the machine to.",
+                          "maxProperties": 1,
+                          "minProperties": 1,
+                          "properties": {
+                            "filter": {
+                              "description": "Filter specifies a query to select an OpenStack server group. If provided, it cannot be empty.",
+                              "minProperties": 1,
+                              "properties": {
+                                "name": {
+                                  "description": "Name is the name of a server group to look for.",
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "id": {
+                              "description": "ID is the ID of the server group to use.",
+                              "format": "uuid",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "serverMetadata": {
+                          "description": "Metadata mapping. Allows you to create a map of key value pairs to add to the server instance.",
+                          "items": {
+                            "properties": {
+                              "key": {
+                                "description": "Key is the server metadata key",
+                                "maxLength": 255,
+                                "type": "string"
+                              },
+                              "value": {
+                                "description": "Value is the server metadata value",
+                                "maxLength": 255,
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "key",
+                              "value"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array",
+                          "x-kubernetes-list-map-keys": [
+                            "key"
+                          ],
+                          "x-kubernetes-list-type": "map"
+                        },
+                        "sshKeyName": {
+                          "description": "The ssh key to inject in the instance",
+                          "type": "string"
+                        },
+                        "tags": {
+                          "description": "Tags which will be added to the machine and all dependent resources\nwhich support them. These are in addition to Tags defined on the\ncluster.\nRequires Nova api 2.52 minimum!",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array",
+                          "x-kubernetes-list-type": "set"
+                        },
+                        "trunk": {
+                          "description": "Whether the server instance is created on a trunk port or not.",
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "image"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-validations": [
+                        {
+                          "message": "at least one of flavor or flavorID must be set",
+                          "rule": "(has(self.flavor) || has(self.flavorID))"
+                        }
+                      ],
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "spec is required if bastion is enabled",
+                      "rule": "!self.enabled || has(self.spec)"
+                    }
+                  ],
+                  "additionalProperties": false
+                },
+                "controlPlaneAvailabilityZones": {
+                  "description": "ControlPlaneAvailabilityZones is the set of availability zones which\ncontrol plane machines may be deployed to.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array",
+                  "x-kubernetes-list-type": "set"
+                },
+                "controlPlaneEndpoint": {
+                  "description": "ControlPlaneEndpoint represents the endpoint used to communicate with the control plane.\nIt is normally populated automatically by the OpenStackCluster\ncontroller during cluster provisioning. If it is set on creation the\ncontrol plane endpoint will use the values set here in preference to\nvalues set elsewhere.\nControlPlaneEndpoint cannot be modified after ControlPlaneEndpoint.Host has been set.",
+                  "properties": {
+                    "host": {
+                      "description": "host is the hostname on which the API server is serving.",
+                      "maxLength": 512,
+                      "type": "string"
+                    },
+                    "port": {
+                      "description": "port is the port on which the API server is serving.",
+                      "format": "int32",
+                      "type": "integer"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "controlPlaneOmitAvailabilityZone": {
+                  "description": "ControlPlaneOmitAvailabilityZone causes availability zone to be\nomitted when creating control plane nodes, allowing the Nova\nscheduler to make a decision on which availability zone to use based\non other scheduling constraints",
+                  "type": "boolean"
+                },
+                "disableAPIServerFloatingIP": {
+                  "description": "DisableAPIServerFloatingIP determines whether or not to attempt to attach a floating\nIP to the API server. This allows for the creation of clusters when attaching a floating\nIP to the API server (and hence, in many cases, exposing the API server to the internet)\nis not possible or desirable, e.g. if using a shared VLAN for communication between\nmanagement and workload clusters or when the management cluster is inside the\nproject network.\nThis option requires that the API server use a VIP on the cluster network so that the\nunderlying machines can change without changing ControlPlaneEndpoint.Host.\nWhen using a managed load balancer, this VIP will be managed automatically.\nIf not using a managed load balancer, cluster configuration will fail without additional\nconfiguration to manage the VIP on the control plane machines, which falls outside of\nthe scope of this controller.",
+                  "type": "boolean"
+                },
+                "disableExternalNetwork": {
+                  "description": "DisableExternalNetwork specifies whether or not to attempt to connect the cluster\nto an external network. This allows for the creation of clusters when connecting\nto an external network is not possible or desirable, e.g. if using a provider network.",
+                  "type": "boolean"
+                },
+                "disablePortSecurity": {
+                  "description": "DisablePortSecurity disables the port security of the network created for the\nKubernetes cluster, which also disables SecurityGroups",
+                  "type": "boolean"
+                },
+                "externalNetwork": {
+                  "description": "ExternalNetwork is the OpenStack Network to be used to get public internet to the VMs.\nThis option is ignored if DisableExternalNetwork is set to true.\n\nIf ExternalNetwork is defined it must refer to exactly one external network.\n\nIf ExternalNetwork is not defined or is empty the controller will use any\nexisting external network as long as there is only one. It is an\nerror if ExternalNetwork is not defined and there are multiple\nexternal networks unless DisableExternalNetwork is also set.\n\nIf ExternalNetwork is not defined and there are no external networks\nthe controller will proceed as though DisableExternalNetwork was set.",
+                  "maxProperties": 1,
+                  "minProperties": 1,
+                  "properties": {
+                    "filter": {
+                      "description": "Filter specifies a filter to select an OpenStack network. If provided, cannot be empty.",
+                      "minProperties": 1,
+                      "properties": {
+                        "description": {
+                          "type": "string"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "notTags": {
+                          "description": "NotTags is a list of tags to filter by. If specified, resources which\ncontain all of the given tags will be excluded from the result.",
+                          "items": {
+                            "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                            "minLength": 1,
+                            "pattern": "^[^,]+$",
+                            "type": "string"
+                          },
+                          "type": "array",
+                          "x-kubernetes-list-type": "set"
+                        },
+                        "notTagsAny": {
+                          "description": "NotTagsAny is a list of tags to filter by. If specified, resources\nwhich contain any of the given tags will be excluded from the result.",
+                          "items": {
+                            "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                            "minLength": 1,
+                            "pattern": "^[^,]+$",
+                            "type": "string"
+                          },
+                          "type": "array",
+                          "x-kubernetes-list-type": "set"
+                        },
+                        "projectID": {
+                          "type": "string"
+                        },
+                        "tags": {
+                          "description": "Tags is a list of tags to filter by. If specified, the resource must\nhave all of the tags specified to be included in the result.",
+                          "items": {
+                            "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                            "minLength": 1,
+                            "pattern": "^[^,]+$",
+                            "type": "string"
+                          },
+                          "type": "array",
+                          "x-kubernetes-list-type": "set"
+                        },
+                        "tagsAny": {
+                          "description": "TagsAny is a list of tags to filter by. If specified, the resource\nmust have at least one of the tags specified to be included in the\nresult.",
+                          "items": {
+                            "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                            "minLength": 1,
+                            "pattern": "^[^,]+$",
+                            "type": "string"
+                          },
+                          "type": "array",
+                          "x-kubernetes-list-type": "set"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "id": {
+                      "description": "ID is the ID of the network to use. If ID is provided, the other filters cannot be provided. Must be in UUID format.",
+                      "format": "uuid",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "externalRouterIPs": {
+                  "description": "ExternalRouterIPs is an array of externalIPs on the respective subnets.\nThis is necessary if the router needs a fixed ip in a specific subnet.",
+                  "items": {
+                    "properties": {
+                      "fixedIP": {
+                        "description": "The FixedIP in the corresponding subnet",
+                        "type": "string"
+                      },
+                      "subnet": {
+                        "description": "The subnet in which the FixedIP is used for the Gateway of this router",
+                        "maxProperties": 1,
+                        "minProperties": 1,
+                        "properties": {
+                          "filter": {
+                            "description": "Filter specifies a filter to select the subnet. It must match exactly one subnet.",
+                            "minProperties": 1,
+                            "properties": {
+                              "cidr": {
+                                "type": "string"
+                              },
+                              "description": {
+                                "type": "string"
+                              },
+                              "gatewayIP": {
+                                "type": "string"
+                              },
+                              "ipVersion": {
+                                "type": "integer"
+                              },
+                              "ipv6AddressMode": {
+                                "type": "string"
+                              },
+                              "ipv6RAMode": {
+                                "type": "string"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "notTags": {
+                                "description": "NotTags is a list of tags to filter by. If specified, resources which\ncontain all of the given tags will be excluded from the result.",
+                                "items": {
+                                  "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                                  "minLength": 1,
+                                  "pattern": "^[^,]+$",
+                                  "type": "string"
+                                },
+                                "type": "array",
+                                "x-kubernetes-list-type": "set"
+                              },
+                              "notTagsAny": {
+                                "description": "NotTagsAny is a list of tags to filter by. If specified, resources\nwhich contain any of the given tags will be excluded from the result.",
+                                "items": {
+                                  "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                                  "minLength": 1,
+                                  "pattern": "^[^,]+$",
+                                  "type": "string"
+                                },
+                                "type": "array",
+                                "x-kubernetes-list-type": "set"
+                              },
+                              "projectID": {
+                                "type": "string"
+                              },
+                              "tags": {
+                                "description": "Tags is a list of tags to filter by. If specified, the resource must\nhave all of the tags specified to be included in the result.",
+                                "items": {
+                                  "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                                  "minLength": 1,
+                                  "pattern": "^[^,]+$",
+                                  "type": "string"
+                                },
+                                "type": "array",
+                                "x-kubernetes-list-type": "set"
+                              },
+                              "tagsAny": {
+                                "description": "TagsAny is a list of tags to filter by. If specified, the resource\nmust have at least one of the tags specified to be included in the\nresult.",
+                                "items": {
+                                  "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                                  "minLength": 1,
+                                  "pattern": "^[^,]+$",
+                                  "type": "string"
+                                },
+                                "type": "array",
+                                "x-kubernetes-list-type": "set"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "id": {
+                            "description": "ID is the uuid of the subnet. It will not be validated.",
+                            "format": "uuid",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "required": [
+                      "subnet"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
+                },
+                "identityRef": {
+                  "description": "IdentityRef is a reference to a secret holding OpenStack credentials\nto be used when reconciling this cluster. It is also to reconcile\nmachines unless overridden in the machine spec.",
+                  "properties": {
+                    "cloudName": {
+                      "description": "CloudName specifies the name of the entry in the clouds.yaml file to use.",
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "name": {
+                      "description": "Name is the name of a Secret (type=Secret) in the same namespace as the resource being provisioned,\nor the name of an OpenStackClusterIdentity (type=ClusterIdentity).\nThe Secret must contain a key named `clouds.yaml` which contains an OpenStack clouds.yaml file.\nThe Secret may optionally contain a key named `cacert` containing a PEM-encoded CA certificate.",
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "region": {
+                      "description": "Region specifies an OpenStack region to use. If specified, it overrides\nany value in clouds.yaml. If specified for an OpenStackMachine, its\nvalue will be included in providerID.",
+                      "type": "string"
+                    },
+                    "type": {
+                      "default": "Secret",
+                      "description": "Type specifies the identity reference type. Defaults to Secret for backward compatibility.",
+                      "enum": [
+                        "Secret",
+                        "ClusterIdentity"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "cloudName",
+                    "name",
+                    "type"
+                  ],
+                  "type": "object",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "region is immutable",
+                      "rule": "(!has(self.region) && !has(oldSelf.region)) || self.region == oldSelf.region"
+                    }
+                  ],
+                  "additionalProperties": false
+                },
+                "managedSecurityGroups": {
+                  "description": "ManagedSecurityGroups determines whether OpenStack security groups for the cluster\nwill be managed by the OpenStack provider or whether pre-existing security groups will\nbe specified as part of the configuration.\nBy default, the managed security groups have rules that allow the Kubelet, etcd, and the\nKubernetes API server to function correctly.\nIt's possible to add additional rules to the managed security groups.\nWhen defined to an empty struct, the managed security groups will be created with the default rules.",
+                  "properties": {
+                    "allNodesSecurityGroupRules": {
+                      "description": "allNodesSecurityGroupRules defines the rules that should be applied to all nodes.",
+                      "items": {
+                        "description": "SecurityGroupRuleSpec represent the basic information of the associated OpenStack\nSecurity Group Role.\nFor now this is only used for the allNodesSecurityGroupRules but when we add\nother security groups, we'll need to add a validation because\nRemote* fields are mutually exclusive.",
+                        "properties": {
+                          "description": {
+                            "description": "description of the security group rule.",
+                            "type": "string"
+                          },
+                          "direction": {
+                            "description": "direction in which the security group rule is applied. The only values\nallowed are \"ingress\" or \"egress\". For a compute instance, an ingress\nsecurity group rule is applied to incoming (ingress) traffic for that\ninstance. An egress rule is applied to traffic leaving the instance.",
+                            "enum": [
+                              "ingress",
+                              "egress"
+                            ],
+                            "type": "string"
+                          },
+                          "etherType": {
+                            "description": "etherType must be IPv4 or IPv6, and addresses represented in CIDR must match the\ningress or egress rules.",
+                            "enum": [
+                              "IPv4",
+                              "IPv6"
+                            ],
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "name of the security group rule.\nIt's used to identify the rule so it can be patched and will not be sent to the OpenStack API.",
+                            "type": "string"
+                          },
+                          "portRangeMax": {
+                            "description": "portRangeMax is a number in the range that is matched by the security group\nrule. The portRangeMin attribute constrains the portRangeMax attribute.",
+                            "type": "integer"
+                          },
+                          "portRangeMin": {
+                            "description": "portRangeMin is a number in the range that is matched by the security group\nrule. If the protocol is TCP or UDP, this value must be less than or equal\nto the value of the portRangeMax attribute.",
+                            "type": "integer"
+                          },
+                          "protocol": {
+                            "description": "protocol is the protocol that is matched by the security group rule.",
+                            "type": "string"
+                          },
+                          "remoteGroupID": {
+                            "description": "remoteGroupID is the remote group ID to be associated with this security group rule.\nYou can specify either remoteGroupID or remoteIPPrefix or remoteManagedGroups.",
+                            "type": "string"
+                          },
+                          "remoteIPPrefix": {
+                            "description": "remoteIPPrefix is the remote IP prefix to be associated with this security group rule.\nYou can specify either remoteGroupID or remoteIPPrefix or remoteManagedGroups.",
+                            "type": "string"
+                          },
+                          "remoteManagedGroups": {
+                            "description": "remoteManagedGroups is the remote managed groups to be associated with this security group rule.\nYou can specify either remoteGroupID or remoteIPPrefix or remoteManagedGroups.",
+                            "items": {
+                              "enum": [
+                                "bastion",
+                                "controlplane",
+                                "worker"
+                              ],
+                              "type": "string"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "required": [
+                          "direction",
+                          "name"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array",
+                      "x-kubernetes-list-map-keys": [
+                        "name"
+                      ],
+                      "x-kubernetes-list-type": "map"
+                    },
+                    "allowAllInClusterTraffic": {
+                      "default": false,
+                      "description": "AllowAllInClusterTraffic allows all ingress and egress traffic between cluster nodes when set to true.",
+                      "type": "boolean"
+                    },
+                    "controlPlaneNodesSecurityGroupRules": {
+                      "description": "controlPlaneNodesSecurityGroupRules defines the rules that should be applied to control plane nodes.",
+                      "items": {
+                        "description": "SecurityGroupRuleSpec represent the basic information of the associated OpenStack\nSecurity Group Role.\nFor now this is only used for the allNodesSecurityGroupRules but when we add\nother security groups, we'll need to add a validation because\nRemote* fields are mutually exclusive.",
+                        "properties": {
+                          "description": {
+                            "description": "description of the security group rule.",
+                            "type": "string"
+                          },
+                          "direction": {
+                            "description": "direction in which the security group rule is applied. The only values\nallowed are \"ingress\" or \"egress\". For a compute instance, an ingress\nsecurity group rule is applied to incoming (ingress) traffic for that\ninstance. An egress rule is applied to traffic leaving the instance.",
+                            "enum": [
+                              "ingress",
+                              "egress"
+                            ],
+                            "type": "string"
+                          },
+                          "etherType": {
+                            "description": "etherType must be IPv4 or IPv6, and addresses represented in CIDR must match the\ningress or egress rules.",
+                            "enum": [
+                              "IPv4",
+                              "IPv6"
+                            ],
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "name of the security group rule.\nIt's used to identify the rule so it can be patched and will not be sent to the OpenStack API.",
+                            "type": "string"
+                          },
+                          "portRangeMax": {
+                            "description": "portRangeMax is a number in the range that is matched by the security group\nrule. The portRangeMin attribute constrains the portRangeMax attribute.",
+                            "type": "integer"
+                          },
+                          "portRangeMin": {
+                            "description": "portRangeMin is a number in the range that is matched by the security group\nrule. If the protocol is TCP or UDP, this value must be less than or equal\nto the value of the portRangeMax attribute.",
+                            "type": "integer"
+                          },
+                          "protocol": {
+                            "description": "protocol is the protocol that is matched by the security group rule.",
+                            "type": "string"
+                          },
+                          "remoteGroupID": {
+                            "description": "remoteGroupID is the remote group ID to be associated with this security group rule.\nYou can specify either remoteGroupID or remoteIPPrefix or remoteManagedGroups.",
+                            "type": "string"
+                          },
+                          "remoteIPPrefix": {
+                            "description": "remoteIPPrefix is the remote IP prefix to be associated with this security group rule.\nYou can specify either remoteGroupID or remoteIPPrefix or remoteManagedGroups.",
+                            "type": "string"
+                          },
+                          "remoteManagedGroups": {
+                            "description": "remoteManagedGroups is the remote managed groups to be associated with this security group rule.\nYou can specify either remoteGroupID or remoteIPPrefix or remoteManagedGroups.",
+                            "items": {
+                              "enum": [
+                                "bastion",
+                                "controlplane",
+                                "worker"
+                              ],
+                              "type": "string"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "required": [
+                          "direction",
+                          "name"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array",
+                      "x-kubernetes-list-map-keys": [
+                        "name"
+                      ],
+                      "x-kubernetes-list-type": "map"
+                    },
+                    "workerNodesSecurityGroupRules": {
+                      "description": "workerNodesSecurityGroupRules defines the rules that should be applied to worker nodes.",
+                      "items": {
+                        "description": "SecurityGroupRuleSpec represent the basic information of the associated OpenStack\nSecurity Group Role.\nFor now this is only used for the allNodesSecurityGroupRules but when we add\nother security groups, we'll need to add a validation because\nRemote* fields are mutually exclusive.",
+                        "properties": {
+                          "description": {
+                            "description": "description of the security group rule.",
+                            "type": "string"
+                          },
+                          "direction": {
+                            "description": "direction in which the security group rule is applied. The only values\nallowed are \"ingress\" or \"egress\". For a compute instance, an ingress\nsecurity group rule is applied to incoming (ingress) traffic for that\ninstance. An egress rule is applied to traffic leaving the instance.",
+                            "enum": [
+                              "ingress",
+                              "egress"
+                            ],
+                            "type": "string"
+                          },
+                          "etherType": {
+                            "description": "etherType must be IPv4 or IPv6, and addresses represented in CIDR must match the\ningress or egress rules.",
+                            "enum": [
+                              "IPv4",
+                              "IPv6"
+                            ],
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "name of the security group rule.\nIt's used to identify the rule so it can be patched and will not be sent to the OpenStack API.",
+                            "type": "string"
+                          },
+                          "portRangeMax": {
+                            "description": "portRangeMax is a number in the range that is matched by the security group\nrule. The portRangeMin attribute constrains the portRangeMax attribute.",
+                            "type": "integer"
+                          },
+                          "portRangeMin": {
+                            "description": "portRangeMin is a number in the range that is matched by the security group\nrule. If the protocol is TCP or UDP, this value must be less than or equal\nto the value of the portRangeMax attribute.",
+                            "type": "integer"
+                          },
+                          "protocol": {
+                            "description": "protocol is the protocol that is matched by the security group rule.",
+                            "type": "string"
+                          },
+                          "remoteGroupID": {
+                            "description": "remoteGroupID is the remote group ID to be associated with this security group rule.\nYou can specify either remoteGroupID or remoteIPPrefix or remoteManagedGroups.",
+                            "type": "string"
+                          },
+                          "remoteIPPrefix": {
+                            "description": "remoteIPPrefix is the remote IP prefix to be associated with this security group rule.\nYou can specify either remoteGroupID or remoteIPPrefix or remoteManagedGroups.",
+                            "type": "string"
+                          },
+                          "remoteManagedGroups": {
+                            "description": "remoteManagedGroups is the remote managed groups to be associated with this security group rule.\nYou can specify either remoteGroupID or remoteIPPrefix or remoteManagedGroups.",
+                            "items": {
+                              "enum": [
+                                "bastion",
+                                "controlplane",
+                                "worker"
+                              ],
+                              "type": "string"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "required": [
+                          "direction",
+                          "name"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array",
+                      "x-kubernetes-list-map-keys": [
+                        "name"
+                      ],
+                      "x-kubernetes-list-type": "map"
+                    }
+                  },
+                  "required": [
+                    "allowAllInClusterTraffic"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "managedSubnets": {
+                  "description": "ManagedSubnets describe OpenStack Subnets to be created. Cluster actuator will create a network,\nsubnets with the defined CIDR, and a router connected to these subnets. Currently only one IPv4\nsubnet is supported. If you leave this empty, no network will be created.",
+                  "items": {
+                    "properties": {
+                      "allocationPools": {
+                        "description": "AllocationPools is an array of AllocationPool objects that will be applied to OpenStack Subnet being created.\nIf set, OpenStack will only allocate these IPs for Machines. It will still be possible to create ports from\noutside of these ranges manually.",
+                        "items": {
+                          "properties": {
+                            "end": {
+                              "description": "End represents the end of the AlloctionPool, that is the highest IP of the pool.",
+                              "type": "string"
+                            },
+                            "start": {
+                              "description": "Start represents the start of the AllocationPool, that is the lowest IP of the pool.",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "end",
+                            "start"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "cidr": {
+                        "description": "CIDR is representing the IP address range used to create the subnet, e.g. 10.0.0.0/24.\nThis field is required when defining a subnet.",
+                        "type": "string"
+                      },
+                      "dnsNameservers": {
+                        "description": "DNSNameservers holds a list of DNS server addresses that will be provided when creating\nthe subnet. These addresses need to have the same IP version as CIDR.",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "required": [
+                      "cidr"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "maxItems": 1,
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
+                },
+                "network": {
+                  "description": "Network specifies an existing network to use if no ManagedSubnets\nare specified.",
+                  "maxProperties": 1,
+                  "minProperties": 1,
+                  "properties": {
+                    "filter": {
+                      "description": "Filter specifies a filter to select an OpenStack network. If provided, cannot be empty.",
+                      "minProperties": 1,
+                      "properties": {
+                        "description": {
+                          "type": "string"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "notTags": {
+                          "description": "NotTags is a list of tags to filter by. If specified, resources which\ncontain all of the given tags will be excluded from the result.",
+                          "items": {
+                            "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                            "minLength": 1,
+                            "pattern": "^[^,]+$",
+                            "type": "string"
+                          },
+                          "type": "array",
+                          "x-kubernetes-list-type": "set"
+                        },
+                        "notTagsAny": {
+                          "description": "NotTagsAny is a list of tags to filter by. If specified, resources\nwhich contain any of the given tags will be excluded from the result.",
+                          "items": {
+                            "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                            "minLength": 1,
+                            "pattern": "^[^,]+$",
+                            "type": "string"
+                          },
+                          "type": "array",
+                          "x-kubernetes-list-type": "set"
+                        },
+                        "projectID": {
+                          "type": "string"
+                        },
+                        "tags": {
+                          "description": "Tags is a list of tags to filter by. If specified, the resource must\nhave all of the tags specified to be included in the result.",
+                          "items": {
+                            "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                            "minLength": 1,
+                            "pattern": "^[^,]+$",
+                            "type": "string"
+                          },
+                          "type": "array",
+                          "x-kubernetes-list-type": "set"
+                        },
+                        "tagsAny": {
+                          "description": "TagsAny is a list of tags to filter by. If specified, the resource\nmust have at least one of the tags specified to be included in the\nresult.",
+                          "items": {
+                            "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                            "minLength": 1,
+                            "pattern": "^[^,]+$",
+                            "type": "string"
+                          },
+                          "type": "array",
+                          "x-kubernetes-list-type": "set"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "id": {
+                      "description": "ID is the ID of the network to use. If ID is provided, the other filters cannot be provided. Must be in UUID format.",
+                      "format": "uuid",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "networkMTU": {
+                  "description": "NetworkMTU sets the maximum transmission unit (MTU) value to address fragmentation for the private network ID.\nThis value will be used only if the Cluster actuator creates the network.\nIf left empty, the network will have the default MTU defined in Openstack network service.\nTo use this field, the Openstack installation requires the net-mtu neutron API extension.",
+                  "type": "integer"
+                },
+                "router": {
+                  "description": "Router specifies an existing router to be used if ManagedSubnets are\nspecified. If specified, no new router will be created.",
+                  "maxProperties": 1,
+                  "minProperties": 1,
+                  "properties": {
+                    "filter": {
+                      "description": "Filter specifies a filter to select an OpenStack router. If provided, cannot be empty.",
+                      "minProperties": 1,
+                      "properties": {
+                        "description": {
+                          "type": "string"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "notTags": {
+                          "description": "NotTags is a list of tags to filter by. If specified, resources which\ncontain all of the given tags will be excluded from the result.",
+                          "items": {
+                            "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                            "minLength": 1,
+                            "pattern": "^[^,]+$",
+                            "type": "string"
+                          },
+                          "type": "array",
+                          "x-kubernetes-list-type": "set"
+                        },
+                        "notTagsAny": {
+                          "description": "NotTagsAny is a list of tags to filter by. If specified, resources\nwhich contain any of the given tags will be excluded from the result.",
+                          "items": {
+                            "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                            "minLength": 1,
+                            "pattern": "^[^,]+$",
+                            "type": "string"
+                          },
+                          "type": "array",
+                          "x-kubernetes-list-type": "set"
+                        },
+                        "projectID": {
+                          "type": "string"
+                        },
+                        "tags": {
+                          "description": "Tags is a list of tags to filter by. If specified, the resource must\nhave all of the tags specified to be included in the result.",
+                          "items": {
+                            "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                            "minLength": 1,
+                            "pattern": "^[^,]+$",
+                            "type": "string"
+                          },
+                          "type": "array",
+                          "x-kubernetes-list-type": "set"
+                        },
+                        "tagsAny": {
+                          "description": "TagsAny is a list of tags to filter by. If specified, the resource\nmust have at least one of the tags specified to be included in the\nresult.",
+                          "items": {
+                            "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                            "minLength": 1,
+                            "pattern": "^[^,]+$",
+                            "type": "string"
+                          },
+                          "type": "array",
+                          "x-kubernetes-list-type": "set"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "id": {
+                      "description": "ID is the ID of the router to use. If ID is provided, the other filters cannot be provided. Must be in UUID format.",
+                      "format": "uuid",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "subnets": {
+                  "description": "Subnets specifies existing subnets to use if not ManagedSubnets are\nspecified. All subnets must be in the network specified by Network.\nThere can be zero, one, or two subnets. If no subnets are specified,\nall subnets in Network will be used. If 2 subnets are specified, one\nmust be IPv4 and the other IPv6.",
+                  "items": {
+                    "description": "SubnetParam specifies an OpenStack subnet to use. It may be specified by either ID or filter, but not both.",
+                    "maxProperties": 1,
+                    "minProperties": 1,
+                    "properties": {
+                      "filter": {
+                        "description": "Filter specifies a filter to select the subnet. It must match exactly one subnet.",
+                        "minProperties": 1,
+                        "properties": {
+                          "cidr": {
+                            "type": "string"
+                          },
+                          "description": {
+                            "type": "string"
+                          },
+                          "gatewayIP": {
+                            "type": "string"
+                          },
+                          "ipVersion": {
+                            "type": "integer"
+                          },
+                          "ipv6AddressMode": {
+                            "type": "string"
+                          },
+                          "ipv6RAMode": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "notTags": {
+                            "description": "NotTags is a list of tags to filter by. If specified, resources which\ncontain all of the given tags will be excluded from the result.",
+                            "items": {
+                              "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                              "minLength": 1,
+                              "pattern": "^[^,]+$",
+                              "type": "string"
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "set"
+                          },
+                          "notTagsAny": {
+                            "description": "NotTagsAny is a list of tags to filter by. If specified, resources\nwhich contain any of the given tags will be excluded from the result.",
+                            "items": {
+                              "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                              "minLength": 1,
+                              "pattern": "^[^,]+$",
+                              "type": "string"
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "set"
+                          },
+                          "projectID": {
+                            "type": "string"
+                          },
+                          "tags": {
+                            "description": "Tags is a list of tags to filter by. If specified, the resource must\nhave all of the tags specified to be included in the result.",
+                            "items": {
+                              "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                              "minLength": 1,
+                              "pattern": "^[^,]+$",
+                              "type": "string"
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "set"
+                          },
+                          "tagsAny": {
+                            "description": "TagsAny is a list of tags to filter by. If specified, the resource\nmust have at least one of the tags specified to be included in the\nresult.",
+                            "items": {
+                              "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                              "minLength": 1,
+                              "pattern": "^[^,]+$",
+                              "type": "string"
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "set"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "id": {
+                        "description": "ID is the uuid of the subnet. It will not be validated.",
+                        "format": "uuid",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "maxItems": 2,
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
+                },
+                "tags": {
+                  "description": "Tags to set on all resources in cluster which support tags",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array",
+                  "x-kubernetes-list-type": "set"
+                }
+              },
+              "required": [
+                "identityRef"
+              ],
+              "type": "object",
+              "x-kubernetes-validations": [
+                {
+                  "message": "bastion floating IP cannot be set when disableExternalNetwork is true",
+                  "rule": "has(self.disableExternalNetwork) && self.disableExternalNetwork ? !has(self.bastion) || !has(self.bastion.floatingIP) : true"
+                },
+                {
+                  "message": "disableAPIServerFloatingIP cannot be false when disableExternalNetwork is true",
+                  "rule": "has(self.disableExternalNetwork) && self.disableExternalNetwork ? has(self.disableAPIServerFloatingIP) && self.disableAPIServerFloatingIP : true"
+                }
+              ],
+              "additionalProperties": false
+            }
+          },
+          "required": [
+            "spec"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "template"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/infrastructure.cluster.x-k8s.io/openstackfloatingippool_v1alpha1.json
+++ b/infrastructure.cluster.x-k8s.io/openstackfloatingippool_v1alpha1.json
@@ -1,0 +1,262 @@
+{
+  "description": "OpenStackFloatingIPPool is the Schema for the openstackfloatingippools API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "OpenStackFloatingIPPoolSpec defines the desired state of OpenStackFloatingIPPool.",
+      "properties": {
+        "floatingIPNetwork": {
+          "description": "FloatingIPNetwork is the external network to use for floating ips, if there's only one external network it will be used by default",
+          "maxProperties": 1,
+          "minProperties": 1,
+          "properties": {
+            "filter": {
+              "description": "Filter specifies a filter to select an OpenStack network. If provided, cannot be empty.",
+              "minProperties": 1,
+              "properties": {
+                "description": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "notTags": {
+                  "description": "NotTags is a list of tags to filter by. If specified, resources which\ncontain all of the given tags will be excluded from the result.",
+                  "items": {
+                    "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                    "minLength": 1,
+                    "pattern": "^[^,]+$",
+                    "type": "string"
+                  },
+                  "type": "array",
+                  "x-kubernetes-list-type": "set"
+                },
+                "notTagsAny": {
+                  "description": "NotTagsAny is a list of tags to filter by. If specified, resources\nwhich contain any of the given tags will be excluded from the result.",
+                  "items": {
+                    "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                    "minLength": 1,
+                    "pattern": "^[^,]+$",
+                    "type": "string"
+                  },
+                  "type": "array",
+                  "x-kubernetes-list-type": "set"
+                },
+                "projectID": {
+                  "type": "string"
+                },
+                "tags": {
+                  "description": "Tags is a list of tags to filter by. If specified, the resource must\nhave all of the tags specified to be included in the result.",
+                  "items": {
+                    "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                    "minLength": 1,
+                    "pattern": "^[^,]+$",
+                    "type": "string"
+                  },
+                  "type": "array",
+                  "x-kubernetes-list-type": "set"
+                },
+                "tagsAny": {
+                  "description": "TagsAny is a list of tags to filter by. If specified, the resource\nmust have at least one of the tags specified to be included in the\nresult.",
+                  "items": {
+                    "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                    "minLength": 1,
+                    "pattern": "^[^,]+$",
+                    "type": "string"
+                  },
+                  "type": "array",
+                  "x-kubernetes-list-type": "set"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "id": {
+              "description": "ID is the ID of the network to use. If ID is provided, the other filters cannot be provided. Must be in UUID format.",
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "identityRef": {
+          "description": "IdentityRef is a reference to a identity to be used when reconciling this pool.",
+          "properties": {
+            "cloudName": {
+              "description": "CloudName specifies the name of the entry in the clouds.yaml file to use.",
+              "minLength": 1,
+              "type": "string"
+            },
+            "name": {
+              "description": "Name is the name of a Secret (type=Secret) in the same namespace as the resource being provisioned,\nor the name of an OpenStackClusterIdentity (type=ClusterIdentity).\nThe Secret must contain a key named `clouds.yaml` which contains an OpenStack clouds.yaml file.\nThe Secret may optionally contain a key named `cacert` containing a PEM-encoded CA certificate.",
+              "minLength": 1,
+              "type": "string"
+            },
+            "region": {
+              "description": "Region specifies an OpenStack region to use. If specified, it overrides\nany value in clouds.yaml. If specified for an OpenStackMachine, its\nvalue will be included in providerID.",
+              "type": "string"
+            },
+            "type": {
+              "default": "Secret",
+              "description": "Type specifies the identity reference type. Defaults to Secret for backward compatibility.",
+              "enum": [
+                "Secret",
+                "ClusterIdentity"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "cloudName",
+            "name",
+            "type"
+          ],
+          "type": "object",
+          "x-kubernetes-validations": [
+            {
+              "message": "region is immutable",
+              "rule": "(!has(self.region) && !has(oldSelf.region)) || self.region == oldSelf.region"
+            }
+          ],
+          "additionalProperties": false
+        },
+        "maxIPs": {
+          "description": "MaxIPs is the maximum number of floating ips that can be allocated from this pool, if nil there is no limit.\nIf set, the pool will stop allocating floating ips when it reaches this number of ClaimedIPs.",
+          "type": "integer"
+        },
+        "preAllocatedFloatingIPs": {
+          "description": "PreAllocatedFloatingIPs is a list of floating IPs precreated in OpenStack that should be used by this pool.\nThese are used before allocating new ones and are not deleted from OpenStack when the pool is deleted.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "reclaimPolicy": {
+          "description": "The stratergy to use for reclaiming floating ips when they are released from a machine",
+          "enum": [
+            "Retain",
+            "Delete"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "identityRef",
+        "reclaimPolicy"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "OpenStackFloatingIPPoolStatus defines the observed state of OpenStackFloatingIPPool.",
+      "properties": {
+        "availableIPs": {
+          "default": [],
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "claimedIPs": {
+          "default": [],
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "conditions": {
+          "description": "Conditions provide observations of the operational state of a Cluster API resource.",
+          "items": {
+            "description": "Condition defines an observation of a Cluster API resource operational state.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "lastTransitionTime is the last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed. If that is not known, then using the time when\nthe API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "message is a human readable message indicating details about the transition.\nThis field may be empty.",
+                "maxLength": 10240,
+                "minLength": 1,
+                "type": "string"
+              },
+              "reason": {
+                "description": "reason is the reason for the condition's last transition in CamelCase.\nThe specific API may choose whether or not this field is considered a guaranteed API.\nThis field may be empty.",
+                "maxLength": 256,
+                "minLength": 1,
+                "type": "string"
+              },
+              "severity": {
+                "description": "severity provides an explicit classification of Reason code, so the users or machines can immediately\nunderstand the current situation and act accordingly.\nThe Severity field MUST be set only when Status=False.",
+                "maxLength": 32,
+                "type": "string"
+              },
+              "status": {
+                "description": "status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "type of condition in CamelCase or in foo.example.com/CamelCase.\nMany .condition.type values are consistent across resources like Available, but because arbitrary conditions\ncan be useful (see .node.status.conditions), the ability to deconflict is important.",
+                "maxLength": 256,
+                "minLength": 1,
+                "type": "string"
+              }
+            },
+            "required": [
+              "lastTransitionTime",
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "failedIPs": {
+          "description": "FailedIPs contains a list of floating ips that failed to be allocated",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "floatingIPNetwork": {
+          "description": "floatingIPNetwork contains information about the network used for floating ips",
+          "properties": {
+            "id": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "tags": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "id",
+            "name"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/infrastructure.cluster.x-k8s.io/openstackmachine_v1beta1.json
+++ b/infrastructure.cluster.x-k8s.io/openstackmachine_v1beta1.json
@@ -1,0 +1,1207 @@
+{
+  "description": "OpenStackMachine is the Schema for the openstackmachines API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "OpenStackMachineSpec defines the desired state of OpenStackMachine.",
+      "properties": {
+        "additionalBlockDevices": {
+          "description": "AdditionalBlockDevices is a list of specifications for additional block devices to attach to the server instance",
+          "items": {
+            "description": "AdditionalBlockDevice is a block device to attach to the server.",
+            "properties": {
+              "name": {
+                "description": "Name of the block device in the context of a machine.\nIf the block device is a volume, the Cinder volume will be named\nas a combination of the machine name and this name.\nAlso, this name will be used for tagging the block device.\nInformation about the block device tag can be obtained from the OpenStack\nmetadata API or the config drive.\nName cannot be 'root', which is reserved for the root volume.",
+                "type": "string"
+              },
+              "sizeGiB": {
+                "description": "SizeGiB is the size of the block device in gibibytes (GiB).",
+                "minimum": 1,
+                "type": "integer"
+              },
+              "storage": {
+                "description": "Storage specifies the storage type of the block device and\nadditional storage options.",
+                "properties": {
+                  "type": {
+                    "description": "Type is the type of block device to create.\nThis can be either \"Volume\" or \"Local\".",
+                    "type": "string"
+                  },
+                  "volume": {
+                    "description": "Volume contains additional storage options for a volume block device.",
+                    "properties": {
+                      "availabilityZone": {
+                        "description": "AvailabilityZone is the volume availability zone to create the volume\nin. If not specified, the volume will be created without an explicit\navailability zone.",
+                        "properties": {
+                          "from": {
+                            "default": "Name",
+                            "description": "From specifies where we will obtain the availability zone for the\nvolume. The options are \"Name\" and \"Machine\". If \"Name\" is specified\nthen the Name field must also be specified. If \"Machine\" is specified\nthe volume will use the value of FailureDomain, if any, from the\nassociated Machine.",
+                            "enum": [
+                              "Name",
+                              "Machine"
+                            ],
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "Name is the name of a volume availability zone to use. It is required\nif From is \"Name\". The volume availability zone name may not contain\nspaces.",
+                            "minLength": 1,
+                            "pattern": "^[^ ]+$",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-validations": [
+                          {
+                            "message": "name is required when from is 'Name' or default",
+                            "rule": "!has(self.from) || self.from == 'Name' ? has(self.name) : !has(self.name)"
+                          }
+                        ],
+                        "additionalProperties": false
+                      },
+                      "type": {
+                        "description": "Type is the Cinder volume type of the volume.\nIf omitted, the default Cinder volume type that is configured in the OpenStack cloud\nwill be used.",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  }
+                },
+                "required": [
+                  "type"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              }
+            },
+            "required": [
+              "name",
+              "sizeGiB",
+              "storage"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array",
+          "x-kubernetes-list-map-keys": [
+            "name"
+          ],
+          "x-kubernetes-list-type": "map"
+        },
+        "configDrive": {
+          "description": "Config Drive support",
+          "type": "boolean"
+        },
+        "flavor": {
+          "description": "The flavor reference for the flavor for your server instance.",
+          "minLength": 1,
+          "type": "string"
+        },
+        "flavorID": {
+          "description": "FlavorID allows flavors to be specified by ID.  This field takes precedence\nover Flavor.",
+          "minLength": 1,
+          "type": "string"
+        },
+        "floatingIPPoolRef": {
+          "description": "floatingIPPoolRef is a reference to a IPPool that will be assigned\nto an IPAddressClaim. Once the IPAddressClaim is fulfilled, the FloatingIP\nwill be assigned to the OpenStackMachine.",
+          "properties": {
+            "apiGroup": {
+              "description": "APIGroup is the group for the resource being referenced.\nIf APIGroup is not specified, the specified Kind must be in the core API group.\nFor any other third-party types, APIGroup is required.",
+              "type": "string"
+            },
+            "kind": {
+              "description": "Kind is the type of resource being referenced",
+              "type": "string"
+            },
+            "name": {
+              "description": "Name is the name of resource being referenced",
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "name"
+          ],
+          "type": "object",
+          "x-kubernetes-map-type": "atomic",
+          "additionalProperties": false
+        },
+        "identityRef": {
+          "description": "IdentityRef is a reference to a secret holding OpenStack credentials\nto be used when reconciling this machine. If not specified, the\ncredentials specified in the cluster will be used.",
+          "properties": {
+            "cloudName": {
+              "description": "CloudName specifies the name of the entry in the clouds.yaml file to use.",
+              "minLength": 1,
+              "type": "string"
+            },
+            "name": {
+              "description": "Name is the name of a Secret (type=Secret) in the same namespace as the resource being provisioned,\nor the name of an OpenStackClusterIdentity (type=ClusterIdentity).\nThe Secret must contain a key named `clouds.yaml` which contains an OpenStack clouds.yaml file.\nThe Secret may optionally contain a key named `cacert` containing a PEM-encoded CA certificate.",
+              "minLength": 1,
+              "type": "string"
+            },
+            "region": {
+              "description": "Region specifies an OpenStack region to use. If specified, it overrides\nany value in clouds.yaml. If specified for an OpenStackMachine, its\nvalue will be included in providerID.",
+              "type": "string"
+            },
+            "type": {
+              "default": "Secret",
+              "description": "Type specifies the identity reference type. Defaults to Secret for backward compatibility.",
+              "enum": [
+                "Secret",
+                "ClusterIdentity"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "cloudName",
+            "name",
+            "type"
+          ],
+          "type": "object",
+          "x-kubernetes-validations": [
+            {
+              "message": "region is immutable",
+              "rule": "(!has(self.region) && !has(oldSelf.region)) || self.region == oldSelf.region"
+            }
+          ],
+          "additionalProperties": false
+        },
+        "image": {
+          "description": "The image to use for your server instance.\nIf the rootVolume is specified, this will be used when creating the root volume.",
+          "maxProperties": 1,
+          "minProperties": 1,
+          "properties": {
+            "filter": {
+              "description": "Filter describes a query for an image. If specified, the combination\nof name and tags must return a single matching image or an error will\nbe raised.",
+              "minProperties": 1,
+              "properties": {
+                "name": {
+                  "description": "The name of the desired image. If specified, the combination of name and tags must return a single matching image or an error will be raised.",
+                  "type": "string"
+                },
+                "tags": {
+                  "description": "The tags associated with the desired image. If specified, the combination of name and tags must return a single matching image or an error will be raised.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array",
+                  "x-kubernetes-list-type": "set"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "id": {
+              "description": "ID is the uuid of the image. ID will not be validated before use.",
+              "format": "uuid",
+              "type": "string"
+            },
+            "imageRef": {
+              "description": "ImageRef is a reference to an ORC Image in the same namespace as the\nreferring object.",
+              "properties": {
+                "name": {
+                  "description": "Name is the name of the referenced resource",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "name"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "ports": {
+          "description": "Ports to be attached to the server instance. They are created if a port with the given name does not already exist.\nIf not specified a default port will be added for the default cluster network.",
+          "items": {
+            "properties": {
+              "adminStateUp": {
+                "description": "AdminStateUp specifies whether the port should be created in the up (true) or down (false) state. The default is up.",
+                "type": "boolean"
+              },
+              "allowedAddressPairs": {
+                "description": "AllowedAddressPairs is a list of address pairs which Neutron will\nallow the port to send traffic from in addition to the port's\naddresses. If not specified, the MAC Address will be the MAC Address\nof the port. Depending on the configuration of Neutron, it may be\nsupported to specify a CIDR instead of a specific IP address.",
+                "items": {
+                  "properties": {
+                    "ipAddress": {
+                      "description": "IPAddress is the IP address of the allowed address pair. Depending on\nthe configuration of Neutron, it may be supported to specify a CIDR\ninstead of a specific IP address.",
+                      "type": "string"
+                    },
+                    "macAddress": {
+                      "description": "MACAddress is the MAC address of the allowed address pair. If not\nspecified, the MAC address will be the MAC address of the port.",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "ipAddress"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "array"
+              },
+              "description": {
+                "description": "Description is a human-readable description for the port.",
+                "type": "string"
+              },
+              "disablePortSecurity": {
+                "description": "DisablePortSecurity enables or disables the port security when set.\nWhen not set, it takes the value of the corresponding field at the network level.",
+                "type": "boolean"
+              },
+              "fixedIPs": {
+                "description": "FixedIPs is a list of pairs of subnet and/or IP address to assign to the port. If specified, these must be subnets of the port's network.",
+                "items": {
+                  "properties": {
+                    "ipAddress": {
+                      "description": "IPAddress is a specific IP address to assign to the port. If Subnet\nis also specified, IPAddress must be a valid IP address in the\nsubnet. If Subnet is not specified, IPAddress must be a valid IP\naddress in any subnet of the port's network.",
+                      "type": "string"
+                    },
+                    "subnet": {
+                      "description": "Subnet is an openstack subnet query that will return the id of a subnet to create\nthe fixed IP of a port in. This query must not return more than one subnet.",
+                      "maxProperties": 1,
+                      "minProperties": 1,
+                      "properties": {
+                        "filter": {
+                          "description": "Filter specifies a filter to select the subnet. It must match exactly one subnet.",
+                          "minProperties": 1,
+                          "properties": {
+                            "cidr": {
+                              "type": "string"
+                            },
+                            "description": {
+                              "type": "string"
+                            },
+                            "gatewayIP": {
+                              "type": "string"
+                            },
+                            "ipVersion": {
+                              "type": "integer"
+                            },
+                            "ipv6AddressMode": {
+                              "type": "string"
+                            },
+                            "ipv6RAMode": {
+                              "type": "string"
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "notTags": {
+                              "description": "NotTags is a list of tags to filter by. If specified, resources which\ncontain all of the given tags will be excluded from the result.",
+                              "items": {
+                                "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                                "minLength": 1,
+                                "pattern": "^[^,]+$",
+                                "type": "string"
+                              },
+                              "type": "array",
+                              "x-kubernetes-list-type": "set"
+                            },
+                            "notTagsAny": {
+                              "description": "NotTagsAny is a list of tags to filter by. If specified, resources\nwhich contain any of the given tags will be excluded from the result.",
+                              "items": {
+                                "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                                "minLength": 1,
+                                "pattern": "^[^,]+$",
+                                "type": "string"
+                              },
+                              "type": "array",
+                              "x-kubernetes-list-type": "set"
+                            },
+                            "projectID": {
+                              "type": "string"
+                            },
+                            "tags": {
+                              "description": "Tags is a list of tags to filter by. If specified, the resource must\nhave all of the tags specified to be included in the result.",
+                              "items": {
+                                "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                                "minLength": 1,
+                                "pattern": "^[^,]+$",
+                                "type": "string"
+                              },
+                              "type": "array",
+                              "x-kubernetes-list-type": "set"
+                            },
+                            "tagsAny": {
+                              "description": "TagsAny is a list of tags to filter by. If specified, the resource\nmust have at least one of the tags specified to be included in the\nresult.",
+                              "items": {
+                                "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                                "minLength": 1,
+                                "pattern": "^[^,]+$",
+                                "type": "string"
+                              },
+                              "type": "array",
+                              "x-kubernetes-list-type": "set"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "id": {
+                          "description": "ID is the uuid of the subnet. It will not be validated.",
+                          "format": "uuid",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "array",
+                "x-kubernetes-list-type": "atomic"
+              },
+              "hostID": {
+                "description": "HostID specifies the ID of the host where the port resides.",
+                "type": "string"
+              },
+              "macAddress": {
+                "description": "MACAddress specifies the MAC address of the port. If not specified, the MAC address will be generated.",
+                "type": "string"
+              },
+              "nameSuffix": {
+                "description": "NameSuffix will be appended to the name of the port if specified. If unspecified, instead the 0-based index of the port in the list is used.",
+                "type": "string"
+              },
+              "network": {
+                "description": "Network is a query for an openstack network that the port will be created or discovered on.\nThis will fail if the query returns more than one network.",
+                "maxProperties": 1,
+                "minProperties": 1,
+                "properties": {
+                  "filter": {
+                    "description": "Filter specifies a filter to select an OpenStack network. If provided, cannot be empty.",
+                    "minProperties": 1,
+                    "properties": {
+                      "description": {
+                        "type": "string"
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "notTags": {
+                        "description": "NotTags is a list of tags to filter by. If specified, resources which\ncontain all of the given tags will be excluded from the result.",
+                        "items": {
+                          "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                          "minLength": 1,
+                          "pattern": "^[^,]+$",
+                          "type": "string"
+                        },
+                        "type": "array",
+                        "x-kubernetes-list-type": "set"
+                      },
+                      "notTagsAny": {
+                        "description": "NotTagsAny is a list of tags to filter by. If specified, resources\nwhich contain any of the given tags will be excluded from the result.",
+                        "items": {
+                          "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                          "minLength": 1,
+                          "pattern": "^[^,]+$",
+                          "type": "string"
+                        },
+                        "type": "array",
+                        "x-kubernetes-list-type": "set"
+                      },
+                      "projectID": {
+                        "type": "string"
+                      },
+                      "tags": {
+                        "description": "Tags is a list of tags to filter by. If specified, the resource must\nhave all of the tags specified to be included in the result.",
+                        "items": {
+                          "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                          "minLength": 1,
+                          "pattern": "^[^,]+$",
+                          "type": "string"
+                        },
+                        "type": "array",
+                        "x-kubernetes-list-type": "set"
+                      },
+                      "tagsAny": {
+                        "description": "TagsAny is a list of tags to filter by. If specified, the resource\nmust have at least one of the tags specified to be included in the\nresult.",
+                        "items": {
+                          "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                          "minLength": 1,
+                          "pattern": "^[^,]+$",
+                          "type": "string"
+                        },
+                        "type": "array",
+                        "x-kubernetes-list-type": "set"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "id": {
+                    "description": "ID is the ID of the network to use. If ID is provided, the other filters cannot be provided. Must be in UUID format.",
+                    "format": "uuid",
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "profile": {
+                "description": "Profile is a set of key-value pairs that are used for binding\ndetails. We intentionally don't expose this as a map[string]string\nbecause we only want to enable the users to set the values of the\nkeys that are known to work in OpenStack Networking API.  See\nhttps://docs.openstack.org/api-ref/network/v2/index.html?expanded=create-port-detail#create-port\nTo set profiles, your tenant needs permissions rule:create_port, and\nrule:create_port:binding:profile",
+                "properties": {
+                  "ovsHWOffload": {
+                    "description": "OVSHWOffload enables or disables the OVS hardware offload feature.\nThis flag is not required on OpenStack clouds since Yoga as Nova will set it automatically when the port is attached.\nSee: https://bugs.launchpad.net/nova/+bug/2020813",
+                    "type": "boolean"
+                  },
+                  "trustedVF": {
+                    "description": "TrustedVF enables or disables the \u201ctrusted mode\u201d for the VF.",
+                    "type": "boolean"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "propagateUplinkStatus": {
+                "description": "PropageteUplinkStatus enables or disables the propagate uplink status on the port.",
+                "type": "boolean"
+              },
+              "securityGroups": {
+                "description": "SecurityGroups is a list of the names, uuids, filters or any combination these of the security groups to assign to the instance.",
+                "items": {
+                  "description": "SecurityGroupParam specifies an OpenStack security group. It may be specified by ID or filter, but not both.",
+                  "maxProperties": 1,
+                  "minProperties": 1,
+                  "properties": {
+                    "filter": {
+                      "description": "Filter specifies a query to select an OpenStack security group. If provided, cannot be empty.",
+                      "minProperties": 1,
+                      "properties": {
+                        "description": {
+                          "type": "string"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "notTags": {
+                          "description": "NotTags is a list of tags to filter by. If specified, resources which\ncontain all of the given tags will be excluded from the result.",
+                          "items": {
+                            "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                            "minLength": 1,
+                            "pattern": "^[^,]+$",
+                            "type": "string"
+                          },
+                          "type": "array",
+                          "x-kubernetes-list-type": "set"
+                        },
+                        "notTagsAny": {
+                          "description": "NotTagsAny is a list of tags to filter by. If specified, resources\nwhich contain any of the given tags will be excluded from the result.",
+                          "items": {
+                            "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                            "minLength": 1,
+                            "pattern": "^[^,]+$",
+                            "type": "string"
+                          },
+                          "type": "array",
+                          "x-kubernetes-list-type": "set"
+                        },
+                        "projectID": {
+                          "type": "string"
+                        },
+                        "tags": {
+                          "description": "Tags is a list of tags to filter by. If specified, the resource must\nhave all of the tags specified to be included in the result.",
+                          "items": {
+                            "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                            "minLength": 1,
+                            "pattern": "^[^,]+$",
+                            "type": "string"
+                          },
+                          "type": "array",
+                          "x-kubernetes-list-type": "set"
+                        },
+                        "tagsAny": {
+                          "description": "TagsAny is a list of tags to filter by. If specified, the resource\nmust have at least one of the tags specified to be included in the\nresult.",
+                          "items": {
+                            "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                            "minLength": 1,
+                            "pattern": "^[^,]+$",
+                            "type": "string"
+                          },
+                          "type": "array",
+                          "x-kubernetes-list-type": "set"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "id": {
+                      "description": "ID is the ID of the security group to use. If ID is provided, the other filters cannot be provided. Must be in UUID format.",
+                      "format": "uuid",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "array",
+                "x-kubernetes-list-type": "atomic"
+              },
+              "tags": {
+                "description": "Tags applied to the port (and corresponding trunk, if a trunk is configured.)\nThese tags are applied in addition to the instance's tags, which will also be applied to the port.",
+                "items": {
+                  "type": "string"
+                },
+                "type": "array",
+                "x-kubernetes-list-type": "set"
+              },
+              "trunk": {
+                "description": "Trunk specifies whether trunking is enabled at the port level. If not\nprovided the value is inherited from the machine, or false for a\nbastion host.",
+                "type": "boolean"
+              },
+              "valueSpecs": {
+                "description": "Value specs are extra parameters to include in the API request with OpenStack.\nThis is an extension point for the API, so what they do and if they are supported,\ndepends on the specific OpenStack implementation.",
+                "items": {
+                  "description": "ValueSpec represents a single value_spec key-value pair.",
+                  "properties": {
+                    "key": {
+                      "description": "Key is the key in the key-value pair.",
+                      "type": "string"
+                    },
+                    "name": {
+                      "description": "Name is the name of the key-value pair.\nThis is just for identifying the pair and will not be sent to the OpenStack API.",
+                      "type": "string"
+                    },
+                    "value": {
+                      "description": "Value is the value in the key-value pair.",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "key",
+                    "name",
+                    "value"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "array",
+                "x-kubernetes-list-map-keys": [
+                  "name"
+                ],
+                "x-kubernetes-list-type": "map"
+              },
+              "vnicType": {
+                "description": "VNICType specifies the type of vNIC which this port should be\nattached to. This is used to determine which mechanism driver(s) to\nbe used to bind the port. The valid values are normal, macvtap,\ndirect, baremetal, direct-physical, virtio-forwarder, smart-nic and\nremote-managed, although these values will not be validated in this\nAPI to ensure compatibility with future neutron changes or custom\nimplementations. What type of vNIC is actually available depends on\ndeployments. If not specified, the Neutron default value is used.",
+                "type": "string"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "providerID": {
+          "description": "ProviderID is the unique identifier as specified by the cloud provider.",
+          "type": "string"
+        },
+        "rootVolume": {
+          "description": "The volume metadata to boot from",
+          "properties": {
+            "availabilityZone": {
+              "description": "AvailabilityZone is the volume availability zone to create the volume\nin. If not specified, the volume will be created without an explicit\navailability zone.",
+              "properties": {
+                "from": {
+                  "default": "Name",
+                  "description": "From specifies where we will obtain the availability zone for the\nvolume. The options are \"Name\" and \"Machine\". If \"Name\" is specified\nthen the Name field must also be specified. If \"Machine\" is specified\nthe volume will use the value of FailureDomain, if any, from the\nassociated Machine.",
+                  "enum": [
+                    "Name",
+                    "Machine"
+                  ],
+                  "type": "string"
+                },
+                "name": {
+                  "description": "Name is the name of a volume availability zone to use. It is required\nif From is \"Name\". The volume availability zone name may not contain\nspaces.",
+                  "minLength": 1,
+                  "pattern": "^[^ ]+$",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "x-kubernetes-validations": [
+                {
+                  "message": "name is required when from is 'Name' or default",
+                  "rule": "!has(self.from) || self.from == 'Name' ? has(self.name) : !has(self.name)"
+                }
+              ],
+              "additionalProperties": false
+            },
+            "sizeGiB": {
+              "description": "SizeGiB is the size of the block device in gibibytes (GiB).",
+              "minimum": 1,
+              "type": "integer"
+            },
+            "type": {
+              "description": "Type is the Cinder volume type of the volume.\nIf omitted, the default Cinder volume type that is configured in the OpenStack cloud\nwill be used.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "sizeGiB"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "schedulerHintAdditionalProperties": {
+          "description": "SchedulerHintAdditionalProperties are arbitrary key/value pairs that provide additional hints\nto the OpenStack scheduler. These hints can influence how instances are placed on the infrastructure,\nsuch as specifying certain host aggregates or availability zones.",
+          "items": {
+            "description": "SchedulerHintAdditionalProperty represents a single additional property for a scheduler hint.\nIt includes a Name to identify the property and a Value that can be of various types.",
+            "properties": {
+              "name": {
+                "description": "Name is the name of the scheduler hint property.\nIt is a unique identifier for the property.",
+                "minLength": 1,
+                "type": "string"
+              },
+              "value": {
+                "description": "Value is the value of the scheduler hint property, which can be of various types\n(e.g., bool, string, int). The type is indicated by the Value.Type field.",
+                "properties": {
+                  "bool": {
+                    "description": "Bool is the boolean value of the scheduler hint, used when Type is \"Bool\".\nThis field is required if type is 'Bool', and must not be set otherwise.",
+                    "type": "boolean"
+                  },
+                  "number": {
+                    "description": "Number is the integer value of the scheduler hint, used when Type is \"Number\".\nThis field is required if type is 'Number', and must not be set otherwise.",
+                    "type": "integer"
+                  },
+                  "string": {
+                    "description": "String is the string value of the scheduler hint, used when Type is \"String\".\nThis field is required if type is 'String', and must not be set otherwise.",
+                    "maxLength": 255,
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "type": {
+                    "description": "Type represents the type of the value.\nValid values are Bool, String, and Number.",
+                    "enum": [
+                      "Bool",
+                      "String",
+                      "Number"
+                    ],
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "type"
+                ],
+                "type": "object",
+                "x-kubernetes-validations": [
+                  {
+                    "message": "bool is required when type is Bool, and forbidden otherwise",
+                    "rule": "has(self.type) && self.type == 'Bool' ? has(self.bool) : !has(self.bool)"
+                  },
+                  {
+                    "message": "number is required when type is Number, and forbidden otherwise",
+                    "rule": "has(self.type) && self.type == 'Number' ? has(self.number) : !has(self.number)"
+                  },
+                  {
+                    "message": "string is required when type is String, and forbidden otherwise",
+                    "rule": "has(self.type) && self.type == 'String' ? has(self.string) : !has(self.string)"
+                  }
+                ],
+                "additionalProperties": false
+              }
+            },
+            "required": [
+              "name",
+              "value"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array",
+          "x-kubernetes-list-map-keys": [
+            "name"
+          ],
+          "x-kubernetes-list-type": "map"
+        },
+        "securityGroups": {
+          "description": "The names of the security groups to assign to the instance",
+          "items": {
+            "description": "SecurityGroupParam specifies an OpenStack security group. It may be specified by ID or filter, but not both.",
+            "maxProperties": 1,
+            "minProperties": 1,
+            "properties": {
+              "filter": {
+                "description": "Filter specifies a query to select an OpenStack security group. If provided, cannot be empty.",
+                "minProperties": 1,
+                "properties": {
+                  "description": {
+                    "type": "string"
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "notTags": {
+                    "description": "NotTags is a list of tags to filter by. If specified, resources which\ncontain all of the given tags will be excluded from the result.",
+                    "items": {
+                      "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                      "minLength": 1,
+                      "pattern": "^[^,]+$",
+                      "type": "string"
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-type": "set"
+                  },
+                  "notTagsAny": {
+                    "description": "NotTagsAny is a list of tags to filter by. If specified, resources\nwhich contain any of the given tags will be excluded from the result.",
+                    "items": {
+                      "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                      "minLength": 1,
+                      "pattern": "^[^,]+$",
+                      "type": "string"
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-type": "set"
+                  },
+                  "projectID": {
+                    "type": "string"
+                  },
+                  "tags": {
+                    "description": "Tags is a list of tags to filter by. If specified, the resource must\nhave all of the tags specified to be included in the result.",
+                    "items": {
+                      "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                      "minLength": 1,
+                      "pattern": "^[^,]+$",
+                      "type": "string"
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-type": "set"
+                  },
+                  "tagsAny": {
+                    "description": "TagsAny is a list of tags to filter by. If specified, the resource\nmust have at least one of the tags specified to be included in the\nresult.",
+                    "items": {
+                      "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                      "minLength": 1,
+                      "pattern": "^[^,]+$",
+                      "type": "string"
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-type": "set"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "id": {
+                "description": "ID is the ID of the security group to use. If ID is provided, the other filters cannot be provided. Must be in UUID format.",
+                "format": "uuid",
+                "type": "string"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "serverGroup": {
+          "description": "The server group to assign the machine to.",
+          "maxProperties": 1,
+          "minProperties": 1,
+          "properties": {
+            "filter": {
+              "description": "Filter specifies a query to select an OpenStack server group. If provided, it cannot be empty.",
+              "minProperties": 1,
+              "properties": {
+                "name": {
+                  "description": "Name is the name of a server group to look for.",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "id": {
+              "description": "ID is the ID of the server group to use.",
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "serverMetadata": {
+          "description": "Metadata mapping. Allows you to create a map of key value pairs to add to the server instance.",
+          "items": {
+            "properties": {
+              "key": {
+                "description": "Key is the server metadata key",
+                "maxLength": 255,
+                "type": "string"
+              },
+              "value": {
+                "description": "Value is the server metadata value",
+                "maxLength": 255,
+                "type": "string"
+              }
+            },
+            "required": [
+              "key",
+              "value"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array",
+          "x-kubernetes-list-map-keys": [
+            "key"
+          ],
+          "x-kubernetes-list-type": "map"
+        },
+        "sshKeyName": {
+          "description": "The ssh key to inject in the instance",
+          "type": "string"
+        },
+        "tags": {
+          "description": "Tags which will be added to the machine and all dependent resources\nwhich support them. These are in addition to Tags defined on the\ncluster.\nRequires Nova api 2.52 minimum!",
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "set"
+        },
+        "trunk": {
+          "description": "Whether the server instance is created on a trunk port or not.",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "image"
+      ],
+      "type": "object",
+      "x-kubernetes-validations": [
+        {
+          "message": "at least one of flavor or flavorID must be set",
+          "rule": "(has(self.flavor) || has(self.flavorID))"
+        }
+      ],
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "OpenStackMachineStatus defines the observed state of OpenStackMachine.",
+      "properties": {
+        "addresses": {
+          "description": "Addresses contains the OpenStack instance associated addresses.",
+          "items": {
+            "description": "NodeAddress contains information for the node's address.",
+            "properties": {
+              "address": {
+                "description": "The node address.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Node address type, one of Hostname, ExternalIP or InternalIP.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "address",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "conditions": {
+          "description": "Conditions defines current service state of the OpenStackMachine.\nThis field surfaces into Machine's status.conditions[InfrastructureReady] condition.\nThe Ready condition must surface issues during the entire lifecycle of the OpenStackMachine\n(both during initial provisioning and after the initial provisioning is completed).",
+          "items": {
+            "description": "Condition defines an observation of a Cluster API resource operational state.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "lastTransitionTime is the last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed. If that is not known, then using the time when\nthe API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "message is a human readable message indicating details about the transition.\nThis field may be empty.",
+                "maxLength": 10240,
+                "minLength": 1,
+                "type": "string"
+              },
+              "reason": {
+                "description": "reason is the reason for the condition's last transition in CamelCase.\nThe specific API may choose whether or not this field is considered a guaranteed API.\nThis field may be empty.",
+                "maxLength": 256,
+                "minLength": 1,
+                "type": "string"
+              },
+              "severity": {
+                "description": "severity provides an explicit classification of Reason code, so the users or machines can immediately\nunderstand the current situation and act accordingly.\nThe Severity field MUST be set only when Status=False.",
+                "maxLength": 32,
+                "type": "string"
+              },
+              "status": {
+                "description": "status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "type of condition in CamelCase or in foo.example.com/CamelCase.\nMany .condition.type values are consistent across resources like Available, but because arbitrary conditions\ncan be useful (see .node.status.conditions), the ability to deconflict is important.",
+                "maxLength": 256,
+                "minLength": 1,
+                "type": "string"
+              }
+            },
+            "required": [
+              "lastTransitionTime",
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "failureMessage": {
+          "description": "FailureMessage will be set in the event that there is a terminal problem\nreconciling the Machine and will contain a more verbose string suitable\nfor logging and human consumption.\n\nThis field should not be set for transitive errors that a controller\nfaces that are expected to be fixed automatically over\ntime (like service outages), but instead indicate that something is\nfundamentally wrong with the Machine's spec or the configuration of\nthe controller, and that manual intervention is required. Examples\nof terminal errors would be invalid combinations of settings in the\nspec, values that are unsupported by the controller, or the\nresponsible controller itself being critically misconfigured.\n\nAny transient errors that occur during the reconciliation of Machines\ncan be added as events to the Machine object and/or logged in the\ncontroller's output.\n\nDeprecated: This field is deprecated and will be removed in a future API version.\nUse status.conditions to report failures.",
+          "type": "string"
+        },
+        "failureReason": {
+          "description": "FailureReason explains the reson behind a failure.\n\nDeprecated: This field is deprecated and will be removed in a future API version.\nUse status.conditions to report failures.",
+          "type": "string"
+        },
+        "initialization": {
+          "description": "Initialization contains information about the initialization status of the machine.",
+          "properties": {
+            "provisioned": {
+              "description": "Provisioned is set to true when the initial provisioning of the machine infrastructure is completed.\nThe value of this field is never updated after provisioning is completed.",
+              "type": "boolean"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "instanceID": {
+          "description": "InstanceID is the OpenStack instance ID for this machine.",
+          "type": "string"
+        },
+        "instanceState": {
+          "description": "InstanceState is the state of the OpenStack instance for this machine.\nThis field is not set anymore by the OpenStackMachine controller.\nInstead, it's set by the OpenStackServer controller.",
+          "type": "string"
+        },
+        "ready": {
+          "description": "Ready is true when the provider resource is ready.\n\nDeprecated: This field is deprecated and will be removed in a future API version.\nUse status.conditions to determine the ready state of the machine.",
+          "type": "boolean"
+        },
+        "resolved": {
+          "description": "Resolved contains parts of the machine spec with all external\nreferences fully resolved.",
+          "properties": {
+            "flavorID": {
+              "description": "FlavorID is the ID of the flavor to use.",
+              "type": "string"
+            },
+            "imageID": {
+              "description": "ImageID is the ID of the image to use for the machine and is calculated based on ImageFilter.",
+              "type": "string"
+            },
+            "ports": {
+              "description": "Ports is the fully resolved list of ports to create for the machine.",
+              "items": {
+                "description": "ResolvedPortSpec is a PortOpts with all contained references fully resolved.",
+                "properties": {
+                  "adminStateUp": {
+                    "description": "AdminStateUp specifies whether the port should be created in the up (true) or down (false) state. The default is up.",
+                    "type": "boolean"
+                  },
+                  "allowedAddressPairs": {
+                    "description": "AllowedAddressPairs is a list of address pairs which Neutron will\nallow the port to send traffic from in addition to the port's\naddresses. If not specified, the MAC Address will be the MAC Address\nof the port. Depending on the configuration of Neutron, it may be\nsupported to specify a CIDR instead of a specific IP address.",
+                    "items": {
+                      "properties": {
+                        "ipAddress": {
+                          "description": "IPAddress is the IP address of the allowed address pair. Depending on\nthe configuration of Neutron, it may be supported to specify a CIDR\ninstead of a specific IP address.",
+                          "type": "string"
+                        },
+                        "macAddress": {
+                          "description": "MACAddress is the MAC address of the allowed address pair. If not\nspecified, the MAC address will be the MAC address of the port.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "ipAddress"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
+                  },
+                  "description": {
+                    "description": "Description is a human-readable description for the port.",
+                    "type": "string"
+                  },
+                  "disablePortSecurity": {
+                    "description": "DisablePortSecurity enables or disables the port security when set.\nWhen not set, it takes the value of the corresponding field at the network level.",
+                    "type": "boolean"
+                  },
+                  "fixedIPs": {
+                    "description": "FixedIPs is a list of pairs of subnet and/or IP address to assign to the port. If specified, these must be subnets of the port's network.",
+                    "items": {
+                      "description": "ResolvedFixedIP is a FixedIP with the Subnet resolved to an ID.",
+                      "properties": {
+                        "ipAddress": {
+                          "description": "IPAddress is a specific IP address to assign to the port. If SubnetID\nis also specified, IPAddress must be a valid IP address in the\nsubnet. If Subnet is not specified, IPAddress must be a valid IP\naddress in any subnet of the port's network.",
+                          "type": "string"
+                        },
+                        "subnet": {
+                          "description": "SubnetID is the id of a subnet to create the fixed IP of a port in.",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
+                  },
+                  "hostID": {
+                    "description": "HostID specifies the ID of the host where the port resides.",
+                    "type": "string"
+                  },
+                  "macAddress": {
+                    "description": "MACAddress specifies the MAC address of the port. If not specified, the MAC address will be generated.",
+                    "type": "string"
+                  },
+                  "name": {
+                    "description": "Name is the name of the port.",
+                    "type": "string"
+                  },
+                  "networkID": {
+                    "description": "NetworkID is the ID of the network the port will be created in.",
+                    "type": "string"
+                  },
+                  "profile": {
+                    "description": "Profile is a set of key-value pairs that are used for binding\ndetails. We intentionally don't expose this as a map[string]string\nbecause we only want to enable the users to set the values of the\nkeys that are known to work in OpenStack Networking API.  See\nhttps://docs.openstack.org/api-ref/network/v2/index.html?expanded=create-port-detail#create-port\nTo set profiles, your tenant needs permissions rule:create_port, and\nrule:create_port:binding:profile",
+                    "properties": {
+                      "ovsHWOffload": {
+                        "description": "OVSHWOffload enables or disables the OVS hardware offload feature.\nThis flag is not required on OpenStack clouds since Yoga as Nova will set it automatically when the port is attached.\nSee: https://bugs.launchpad.net/nova/+bug/2020813",
+                        "type": "boolean"
+                      },
+                      "trustedVF": {
+                        "description": "TrustedVF enables or disables the \u201ctrusted mode\u201d for the VF.",
+                        "type": "boolean"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "propagateUplinkStatus": {
+                    "description": "PropageteUplinkStatus enables or disables the propagate uplink status on the port.",
+                    "type": "boolean"
+                  },
+                  "securityGroups": {
+                    "description": "SecurityGroups is a list of security group IDs to assign to the port.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
+                  },
+                  "tags": {
+                    "description": "Tags applied to the port (and corresponding trunk, if a trunk is configured.)",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-type": "set"
+                  },
+                  "trunk": {
+                    "description": "Trunk specifies whether trunking is enabled at the port level.",
+                    "type": "boolean"
+                  },
+                  "valueSpecs": {
+                    "description": "Value specs are extra parameters to include in the API request with OpenStack.\nThis is an extension point for the API, so what they do and if they are supported,\ndepends on the specific OpenStack implementation.",
+                    "items": {
+                      "description": "ValueSpec represents a single value_spec key-value pair.",
+                      "properties": {
+                        "key": {
+                          "description": "Key is the key in the key-value pair.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "description": "Name is the name of the key-value pair.\nThis is just for identifying the pair and will not be sent to the OpenStack API.",
+                          "type": "string"
+                        },
+                        "value": {
+                          "description": "Value is the value in the key-value pair.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "key",
+                        "name",
+                        "value"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-map-keys": [
+                      "name"
+                    ],
+                    "x-kubernetes-list-type": "map"
+                  },
+                  "vnicType": {
+                    "description": "VNICType specifies the type of vNIC which this port should be\nattached to. This is used to determine which mechanism driver(s) to\nbe used to bind the port. The valid values are normal, macvtap,\ndirect, baremetal, direct-physical, virtio-forwarder, smart-nic and\nremote-managed, although these values will not be validated in this\nAPI to ensure compatibility with future neutron changes or custom\nimplementations. What type of vNIC is actually available depends on\ndeployments. If not specified, the Neutron default value is used.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "description",
+                  "name",
+                  "networkID"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "serverGroupID": {
+              "description": "ServerGroupID is the ID of the server group the machine should be added to and is calculated based on ServerGroupFilter.",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "resources": {
+          "description": "Resources contains references to OpenStack resources created for the machine.",
+          "properties": {
+            "ports": {
+              "description": "Ports is the status of the ports created for the machine.",
+              "items": {
+                "properties": {
+                  "id": {
+                    "description": "ID is the unique identifier of the port.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "id"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/infrastructure.cluster.x-k8s.io/openstackmachinetemplate_v1beta1.json
+++ b/infrastructure.cluster.x-k8s.io/openstackmachinetemplate_v1beta1.json
@@ -1,0 +1,950 @@
+{
+  "description": "OpenStackMachineTemplate is the Schema for the openstackmachinetemplates API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "OpenStackMachineTemplateSpec defines the desired state of OpenStackMachineTemplate.",
+      "properties": {
+        "template": {
+          "description": "OpenStackMachineTemplateResource describes the data needed to create a OpenStackMachine from a template.",
+          "properties": {
+            "spec": {
+              "description": "Spec is the specification of the desired behavior of the machine.",
+              "properties": {
+                "additionalBlockDevices": {
+                  "description": "AdditionalBlockDevices is a list of specifications for additional block devices to attach to the server instance",
+                  "items": {
+                    "description": "AdditionalBlockDevice is a block device to attach to the server.",
+                    "properties": {
+                      "name": {
+                        "description": "Name of the block device in the context of a machine.\nIf the block device is a volume, the Cinder volume will be named\nas a combination of the machine name and this name.\nAlso, this name will be used for tagging the block device.\nInformation about the block device tag can be obtained from the OpenStack\nmetadata API or the config drive.\nName cannot be 'root', which is reserved for the root volume.",
+                        "type": "string"
+                      },
+                      "sizeGiB": {
+                        "description": "SizeGiB is the size of the block device in gibibytes (GiB).",
+                        "minimum": 1,
+                        "type": "integer"
+                      },
+                      "storage": {
+                        "description": "Storage specifies the storage type of the block device and\nadditional storage options.",
+                        "properties": {
+                          "type": {
+                            "description": "Type is the type of block device to create.\nThis can be either \"Volume\" or \"Local\".",
+                            "type": "string"
+                          },
+                          "volume": {
+                            "description": "Volume contains additional storage options for a volume block device.",
+                            "properties": {
+                              "availabilityZone": {
+                                "description": "AvailabilityZone is the volume availability zone to create the volume\nin. If not specified, the volume will be created without an explicit\navailability zone.",
+                                "properties": {
+                                  "from": {
+                                    "default": "Name",
+                                    "description": "From specifies where we will obtain the availability zone for the\nvolume. The options are \"Name\" and \"Machine\". If \"Name\" is specified\nthen the Name field must also be specified. If \"Machine\" is specified\nthe volume will use the value of FailureDomain, if any, from the\nassociated Machine.",
+                                    "enum": [
+                                      "Name",
+                                      "Machine"
+                                    ],
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "description": "Name is the name of a volume availability zone to use. It is required\nif From is \"Name\". The volume availability zone name may not contain\nspaces.",
+                                    "minLength": 1,
+                                    "pattern": "^[^ ]+$",
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "x-kubernetes-validations": [
+                                  {
+                                    "message": "name is required when from is 'Name' or default",
+                                    "rule": "!has(self.from) || self.from == 'Name' ? has(self.name) : !has(self.name)"
+                                  }
+                                ],
+                                "additionalProperties": false
+                              },
+                              "type": {
+                                "description": "Type is the Cinder volume type of the volume.\nIf omitted, the default Cinder volume type that is configured in the OpenStack cloud\nwill be used.",
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "required": [
+                          "type"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "required": [
+                      "name",
+                      "sizeGiB",
+                      "storage"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array",
+                  "x-kubernetes-list-map-keys": [
+                    "name"
+                  ],
+                  "x-kubernetes-list-type": "map"
+                },
+                "configDrive": {
+                  "description": "Config Drive support",
+                  "type": "boolean"
+                },
+                "flavor": {
+                  "description": "The flavor reference for the flavor for your server instance.",
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "flavorID": {
+                  "description": "FlavorID allows flavors to be specified by ID.  This field takes precedence\nover Flavor.",
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "floatingIPPoolRef": {
+                  "description": "floatingIPPoolRef is a reference to a IPPool that will be assigned\nto an IPAddressClaim. Once the IPAddressClaim is fulfilled, the FloatingIP\nwill be assigned to the OpenStackMachine.",
+                  "properties": {
+                    "apiGroup": {
+                      "description": "APIGroup is the group for the resource being referenced.\nIf APIGroup is not specified, the specified Kind must be in the core API group.\nFor any other third-party types, APIGroup is required.",
+                      "type": "string"
+                    },
+                    "kind": {
+                      "description": "Kind is the type of resource being referenced",
+                      "type": "string"
+                    },
+                    "name": {
+                      "description": "Name is the name of resource being referenced",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "kind",
+                    "name"
+                  ],
+                  "type": "object",
+                  "x-kubernetes-map-type": "atomic",
+                  "additionalProperties": false
+                },
+                "identityRef": {
+                  "description": "IdentityRef is a reference to a secret holding OpenStack credentials\nto be used when reconciling this machine. If not specified, the\ncredentials specified in the cluster will be used.",
+                  "properties": {
+                    "cloudName": {
+                      "description": "CloudName specifies the name of the entry in the clouds.yaml file to use.",
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "name": {
+                      "description": "Name is the name of a Secret (type=Secret) in the same namespace as the resource being provisioned,\nor the name of an OpenStackClusterIdentity (type=ClusterIdentity).\nThe Secret must contain a key named `clouds.yaml` which contains an OpenStack clouds.yaml file.\nThe Secret may optionally contain a key named `cacert` containing a PEM-encoded CA certificate.",
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "region": {
+                      "description": "Region specifies an OpenStack region to use. If specified, it overrides\nany value in clouds.yaml. If specified for an OpenStackMachine, its\nvalue will be included in providerID.",
+                      "type": "string"
+                    },
+                    "type": {
+                      "default": "Secret",
+                      "description": "Type specifies the identity reference type. Defaults to Secret for backward compatibility.",
+                      "enum": [
+                        "Secret",
+                        "ClusterIdentity"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "cloudName",
+                    "name",
+                    "type"
+                  ],
+                  "type": "object",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "region is immutable",
+                      "rule": "(!has(self.region) && !has(oldSelf.region)) || self.region == oldSelf.region"
+                    }
+                  ],
+                  "additionalProperties": false
+                },
+                "image": {
+                  "description": "The image to use for your server instance.\nIf the rootVolume is specified, this will be used when creating the root volume.",
+                  "maxProperties": 1,
+                  "minProperties": 1,
+                  "properties": {
+                    "filter": {
+                      "description": "Filter describes a query for an image. If specified, the combination\nof name and tags must return a single matching image or an error will\nbe raised.",
+                      "minProperties": 1,
+                      "properties": {
+                        "name": {
+                          "description": "The name of the desired image. If specified, the combination of name and tags must return a single matching image or an error will be raised.",
+                          "type": "string"
+                        },
+                        "tags": {
+                          "description": "The tags associated with the desired image. If specified, the combination of name and tags must return a single matching image or an error will be raised.",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array",
+                          "x-kubernetes-list-type": "set"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "id": {
+                      "description": "ID is the uuid of the image. ID will not be validated before use.",
+                      "format": "uuid",
+                      "type": "string"
+                    },
+                    "imageRef": {
+                      "description": "ImageRef is a reference to an ORC Image in the same namespace as the\nreferring object.",
+                      "properties": {
+                        "name": {
+                          "description": "Name is the name of the referenced resource",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "ports": {
+                  "description": "Ports to be attached to the server instance. They are created if a port with the given name does not already exist.\nIf not specified a default port will be added for the default cluster network.",
+                  "items": {
+                    "properties": {
+                      "adminStateUp": {
+                        "description": "AdminStateUp specifies whether the port should be created in the up (true) or down (false) state. The default is up.",
+                        "type": "boolean"
+                      },
+                      "allowedAddressPairs": {
+                        "description": "AllowedAddressPairs is a list of address pairs which Neutron will\nallow the port to send traffic from in addition to the port's\naddresses. If not specified, the MAC Address will be the MAC Address\nof the port. Depending on the configuration of Neutron, it may be\nsupported to specify a CIDR instead of a specific IP address.",
+                        "items": {
+                          "properties": {
+                            "ipAddress": {
+                              "description": "IPAddress is the IP address of the allowed address pair. Depending on\nthe configuration of Neutron, it may be supported to specify a CIDR\ninstead of a specific IP address.",
+                              "type": "string"
+                            },
+                            "macAddress": {
+                              "description": "MACAddress is the MAC address of the allowed address pair. If not\nspecified, the MAC address will be the MAC address of the port.",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "ipAddress"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "description": {
+                        "description": "Description is a human-readable description for the port.",
+                        "type": "string"
+                      },
+                      "disablePortSecurity": {
+                        "description": "DisablePortSecurity enables or disables the port security when set.\nWhen not set, it takes the value of the corresponding field at the network level.",
+                        "type": "boolean"
+                      },
+                      "fixedIPs": {
+                        "description": "FixedIPs is a list of pairs of subnet and/or IP address to assign to the port. If specified, these must be subnets of the port's network.",
+                        "items": {
+                          "properties": {
+                            "ipAddress": {
+                              "description": "IPAddress is a specific IP address to assign to the port. If Subnet\nis also specified, IPAddress must be a valid IP address in the\nsubnet. If Subnet is not specified, IPAddress must be a valid IP\naddress in any subnet of the port's network.",
+                              "type": "string"
+                            },
+                            "subnet": {
+                              "description": "Subnet is an openstack subnet query that will return the id of a subnet to create\nthe fixed IP of a port in. This query must not return more than one subnet.",
+                              "maxProperties": 1,
+                              "minProperties": 1,
+                              "properties": {
+                                "filter": {
+                                  "description": "Filter specifies a filter to select the subnet. It must match exactly one subnet.",
+                                  "minProperties": 1,
+                                  "properties": {
+                                    "cidr": {
+                                      "type": "string"
+                                    },
+                                    "description": {
+                                      "type": "string"
+                                    },
+                                    "gatewayIP": {
+                                      "type": "string"
+                                    },
+                                    "ipVersion": {
+                                      "type": "integer"
+                                    },
+                                    "ipv6AddressMode": {
+                                      "type": "string"
+                                    },
+                                    "ipv6RAMode": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "notTags": {
+                                      "description": "NotTags is a list of tags to filter by. If specified, resources which\ncontain all of the given tags will be excluded from the result.",
+                                      "items": {
+                                        "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                                        "minLength": 1,
+                                        "pattern": "^[^,]+$",
+                                        "type": "string"
+                                      },
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "set"
+                                    },
+                                    "notTagsAny": {
+                                      "description": "NotTagsAny is a list of tags to filter by. If specified, resources\nwhich contain any of the given tags will be excluded from the result.",
+                                      "items": {
+                                        "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                                        "minLength": 1,
+                                        "pattern": "^[^,]+$",
+                                        "type": "string"
+                                      },
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "set"
+                                    },
+                                    "projectID": {
+                                      "type": "string"
+                                    },
+                                    "tags": {
+                                      "description": "Tags is a list of tags to filter by. If specified, the resource must\nhave all of the tags specified to be included in the result.",
+                                      "items": {
+                                        "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                                        "minLength": 1,
+                                        "pattern": "^[^,]+$",
+                                        "type": "string"
+                                      },
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "set"
+                                    },
+                                    "tagsAny": {
+                                      "description": "TagsAny is a list of tags to filter by. If specified, the resource\nmust have at least one of the tags specified to be included in the\nresult.",
+                                      "items": {
+                                        "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                                        "minLength": 1,
+                                        "pattern": "^[^,]+$",
+                                        "type": "string"
+                                      },
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "set"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "id": {
+                                  "description": "ID is the uuid of the subnet. It will not be validated.",
+                                  "format": "uuid",
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
+                      },
+                      "hostID": {
+                        "description": "HostID specifies the ID of the host where the port resides.",
+                        "type": "string"
+                      },
+                      "macAddress": {
+                        "description": "MACAddress specifies the MAC address of the port. If not specified, the MAC address will be generated.",
+                        "type": "string"
+                      },
+                      "nameSuffix": {
+                        "description": "NameSuffix will be appended to the name of the port if specified. If unspecified, instead the 0-based index of the port in the list is used.",
+                        "type": "string"
+                      },
+                      "network": {
+                        "description": "Network is a query for an openstack network that the port will be created or discovered on.\nThis will fail if the query returns more than one network.",
+                        "maxProperties": 1,
+                        "minProperties": 1,
+                        "properties": {
+                          "filter": {
+                            "description": "Filter specifies a filter to select an OpenStack network. If provided, cannot be empty.",
+                            "minProperties": 1,
+                            "properties": {
+                              "description": {
+                                "type": "string"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "notTags": {
+                                "description": "NotTags is a list of tags to filter by. If specified, resources which\ncontain all of the given tags will be excluded from the result.",
+                                "items": {
+                                  "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                                  "minLength": 1,
+                                  "pattern": "^[^,]+$",
+                                  "type": "string"
+                                },
+                                "type": "array",
+                                "x-kubernetes-list-type": "set"
+                              },
+                              "notTagsAny": {
+                                "description": "NotTagsAny is a list of tags to filter by. If specified, resources\nwhich contain any of the given tags will be excluded from the result.",
+                                "items": {
+                                  "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                                  "minLength": 1,
+                                  "pattern": "^[^,]+$",
+                                  "type": "string"
+                                },
+                                "type": "array",
+                                "x-kubernetes-list-type": "set"
+                              },
+                              "projectID": {
+                                "type": "string"
+                              },
+                              "tags": {
+                                "description": "Tags is a list of tags to filter by. If specified, the resource must\nhave all of the tags specified to be included in the result.",
+                                "items": {
+                                  "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                                  "minLength": 1,
+                                  "pattern": "^[^,]+$",
+                                  "type": "string"
+                                },
+                                "type": "array",
+                                "x-kubernetes-list-type": "set"
+                              },
+                              "tagsAny": {
+                                "description": "TagsAny is a list of tags to filter by. If specified, the resource\nmust have at least one of the tags specified to be included in the\nresult.",
+                                "items": {
+                                  "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                                  "minLength": 1,
+                                  "pattern": "^[^,]+$",
+                                  "type": "string"
+                                },
+                                "type": "array",
+                                "x-kubernetes-list-type": "set"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "id": {
+                            "description": "ID is the ID of the network to use. If ID is provided, the other filters cannot be provided. Must be in UUID format.",
+                            "format": "uuid",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "profile": {
+                        "description": "Profile is a set of key-value pairs that are used for binding\ndetails. We intentionally don't expose this as a map[string]string\nbecause we only want to enable the users to set the values of the\nkeys that are known to work in OpenStack Networking API.  See\nhttps://docs.openstack.org/api-ref/network/v2/index.html?expanded=create-port-detail#create-port\nTo set profiles, your tenant needs permissions rule:create_port, and\nrule:create_port:binding:profile",
+                        "properties": {
+                          "ovsHWOffload": {
+                            "description": "OVSHWOffload enables or disables the OVS hardware offload feature.\nThis flag is not required on OpenStack clouds since Yoga as Nova will set it automatically when the port is attached.\nSee: https://bugs.launchpad.net/nova/+bug/2020813",
+                            "type": "boolean"
+                          },
+                          "trustedVF": {
+                            "description": "TrustedVF enables or disables the \u201ctrusted mode\u201d for the VF.",
+                            "type": "boolean"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "propagateUplinkStatus": {
+                        "description": "PropageteUplinkStatus enables or disables the propagate uplink status on the port.",
+                        "type": "boolean"
+                      },
+                      "securityGroups": {
+                        "description": "SecurityGroups is a list of the names, uuids, filters or any combination these of the security groups to assign to the instance.",
+                        "items": {
+                          "description": "SecurityGroupParam specifies an OpenStack security group. It may be specified by ID or filter, but not both.",
+                          "maxProperties": 1,
+                          "minProperties": 1,
+                          "properties": {
+                            "filter": {
+                              "description": "Filter specifies a query to select an OpenStack security group. If provided, cannot be empty.",
+                              "minProperties": 1,
+                              "properties": {
+                                "description": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "notTags": {
+                                  "description": "NotTags is a list of tags to filter by. If specified, resources which\ncontain all of the given tags will be excluded from the result.",
+                                  "items": {
+                                    "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                                    "minLength": 1,
+                                    "pattern": "^[^,]+$",
+                                    "type": "string"
+                                  },
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "set"
+                                },
+                                "notTagsAny": {
+                                  "description": "NotTagsAny is a list of tags to filter by. If specified, resources\nwhich contain any of the given tags will be excluded from the result.",
+                                  "items": {
+                                    "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                                    "minLength": 1,
+                                    "pattern": "^[^,]+$",
+                                    "type": "string"
+                                  },
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "set"
+                                },
+                                "projectID": {
+                                  "type": "string"
+                                },
+                                "tags": {
+                                  "description": "Tags is a list of tags to filter by. If specified, the resource must\nhave all of the tags specified to be included in the result.",
+                                  "items": {
+                                    "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                                    "minLength": 1,
+                                    "pattern": "^[^,]+$",
+                                    "type": "string"
+                                  },
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "set"
+                                },
+                                "tagsAny": {
+                                  "description": "TagsAny is a list of tags to filter by. If specified, the resource\nmust have at least one of the tags specified to be included in the\nresult.",
+                                  "items": {
+                                    "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                                    "minLength": 1,
+                                    "pattern": "^[^,]+$",
+                                    "type": "string"
+                                  },
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "set"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "id": {
+                              "description": "ID is the ID of the security group to use. If ID is provided, the other filters cannot be provided. Must be in UUID format.",
+                              "format": "uuid",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
+                      },
+                      "tags": {
+                        "description": "Tags applied to the port (and corresponding trunk, if a trunk is configured.)\nThese tags are applied in addition to the instance's tags, which will also be applied to the port.",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array",
+                        "x-kubernetes-list-type": "set"
+                      },
+                      "trunk": {
+                        "description": "Trunk specifies whether trunking is enabled at the port level. If not\nprovided the value is inherited from the machine, or false for a\nbastion host.",
+                        "type": "boolean"
+                      },
+                      "valueSpecs": {
+                        "description": "Value specs are extra parameters to include in the API request with OpenStack.\nThis is an extension point for the API, so what they do and if they are supported,\ndepends on the specific OpenStack implementation.",
+                        "items": {
+                          "description": "ValueSpec represents a single value_spec key-value pair.",
+                          "properties": {
+                            "key": {
+                              "description": "Key is the key in the key-value pair.",
+                              "type": "string"
+                            },
+                            "name": {
+                              "description": "Name is the name of the key-value pair.\nThis is just for identifying the pair and will not be sent to the OpenStack API.",
+                              "type": "string"
+                            },
+                            "value": {
+                              "description": "Value is the value in the key-value pair.",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "key",
+                            "name",
+                            "value"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array",
+                        "x-kubernetes-list-map-keys": [
+                          "name"
+                        ],
+                        "x-kubernetes-list-type": "map"
+                      },
+                      "vnicType": {
+                        "description": "VNICType specifies the type of vNIC which this port should be\nattached to. This is used to determine which mechanism driver(s) to\nbe used to bind the port. The valid values are normal, macvtap,\ndirect, baremetal, direct-physical, virtio-forwarder, smart-nic and\nremote-managed, although these values will not be validated in this\nAPI to ensure compatibility with future neutron changes or custom\nimplementations. What type of vNIC is actually available depends on\ndeployments. If not specified, the Neutron default value is used.",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "providerID": {
+                  "description": "ProviderID is the unique identifier as specified by the cloud provider.",
+                  "type": "string"
+                },
+                "rootVolume": {
+                  "description": "The volume metadata to boot from",
+                  "properties": {
+                    "availabilityZone": {
+                      "description": "AvailabilityZone is the volume availability zone to create the volume\nin. If not specified, the volume will be created without an explicit\navailability zone.",
+                      "properties": {
+                        "from": {
+                          "default": "Name",
+                          "description": "From specifies where we will obtain the availability zone for the\nvolume. The options are \"Name\" and \"Machine\". If \"Name\" is specified\nthen the Name field must also be specified. If \"Machine\" is specified\nthe volume will use the value of FailureDomain, if any, from the\nassociated Machine.",
+                          "enum": [
+                            "Name",
+                            "Machine"
+                          ],
+                          "type": "string"
+                        },
+                        "name": {
+                          "description": "Name is the name of a volume availability zone to use. It is required\nif From is \"Name\". The volume availability zone name may not contain\nspaces.",
+                          "minLength": 1,
+                          "pattern": "^[^ ]+$",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "x-kubernetes-validations": [
+                        {
+                          "message": "name is required when from is 'Name' or default",
+                          "rule": "!has(self.from) || self.from == 'Name' ? has(self.name) : !has(self.name)"
+                        }
+                      ],
+                      "additionalProperties": false
+                    },
+                    "sizeGiB": {
+                      "description": "SizeGiB is the size of the block device in gibibytes (GiB).",
+                      "minimum": 1,
+                      "type": "integer"
+                    },
+                    "type": {
+                      "description": "Type is the Cinder volume type of the volume.\nIf omitted, the default Cinder volume type that is configured in the OpenStack cloud\nwill be used.",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "sizeGiB"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "schedulerHintAdditionalProperties": {
+                  "description": "SchedulerHintAdditionalProperties are arbitrary key/value pairs that provide additional hints\nto the OpenStack scheduler. These hints can influence how instances are placed on the infrastructure,\nsuch as specifying certain host aggregates or availability zones.",
+                  "items": {
+                    "description": "SchedulerHintAdditionalProperty represents a single additional property for a scheduler hint.\nIt includes a Name to identify the property and a Value that can be of various types.",
+                    "properties": {
+                      "name": {
+                        "description": "Name is the name of the scheduler hint property.\nIt is a unique identifier for the property.",
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "value": {
+                        "description": "Value is the value of the scheduler hint property, which can be of various types\n(e.g., bool, string, int). The type is indicated by the Value.Type field.",
+                        "properties": {
+                          "bool": {
+                            "description": "Bool is the boolean value of the scheduler hint, used when Type is \"Bool\".\nThis field is required if type is 'Bool', and must not be set otherwise.",
+                            "type": "boolean"
+                          },
+                          "number": {
+                            "description": "Number is the integer value of the scheduler hint, used when Type is \"Number\".\nThis field is required if type is 'Number', and must not be set otherwise.",
+                            "type": "integer"
+                          },
+                          "string": {
+                            "description": "String is the string value of the scheduler hint, used when Type is \"String\".\nThis field is required if type is 'String', and must not be set otherwise.",
+                            "maxLength": 255,
+                            "minLength": 1,
+                            "type": "string"
+                          },
+                          "type": {
+                            "description": "Type represents the type of the value.\nValid values are Bool, String, and Number.",
+                            "enum": [
+                              "Bool",
+                              "String",
+                              "Number"
+                            ],
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "type"
+                        ],
+                        "type": "object",
+                        "x-kubernetes-validations": [
+                          {
+                            "message": "bool is required when type is Bool, and forbidden otherwise",
+                            "rule": "has(self.type) && self.type == 'Bool' ? has(self.bool) : !has(self.bool)"
+                          },
+                          {
+                            "message": "number is required when type is Number, and forbidden otherwise",
+                            "rule": "has(self.type) && self.type == 'Number' ? has(self.number) : !has(self.number)"
+                          },
+                          {
+                            "message": "string is required when type is String, and forbidden otherwise",
+                            "rule": "has(self.type) && self.type == 'String' ? has(self.string) : !has(self.string)"
+                          }
+                        ],
+                        "additionalProperties": false
+                      }
+                    },
+                    "required": [
+                      "name",
+                      "value"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array",
+                  "x-kubernetes-list-map-keys": [
+                    "name"
+                  ],
+                  "x-kubernetes-list-type": "map"
+                },
+                "securityGroups": {
+                  "description": "The names of the security groups to assign to the instance",
+                  "items": {
+                    "description": "SecurityGroupParam specifies an OpenStack security group. It may be specified by ID or filter, but not both.",
+                    "maxProperties": 1,
+                    "minProperties": 1,
+                    "properties": {
+                      "filter": {
+                        "description": "Filter specifies a query to select an OpenStack security group. If provided, cannot be empty.",
+                        "minProperties": 1,
+                        "properties": {
+                          "description": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "notTags": {
+                            "description": "NotTags is a list of tags to filter by. If specified, resources which\ncontain all of the given tags will be excluded from the result.",
+                            "items": {
+                              "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                              "minLength": 1,
+                              "pattern": "^[^,]+$",
+                              "type": "string"
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "set"
+                          },
+                          "notTagsAny": {
+                            "description": "NotTagsAny is a list of tags to filter by. If specified, resources\nwhich contain any of the given tags will be excluded from the result.",
+                            "items": {
+                              "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                              "minLength": 1,
+                              "pattern": "^[^,]+$",
+                              "type": "string"
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "set"
+                          },
+                          "projectID": {
+                            "type": "string"
+                          },
+                          "tags": {
+                            "description": "Tags is a list of tags to filter by. If specified, the resource must\nhave all of the tags specified to be included in the result.",
+                            "items": {
+                              "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                              "minLength": 1,
+                              "pattern": "^[^,]+$",
+                              "type": "string"
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "set"
+                          },
+                          "tagsAny": {
+                            "description": "TagsAny is a list of tags to filter by. If specified, the resource\nmust have at least one of the tags specified to be included in the\nresult.",
+                            "items": {
+                              "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                              "minLength": 1,
+                              "pattern": "^[^,]+$",
+                              "type": "string"
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "set"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "id": {
+                        "description": "ID is the ID of the security group to use. If ID is provided, the other filters cannot be provided. Must be in UUID format.",
+                        "format": "uuid",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "serverGroup": {
+                  "description": "The server group to assign the machine to.",
+                  "maxProperties": 1,
+                  "minProperties": 1,
+                  "properties": {
+                    "filter": {
+                      "description": "Filter specifies a query to select an OpenStack server group. If provided, it cannot be empty.",
+                      "minProperties": 1,
+                      "properties": {
+                        "name": {
+                          "description": "Name is the name of a server group to look for.",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "id": {
+                      "description": "ID is the ID of the server group to use.",
+                      "format": "uuid",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "serverMetadata": {
+                  "description": "Metadata mapping. Allows you to create a map of key value pairs to add to the server instance.",
+                  "items": {
+                    "properties": {
+                      "key": {
+                        "description": "Key is the server metadata key",
+                        "maxLength": 255,
+                        "type": "string"
+                      },
+                      "value": {
+                        "description": "Value is the server metadata value",
+                        "maxLength": 255,
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "key",
+                      "value"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array",
+                  "x-kubernetes-list-map-keys": [
+                    "key"
+                  ],
+                  "x-kubernetes-list-type": "map"
+                },
+                "sshKeyName": {
+                  "description": "The ssh key to inject in the instance",
+                  "type": "string"
+                },
+                "tags": {
+                  "description": "Tags which will be added to the machine and all dependent resources\nwhich support them. These are in addition to Tags defined on the\ncluster.\nRequires Nova api 2.52 minimum!",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array",
+                  "x-kubernetes-list-type": "set"
+                },
+                "trunk": {
+                  "description": "Whether the server instance is created on a trunk port or not.",
+                  "type": "boolean"
+                }
+              },
+              "required": [
+                "image"
+              ],
+              "type": "object",
+              "x-kubernetes-validations": [
+                {
+                  "message": "at least one of flavor or flavorID must be set",
+                  "rule": "(has(self.flavor) || has(self.flavorID))"
+                }
+              ],
+              "additionalProperties": false
+            }
+          },
+          "required": [
+            "spec"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "template"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "OpenStackMachineTemplateStatus defines the observed state of OpenStackMachineTemplate.",
+      "properties": {
+        "capacity": {
+          "additionalProperties": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "string"
+              }
+            ],
+            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+            "x-kubernetes-int-or-string": true
+          },
+          "description": "Capacity defines the resource capacity for this machine.\nThis value is used for autoscaling from zero operations as defined in:\nhttps://github.com/kubernetes-sigs/cluster-api/blob/main/docs/proposals/20210310-opt-in-autoscaling-from-zero.md",
+          "type": "object"
+        },
+        "nodeInfo": {
+          "description": "NodeInfo contains information about the node's architecture and operating system.",
+          "minProperties": 1,
+          "properties": {
+            "operatingSystem": {
+              "description": "operatingSystem is a string representing the operating system of the node.\nThis may be a string like 'linux' or 'windows'.",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/infrastructure.cluster.x-k8s.io/openstackserver_v1alpha1.json
+++ b/infrastructure.cluster.x-k8s.io/openstackserver_v1alpha1.json
@@ -1,0 +1,1208 @@
+{
+  "description": "OpenStackServer is the Schema for the openstackservers API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "OpenStackServerSpec defines the desired state of OpenStackServer.",
+      "properties": {
+        "additionalBlockDevices": {
+          "description": "AdditionalBlockDevices is a list of specifications for additional block devices to attach to the server instance.",
+          "items": {
+            "description": "AdditionalBlockDevice is a block device to attach to the server.",
+            "properties": {
+              "name": {
+                "description": "Name of the block device in the context of a machine.\nIf the block device is a volume, the Cinder volume will be named\nas a combination of the machine name and this name.\nAlso, this name will be used for tagging the block device.\nInformation about the block device tag can be obtained from the OpenStack\nmetadata API or the config drive.\nName cannot be 'root', which is reserved for the root volume.",
+                "type": "string"
+              },
+              "sizeGiB": {
+                "description": "SizeGiB is the size of the block device in gibibytes (GiB).",
+                "minimum": 1,
+                "type": "integer"
+              },
+              "storage": {
+                "description": "Storage specifies the storage type of the block device and\nadditional storage options.",
+                "properties": {
+                  "type": {
+                    "description": "Type is the type of block device to create.\nThis can be either \"Volume\" or \"Local\".",
+                    "type": "string"
+                  },
+                  "volume": {
+                    "description": "Volume contains additional storage options for a volume block device.",
+                    "properties": {
+                      "availabilityZone": {
+                        "description": "AvailabilityZone is the volume availability zone to create the volume\nin. If not specified, the volume will be created without an explicit\navailability zone.",
+                        "properties": {
+                          "from": {
+                            "default": "Name",
+                            "description": "From specifies where we will obtain the availability zone for the\nvolume. The options are \"Name\" and \"Machine\". If \"Name\" is specified\nthen the Name field must also be specified. If \"Machine\" is specified\nthe volume will use the value of FailureDomain, if any, from the\nassociated Machine.",
+                            "enum": [
+                              "Name",
+                              "Machine"
+                            ],
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "Name is the name of a volume availability zone to use. It is required\nif From is \"Name\". The volume availability zone name may not contain\nspaces.",
+                            "minLength": 1,
+                            "pattern": "^[^ ]+$",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-validations": [
+                          {
+                            "message": "name is required when from is 'Name' or default",
+                            "rule": "!has(self.from) || self.from == 'Name' ? has(self.name) : !has(self.name)"
+                          }
+                        ],
+                        "additionalProperties": false
+                      },
+                      "type": {
+                        "description": "Type is the Cinder volume type of the volume.\nIf omitted, the default Cinder volume type that is configured in the OpenStack cloud\nwill be used.",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  }
+                },
+                "required": [
+                  "type"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              }
+            },
+            "required": [
+              "name",
+              "sizeGiB",
+              "storage"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array",
+          "x-kubernetes-list-map-keys": [
+            "name"
+          ],
+          "x-kubernetes-list-type": "map"
+        },
+        "availabilityZone": {
+          "description": "AvailabilityZone is the availability zone in which to create the server instance.",
+          "type": "string"
+        },
+        "configDrive": {
+          "description": "ConfigDrive is a flag to enable config drive for the server instance.",
+          "type": "boolean"
+        },
+        "flavor": {
+          "description": "The flavor reference for the flavor for the server instance.",
+          "minLength": 1,
+          "type": "string"
+        },
+        "flavorID": {
+          "description": "FlavorID allows flavors to be specified by ID.  This field takes precedence\nover Flavor.",
+          "minLength": 1,
+          "type": "string"
+        },
+        "floatingIPPoolRef": {
+          "description": "FloatingIPPoolRef is a reference to a FloatingIPPool to allocate a floating IP from.",
+          "properties": {
+            "apiGroup": {
+              "description": "APIGroup is the group for the resource being referenced.\nIf APIGroup is not specified, the specified Kind must be in the core API group.\nFor any other third-party types, APIGroup is required.",
+              "type": "string"
+            },
+            "kind": {
+              "description": "Kind is the type of resource being referenced",
+              "type": "string"
+            },
+            "name": {
+              "description": "Name is the name of resource being referenced",
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "name"
+          ],
+          "type": "object",
+          "x-kubernetes-map-type": "atomic",
+          "additionalProperties": false
+        },
+        "identityRef": {
+          "description": "IdentityRef is a reference to a secret holding OpenStack credentials.",
+          "properties": {
+            "cloudName": {
+              "description": "CloudName specifies the name of the entry in the clouds.yaml file to use.",
+              "minLength": 1,
+              "type": "string"
+            },
+            "name": {
+              "description": "Name is the name of a Secret (type=Secret) in the same namespace as the resource being provisioned,\nor the name of an OpenStackClusterIdentity (type=ClusterIdentity).\nThe Secret must contain a key named `clouds.yaml` which contains an OpenStack clouds.yaml file.\nThe Secret may optionally contain a key named `cacert` containing a PEM-encoded CA certificate.",
+              "minLength": 1,
+              "type": "string"
+            },
+            "region": {
+              "description": "Region specifies an OpenStack region to use. If specified, it overrides\nany value in clouds.yaml. If specified for an OpenStackMachine, its\nvalue will be included in providerID.",
+              "type": "string"
+            },
+            "type": {
+              "default": "Secret",
+              "description": "Type specifies the identity reference type. Defaults to Secret for backward compatibility.",
+              "enum": [
+                "Secret",
+                "ClusterIdentity"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "cloudName",
+            "name",
+            "type"
+          ],
+          "type": "object",
+          "x-kubernetes-validations": [
+            {
+              "message": "region is immutable",
+              "rule": "(!has(self.region) && !has(oldSelf.region)) || self.region == oldSelf.region"
+            }
+          ],
+          "additionalProperties": false
+        },
+        "image": {
+          "description": "The image to use for the server instance.",
+          "maxProperties": 1,
+          "minProperties": 1,
+          "properties": {
+            "filter": {
+              "description": "Filter describes a query for an image. If specified, the combination\nof name and tags must return a single matching image or an error will\nbe raised.",
+              "minProperties": 1,
+              "properties": {
+                "name": {
+                  "description": "The name of the desired image. If specified, the combination of name and tags must return a single matching image or an error will be raised.",
+                  "type": "string"
+                },
+                "tags": {
+                  "description": "The tags associated with the desired image. If specified, the combination of name and tags must return a single matching image or an error will be raised.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array",
+                  "x-kubernetes-list-type": "set"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "id": {
+              "description": "ID is the uuid of the image. ID will not be validated before use.",
+              "format": "uuid",
+              "type": "string"
+            },
+            "imageRef": {
+              "description": "ImageRef is a reference to an ORC Image in the same namespace as the\nreferring object.",
+              "properties": {
+                "name": {
+                  "description": "Name is the name of the referenced resource",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "name"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "ports": {
+          "description": "Ports to be attached to the server instance.",
+          "items": {
+            "properties": {
+              "adminStateUp": {
+                "description": "AdminStateUp specifies whether the port should be created in the up (true) or down (false) state. The default is up.",
+                "type": "boolean"
+              },
+              "allowedAddressPairs": {
+                "description": "AllowedAddressPairs is a list of address pairs which Neutron will\nallow the port to send traffic from in addition to the port's\naddresses. If not specified, the MAC Address will be the MAC Address\nof the port. Depending on the configuration of Neutron, it may be\nsupported to specify a CIDR instead of a specific IP address.",
+                "items": {
+                  "properties": {
+                    "ipAddress": {
+                      "description": "IPAddress is the IP address of the allowed address pair. Depending on\nthe configuration of Neutron, it may be supported to specify a CIDR\ninstead of a specific IP address.",
+                      "type": "string"
+                    },
+                    "macAddress": {
+                      "description": "MACAddress is the MAC address of the allowed address pair. If not\nspecified, the MAC address will be the MAC address of the port.",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "ipAddress"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "array"
+              },
+              "description": {
+                "description": "Description is a human-readable description for the port.",
+                "type": "string"
+              },
+              "disablePortSecurity": {
+                "description": "DisablePortSecurity enables or disables the port security when set.\nWhen not set, it takes the value of the corresponding field at the network level.",
+                "type": "boolean"
+              },
+              "fixedIPs": {
+                "description": "FixedIPs is a list of pairs of subnet and/or IP address to assign to the port. If specified, these must be subnets of the port's network.",
+                "items": {
+                  "properties": {
+                    "ipAddress": {
+                      "description": "IPAddress is a specific IP address to assign to the port. If Subnet\nis also specified, IPAddress must be a valid IP address in the\nsubnet. If Subnet is not specified, IPAddress must be a valid IP\naddress in any subnet of the port's network.",
+                      "type": "string"
+                    },
+                    "subnet": {
+                      "description": "Subnet is an openstack subnet query that will return the id of a subnet to create\nthe fixed IP of a port in. This query must not return more than one subnet.",
+                      "maxProperties": 1,
+                      "minProperties": 1,
+                      "properties": {
+                        "filter": {
+                          "description": "Filter specifies a filter to select the subnet. It must match exactly one subnet.",
+                          "minProperties": 1,
+                          "properties": {
+                            "cidr": {
+                              "type": "string"
+                            },
+                            "description": {
+                              "type": "string"
+                            },
+                            "gatewayIP": {
+                              "type": "string"
+                            },
+                            "ipVersion": {
+                              "type": "integer"
+                            },
+                            "ipv6AddressMode": {
+                              "type": "string"
+                            },
+                            "ipv6RAMode": {
+                              "type": "string"
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "notTags": {
+                              "description": "NotTags is a list of tags to filter by. If specified, resources which\ncontain all of the given tags will be excluded from the result.",
+                              "items": {
+                                "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                                "minLength": 1,
+                                "pattern": "^[^,]+$",
+                                "type": "string"
+                              },
+                              "type": "array",
+                              "x-kubernetes-list-type": "set"
+                            },
+                            "notTagsAny": {
+                              "description": "NotTagsAny is a list of tags to filter by. If specified, resources\nwhich contain any of the given tags will be excluded from the result.",
+                              "items": {
+                                "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                                "minLength": 1,
+                                "pattern": "^[^,]+$",
+                                "type": "string"
+                              },
+                              "type": "array",
+                              "x-kubernetes-list-type": "set"
+                            },
+                            "projectID": {
+                              "type": "string"
+                            },
+                            "tags": {
+                              "description": "Tags is a list of tags to filter by. If specified, the resource must\nhave all of the tags specified to be included in the result.",
+                              "items": {
+                                "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                                "minLength": 1,
+                                "pattern": "^[^,]+$",
+                                "type": "string"
+                              },
+                              "type": "array",
+                              "x-kubernetes-list-type": "set"
+                            },
+                            "tagsAny": {
+                              "description": "TagsAny is a list of tags to filter by. If specified, the resource\nmust have at least one of the tags specified to be included in the\nresult.",
+                              "items": {
+                                "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                                "minLength": 1,
+                                "pattern": "^[^,]+$",
+                                "type": "string"
+                              },
+                              "type": "array",
+                              "x-kubernetes-list-type": "set"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "id": {
+                          "description": "ID is the uuid of the subnet. It will not be validated.",
+                          "format": "uuid",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "array",
+                "x-kubernetes-list-type": "atomic"
+              },
+              "hostID": {
+                "description": "HostID specifies the ID of the host where the port resides.",
+                "type": "string"
+              },
+              "macAddress": {
+                "description": "MACAddress specifies the MAC address of the port. If not specified, the MAC address will be generated.",
+                "type": "string"
+              },
+              "nameSuffix": {
+                "description": "NameSuffix will be appended to the name of the port if specified. If unspecified, instead the 0-based index of the port in the list is used.",
+                "type": "string"
+              },
+              "network": {
+                "description": "Network is a query for an openstack network that the port will be created or discovered on.\nThis will fail if the query returns more than one network.",
+                "maxProperties": 1,
+                "minProperties": 1,
+                "properties": {
+                  "filter": {
+                    "description": "Filter specifies a filter to select an OpenStack network. If provided, cannot be empty.",
+                    "minProperties": 1,
+                    "properties": {
+                      "description": {
+                        "type": "string"
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "notTags": {
+                        "description": "NotTags is a list of tags to filter by. If specified, resources which\ncontain all of the given tags will be excluded from the result.",
+                        "items": {
+                          "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                          "minLength": 1,
+                          "pattern": "^[^,]+$",
+                          "type": "string"
+                        },
+                        "type": "array",
+                        "x-kubernetes-list-type": "set"
+                      },
+                      "notTagsAny": {
+                        "description": "NotTagsAny is a list of tags to filter by. If specified, resources\nwhich contain any of the given tags will be excluded from the result.",
+                        "items": {
+                          "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                          "minLength": 1,
+                          "pattern": "^[^,]+$",
+                          "type": "string"
+                        },
+                        "type": "array",
+                        "x-kubernetes-list-type": "set"
+                      },
+                      "projectID": {
+                        "type": "string"
+                      },
+                      "tags": {
+                        "description": "Tags is a list of tags to filter by. If specified, the resource must\nhave all of the tags specified to be included in the result.",
+                        "items": {
+                          "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                          "minLength": 1,
+                          "pattern": "^[^,]+$",
+                          "type": "string"
+                        },
+                        "type": "array",
+                        "x-kubernetes-list-type": "set"
+                      },
+                      "tagsAny": {
+                        "description": "TagsAny is a list of tags to filter by. If specified, the resource\nmust have at least one of the tags specified to be included in the\nresult.",
+                        "items": {
+                          "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                          "minLength": 1,
+                          "pattern": "^[^,]+$",
+                          "type": "string"
+                        },
+                        "type": "array",
+                        "x-kubernetes-list-type": "set"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "id": {
+                    "description": "ID is the ID of the network to use. If ID is provided, the other filters cannot be provided. Must be in UUID format.",
+                    "format": "uuid",
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "profile": {
+                "description": "Profile is a set of key-value pairs that are used for binding\ndetails. We intentionally don't expose this as a map[string]string\nbecause we only want to enable the users to set the values of the\nkeys that are known to work in OpenStack Networking API.  See\nhttps://docs.openstack.org/api-ref/network/v2/index.html?expanded=create-port-detail#create-port\nTo set profiles, your tenant needs permissions rule:create_port, and\nrule:create_port:binding:profile",
+                "properties": {
+                  "ovsHWOffload": {
+                    "description": "OVSHWOffload enables or disables the OVS hardware offload feature.\nThis flag is not required on OpenStack clouds since Yoga as Nova will set it automatically when the port is attached.\nSee: https://bugs.launchpad.net/nova/+bug/2020813",
+                    "type": "boolean"
+                  },
+                  "trustedVF": {
+                    "description": "TrustedVF enables or disables the \u201ctrusted mode\u201d for the VF.",
+                    "type": "boolean"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "propagateUplinkStatus": {
+                "description": "PropageteUplinkStatus enables or disables the propagate uplink status on the port.",
+                "type": "boolean"
+              },
+              "securityGroups": {
+                "description": "SecurityGroups is a list of the names, uuids, filters or any combination these of the security groups to assign to the instance.",
+                "items": {
+                  "description": "SecurityGroupParam specifies an OpenStack security group. It may be specified by ID or filter, but not both.",
+                  "maxProperties": 1,
+                  "minProperties": 1,
+                  "properties": {
+                    "filter": {
+                      "description": "Filter specifies a query to select an OpenStack security group. If provided, cannot be empty.",
+                      "minProperties": 1,
+                      "properties": {
+                        "description": {
+                          "type": "string"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "notTags": {
+                          "description": "NotTags is a list of tags to filter by. If specified, resources which\ncontain all of the given tags will be excluded from the result.",
+                          "items": {
+                            "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                            "minLength": 1,
+                            "pattern": "^[^,]+$",
+                            "type": "string"
+                          },
+                          "type": "array",
+                          "x-kubernetes-list-type": "set"
+                        },
+                        "notTagsAny": {
+                          "description": "NotTagsAny is a list of tags to filter by. If specified, resources\nwhich contain any of the given tags will be excluded from the result.",
+                          "items": {
+                            "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                            "minLength": 1,
+                            "pattern": "^[^,]+$",
+                            "type": "string"
+                          },
+                          "type": "array",
+                          "x-kubernetes-list-type": "set"
+                        },
+                        "projectID": {
+                          "type": "string"
+                        },
+                        "tags": {
+                          "description": "Tags is a list of tags to filter by. If specified, the resource must\nhave all of the tags specified to be included in the result.",
+                          "items": {
+                            "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                            "minLength": 1,
+                            "pattern": "^[^,]+$",
+                            "type": "string"
+                          },
+                          "type": "array",
+                          "x-kubernetes-list-type": "set"
+                        },
+                        "tagsAny": {
+                          "description": "TagsAny is a list of tags to filter by. If specified, the resource\nmust have at least one of the tags specified to be included in the\nresult.",
+                          "items": {
+                            "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                            "minLength": 1,
+                            "pattern": "^[^,]+$",
+                            "type": "string"
+                          },
+                          "type": "array",
+                          "x-kubernetes-list-type": "set"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "id": {
+                      "description": "ID is the ID of the security group to use. If ID is provided, the other filters cannot be provided. Must be in UUID format.",
+                      "format": "uuid",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "array",
+                "x-kubernetes-list-type": "atomic"
+              },
+              "tags": {
+                "description": "Tags applied to the port (and corresponding trunk, if a trunk is configured.)\nThese tags are applied in addition to the instance's tags, which will also be applied to the port.",
+                "items": {
+                  "type": "string"
+                },
+                "type": "array",
+                "x-kubernetes-list-type": "set"
+              },
+              "trunk": {
+                "description": "Trunk specifies whether trunking is enabled at the port level. If not\nprovided the value is inherited from the machine, or false for a\nbastion host.",
+                "type": "boolean"
+              },
+              "valueSpecs": {
+                "description": "Value specs are extra parameters to include in the API request with OpenStack.\nThis is an extension point for the API, so what they do and if they are supported,\ndepends on the specific OpenStack implementation.",
+                "items": {
+                  "description": "ValueSpec represents a single value_spec key-value pair.",
+                  "properties": {
+                    "key": {
+                      "description": "Key is the key in the key-value pair.",
+                      "type": "string"
+                    },
+                    "name": {
+                      "description": "Name is the name of the key-value pair.\nThis is just for identifying the pair and will not be sent to the OpenStack API.",
+                      "type": "string"
+                    },
+                    "value": {
+                      "description": "Value is the value in the key-value pair.",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "key",
+                    "name",
+                    "value"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "array",
+                "x-kubernetes-list-map-keys": [
+                  "name"
+                ],
+                "x-kubernetes-list-type": "map"
+              },
+              "vnicType": {
+                "description": "VNICType specifies the type of vNIC which this port should be\nattached to. This is used to determine which mechanism driver(s) to\nbe used to bind the port. The valid values are normal, macvtap,\ndirect, baremetal, direct-physical, virtio-forwarder, smart-nic and\nremote-managed, although these values will not be validated in this\nAPI to ensure compatibility with future neutron changes or custom\nimplementations. What type of vNIC is actually available depends on\ndeployments. If not specified, the Neutron default value is used.",
+                "type": "string"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "rootVolume": {
+          "description": "RootVolume is the specification for the root volume of the server instance.",
+          "properties": {
+            "availabilityZone": {
+              "description": "AvailabilityZone is the volume availability zone to create the volume\nin. If not specified, the volume will be created without an explicit\navailability zone.",
+              "properties": {
+                "from": {
+                  "default": "Name",
+                  "description": "From specifies where we will obtain the availability zone for the\nvolume. The options are \"Name\" and \"Machine\". If \"Name\" is specified\nthen the Name field must also be specified. If \"Machine\" is specified\nthe volume will use the value of FailureDomain, if any, from the\nassociated Machine.",
+                  "enum": [
+                    "Name",
+                    "Machine"
+                  ],
+                  "type": "string"
+                },
+                "name": {
+                  "description": "Name is the name of a volume availability zone to use. It is required\nif From is \"Name\". The volume availability zone name may not contain\nspaces.",
+                  "minLength": 1,
+                  "pattern": "^[^ ]+$",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "x-kubernetes-validations": [
+                {
+                  "message": "name is required when from is 'Name' or default",
+                  "rule": "!has(self.from) || self.from == 'Name' ? has(self.name) : !has(self.name)"
+                }
+              ],
+              "additionalProperties": false
+            },
+            "sizeGiB": {
+              "description": "SizeGiB is the size of the block device in gibibytes (GiB).",
+              "minimum": 1,
+              "type": "integer"
+            },
+            "type": {
+              "description": "Type is the Cinder volume type of the volume.\nIf omitted, the default Cinder volume type that is configured in the OpenStack cloud\nwill be used.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "sizeGiB"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "schedulerHintAdditionalProperties": {
+          "description": "SchedulerHintAdditionalProperties are arbitrary key/value pairs that provide additional hints\nto the OpenStack scheduler. These hints can influence how instances are placed on the infrastructure,\nsuch as specifying certain host aggregates or availability zones.",
+          "items": {
+            "description": "SchedulerHintAdditionalProperty represents a single additional property for a scheduler hint.\nIt includes a Name to identify the property and a Value that can be of various types.",
+            "properties": {
+              "name": {
+                "description": "Name is the name of the scheduler hint property.\nIt is a unique identifier for the property.",
+                "minLength": 1,
+                "type": "string"
+              },
+              "value": {
+                "description": "Value is the value of the scheduler hint property, which can be of various types\n(e.g., bool, string, int). The type is indicated by the Value.Type field.",
+                "properties": {
+                  "bool": {
+                    "description": "Bool is the boolean value of the scheduler hint, used when Type is \"Bool\".\nThis field is required if type is 'Bool', and must not be set otherwise.",
+                    "type": "boolean"
+                  },
+                  "number": {
+                    "description": "Number is the integer value of the scheduler hint, used when Type is \"Number\".\nThis field is required if type is 'Number', and must not be set otherwise.",
+                    "type": "integer"
+                  },
+                  "string": {
+                    "description": "String is the string value of the scheduler hint, used when Type is \"String\".\nThis field is required if type is 'String', and must not be set otherwise.",
+                    "maxLength": 255,
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "type": {
+                    "description": "Type represents the type of the value.\nValid values are Bool, String, and Number.",
+                    "enum": [
+                      "Bool",
+                      "String",
+                      "Number"
+                    ],
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "type"
+                ],
+                "type": "object",
+                "x-kubernetes-validations": [
+                  {
+                    "message": "bool is required when type is Bool, and forbidden otherwise",
+                    "rule": "has(self.type) && self.type == 'Bool' ? has(self.bool) : !has(self.bool)"
+                  },
+                  {
+                    "message": "number is required when type is Number, and forbidden otherwise",
+                    "rule": "has(self.type) && self.type == 'Number' ? has(self.number) : !has(self.number)"
+                  },
+                  {
+                    "message": "string is required when type is String, and forbidden otherwise",
+                    "rule": "has(self.type) && self.type == 'String' ? has(self.string) : !has(self.string)"
+                  }
+                ],
+                "additionalProperties": false
+              }
+            },
+            "required": [
+              "name",
+              "value"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array",
+          "x-kubernetes-list-map-keys": [
+            "name"
+          ],
+          "x-kubernetes-list-type": "map"
+        },
+        "securityGroups": {
+          "description": "SecurityGroups is a list of security groups names to assign to the instance.",
+          "items": {
+            "description": "SecurityGroupParam specifies an OpenStack security group. It may be specified by ID or filter, but not both.",
+            "maxProperties": 1,
+            "minProperties": 1,
+            "properties": {
+              "filter": {
+                "description": "Filter specifies a query to select an OpenStack security group. If provided, cannot be empty.",
+                "minProperties": 1,
+                "properties": {
+                  "description": {
+                    "type": "string"
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "notTags": {
+                    "description": "NotTags is a list of tags to filter by. If specified, resources which\ncontain all of the given tags will be excluded from the result.",
+                    "items": {
+                      "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                      "minLength": 1,
+                      "pattern": "^[^,]+$",
+                      "type": "string"
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-type": "set"
+                  },
+                  "notTagsAny": {
+                    "description": "NotTagsAny is a list of tags to filter by. If specified, resources\nwhich contain any of the given tags will be excluded from the result.",
+                    "items": {
+                      "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                      "minLength": 1,
+                      "pattern": "^[^,]+$",
+                      "type": "string"
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-type": "set"
+                  },
+                  "projectID": {
+                    "type": "string"
+                  },
+                  "tags": {
+                    "description": "Tags is a list of tags to filter by. If specified, the resource must\nhave all of the tags specified to be included in the result.",
+                    "items": {
+                      "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                      "minLength": 1,
+                      "pattern": "^[^,]+$",
+                      "type": "string"
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-type": "set"
+                  },
+                  "tagsAny": {
+                    "description": "TagsAny is a list of tags to filter by. If specified, the resource\nmust have at least one of the tags specified to be included in the\nresult.",
+                    "items": {
+                      "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                      "minLength": 1,
+                      "pattern": "^[^,]+$",
+                      "type": "string"
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-type": "set"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "id": {
+                "description": "ID is the ID of the security group to use. If ID is provided, the other filters cannot be provided. Must be in UUID format.",
+                "format": "uuid",
+                "type": "string"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "serverGroup": {
+          "description": "ServerGroup is the server group to which the server instance belongs.",
+          "maxProperties": 1,
+          "minProperties": 1,
+          "properties": {
+            "filter": {
+              "description": "Filter specifies a query to select an OpenStack server group. If provided, it cannot be empty.",
+              "minProperties": 1,
+              "properties": {
+                "name": {
+                  "description": "Name is the name of a server group to look for.",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "id": {
+              "description": "ID is the ID of the server group to use.",
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "serverMetadata": {
+          "description": "ServerMetadata is a map of key value pairs to add to the server instance.",
+          "items": {
+            "properties": {
+              "key": {
+                "description": "Key is the server metadata key",
+                "maxLength": 255,
+                "type": "string"
+              },
+              "value": {
+                "description": "Value is the server metadata value",
+                "maxLength": 255,
+                "type": "string"
+              }
+            },
+            "required": [
+              "key",
+              "value"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array",
+          "x-kubernetes-list-map-keys": [
+            "key"
+          ],
+          "x-kubernetes-list-type": "map"
+        },
+        "sshKeyName": {
+          "description": "SSHKeyName is the name of the SSH key to inject in the instance.",
+          "type": "string"
+        },
+        "tags": {
+          "description": "Tags which will be added to the machine and all dependent resources\nwhich support them. These are in addition to Tags defined on the\ncluster.\nRequires Nova api 2.52 minimum!",
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "set"
+        },
+        "trunk": {
+          "description": "Trunk is a flag to indicate if the server instance is created on a trunk port or not.",
+          "type": "boolean"
+        },
+        "userDataRef": {
+          "description": "UserDataRef is a reference to a secret containing the user data to\nbe injected into the server instance.",
+          "properties": {
+            "name": {
+              "default": "",
+              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "x-kubernetes-map-type": "atomic",
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "identityRef",
+        "image",
+        "ports",
+        "sshKeyName"
+      ],
+      "type": "object",
+      "x-kubernetes-validations": [
+        {
+          "message": "at least one of flavor or flavorID must be set",
+          "rule": "(has(self.flavor) || has(self.flavorID))"
+        }
+      ],
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "OpenStackServerStatus defines the observed state of OpenStackServer.",
+      "properties": {
+        "addresses": {
+          "description": "Addresses is the list of addresses of the server instance.",
+          "items": {
+            "description": "NodeAddress contains information for the node's address.",
+            "properties": {
+              "address": {
+                "description": "The node address.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Node address type, one of Hostname, ExternalIP or InternalIP.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "address",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "conditions": {
+          "description": "Conditions defines current service state of the OpenStackServer.",
+          "items": {
+            "description": "Condition defines an observation of a Cluster API resource operational state.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "lastTransitionTime is the last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed. If that is not known, then using the time when\nthe API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "message is a human readable message indicating details about the transition.\nThis field may be empty.",
+                "maxLength": 10240,
+                "minLength": 1,
+                "type": "string"
+              },
+              "reason": {
+                "description": "reason is the reason for the condition's last transition in CamelCase.\nThe specific API may choose whether or not this field is considered a guaranteed API.\nThis field may be empty.",
+                "maxLength": 256,
+                "minLength": 1,
+                "type": "string"
+              },
+              "severity": {
+                "description": "severity provides an explicit classification of Reason code, so the users or machines can immediately\nunderstand the current situation and act accordingly.\nThe Severity field MUST be set only when Status=False.",
+                "maxLength": 32,
+                "type": "string"
+              },
+              "status": {
+                "description": "status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "type of condition in CamelCase or in foo.example.com/CamelCase.\nMany .condition.type values are consistent across resources like Available, but because arbitrary conditions\ncan be useful (see .node.status.conditions), the ability to deconflict is important.",
+                "maxLength": 256,
+                "minLength": 1,
+                "type": "string"
+              }
+            },
+            "required": [
+              "lastTransitionTime",
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "instanceID": {
+          "description": "InstanceID is the ID of the server instance.",
+          "type": "string"
+        },
+        "instanceState": {
+          "description": "InstanceState is the state of the server instance.",
+          "type": "string"
+        },
+        "ready": {
+          "default": false,
+          "description": "Ready is true when the OpenStack server is ready.",
+          "type": "boolean"
+        },
+        "resolved": {
+          "description": "Resolved contains parts of the machine spec with all external\nreferences fully resolved.",
+          "properties": {
+            "flavorID": {
+              "description": "FlavorID is the ID of the flavor to use.",
+              "type": "string"
+            },
+            "imageID": {
+              "description": "ImageID is the ID of the image to use for the server and is calculated based on ImageFilter.",
+              "type": "string"
+            },
+            "ports": {
+              "description": "Ports is the fully resolved list of ports to create for the server.",
+              "items": {
+                "description": "ResolvedPortSpec is a PortOpts with all contained references fully resolved.",
+                "properties": {
+                  "adminStateUp": {
+                    "description": "AdminStateUp specifies whether the port should be created in the up (true) or down (false) state. The default is up.",
+                    "type": "boolean"
+                  },
+                  "allowedAddressPairs": {
+                    "description": "AllowedAddressPairs is a list of address pairs which Neutron will\nallow the port to send traffic from in addition to the port's\naddresses. If not specified, the MAC Address will be the MAC Address\nof the port. Depending on the configuration of Neutron, it may be\nsupported to specify a CIDR instead of a specific IP address.",
+                    "items": {
+                      "properties": {
+                        "ipAddress": {
+                          "description": "IPAddress is the IP address of the allowed address pair. Depending on\nthe configuration of Neutron, it may be supported to specify a CIDR\ninstead of a specific IP address.",
+                          "type": "string"
+                        },
+                        "macAddress": {
+                          "description": "MACAddress is the MAC address of the allowed address pair. If not\nspecified, the MAC address will be the MAC address of the port.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "ipAddress"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
+                  },
+                  "description": {
+                    "description": "Description is a human-readable description for the port.",
+                    "type": "string"
+                  },
+                  "disablePortSecurity": {
+                    "description": "DisablePortSecurity enables or disables the port security when set.\nWhen not set, it takes the value of the corresponding field at the network level.",
+                    "type": "boolean"
+                  },
+                  "fixedIPs": {
+                    "description": "FixedIPs is a list of pairs of subnet and/or IP address to assign to the port. If specified, these must be subnets of the port's network.",
+                    "items": {
+                      "description": "ResolvedFixedIP is a FixedIP with the Subnet resolved to an ID.",
+                      "properties": {
+                        "ipAddress": {
+                          "description": "IPAddress is a specific IP address to assign to the port. If SubnetID\nis also specified, IPAddress must be a valid IP address in the\nsubnet. If Subnet is not specified, IPAddress must be a valid IP\naddress in any subnet of the port's network.",
+                          "type": "string"
+                        },
+                        "subnet": {
+                          "description": "SubnetID is the id of a subnet to create the fixed IP of a port in.",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
+                  },
+                  "hostID": {
+                    "description": "HostID specifies the ID of the host where the port resides.",
+                    "type": "string"
+                  },
+                  "macAddress": {
+                    "description": "MACAddress specifies the MAC address of the port. If not specified, the MAC address will be generated.",
+                    "type": "string"
+                  },
+                  "name": {
+                    "description": "Name is the name of the port.",
+                    "type": "string"
+                  },
+                  "networkID": {
+                    "description": "NetworkID is the ID of the network the port will be created in.",
+                    "type": "string"
+                  },
+                  "profile": {
+                    "description": "Profile is a set of key-value pairs that are used for binding\ndetails. We intentionally don't expose this as a map[string]string\nbecause we only want to enable the users to set the values of the\nkeys that are known to work in OpenStack Networking API.  See\nhttps://docs.openstack.org/api-ref/network/v2/index.html?expanded=create-port-detail#create-port\nTo set profiles, your tenant needs permissions rule:create_port, and\nrule:create_port:binding:profile",
+                    "properties": {
+                      "ovsHWOffload": {
+                        "description": "OVSHWOffload enables or disables the OVS hardware offload feature.\nThis flag is not required on OpenStack clouds since Yoga as Nova will set it automatically when the port is attached.\nSee: https://bugs.launchpad.net/nova/+bug/2020813",
+                        "type": "boolean"
+                      },
+                      "trustedVF": {
+                        "description": "TrustedVF enables or disables the \u201ctrusted mode\u201d for the VF.",
+                        "type": "boolean"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "propagateUplinkStatus": {
+                    "description": "PropageteUplinkStatus enables or disables the propagate uplink status on the port.",
+                    "type": "boolean"
+                  },
+                  "securityGroups": {
+                    "description": "SecurityGroups is a list of security group IDs to assign to the port.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
+                  },
+                  "tags": {
+                    "description": "Tags applied to the port (and corresponding trunk, if a trunk is configured.)",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-type": "set"
+                  },
+                  "trunk": {
+                    "description": "Trunk specifies whether trunking is enabled at the port level.",
+                    "type": "boolean"
+                  },
+                  "valueSpecs": {
+                    "description": "Value specs are extra parameters to include in the API request with OpenStack.\nThis is an extension point for the API, so what they do and if they are supported,\ndepends on the specific OpenStack implementation.",
+                    "items": {
+                      "description": "ValueSpec represents a single value_spec key-value pair.",
+                      "properties": {
+                        "key": {
+                          "description": "Key is the key in the key-value pair.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "description": "Name is the name of the key-value pair.\nThis is just for identifying the pair and will not be sent to the OpenStack API.",
+                          "type": "string"
+                        },
+                        "value": {
+                          "description": "Value is the value in the key-value pair.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "key",
+                        "name",
+                        "value"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-map-keys": [
+                      "name"
+                    ],
+                    "x-kubernetes-list-type": "map"
+                  },
+                  "vnicType": {
+                    "description": "VNICType specifies the type of vNIC which this port should be\nattached to. This is used to determine which mechanism driver(s) to\nbe used to bind the port. The valid values are normal, macvtap,\ndirect, baremetal, direct-physical, virtio-forwarder, smart-nic and\nremote-managed, although these values will not be validated in this\nAPI to ensure compatibility with future neutron changes or custom\nimplementations. What type of vNIC is actually available depends on\ndeployments. If not specified, the Neutron default value is used.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "description",
+                  "name",
+                  "networkID"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "serverGroupID": {
+              "description": "ServerGroupID is the ID of the server group the server should be added to and is calculated based on ServerGroupFilter.",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "resources": {
+          "description": "Resources contains references to OpenStack resources created for the machine.",
+          "properties": {
+            "ports": {
+              "description": "Ports is the status of the ports created for the server.",
+              "items": {
+                "properties": {
+                  "id": {
+                    "description": "ID is the unique identifier of the port.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "id"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "ready"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}


### PR DESCRIPTION
## PR Checklist

The source of these schemas is https://github.com/kubernetes-sigs/cluster-api-provider-openstack

- [x] I generated these CRs using the [CRD Extractor tool](https://github.com/datreeio/CRDs-catalog?tab=readme-ov-file#crd-extractor). If I used a different method, I have described the method in this PR.
- [ ] I am updating existing schemas and have specified the updated schema version.
- [x] I am adding new schemas and included a link to the GitHub repository that contains the source of these schemas.
