### PR TITLE
feat: Update Grafana Operator CRDs to version 5.24.0

### DIFF
--- a/grafana.integreatly.org/grafana_v1beta1.json
+++ b/grafana.integreatly.org/grafana_v1beta1.json
@@ -6274,7 +6274,6 @@
             }
           },
           "required": [
-            "tenantNamespace",
             "url"
           ],
           "type": "object",
@@ -9397,7 +9396,7 @@
           "type": "boolean"
         },
         "version": {
-          "description": "Version sets the tag of the default image: docker.io/grafana/grafana.\nAllows full image refs with/without sha256checksum: \"registry/repo/image:tag@sha\"\ndefault: 12.4.1",
+          "description": "Version sets the tag of the default image: docker.io/grafana/grafana.\nAllows full image refs with/without sha256checksum: \"registry/repo/image:tag@sha\"\ndefault: 13.0.1",
           "type": "string"
         }
       },

--- a/grafana.integreatly.org/grafanadashboard_v1beta1.json
+++ b/grafana.integreatly.org/grafanadashboard_v1beta1.json
@@ -320,6 +320,47 @@
           "type": "object",
           "additionalProperties": false
         },
+        "oci": {
+          "description": "model from an OCI artifact (e.g. ghcr.io/team/dashboards:v1)",
+          "properties": {
+            "insecurePlainHTTP": {
+              "description": "InsecurePlainHTTP switches the registry connection to plain HTTP (non-TLS) instead of HTTPS.\nIntended for in-cluster or test registries; HTTPS registries with self-signed\ncertificates are not supported. Default false.",
+              "type": "boolean"
+            },
+            "path": {
+              "description": "Path is the path of the file to extract from the artifact.",
+              "maxLength": 512,
+              "minLength": 1,
+              "type": "string"
+            },
+            "pullSecretRef": {
+              "description": "PullSecretRef references a kubernetes.io/dockerconfigjson Secret in the same namespace as the CR.\nIf omitted, anonymous pull is attempted.",
+              "properties": {
+                "name": {
+                  "default": "",
+                  "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "x-kubernetes-map-type": "atomic",
+              "additionalProperties": false
+            },
+            "reference": {
+              "description": "Reference is the full OCI artifact reference including a tag or digest,\ne.g. \"ghcr.io/team/dashboards:v1.4.7\" or\n\"ghcr.io/team/dashboards@sha256:abc123...\". Prefer a digest for\nreproducible deployments.",
+              "maxLength": 512,
+              "minLength": 3,
+              "pattern": "^[^:@]+(:[^:@/]+|@sha256:[a-fA-F0-9]{64})$",
+              "type": "string"
+            }
+          },
+          "required": [
+            "path",
+            "reference"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
         "plugins": {
           "description": "plugins",
           "items": {

--- a/grafana.integreatly.org/grafanalibrarypanel_v1beta1.json
+++ b/grafana.integreatly.org/grafanalibrarypanel_v1beta1.json
@@ -316,6 +316,47 @@
           "type": "object",
           "additionalProperties": false
         },
+        "oci": {
+          "description": "model from an OCI artifact (e.g. ghcr.io/team/dashboards:v1)",
+          "properties": {
+            "insecurePlainHTTP": {
+              "description": "InsecurePlainHTTP switches the registry connection to plain HTTP (non-TLS) instead of HTTPS.\nIntended for in-cluster or test registries; HTTPS registries with self-signed\ncertificates are not supported. Default false.",
+              "type": "boolean"
+            },
+            "path": {
+              "description": "Path is the path of the file to extract from the artifact.",
+              "maxLength": 512,
+              "minLength": 1,
+              "type": "string"
+            },
+            "pullSecretRef": {
+              "description": "PullSecretRef references a kubernetes.io/dockerconfigjson Secret in the same namespace as the CR.\nIf omitted, anonymous pull is attempted.",
+              "properties": {
+                "name": {
+                  "default": "",
+                  "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "x-kubernetes-map-type": "atomic",
+              "additionalProperties": false
+            },
+            "reference": {
+              "description": "Reference is the full OCI artifact reference including a tag or digest,\ne.g. \"ghcr.io/team/dashboards:v1.4.7\" or\n\"ghcr.io/team/dashboards@sha256:abc123...\". Prefer a digest for\nreproducible deployments.",
+              "maxLength": 512,
+              "minLength": 3,
+              "pattern": "^[^:@]+(:[^:@/]+|@sha256:[a-fA-F0-9]{64})$",
+              "type": "string"
+            }
+          },
+          "required": [
+            "path",
+            "reference"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
         "plugins": {
           "description": "plugins",
           "items": {

--- a/grafana.integreatly.org/grafananotificationpolicy_v1beta1.json
+++ b/grafana.integreatly.org/grafananotificationpolicy_v1beta1.json
@@ -129,11 +129,11 @@
               "items": {
                 "properties": {
                   "isEqual": {
-                    "description": "is equal",
+                    "description": "Deprecated: Does nothing and is not exported by Grafana",
                     "type": "boolean"
                   },
                   "isRegex": {
-                    "description": "is regex",
+                    "description": "Deprecated: Does nothing and is not exported by Grafana",
                     "type": "boolean"
                   },
                   "name": {

--- a/grafana.integreatly.org/grafananotificationpolicyroute_v1beta1.json
+++ b/grafana.integreatly.org/grafananotificationpolicyroute_v1beta1.json
@@ -53,11 +53,11 @@
           "items": {
             "properties": {
               "isEqual": {
-                "description": "is equal",
+                "description": "Deprecated: Does nothing and is not exported by Grafana",
                 "type": "boolean"
               },
               "isRegex": {
-                "description": "is regex",
+                "description": "Deprecated: Does nothing and is not exported by Grafana",
                 "type": "boolean"
               },
               "name": {


### PR DESCRIPTION
## PR Checklist

- [x] I generated these CRs using the [CRD Extractor tool](https://github.com/datreeio/CRDs-catalog?tab=readme-ov-file#crd-extractor). If I used a different method, I have described the method in this PR.
- [x] I am updating existing schemas and have specified the updated schema version.

These CRDs live at https://github.com/grafana/grafana-operator/releases/download/v5.22.2/crds.yaml

I generated this update with:

```sh
git clone https://github.com/datreeio/CRDs-catalog.git /tmp/crds-catalog && \
  cd /tmp/crds-catalog && \
  kind create cluster --name grafana-crd-catalog && \
  helm install grafana-operator oci://ghcr.io/grafana/helm-charts/grafana-operator --version 5.24.0 --wait --timeout 5m && \
  ./Utilities/crd-extractor.sh 
```