### PR TITLE
feat: NAuth v0.7.2 CRDs

### DIFF
--- a/nauth.io/account_v1alpha1.json
+++ b/nauth.io/account_v1alpha1.json
@@ -267,6 +267,49 @@
           },
           "type": "object",
           "additionalProperties": false
+        },
+        "signingKeyRefs": {
+          "description": "SigningKeyRefs lists references whose public keys are trusted as additional\nsigning keys for this account. The implicit default signing key is always\npresent and is not listed here.",
+          "items": {
+            "description": "AccountSigningKeyRef references a signing-key resource whose public key is\ntrusted by the Account (and may be used to sign Users). Only AccountSigningKey\nis supported; Kind is reserved for future kinds (e.g. issuers).",
+            "properties": {
+              "kind": {
+                "default": "AccountSigningKey",
+                "description": "Kind of the referenced resource. Defaults to AccountSigningKey.",
+                "enum": [
+                  "AccountSigningKey"
+                ],
+                "type": "string"
+              },
+              "name": {
+                "description": "Name of the referenced resource.",
+                "maxLength": 253,
+                "minLength": 1,
+                "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                "type": "string"
+              },
+              "namespace": {
+                "default": "",
+                "description": "Namespace of the referenced resource. When empty, defaults to the\nreferrer's namespace. Cross-namespace references let multiple Accounts\ntrust a shared signing key (e.g. a cluster-wide Auth Callout service).",
+                "maxLength": 253,
+                "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?)?$",
+                "type": "string"
+              }
+            },
+            "required": [
+              "name"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "maxItems": 64,
+          "type": "array",
+          "x-kubernetes-list-map-keys": [
+            "kind",
+            "namespace",
+            "name"
+          ],
+          "x-kubernetes-list-type": "map"
         }
       },
       "type": "object",

--- a/nauth.io/accountsigningkey_v1alpha1.json
+++ b/nauth.io/accountsigningkey_v1alpha1.json
@@ -1,0 +1,125 @@
+{
+  "description": "AccountSigningKey manages one NATS account signing-key seed in a Kubernetes Secret.\nBy default NAuth manages the signing key seed: it generates a new key and stores it in\na Secret named spec.secretName (defaulting to <resourceName>-ac-sign). The Secret is\nowned by this resource and garbage-collected when the resource is deleted.\n\nIn observe mode (label nauth.io/management-policy=observe), NAuth only reads an existing\nSecret with the resolved name and derives the public key. Observed Secrets are not\nmodified, owned, or deleted by the operator.\n\nAn Account trusts the public key by listing this resource in Account.spec.signingKeyRefs.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "AccountSigningKeySpec defines the desired state of AccountSigningKey.",
+      "properties": {
+        "secretName": {
+          "description": "SecretName names the Kubernetes Secret that holds the account signing-key seed.\n\nIn managed mode (default), SecretName is optional and defaults to\n<resourceName>-ac-sign; the Secret is created and owned by this AccountSigningKey.\nIn observe mode (label nauth.io/management-policy=observe), SecretName is\nrequired and identifies the existing Secret to read; the operator never falls\nback to the managed default name and never modifies the Secret.\n\nImmutable.",
+          "maxLength": 253,
+          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+          "type": "string",
+          "x-kubernetes-validations": [
+            {
+              "message": "secretName is immutable",
+              "rule": "self == oldSelf"
+            }
+          ]
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "AccountSigningKeyStatus defines the observed state of AccountSigningKey.",
+      "properties": {
+        "conditions": {
+          "items": {
+            "description": "Condition contains details for one aspect of the current state of this API Resource.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "lastTransitionTime is the last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "message is a human readable message indicating details about the transition.\nThis may be an empty string.",
+                "maxLength": 32768,
+                "type": "string"
+              },
+              "observedGeneration": {
+                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon.\nFor instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date\nwith respect to the current state of the instance.",
+                "format": "int64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "reason": {
+                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition.\nProducers of specific condition types may define expected values and meanings for this field,\nand whether the values are considered a guaranteed API.\nThe value should be a CamelCase string.\nThis field may not be empty.",
+                "maxLength": 1024,
+                "minLength": 1,
+                "pattern": "^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$",
+                "type": "string"
+              },
+              "status": {
+                "description": "status of the condition, one of True, False, Unknown.",
+                "enum": [
+                  "True",
+                  "False",
+                  "Unknown"
+                ],
+                "type": "string"
+              },
+              "type": {
+                "description": "type of condition in CamelCase or in foo.example.com/CamelCase.",
+                "maxLength": 316,
+                "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$",
+                "type": "string"
+              }
+            },
+            "required": [
+              "lastTransitionTime",
+              "message",
+              "reason",
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array",
+          "x-kubernetes-list-map-keys": [
+            "type"
+          ],
+          "x-kubernetes-list-type": "map"
+        },
+        "managementPolicy": {
+          "description": "ManagementPolicy reflects the effective management policy for this resource.\nEmpty means managed (default); \"observe\" means the Secret is only read.",
+          "type": "string"
+        },
+        "observedGeneration": {
+          "format": "int64",
+          "type": "integer"
+        },
+        "operatorVersion": {
+          "type": "string"
+        },
+        "publicKey": {
+          "description": "PublicKey is the resolved NATS public key (A-prefixed nkey) for this signing key.",
+          "type": "string"
+        },
+        "reconcileTimestamp": {
+          "format": "date-time",
+          "type": "string"
+        },
+        "secretName": {
+          "description": "SecretName is the resolved name of the Secret holding the seed.",
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/nauth.io/user_v1alpha1.json
+++ b/nauth.io/user_v1alpha1.json
@@ -113,6 +113,38 @@
           "type": "object",
           "additionalProperties": false
         },
+        "signingKeyRef": {
+          "description": "SigningKeyRef optionally references the signing key used to sign this User's\nJWT. When absent, the Account's implicit signing key is used. The referenced\nAccountSigningKey's public key must appear in Account.status.claims.signingKeys\nat reconciliation time.",
+          "properties": {
+            "kind": {
+              "default": "AccountSigningKey",
+              "description": "Kind of the referenced resource. Defaults to AccountSigningKey.",
+              "enum": [
+                "AccountSigningKey"
+              ],
+              "type": "string"
+            },
+            "name": {
+              "description": "Name of the referenced resource.",
+              "maxLength": 253,
+              "minLength": 1,
+              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "type": "string"
+            },
+            "namespace": {
+              "default": "",
+              "description": "Namespace of the referenced resource. When empty, defaults to the\nreferrer's namespace. Cross-namespace references let multiple Accounts\ntrust a shared signing key (e.g. a cluster-wide Auth Callout service).",
+              "maxLength": 253,
+              "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?)?$",
+              "type": "string"
+            }
+          },
+          "required": [
+            "name"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
         "userLimits": {
           "properties": {
             "src": {


### PR DESCRIPTION
CRDs bound to [NAuth v0.7.2](https://github.com/WirelessCar/nauth/releases/tag/v0.7.2).

Schema source: https://github.com/WirelessCar/nauth

Generated from `charts/nauth-crds/crds/*.yaml` using `/Utilities/openapi2jsonschema.py`.

## Changes
- `nauth.io/account_v1alpha1.json` UPDATED
  - Extended with optional `SigningKeyRefs` for trusted Account Signing Keys
- `nauth.io/accountsigningkey_v1alpha1.json` NEW
- `nauth.io/user_v1alpha1.json` UPDATED
  - Extended with optional `SigningKeyRef` for explicit Account Signing Key

## PR Checklist

- [x] I generated these CRs using the [CRD Extractor tool](https://github.com/datreeio/CRDs-catalog?tab=readme-ov-file#crd-extractor). If I used a different method, I have described the method in this PR.
- [x] I am updating existing schemas and have specified the updated schema version.
- [x] I am adding new schemas and included a link to the GitHub repository that contains the source of these schemas.
