### PR TITLE
Add agentgateway.dev v1alpha1 CRD schemas

### DIFF
--- a/agentgateway.dev/agentgatewaybackend_v1alpha1.json
+++ b/agentgateway.dev/agentgatewaybackend_v1alpha1.json
@@ -1,0 +1,11651 @@
+{
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "Desired backend configuration.",
+      "properties": {
+        "a2a": {
+          "description": "A2A backend.",
+          "properties": {
+            "host": {
+              "description": "Hostname or IP address of the A2A backend.",
+              "maxLength": 256,
+              "minLength": 1,
+              "type": "string"
+            },
+            "port": {
+              "description": "Port number of the A2A backend.",
+              "format": "int32",
+              "maximum": 65535,
+              "minimum": 1,
+              "type": "integer"
+            }
+          },
+          "required": [
+            "host",
+            "port"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "ai": {
+          "description": "LLM backend.",
+          "properties": {
+            "groups": {
+              "description": "Groups in priority order, where each group\ndefines a set of LLM providers. The priority determines the priority of\nthe backend endpoints chosen.\nNote: provider names must be unique across all providers in all priority\ngroups. Backend policies may target a specific provider by name using\n`targetRefs[].sectionName`.\n\nExample configuration with two priority groups:\n\n\tgroups:\n\t- providers:\n\t  - azureopenai:\n\t      deploymentName: gpt-4o-mini\n\t      apiVersion: 2024-02-15-preview\n\t      endpoint: ai-gateway.openai.azure.com\n\t- providers:\n\t  - azureopenai:\n\t      deploymentName: gpt-4o-mini-2\n\t      apiVersion: 2024-02-15-preview\n\t      endpoint: ai-gateway-2.openai.azure.com\n\t     policies:\n\t       auth:\n\t         secretRef:\n\t           name: azure-secret",
+              "items": {
+                "properties": {
+                  "providers": {
+                    "description": "LLM providers within this group. Each provider is treated equally in terms of priority,\nwith automatic weighting based on health.",
+                    "items": {
+                      "properties": {
+                        "anthropic": {
+                          "description": "Anthropic provider settings.",
+                          "properties": {
+                            "model": {
+                              "description": "Model name override, such as `gpt-4o-mini`.\nIf unset, the model name is taken from the request.",
+                              "maxLength": 256,
+                              "minLength": 1,
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "azure": {
+                          "description": "Azure provider with resource-based configuration.\nSupports both Azure OpenAI and Azure AI Foundry resource types.",
+                          "properties": {
+                            "apiVersion": {
+                              "description": "The version of the Azure OpenAI API to use.\nIf unset, defaults to `v1`.",
+                              "maxLength": 64,
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "model": {
+                              "description": "Model name override, such as `gpt-4o-mini`.\nIf unset, the model name is taken from the request.",
+                              "maxLength": 256,
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "projectName": {
+                              "description": "The Foundry project name, required when `resourceType` is `Foundry`.\nUsed to construct paths: /api/projects/{projectName}/openai/v1/...",
+                              "maxLength": 256,
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "resourceName": {
+                              "description": "The Azure resource name used to construct the endpoint host.\nFor OpenAI: {resourceName}.openai.azure.com\nFor Foundry: {resourceName}.services.ai.azure.com\nNote: when the Azure portal \"Foundry legacy\" template was used, the\ngenerated resource name may end in \"-resource\" (e.g. \"myproject-resource\");\nthat suffix is part of the resource name as the user configured it, not\npart of the hostname suffix agentgateway should append.",
+                              "maxLength": 256,
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "resourceType": {
+                              "description": "The type of Azure endpoint. Determines the host suffix.",
+                              "enum": [
+                                "Foundry",
+                                "OpenAI"
+                              ],
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "resourceName",
+                            "resourceType"
+                          ],
+                          "type": "object",
+                          "x-kubernetes-validations": [
+                            {
+                              "message": "projectName is required when resourceType is Foundry",
+                              "rule": "self.resourceType != 'Foundry' || has(self.projectName)"
+                            }
+                          ],
+                          "additionalProperties": false
+                        },
+                        "azureopenai": {
+                          "description": "Azure OpenAI provider settings.",
+                          "properties": {
+                            "apiVersion": {
+                              "description": "The version of the Azure OpenAI API to use.\nFor more information, see the [Azure OpenAI API version reference](https://learn.microsoft.com/en-us/azure/foundry/openai/reference).\nIf unset, defaults to `v1`.",
+                              "maxLength": 64,
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "deploymentName": {
+                              "description": "The name of the Azure OpenAI model deployment to use.\nFor more information, see the [Azure OpenAI model docs](https://learn.microsoft.com/en-us/azure/foundry/foundry-models/concepts/models-sold-directly-by-azure?view=foundry-classic).\nThis is required if `apiVersion` is not `v1`. For `v1`, the model can be\nset in the request.",
+                              "maxLength": 256,
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "endpoint": {
+                              "description": "The endpoint for the Azure OpenAI API to use, such as `my-endpoint.openai.azure.com`.\nIf the scheme is included, it is stripped.",
+                              "maxLength": 256,
+                              "minLength": 1,
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "endpoint"
+                          ],
+                          "type": "object",
+                          "x-kubernetes-validations": [
+                            {
+                              "message": "deploymentName is required for this apiVersion",
+                              "rule": "!has(self.apiVersion) || self.apiVersion == 'v1' ? true : has(self.deploymentName)"
+                            }
+                          ],
+                          "additionalProperties": false
+                        },
+                        "bedrock": {
+                          "description": "Bedrock provider settings.",
+                          "properties": {
+                            "guardrail": {
+                              "description": "Guardrail policy to use for the backend. See\n<https://docs.aws.amazon.com/bedrock/latest/userguide/guardrails.html>.\nIf not specified, the AWS Guardrail policy will not be used.",
+                              "properties": {
+                                "identifier": {
+                                  "description": "Identifier of the Guardrail policy to use for the backend.",
+                                  "maxLength": 256,
+                                  "minLength": 1,
+                                  "type": "string"
+                                },
+                                "version": {
+                                  "description": "Version of the Guardrail policy to use for the backend.",
+                                  "maxLength": 256,
+                                  "minLength": 1,
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "identifier",
+                                "version"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "model": {
+                              "description": "Model name override, such as `gpt-4o-mini`.\nIf unset, the model name is taken from the request.",
+                              "maxLength": 256,
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "region": {
+                              "default": "us-east-1",
+                              "description": "AWS region to use for the backend.\nDefaults to `us-east-1` if not specified.",
+                              "maxLength": 63,
+                              "minLength": 1,
+                              "pattern": "^[a-z0-9-]+$",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "custom": {
+                          "description": "Custom provider configures a non-managed or self-hosted LLM provider.\nUse this when the provider target and API formats should be declared\nexplicitly instead of inferred from a managed provider such as OpenAI or\nAnthropic.",
+                          "properties": {
+                            "backendRef": {
+                              "description": "Kubernetes backend that serves this provider.\n`backendRef` may target only a namespace-local Service or InferencePool.\nIf unset, host and port must be set on the parent provider.",
+                              "properties": {
+                                "group": {
+                                  "default": "",
+                                  "description": "API group of the referenced resource. For example, `gateway.networking.k8s.io`.\nWhen unspecified or empty string, core API group is inferred.",
+                                  "maxLength": 253,
+                                  "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                                  "type": "string"
+                                },
+                                "kind": {
+                                  "default": "Service",
+                                  "description": "Kind of the referenced resource. For example, `Service`.\nDefaults to \"Service\" when not specified.",
+                                  "maxLength": 63,
+                                  "minLength": 1,
+                                  "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "description": "Name of the referenced resource.",
+                                  "maxLength": 253,
+                                  "minLength": 1,
+                                  "type": "string"
+                                },
+                                "port": {
+                                  "description": "Destination port number to use for this resource.\nRequired when the referenced resource is a Kubernetes Service.",
+                                  "format": "int32",
+                                  "maximum": 65535,
+                                  "minimum": 1,
+                                  "type": "integer"
+                                }
+                              },
+                              "required": [
+                                "name"
+                              ],
+                              "type": "object",
+                              "x-kubernetes-validations": [
+                                {
+                                  "message": "Must have port for Service reference",
+                                  "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
+                                }
+                              ],
+                              "additionalProperties": false
+                            },
+                            "formats": {
+                              "description": "Provider-native API formats this provider supports.",
+                              "items": {
+                                "description": "Provider-native LLM API format settings.",
+                                "properties": {
+                                  "path": {
+                                    "description": "Default upstream path override for this format.\nIf unset, agentgateway uses the default path for the format.",
+                                    "maxLength": 1024,
+                                    "minLength": 1,
+                                    "type": "string"
+                                  },
+                                  "type": {
+                                    "description": "Provider-native API format.",
+                                    "enum": [
+                                      "AnthropicTokenCount",
+                                      "Completions",
+                                      "Embeddings",
+                                      "Messages",
+                                      "Realtime",
+                                      "Rerank",
+                                      "Responses"
+                                    ],
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "type"
+                                ],
+                                "type": "object",
+                                "x-kubernetes-validations": [
+                                  {
+                                    "message": "path must start with /",
+                                    "rule": "!has(self.path) || self.path.startsWith('/')"
+                                  }
+                                ],
+                                "additionalProperties": false
+                              },
+                              "maxItems": 6,
+                              "minItems": 1,
+                              "type": "array",
+                              "x-kubernetes-list-map-keys": [
+                                "type"
+                              ],
+                              "x-kubernetes-list-type": "map"
+                            },
+                            "model": {
+                              "description": "Model name override, such as `gpt-oss`.\nIf unset, the model name is taken from the request.",
+                              "maxLength": 256,
+                              "minLength": 1,
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "formats"
+                          ],
+                          "type": "object",
+                          "x-kubernetes-validations": [
+                            {
+                              "message": "custom provider backendRef may target only Service or InferencePool",
+                              "rule": "!has(self.backendRef) || (((!has(self.backendRef.group) || self.backendRef.group == \"\") && (!has(self.backendRef.kind) || self.backendRef.kind == 'Service')) || (has(self.backendRef.group) && self.backendRef.group == 'inference.networking.k8s.io' && has(self.backendRef.kind) && self.backendRef.kind == 'InferencePool'))"
+                            }
+                          ],
+                          "additionalProperties": false
+                        },
+                        "gemini": {
+                          "description": "Gemini provider settings.",
+                          "properties": {
+                            "model": {
+                              "description": "Model name override, such as `gemini-2.5-pro`.\nIf unset, the model name is taken from the request.",
+                              "maxLength": 256,
+                              "minLength": 1,
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "host": {
+                          "description": "Hostname to send requests to.\nFor custom providers without backendRef, host and port specify the target.\nFor managed providers, host and port override the provider default.",
+                          "maxLength": 256,
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "name": {
+                          "description": "Name of the provider. Policies can target this provider by name.",
+                          "maxLength": 253,
+                          "minLength": 1,
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                          "type": "string"
+                        },
+                        "openai": {
+                          "description": "OpenAI provider settings.",
+                          "properties": {
+                            "model": {
+                              "description": "Model name override, such as `gpt-4o-mini`.\nIf unset, the model name is taken from the request.",
+                              "maxLength": 256,
+                              "minLength": 1,
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "path": {
+                          "description": "URL path to use for LLM provider API requests.\nThis is useful when you need to route requests to a different API endpoint while maintaining\ncompatibility with the original provider's API structure.\nIf not specified, the default path for the provider is used.",
+                          "maxLength": 1024,
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "pathPrefix": {
+                          "description": "Overrides the default base path prefix, such as `/v1`, for upstream requests.\nPath translation for cross-format requests still applies using this prefix.\nOnly supported for OpenAI and Anthropic providers.",
+                          "maxLength": 1024,
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "policies": {
+                          "description": "Policies for communicating with this backend.\nPolicies may also be set in `AgentgatewayPolicy`, or in the top-level\n`AgentgatewayBackend`. Policies are merged on a field-level basis, with\norder: `AgentgatewayPolicy` < `AgentgatewayBackend` < `AgentgatewayBackend`\nLLM provider (this field).",
+                          "properties": {
+                            "ai": {
+                              "description": "Settings for AI workloads. This is only applicable when\nconnecting to a `Backend` of type `ai`.",
+                              "properties": {
+                                "defaults": {
+                                  "description": "Defaults to merge with user input fields. If the field is already set, the field in the request is used.",
+                                  "items": {
+                                    "description": "Default value for a field in the JSON request body sent to the LLM provider.\nThese defaults are merged with the user-provided request to ensure missing fields are populated.\n\nUser input fields here refer to the fields in the JSON request body that a client sends when making a request to the LLM provider.\nDefaults set here do _not_ override those user-provided values unless you explicitly set `override` to `true`.\n\nExample: Setting a default system field for Anthropic, which does not support system role messages:\n\n\tdefaults:\n\t  - field: \"system\"\n\t    value: \"answer all questions in French\"\n\nExample: Setting a default temperature and overriding `max_tokens`:\n\n\tdefaults:\n\t  - field: \"temperature\"\n\t    value: \"0.5\"\n\t  - field: \"max_tokens\"\n\t    value: \"100\"\n\t    override: true\n\nExample: Setting custom lists fields:\n\n\tdefaults:\n\t  - field: \"custom_integer_list\"\n\t    value: [1,2,3]\n\n\toverrides:\n\t  - field: \"custom_string_list\"\n\t    value: [\"one\",\"two\",\"three\"]\n\nNote: The `field` values correspond to keys in the JSON request body, not fields in this CRD.",
+                                    "properties": {
+                                      "field": {
+                                        "allOf": [
+                                          {
+                                            "minLength": 1
+                                          },
+                                          {
+                                            "minLength": 1
+                                          }
+                                        ],
+                                        "description": "Name of the field.",
+                                        "maxLength": 256,
+                                        "type": "string"
+                                      },
+                                      "value": {
+                                        "description": "Default value for the field. This can be any JSON data type.",
+                                        "x-kubernetes-preserve-unknown-fields": true
+                                      }
+                                    },
+                                    "required": [
+                                      "field",
+                                      "value"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "maxItems": 64,
+                                  "minItems": 1,
+                                  "type": "array"
+                                },
+                                "modelAliases": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "description": "Maps friendly model names to actual provider model names.\nExample: `{\"fast\": \"gpt-3.5-turbo\", \"smart\": \"gpt-4-turbo\"}`.\nNote: This field is only applicable when using the agentgateway data plane.",
+                                  "maxProperties": 64,
+                                  "type": "object"
+                                },
+                                "overrides": {
+                                  "description": "Overrides to merge with user input fields. If the field is already set, the field is overwritten.",
+                                  "items": {
+                                    "description": "Default value for a field in the JSON request body sent to the LLM provider.\nThese defaults are merged with the user-provided request to ensure missing fields are populated.\n\nUser input fields here refer to the fields in the JSON request body that a client sends when making a request to the LLM provider.\nDefaults set here do _not_ override those user-provided values unless you explicitly set `override` to `true`.\n\nExample: Setting a default system field for Anthropic, which does not support system role messages:\n\n\tdefaults:\n\t  - field: \"system\"\n\t    value: \"answer all questions in French\"\n\nExample: Setting a default temperature and overriding `max_tokens`:\n\n\tdefaults:\n\t  - field: \"temperature\"\n\t    value: \"0.5\"\n\t  - field: \"max_tokens\"\n\t    value: \"100\"\n\t    override: true\n\nExample: Setting custom lists fields:\n\n\tdefaults:\n\t  - field: \"custom_integer_list\"\n\t    value: [1,2,3]\n\n\toverrides:\n\t  - field: \"custom_string_list\"\n\t    value: [\"one\",\"two\",\"three\"]\n\nNote: The `field` values correspond to keys in the JSON request body, not fields in this CRD.",
+                                    "properties": {
+                                      "field": {
+                                        "allOf": [
+                                          {
+                                            "minLength": 1
+                                          },
+                                          {
+                                            "minLength": 1
+                                          }
+                                        ],
+                                        "description": "Name of the field.",
+                                        "maxLength": 256,
+                                        "type": "string"
+                                      },
+                                      "value": {
+                                        "description": "Default value for the field. This can be any JSON data type.",
+                                        "x-kubernetes-preserve-unknown-fields": true
+                                      }
+                                    },
+                                    "required": [
+                                      "field",
+                                      "value"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "maxItems": 64,
+                                  "minItems": 1,
+                                  "type": "array"
+                                },
+                                "prompt": {
+                                  "description": "Enriches requests sent to the LLM provider by appending and prepending system prompts. This can be configured only for\nLLM providers that use the `CHAT` or `CHAT_STREAMING` API route type.",
+                                  "properties": {
+                                    "append": {
+                                      "description": "Messages to append to the prompt sent by the client.",
+                                      "items": {
+                                        "description": "An entry for a message to prepend or append to each prompt.",
+                                        "properties": {
+                                          "content": {
+                                            "description": "String content of the message.",
+                                            "type": "string"
+                                          },
+                                          "role": {
+                                            "description": "Role of the message. The available roles depend on the backend\nLLM provider model, such as `SYSTEM` or `USER` in the OpenAI API.",
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "content",
+                                          "role"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "prepend": {
+                                      "description": "Messages to prepend to the prompt sent by the client.",
+                                      "items": {
+                                        "description": "An entry for a message to prepend or append to each prompt.",
+                                        "properties": {
+                                          "content": {
+                                            "description": "String content of the message.",
+                                            "type": "string"
+                                          },
+                                          "role": {
+                                            "description": "Role of the message. The available roles depend on the backend\nLLM provider model, such as `SYSTEM` or `USER` in the OpenAI API.",
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "content",
+                                          "role"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "promptCaching": {
+                                  "description": "Automatic prompt caching for supported\nproviders, currently AWS Bedrock.\nReduces API costs by caching static content like system prompts and tool definitions.\nOnly applicable for Bedrock Claude 3+ and Nova models.",
+                                  "properties": {
+                                    "cacheMessageOffset": {
+                                      "default": 0,
+                                      "description": "Shifts the message cache point further back in the\nconversation. 0 (default) places it at the second-to-last message.\nHigher values move it N additional messages towards the start, clamped\nto bounds.",
+                                      "minimum": 0,
+                                      "type": "integer"
+                                    },
+                                    "cacheMessages": {
+                                      "default": true,
+                                      "description": "Enables caching for conversation messages.\nCaches all messages in the conversation for cost savings.",
+                                      "type": "boolean"
+                                    },
+                                    "cacheSystem": {
+                                      "default": true,
+                                      "description": "Enables caching for system prompts.\nInserts a cache point after all system messages.",
+                                      "type": "boolean"
+                                    },
+                                    "cacheTools": {
+                                      "default": false,
+                                      "description": "Enables caching for tool definitions.\nInserts a cache point after all tool specifications.",
+                                      "type": "boolean"
+                                    },
+                                    "minTokens": {
+                                      "default": 1024,
+                                      "description": "Minimum estimated token count\nbefore caching is enabled. Uses rough heuristic (word count \u00d7 1.3) to estimate tokens.\nBedrock requires at least 1,024 tokens for caching to be effective.",
+                                      "minimum": 0,
+                                      "type": "integer"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "promptGuard": {
+                                  "description": "Guardrails for LLM requests and responses.",
+                                  "properties": {
+                                    "request": {
+                                      "description": "Prompt guards to apply to requests sent by the client.",
+                                      "items": {
+                                        "description": "Prompt guards to apply to requests sent by the client.",
+                                        "properties": {
+                                          "bedrockGuardrails": {
+                                            "description": "AWS Bedrock Guardrails settings for prompt\nguarding.",
+                                            "properties": {
+                                              "identifier": {
+                                                "description": "Identifier of the Guardrail policy to use for the backend.",
+                                                "maxLength": 256,
+                                                "minLength": 1,
+                                                "type": "string"
+                                              },
+                                              "policies": {
+                                                "description": "Policies for communicating with AWS Bedrock Guardrails.",
+                                                "properties": {
+                                                  "auth": {
+                                                    "description": "Settings for managing authentication to the backend.",
+                                                    "properties": {
+                                                      "aws": {
+                                                        "description": "Explicit AWS authentication method for the backend.\nWhen omitted, default AWS SDK credential discovery is used.",
+                                                        "properties": {
+                                                          "assumeRole": {
+                                                            "description": "AWS STS AssumeRole settings to use before signing backend requests.\nAmbient AWS credentials are used as the source credentials for STS.",
+                                                            "properties": {
+                                                              "roleArn": {
+                                                                "description": "AWS IAM role ARN to assume.",
+                                                                "minLength": 1,
+                                                                "pattern": "^arn:aws[a-z-]*:iam::[0-9]{12}:role/.+$",
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "roleArn"
+                                                            ],
+                                                            "type": "object",
+                                                            "additionalProperties": false
+                                                          },
+                                                          "secretRef": {
+                                                            "description": "Credential source, defaulting to a Kubernetes\n`Secret`, containing the AWS credentials. When using the default Secret\nresolver, the `Secret` must have keys `accessKey`, `secretKey`, and\noptionally `sessionToken`.",
+                                                            "properties": {
+                                                              "group": {
+                                                                "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                                                                "type": "string"
+                                                              },
+                                                              "kind": {
+                                                                "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                                                                "type": "string"
+                                                              },
+                                                              "name": {
+                                                                "description": "The name of the referenced credential.",
+                                                                "maxLength": 253,
+                                                                "minLength": 1,
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "name"
+                                                            ],
+                                                            "type": "object",
+                                                            "x-kubernetes-map-type": "atomic",
+                                                            "x-kubernetes-validations": [
+                                                              {
+                                                                "message": "custom credential refs must set both group and kind",
+                                                                "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                                                              }
+                                                            ],
+                                                            "additionalProperties": false
+                                                          },
+                                                          "serviceName": {
+                                                            "description": "AWS SigV4 signing service name, for example\n`bedrock`, `bedrock-agentcore`, or `execute-api`). If unset, typed AWS\nbackends may provide this automatically.",
+                                                            "maxLength": 256,
+                                                            "minLength": 1,
+                                                            "type": "string"
+                                                          }
+                                                        },
+                                                        "type": "object",
+                                                        "x-kubernetes-validations": [
+                                                          {
+                                                            "message": "secretRef and assumeRole are mutually exclusive",
+                                                            "rule": "!(has(self.secretRef) && has(self.assumeRole))"
+                                                          }
+                                                        ],
+                                                        "additionalProperties": false
+                                                      },
+                                                      "azure": {
+                                                        "description": "Azure authentication method for the backend.",
+                                                        "properties": {
+                                                          "managedIdentity": {
+                                                            "description": "Managed identity authentication settings.",
+                                                            "properties": {
+                                                              "clientId": {
+                                                                "type": "string"
+                                                              },
+                                                              "objectId": {
+                                                                "type": "string"
+                                                              },
+                                                              "resourceId": {
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "clientId",
+                                                              "objectId",
+                                                              "resourceId"
+                                                            ],
+                                                            "type": "object",
+                                                            "additionalProperties": false
+                                                          },
+                                                          "secretRef": {
+                                                            "description": "Credential source, defaulting to a Kubernetes\n`Secret`, containing the Azure credentials. When using the default Secret\nresolver, the `Secret` must have keys `clientID`, `tenantID`, and\n`clientSecret`.",
+                                                            "properties": {
+                                                              "group": {
+                                                                "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                                                                "type": "string"
+                                                              },
+                                                              "kind": {
+                                                                "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                                                                "type": "string"
+                                                              },
+                                                              "name": {
+                                                                "description": "The name of the referenced credential.",
+                                                                "maxLength": 253,
+                                                                "minLength": 1,
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "name"
+                                                            ],
+                                                            "type": "object",
+                                                            "x-kubernetes-map-type": "atomic",
+                                                            "x-kubernetes-validations": [
+                                                              {
+                                                                "message": "custom credential refs must set both group and kind",
+                                                                "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                                                              }
+                                                            ],
+                                                            "additionalProperties": false
+                                                          }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                      },
+                                                      "gcp": {
+                                                        "description": "Google authentication method for the backend.\nWhen omitted, default Google credential discovery is used.",
+                                                        "properties": {
+                                                          "audience": {
+                                                            "description": "Explicit `aud` value for the ID token. Only\nvalid with `IdToken` type. If not set, the `aud` is automatically\nderived from the backend hostname.",
+                                                            "maxLength": 256,
+                                                            "minLength": 1,
+                                                            "type": "string"
+                                                          },
+                                                          "secretRef": {
+                                                            "description": "Credential source, defaulting to a Kubernetes\n`Secret`, containing ADC-compatible Google credential JSON. When using\nthe default Secret resolver, this must be stored in the `credentials.json`\nkey. When omitted, ambient credentials are used.",
+                                                            "properties": {
+                                                              "group": {
+                                                                "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                                                                "type": "string"
+                                                              },
+                                                              "kind": {
+                                                                "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                                                                "type": "string"
+                                                              },
+                                                              "name": {
+                                                                "description": "The name of the referenced credential.",
+                                                                "maxLength": 253,
+                                                                "minLength": 1,
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "name"
+                                                            ],
+                                                            "type": "object",
+                                                            "x-kubernetes-map-type": "atomic",
+                                                            "x-kubernetes-validations": [
+                                                              {
+                                                                "message": "custom credential refs must set both group and kind",
+                                                                "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                                                              }
+                                                            ],
+                                                            "additionalProperties": false
+                                                          },
+                                                          "type": {
+                                                            "description": "The type of token to generate. To authenticate to GCP services,\ngenerally an `AccessToken` is used. To authenticate to Cloud Run, an\n`IdToken` is used.",
+                                                            "enum": [
+                                                              "AccessToken",
+                                                              "IdToken"
+                                                            ],
+                                                            "type": "string"
+                                                          }
+                                                        },
+                                                        "type": "object",
+                                                        "x-kubernetes-validations": [
+                                                          {
+                                                            "message": "audience is only valid with IdToken",
+                                                            "rule": "has(self.audience) ? self.type == 'IdToken' : true"
+                                                          }
+                                                        ],
+                                                        "additionalProperties": false
+                                                      },
+                                                      "key": {
+                                                        "description": "Inline key to use as the value of the\n`Authorization` header. This option is the least secure; usage of a\n`Secret` is preferred.",
+                                                        "maxLength": 2048,
+                                                        "type": "string"
+                                                      },
+                                                      "location": {
+                                                        "description": "Where backend credentials are inserted.\nIf omitted, credentials are written to the `Authorization` header with the `Bearer ` prefix.\nThis applies to `key`, `secretRef`, and `passthrough`.",
+                                                        "properties": {
+                                                          "cookie": {
+                                                            "properties": {
+                                                              "name": {
+                                                                "maxLength": 256,
+                                                                "minLength": 1,
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "name"
+                                                            ],
+                                                            "type": "object",
+                                                            "additionalProperties": false
+                                                          },
+                                                          "header": {
+                                                            "properties": {
+                                                              "name": {
+                                                                "description": "HTTPHeaderName is the name of an HTTP header.\n\nValid values include:\n\n* \"Authorization\"\n* \"Set-Cookie\"\n\nInvalid values include:\n\n  - \":method\" - \":\" is an invalid character. This means that HTTP/2 pseudo\n    headers are not currently supported by this type.\n  - \"/invalid\" - \"/ \" is an invalid character",
+                                                                "maxLength": 256,
+                                                                "minLength": 1,
+                                                                "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                                                                "type": "string"
+                                                              },
+                                                              "prefix": {
+                                                                "maxLength": 256,
+                                                                "minLength": 1,
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "name"
+                                                            ],
+                                                            "type": "object",
+                                                            "additionalProperties": false
+                                                          },
+                                                          "queryParameter": {
+                                                            "properties": {
+                                                              "name": {
+                                                                "maxLength": 256,
+                                                                "minLength": 1,
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "name"
+                                                            ],
+                                                            "type": "object",
+                                                            "additionalProperties": false
+                                                          }
+                                                        },
+                                                        "type": "object",
+                                                        "x-kubernetes-validations": [
+                                                          {
+                                                            "message": "exactly one of the fields in [header queryParameter cookie] must be set",
+                                                            "rule": "[has(self.header),has(self.queryParameter),has(self.cookie)].filter(x,x==true).size() == 1"
+                                                          }
+                                                        ],
+                                                        "additionalProperties": false
+                                                      },
+                                                      "passthrough": {
+                                                        "description": "Passes through an existing token that has been sent by the\nclient and validated. Other policies, like JWT and API key\nauthentication, will strip the original client credentials. Passthrough backend authentication\ncauses the original token to be added back into the request. If there are no client authentication policies on the\nrequest, the original token would be unchanged, so this would have no effect.",
+                                                        "type": "object"
+                                                      },
+                                                      "secretRef": {
+                                                        "description": "Credential source, defaulting to a Kubernetes\n`Secret`, storing the key to use as the authorization value. When using\nthe default Secret resolver, this must be stored in the `Authorization`\nkey.",
+                                                        "properties": {
+                                                          "group": {
+                                                            "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                                                            "type": "string"
+                                                          },
+                                                          "kind": {
+                                                            "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                                                            "type": "string"
+                                                          },
+                                                          "name": {
+                                                            "description": "The name of the referenced credential.",
+                                                            "maxLength": 253,
+                                                            "minLength": 1,
+                                                            "type": "string"
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "name"
+                                                        ],
+                                                        "type": "object",
+                                                        "x-kubernetes-map-type": "atomic",
+                                                        "x-kubernetes-validations": [
+                                                          {
+                                                            "message": "custom credential refs must set both group and kind",
+                                                            "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                                                          }
+                                                        ],
+                                                        "additionalProperties": false
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "x-kubernetes-validations": [
+                                                      {
+                                                        "message": "location may only be set for key or passthrough auth",
+                                                        "rule": "has(self.location) ? has(self.key) || has(self.secretRef) || has(self.passthrough) : true"
+                                                      },
+                                                      {
+                                                        "message": "exactly one of the fields in [key secretRef passthrough aws azure gcp] must be set",
+                                                        "rule": "[has(self.key),has(self.secretRef),has(self.passthrough),has(self.aws),has(self.azure),has(self.gcp)].filter(x,x==true).size() == 1"
+                                                      }
+                                                    ],
+                                                    "additionalProperties": false
+                                                  },
+                                                  "http": {
+                                                    "description": "Settings for managing HTTP requests to the backend.",
+                                                    "properties": {
+                                                      "requestTimeout": {
+                                                        "description": "Deadline for receiving a response from the backend.",
+                                                        "type": "string",
+                                                        "x-kubernetes-validations": [
+                                                          {
+                                                            "message": "invalid duration value",
+                                                            "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                                          },
+                                                          {
+                                                            "message": "requestTimeout must be at least 1ms",
+                                                            "rule": "duration(self) >= duration('1ms')"
+                                                          }
+                                                        ]
+                                                      },
+                                                      "version": {
+                                                        "description": "HTTP protocol version to use when connecting to\nthe backend.\nIf not specified, the version is automatically determined:\n* `Service` types can specify it with `appProtocol` on the `Service`\n  port.\n* If traffic is identified as gRPC, `HTTP2` is used.\n* If the incoming traffic was plaintext HTTP, the original protocol will\n  be used.\n* If the incoming traffic was HTTPS, `HTTP1` will be used. This is\n  because most clients will transparently upgrade HTTPS traffic to\n  `HTTP2`, even if the backend doesn't support it.",
+                                                        "enum": [
+                                                          "HTTP1",
+                                                          "HTTP2"
+                                                        ],
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "tcp": {
+                                                    "description": "Settings for managing TCP connections to the backend.",
+                                                    "properties": {
+                                                      "connectTimeout": {
+                                                        "description": "Deadline for establishing a connection to\nthe destination.",
+                                                        "type": "string",
+                                                        "x-kubernetes-validations": [
+                                                          {
+                                                            "message": "invalid duration value",
+                                                            "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                                          },
+                                                          {
+                                                            "message": "connectTimeout must be at least 100ms",
+                                                            "rule": "duration(self) >= duration('100ms')"
+                                                          }
+                                                        ]
+                                                      },
+                                                      "keepalive": {
+                                                        "description": "Settings for enabling TCP keepalives on the\nconnection.",
+                                                        "properties": {
+                                                          "interval": {
+                                                            "description": "Time between keepalive probes.\nIf unset, this defaults to 180s.",
+                                                            "type": "string",
+                                                            "x-kubernetes-validations": [
+                                                              {
+                                                                "message": "invalid duration value",
+                                                                "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                                              },
+                                                              {
+                                                                "message": "interval must be at least 1 second",
+                                                                "rule": "duration(self) >= duration('1s')"
+                                                              }
+                                                            ]
+                                                          },
+                                                          "retries": {
+                                                            "description": "Maximum number of keepalive probes to send before dropping the connection.\nIf unset, this defaults to 9.",
+                                                            "format": "int32",
+                                                            "maximum": 64,
+                                                            "minimum": 1,
+                                                            "type": "integer"
+                                                          },
+                                                          "time": {
+                                                            "description": "Time a connection needs to be idle before keepalive probes start being sent.\nIf unset, this defaults to 180s.",
+                                                            "type": "string",
+                                                            "x-kubernetes-validations": [
+                                                              {
+                                                                "message": "invalid duration value",
+                                                                "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                                              },
+                                                              {
+                                                                "message": "time must be at least 1 second",
+                                                                "rule": "duration(self) >= duration('1s')"
+                                                              }
+                                                            ]
+                                                          }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "tls": {
+                                                    "description": "Settings for managing TLS connections to the backend.\n\nIf this field is set, TLS will be initiated to the backend; the system trusted CA certificates will be used to\nvalidate the server, and the SNI will automatically be set based on the destination.",
+                                                    "properties": {
+                                                      "alpnProtocols": {
+                                                        "description": "Application-Layer Protocol Negotiation (`ALPN`)\nvalue to use in the TLS handshake.\n\nIf not present, defaults to `[\"h2\", \"http/1.1\"]`.",
+                                                        "items": {
+                                                          "maxLength": 64,
+                                                          "minLength": 1,
+                                                          "type": "string"
+                                                        },
+                                                        "maxItems": 16,
+                                                        "minItems": 1,
+                                                        "type": "array"
+                                                      },
+                                                      "caCertificateRefs": {
+                                                        "description": "CA certificate `ConfigMap` to use to\nverify the server certificate.\nIf unset, the system's trusted certificates are used.",
+                                                        "items": {
+                                                          "description": "LocalObjectReference contains enough information to let you locate the\nreferenced object inside the same namespace.",
+                                                          "properties": {
+                                                            "name": {
+                                                              "default": "",
+                                                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                                              "type": "string"
+                                                            }
+                                                          },
+                                                          "type": "object",
+                                                          "x-kubernetes-map-type": "atomic",
+                                                          "additionalProperties": false
+                                                        },
+                                                        "maxItems": 1,
+                                                        "type": "array",
+                                                        "x-kubernetes-list-type": "atomic"
+                                                      },
+                                                      "insecureSkipVerify": {
+                                                        "description": "Originates TLS but skips verification of the backend's certificate.\nWARNING: This is an insecure option that should only be used if the risks are understood.\n\nThere are two modes:\n* `All` disables all TLS verification.\n* `Hostname` verifies the CA certificate is trusted, but ignores any\n  mismatch of hostname or SANs. Note that this method is still insecure;\n  prefer setting `verifySubjectAltNames` to customize the valid hostnames\n  if possible.",
+                                                        "enum": [
+                                                          "All",
+                                                          "Hostname"
+                                                        ],
+                                                        "type": "string"
+                                                      },
+                                                      "keyExchangeGroups": {
+                                                        "description": "Ordered list of key exchange groups for a TLS connection.\nFor example: `X25519_MLKEM768,X25519`.",
+                                                        "items": {
+                                                          "enum": [
+                                                            "P-256",
+                                                            "P-384",
+                                                            "X25519",
+                                                            "X25519_MLKEM768"
+                                                          ],
+                                                          "type": "string"
+                                                        },
+                                                        "type": "array"
+                                                      },
+                                                      "mtlsCertificateRef": {
+                                                        "description": "Enables mutual TLS to the backend, using the\nspecified key (`tls.key`) and cert (`tls.crt`) from the referenced\ncredential source, defaulting to a Kubernetes `Secret`.\n\nAn optional `ca.cert` field, if present, will be used to verify the\nserver certificate. If `caCertificateRefs` is also specified, the\n`caCertificateRefs` field takes priority.\n\nIf unspecified, no client certificate will be used.",
+                                                        "items": {
+                                                          "description": "References a same-namespace credential.\nSet only `name` to reference a Kubernetes Secret.",
+                                                          "properties": {
+                                                            "group": {
+                                                              "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                                                              "type": "string"
+                                                            },
+                                                            "kind": {
+                                                              "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                                                              "type": "string"
+                                                            },
+                                                            "name": {
+                                                              "description": "The name of the referenced credential.",
+                                                              "maxLength": 253,
+                                                              "minLength": 1,
+                                                              "type": "string"
+                                                            }
+                                                          },
+                                                          "required": [
+                                                            "name"
+                                                          ],
+                                                          "type": "object",
+                                                          "x-kubernetes-map-type": "atomic",
+                                                          "x-kubernetes-validations": [
+                                                            {
+                                                              "message": "custom credential refs must set both group and kind",
+                                                              "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                                                            }
+                                                          ],
+                                                          "additionalProperties": false
+                                                        },
+                                                        "maxItems": 1,
+                                                        "type": "array",
+                                                        "x-kubernetes-list-type": "atomic"
+                                                      },
+                                                      "sni": {
+                                                        "description": "Server Name Indicator (`SNI`) to use in the TLS\nhandshake. If unset, the `SNI` is automatically set based on the\ndestination hostname.",
+                                                        "maxLength": 253,
+                                                        "minLength": 1,
+                                                        "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                                                        "type": "string"
+                                                      },
+                                                      "verifySubjectAltNames": {
+                                                        "description": "Subject Alternative Names (`SAN`)\nto verify in the server certificate.\nIf not present, the destination hostname is automatically used.",
+                                                        "items": {
+                                                          "maxLength": 256,
+                                                          "minLength": 1,
+                                                          "type": "string"
+                                                        },
+                                                        "maxItems": 16,
+                                                        "minItems": 1,
+                                                        "type": "array"
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "x-kubernetes-validations": [
+                                                      {
+                                                        "message": "insecureSkipVerify All and caCertificateRefs may not be set together",
+                                                        "rule": "has(self.insecureSkipVerify) && self.insecureSkipVerify == 'All' ? !has(self.caCertificateRefs) : true"
+                                                      },
+                                                      {
+                                                        "message": "insecureSkipVerify and verifySubjectAltNames may not be set together",
+                                                        "rule": "has(self.insecureSkipVerify) ? !has(self.verifySubjectAltNames) : true"
+                                                      },
+                                                      {
+                                                        "message": "at most one of the fields in [verifySubjectAltNames insecureSkipVerify] may be set",
+                                                        "rule": "[has(self.verifySubjectAltNames),has(self.insecureSkipVerify)].filter(x,x==true).size() <= 1"
+                                                      }
+                                                    ],
+                                                    "additionalProperties": false
+                                                  },
+                                                  "tunnel": {
+                                                    "description": "Settings for managing tunnel connections, with behavior like `HTTPS_PROXY`, to the backend.",
+                                                    "properties": {
+                                                      "backendRef": {
+                                                        "description": "Proxy server to reach.\nSupported types: `Service` and `Backend`.",
+                                                        "properties": {
+                                                          "group": {
+                                                            "default": "",
+                                                            "description": "Group is the group of the referent. For example, \"gateway.networking.k8s.io\".\nWhen unspecified or empty string, core API group is inferred.",
+                                                            "maxLength": 253,
+                                                            "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                                                            "type": "string"
+                                                          },
+                                                          "kind": {
+                                                            "default": "Service",
+                                                            "description": "Kind is the Kubernetes resource kind of the referent. For example\n\"Service\".\n\nDefaults to \"Service\" when not specified.\n\nExternalName services can refer to CNAME DNS records that may live\noutside of the cluster and as such are difficult to reason about in\nterms of conformance. They also may not be safe to forward to (see\nCVE-2021-25740 for more information). Implementations SHOULD NOT\nsupport ExternalName Services.\n\nSupport: Core (Services with a type other than ExternalName)\n\nSupport: Implementation-specific (Services with type ExternalName)",
+                                                            "maxLength": 63,
+                                                            "minLength": 1,
+                                                            "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
+                                                            "type": "string"
+                                                          },
+                                                          "name": {
+                                                            "description": "Name is the name of the referent.",
+                                                            "maxLength": 253,
+                                                            "minLength": 1,
+                                                            "type": "string"
+                                                          },
+                                                          "namespace": {
+                                                            "description": "Namespace is the namespace of the backend. When unspecified, the local\nnamespace is inferred.\n\nNote that when a namespace different than the local namespace is specified,\na ReferenceGrant object is required in the referent namespace to allow that\nnamespace's owner to accept the reference. See the ReferenceGrant\ndocumentation for details.\n\nSupport: Core",
+                                                            "maxLength": 63,
+                                                            "minLength": 1,
+                                                            "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                                                            "type": "string"
+                                                          },
+                                                          "port": {
+                                                            "description": "Port specifies the destination port number to use for this resource.\nPort is required when the referent is a Kubernetes Service. In this\ncase, the port number is the service port number, not the target port.\nFor other resources, destination port might be derived from the referent\nresource or this field.",
+                                                            "format": "int32",
+                                                            "maximum": 65535,
+                                                            "minimum": 1,
+                                                            "type": "integer"
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "name"
+                                                        ],
+                                                        "type": "object",
+                                                        "x-kubernetes-validations": [
+                                                          {
+                                                            "message": "Must have port for Service reference",
+                                                            "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
+                                                          }
+                                                        ],
+                                                        "additionalProperties": false
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "backendRef"
+                                                    ],
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "region": {
+                                                "description": "AWS region where the guardrail is deployed, for example\n`us-west-2`).",
+                                                "maxLength": 256,
+                                                "minLength": 1,
+                                                "type": "string"
+                                              },
+                                              "version": {
+                                                "description": "Version of the Guardrail policy to use for the backend.",
+                                                "maxLength": 256,
+                                                "minLength": 1,
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "identifier",
+                                              "region",
+                                              "version"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "googleModelArmor": {
+                                            "description": "Google Model Armor settings for prompt guarding.",
+                                            "properties": {
+                                              "location": {
+                                                "default": "us-central1",
+                                                "description": "Google Cloud location, for example `us-central1`.\nDefaults to `us-central1` if not specified.",
+                                                "maxLength": 256,
+                                                "minLength": 1,
+                                                "type": "string"
+                                              },
+                                              "policies": {
+                                                "description": "Policies for communicating with Google Model Armor.",
+                                                "properties": {
+                                                  "auth": {
+                                                    "description": "Settings for managing authentication to the backend.",
+                                                    "properties": {
+                                                      "aws": {
+                                                        "description": "Explicit AWS authentication method for the backend.\nWhen omitted, default AWS SDK credential discovery is used.",
+                                                        "properties": {
+                                                          "assumeRole": {
+                                                            "description": "AWS STS AssumeRole settings to use before signing backend requests.\nAmbient AWS credentials are used as the source credentials for STS.",
+                                                            "properties": {
+                                                              "roleArn": {
+                                                                "description": "AWS IAM role ARN to assume.",
+                                                                "minLength": 1,
+                                                                "pattern": "^arn:aws[a-z-]*:iam::[0-9]{12}:role/.+$",
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "roleArn"
+                                                            ],
+                                                            "type": "object",
+                                                            "additionalProperties": false
+                                                          },
+                                                          "secretRef": {
+                                                            "description": "Credential source, defaulting to a Kubernetes\n`Secret`, containing the AWS credentials. When using the default Secret\nresolver, the `Secret` must have keys `accessKey`, `secretKey`, and\noptionally `sessionToken`.",
+                                                            "properties": {
+                                                              "group": {
+                                                                "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                                                                "type": "string"
+                                                              },
+                                                              "kind": {
+                                                                "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                                                                "type": "string"
+                                                              },
+                                                              "name": {
+                                                                "description": "The name of the referenced credential.",
+                                                                "maxLength": 253,
+                                                                "minLength": 1,
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "name"
+                                                            ],
+                                                            "type": "object",
+                                                            "x-kubernetes-map-type": "atomic",
+                                                            "x-kubernetes-validations": [
+                                                              {
+                                                                "message": "custom credential refs must set both group and kind",
+                                                                "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                                                              }
+                                                            ],
+                                                            "additionalProperties": false
+                                                          },
+                                                          "serviceName": {
+                                                            "description": "AWS SigV4 signing service name, for example\n`bedrock`, `bedrock-agentcore`, or `execute-api`). If unset, typed AWS\nbackends may provide this automatically.",
+                                                            "maxLength": 256,
+                                                            "minLength": 1,
+                                                            "type": "string"
+                                                          }
+                                                        },
+                                                        "type": "object",
+                                                        "x-kubernetes-validations": [
+                                                          {
+                                                            "message": "secretRef and assumeRole are mutually exclusive",
+                                                            "rule": "!(has(self.secretRef) && has(self.assumeRole))"
+                                                          }
+                                                        ],
+                                                        "additionalProperties": false
+                                                      },
+                                                      "azure": {
+                                                        "description": "Azure authentication method for the backend.",
+                                                        "properties": {
+                                                          "managedIdentity": {
+                                                            "description": "Managed identity authentication settings.",
+                                                            "properties": {
+                                                              "clientId": {
+                                                                "type": "string"
+                                                              },
+                                                              "objectId": {
+                                                                "type": "string"
+                                                              },
+                                                              "resourceId": {
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "clientId",
+                                                              "objectId",
+                                                              "resourceId"
+                                                            ],
+                                                            "type": "object",
+                                                            "additionalProperties": false
+                                                          },
+                                                          "secretRef": {
+                                                            "description": "Credential source, defaulting to a Kubernetes\n`Secret`, containing the Azure credentials. When using the default Secret\nresolver, the `Secret` must have keys `clientID`, `tenantID`, and\n`clientSecret`.",
+                                                            "properties": {
+                                                              "group": {
+                                                                "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                                                                "type": "string"
+                                                              },
+                                                              "kind": {
+                                                                "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                                                                "type": "string"
+                                                              },
+                                                              "name": {
+                                                                "description": "The name of the referenced credential.",
+                                                                "maxLength": 253,
+                                                                "minLength": 1,
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "name"
+                                                            ],
+                                                            "type": "object",
+                                                            "x-kubernetes-map-type": "atomic",
+                                                            "x-kubernetes-validations": [
+                                                              {
+                                                                "message": "custom credential refs must set both group and kind",
+                                                                "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                                                              }
+                                                            ],
+                                                            "additionalProperties": false
+                                                          }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                      },
+                                                      "gcp": {
+                                                        "description": "Google authentication method for the backend.\nWhen omitted, default Google credential discovery is used.",
+                                                        "properties": {
+                                                          "audience": {
+                                                            "description": "Explicit `aud` value for the ID token. Only\nvalid with `IdToken` type. If not set, the `aud` is automatically\nderived from the backend hostname.",
+                                                            "maxLength": 256,
+                                                            "minLength": 1,
+                                                            "type": "string"
+                                                          },
+                                                          "secretRef": {
+                                                            "description": "Credential source, defaulting to a Kubernetes\n`Secret`, containing ADC-compatible Google credential JSON. When using\nthe default Secret resolver, this must be stored in the `credentials.json`\nkey. When omitted, ambient credentials are used.",
+                                                            "properties": {
+                                                              "group": {
+                                                                "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                                                                "type": "string"
+                                                              },
+                                                              "kind": {
+                                                                "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                                                                "type": "string"
+                                                              },
+                                                              "name": {
+                                                                "description": "The name of the referenced credential.",
+                                                                "maxLength": 253,
+                                                                "minLength": 1,
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "name"
+                                                            ],
+                                                            "type": "object",
+                                                            "x-kubernetes-map-type": "atomic",
+                                                            "x-kubernetes-validations": [
+                                                              {
+                                                                "message": "custom credential refs must set both group and kind",
+                                                                "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                                                              }
+                                                            ],
+                                                            "additionalProperties": false
+                                                          },
+                                                          "type": {
+                                                            "description": "The type of token to generate. To authenticate to GCP services,\ngenerally an `AccessToken` is used. To authenticate to Cloud Run, an\n`IdToken` is used.",
+                                                            "enum": [
+                                                              "AccessToken",
+                                                              "IdToken"
+                                                            ],
+                                                            "type": "string"
+                                                          }
+                                                        },
+                                                        "type": "object",
+                                                        "x-kubernetes-validations": [
+                                                          {
+                                                            "message": "audience is only valid with IdToken",
+                                                            "rule": "has(self.audience) ? self.type == 'IdToken' : true"
+                                                          }
+                                                        ],
+                                                        "additionalProperties": false
+                                                      },
+                                                      "key": {
+                                                        "description": "Inline key to use as the value of the\n`Authorization` header. This option is the least secure; usage of a\n`Secret` is preferred.",
+                                                        "maxLength": 2048,
+                                                        "type": "string"
+                                                      },
+                                                      "location": {
+                                                        "description": "Where backend credentials are inserted.\nIf omitted, credentials are written to the `Authorization` header with the `Bearer ` prefix.\nThis applies to `key`, `secretRef`, and `passthrough`.",
+                                                        "properties": {
+                                                          "cookie": {
+                                                            "properties": {
+                                                              "name": {
+                                                                "maxLength": 256,
+                                                                "minLength": 1,
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "name"
+                                                            ],
+                                                            "type": "object",
+                                                            "additionalProperties": false
+                                                          },
+                                                          "header": {
+                                                            "properties": {
+                                                              "name": {
+                                                                "description": "HTTPHeaderName is the name of an HTTP header.\n\nValid values include:\n\n* \"Authorization\"\n* \"Set-Cookie\"\n\nInvalid values include:\n\n  - \":method\" - \":\" is an invalid character. This means that HTTP/2 pseudo\n    headers are not currently supported by this type.\n  - \"/invalid\" - \"/ \" is an invalid character",
+                                                                "maxLength": 256,
+                                                                "minLength": 1,
+                                                                "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                                                                "type": "string"
+                                                              },
+                                                              "prefix": {
+                                                                "maxLength": 256,
+                                                                "minLength": 1,
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "name"
+                                                            ],
+                                                            "type": "object",
+                                                            "additionalProperties": false
+                                                          },
+                                                          "queryParameter": {
+                                                            "properties": {
+                                                              "name": {
+                                                                "maxLength": 256,
+                                                                "minLength": 1,
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "name"
+                                                            ],
+                                                            "type": "object",
+                                                            "additionalProperties": false
+                                                          }
+                                                        },
+                                                        "type": "object",
+                                                        "x-kubernetes-validations": [
+                                                          {
+                                                            "message": "exactly one of the fields in [header queryParameter cookie] must be set",
+                                                            "rule": "[has(self.header),has(self.queryParameter),has(self.cookie)].filter(x,x==true).size() == 1"
+                                                          }
+                                                        ],
+                                                        "additionalProperties": false
+                                                      },
+                                                      "passthrough": {
+                                                        "description": "Passes through an existing token that has been sent by the\nclient and validated. Other policies, like JWT and API key\nauthentication, will strip the original client credentials. Passthrough backend authentication\ncauses the original token to be added back into the request. If there are no client authentication policies on the\nrequest, the original token would be unchanged, so this would have no effect.",
+                                                        "type": "object"
+                                                      },
+                                                      "secretRef": {
+                                                        "description": "Credential source, defaulting to a Kubernetes\n`Secret`, storing the key to use as the authorization value. When using\nthe default Secret resolver, this must be stored in the `Authorization`\nkey.",
+                                                        "properties": {
+                                                          "group": {
+                                                            "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                                                            "type": "string"
+                                                          },
+                                                          "kind": {
+                                                            "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                                                            "type": "string"
+                                                          },
+                                                          "name": {
+                                                            "description": "The name of the referenced credential.",
+                                                            "maxLength": 253,
+                                                            "minLength": 1,
+                                                            "type": "string"
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "name"
+                                                        ],
+                                                        "type": "object",
+                                                        "x-kubernetes-map-type": "atomic",
+                                                        "x-kubernetes-validations": [
+                                                          {
+                                                            "message": "custom credential refs must set both group and kind",
+                                                            "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                                                          }
+                                                        ],
+                                                        "additionalProperties": false
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "x-kubernetes-validations": [
+                                                      {
+                                                        "message": "location may only be set for key or passthrough auth",
+                                                        "rule": "has(self.location) ? has(self.key) || has(self.secretRef) || has(self.passthrough) : true"
+                                                      },
+                                                      {
+                                                        "message": "exactly one of the fields in [key secretRef passthrough aws azure gcp] must be set",
+                                                        "rule": "[has(self.key),has(self.secretRef),has(self.passthrough),has(self.aws),has(self.azure),has(self.gcp)].filter(x,x==true).size() == 1"
+                                                      }
+                                                    ],
+                                                    "additionalProperties": false
+                                                  },
+                                                  "http": {
+                                                    "description": "Settings for managing HTTP requests to the backend.",
+                                                    "properties": {
+                                                      "requestTimeout": {
+                                                        "description": "Deadline for receiving a response from the backend.",
+                                                        "type": "string",
+                                                        "x-kubernetes-validations": [
+                                                          {
+                                                            "message": "invalid duration value",
+                                                            "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                                          },
+                                                          {
+                                                            "message": "requestTimeout must be at least 1ms",
+                                                            "rule": "duration(self) >= duration('1ms')"
+                                                          }
+                                                        ]
+                                                      },
+                                                      "version": {
+                                                        "description": "HTTP protocol version to use when connecting to\nthe backend.\nIf not specified, the version is automatically determined:\n* `Service` types can specify it with `appProtocol` on the `Service`\n  port.\n* If traffic is identified as gRPC, `HTTP2` is used.\n* If the incoming traffic was plaintext HTTP, the original protocol will\n  be used.\n* If the incoming traffic was HTTPS, `HTTP1` will be used. This is\n  because most clients will transparently upgrade HTTPS traffic to\n  `HTTP2`, even if the backend doesn't support it.",
+                                                        "enum": [
+                                                          "HTTP1",
+                                                          "HTTP2"
+                                                        ],
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "tcp": {
+                                                    "description": "Settings for managing TCP connections to the backend.",
+                                                    "properties": {
+                                                      "connectTimeout": {
+                                                        "description": "Deadline for establishing a connection to\nthe destination.",
+                                                        "type": "string",
+                                                        "x-kubernetes-validations": [
+                                                          {
+                                                            "message": "invalid duration value",
+                                                            "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                                          },
+                                                          {
+                                                            "message": "connectTimeout must be at least 100ms",
+                                                            "rule": "duration(self) >= duration('100ms')"
+                                                          }
+                                                        ]
+                                                      },
+                                                      "keepalive": {
+                                                        "description": "Settings for enabling TCP keepalives on the\nconnection.",
+                                                        "properties": {
+                                                          "interval": {
+                                                            "description": "Time between keepalive probes.\nIf unset, this defaults to 180s.",
+                                                            "type": "string",
+                                                            "x-kubernetes-validations": [
+                                                              {
+                                                                "message": "invalid duration value",
+                                                                "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                                              },
+                                                              {
+                                                                "message": "interval must be at least 1 second",
+                                                                "rule": "duration(self) >= duration('1s')"
+                                                              }
+                                                            ]
+                                                          },
+                                                          "retries": {
+                                                            "description": "Maximum number of keepalive probes to send before dropping the connection.\nIf unset, this defaults to 9.",
+                                                            "format": "int32",
+                                                            "maximum": 64,
+                                                            "minimum": 1,
+                                                            "type": "integer"
+                                                          },
+                                                          "time": {
+                                                            "description": "Time a connection needs to be idle before keepalive probes start being sent.\nIf unset, this defaults to 180s.",
+                                                            "type": "string",
+                                                            "x-kubernetes-validations": [
+                                                              {
+                                                                "message": "invalid duration value",
+                                                                "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                                              },
+                                                              {
+                                                                "message": "time must be at least 1 second",
+                                                                "rule": "duration(self) >= duration('1s')"
+                                                              }
+                                                            ]
+                                                          }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "tls": {
+                                                    "description": "Settings for managing TLS connections to the backend.\n\nIf this field is set, TLS will be initiated to the backend; the system trusted CA certificates will be used to\nvalidate the server, and the SNI will automatically be set based on the destination.",
+                                                    "properties": {
+                                                      "alpnProtocols": {
+                                                        "description": "Application-Layer Protocol Negotiation (`ALPN`)\nvalue to use in the TLS handshake.\n\nIf not present, defaults to `[\"h2\", \"http/1.1\"]`.",
+                                                        "items": {
+                                                          "maxLength": 64,
+                                                          "minLength": 1,
+                                                          "type": "string"
+                                                        },
+                                                        "maxItems": 16,
+                                                        "minItems": 1,
+                                                        "type": "array"
+                                                      },
+                                                      "caCertificateRefs": {
+                                                        "description": "CA certificate `ConfigMap` to use to\nverify the server certificate.\nIf unset, the system's trusted certificates are used.",
+                                                        "items": {
+                                                          "description": "LocalObjectReference contains enough information to let you locate the\nreferenced object inside the same namespace.",
+                                                          "properties": {
+                                                            "name": {
+                                                              "default": "",
+                                                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                                              "type": "string"
+                                                            }
+                                                          },
+                                                          "type": "object",
+                                                          "x-kubernetes-map-type": "atomic",
+                                                          "additionalProperties": false
+                                                        },
+                                                        "maxItems": 1,
+                                                        "type": "array",
+                                                        "x-kubernetes-list-type": "atomic"
+                                                      },
+                                                      "insecureSkipVerify": {
+                                                        "description": "Originates TLS but skips verification of the backend's certificate.\nWARNING: This is an insecure option that should only be used if the risks are understood.\n\nThere are two modes:\n* `All` disables all TLS verification.\n* `Hostname` verifies the CA certificate is trusted, but ignores any\n  mismatch of hostname or SANs. Note that this method is still insecure;\n  prefer setting `verifySubjectAltNames` to customize the valid hostnames\n  if possible.",
+                                                        "enum": [
+                                                          "All",
+                                                          "Hostname"
+                                                        ],
+                                                        "type": "string"
+                                                      },
+                                                      "keyExchangeGroups": {
+                                                        "description": "Ordered list of key exchange groups for a TLS connection.\nFor example: `X25519_MLKEM768,X25519`.",
+                                                        "items": {
+                                                          "enum": [
+                                                            "P-256",
+                                                            "P-384",
+                                                            "X25519",
+                                                            "X25519_MLKEM768"
+                                                          ],
+                                                          "type": "string"
+                                                        },
+                                                        "type": "array"
+                                                      },
+                                                      "mtlsCertificateRef": {
+                                                        "description": "Enables mutual TLS to the backend, using the\nspecified key (`tls.key`) and cert (`tls.crt`) from the referenced\ncredential source, defaulting to a Kubernetes `Secret`.\n\nAn optional `ca.cert` field, if present, will be used to verify the\nserver certificate. If `caCertificateRefs` is also specified, the\n`caCertificateRefs` field takes priority.\n\nIf unspecified, no client certificate will be used.",
+                                                        "items": {
+                                                          "description": "References a same-namespace credential.\nSet only `name` to reference a Kubernetes Secret.",
+                                                          "properties": {
+                                                            "group": {
+                                                              "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                                                              "type": "string"
+                                                            },
+                                                            "kind": {
+                                                              "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                                                              "type": "string"
+                                                            },
+                                                            "name": {
+                                                              "description": "The name of the referenced credential.",
+                                                              "maxLength": 253,
+                                                              "minLength": 1,
+                                                              "type": "string"
+                                                            }
+                                                          },
+                                                          "required": [
+                                                            "name"
+                                                          ],
+                                                          "type": "object",
+                                                          "x-kubernetes-map-type": "atomic",
+                                                          "x-kubernetes-validations": [
+                                                            {
+                                                              "message": "custom credential refs must set both group and kind",
+                                                              "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                                                            }
+                                                          ],
+                                                          "additionalProperties": false
+                                                        },
+                                                        "maxItems": 1,
+                                                        "type": "array",
+                                                        "x-kubernetes-list-type": "atomic"
+                                                      },
+                                                      "sni": {
+                                                        "description": "Server Name Indicator (`SNI`) to use in the TLS\nhandshake. If unset, the `SNI` is automatically set based on the\ndestination hostname.",
+                                                        "maxLength": 253,
+                                                        "minLength": 1,
+                                                        "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                                                        "type": "string"
+                                                      },
+                                                      "verifySubjectAltNames": {
+                                                        "description": "Subject Alternative Names (`SAN`)\nto verify in the server certificate.\nIf not present, the destination hostname is automatically used.",
+                                                        "items": {
+                                                          "maxLength": 256,
+                                                          "minLength": 1,
+                                                          "type": "string"
+                                                        },
+                                                        "maxItems": 16,
+                                                        "minItems": 1,
+                                                        "type": "array"
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "x-kubernetes-validations": [
+                                                      {
+                                                        "message": "insecureSkipVerify All and caCertificateRefs may not be set together",
+                                                        "rule": "has(self.insecureSkipVerify) && self.insecureSkipVerify == 'All' ? !has(self.caCertificateRefs) : true"
+                                                      },
+                                                      {
+                                                        "message": "insecureSkipVerify and verifySubjectAltNames may not be set together",
+                                                        "rule": "has(self.insecureSkipVerify) ? !has(self.verifySubjectAltNames) : true"
+                                                      },
+                                                      {
+                                                        "message": "at most one of the fields in [verifySubjectAltNames insecureSkipVerify] may be set",
+                                                        "rule": "[has(self.verifySubjectAltNames),has(self.insecureSkipVerify)].filter(x,x==true).size() <= 1"
+                                                      }
+                                                    ],
+                                                    "additionalProperties": false
+                                                  },
+                                                  "tunnel": {
+                                                    "description": "Settings for managing tunnel connections, with behavior like `HTTPS_PROXY`, to the backend.",
+                                                    "properties": {
+                                                      "backendRef": {
+                                                        "description": "Proxy server to reach.\nSupported types: `Service` and `Backend`.",
+                                                        "properties": {
+                                                          "group": {
+                                                            "default": "",
+                                                            "description": "Group is the group of the referent. For example, \"gateway.networking.k8s.io\".\nWhen unspecified or empty string, core API group is inferred.",
+                                                            "maxLength": 253,
+                                                            "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                                                            "type": "string"
+                                                          },
+                                                          "kind": {
+                                                            "default": "Service",
+                                                            "description": "Kind is the Kubernetes resource kind of the referent. For example\n\"Service\".\n\nDefaults to \"Service\" when not specified.\n\nExternalName services can refer to CNAME DNS records that may live\noutside of the cluster and as such are difficult to reason about in\nterms of conformance. They also may not be safe to forward to (see\nCVE-2021-25740 for more information). Implementations SHOULD NOT\nsupport ExternalName Services.\n\nSupport: Core (Services with a type other than ExternalName)\n\nSupport: Implementation-specific (Services with type ExternalName)",
+                                                            "maxLength": 63,
+                                                            "minLength": 1,
+                                                            "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
+                                                            "type": "string"
+                                                          },
+                                                          "name": {
+                                                            "description": "Name is the name of the referent.",
+                                                            "maxLength": 253,
+                                                            "minLength": 1,
+                                                            "type": "string"
+                                                          },
+                                                          "namespace": {
+                                                            "description": "Namespace is the namespace of the backend. When unspecified, the local\nnamespace is inferred.\n\nNote that when a namespace different than the local namespace is specified,\na ReferenceGrant object is required in the referent namespace to allow that\nnamespace's owner to accept the reference. See the ReferenceGrant\ndocumentation for details.\n\nSupport: Core",
+                                                            "maxLength": 63,
+                                                            "minLength": 1,
+                                                            "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                                                            "type": "string"
+                                                          },
+                                                          "port": {
+                                                            "description": "Port specifies the destination port number to use for this resource.\nPort is required when the referent is a Kubernetes Service. In this\ncase, the port number is the service port number, not the target port.\nFor other resources, destination port might be derived from the referent\nresource or this field.",
+                                                            "format": "int32",
+                                                            "maximum": 65535,
+                                                            "minimum": 1,
+                                                            "type": "integer"
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "name"
+                                                        ],
+                                                        "type": "object",
+                                                        "x-kubernetes-validations": [
+                                                          {
+                                                            "message": "Must have port for Service reference",
+                                                            "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
+                                                          }
+                                                        ],
+                                                        "additionalProperties": false
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "backendRef"
+                                                    ],
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "projectId": {
+                                                "description": "Google Cloud project ID.",
+                                                "maxLength": 256,
+                                                "minLength": 1,
+                                                "type": "string"
+                                              },
+                                              "templateId": {
+                                                "description": "Template ID for Google Model Armor.",
+                                                "maxLength": 256,
+                                                "minLength": 1,
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "projectId",
+                                              "templateId"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "openAIModeration": {
+                                            "description": "Passes prompt data through the OpenAI Moderations\nendpoint.\nSee https://developers.openai.com/api/reference/resources/moderations for more information.",
+                                            "properties": {
+                                              "model": {
+                                                "description": "Moderation model to use. For example,\n`omni-moderation`.",
+                                                "type": "string"
+                                              },
+                                              "policies": {
+                                                "description": "Policies for communicating with OpenAI.",
+                                                "properties": {
+                                                  "auth": {
+                                                    "description": "Settings for managing authentication to the backend.",
+                                                    "properties": {
+                                                      "aws": {
+                                                        "description": "Explicit AWS authentication method for the backend.\nWhen omitted, default AWS SDK credential discovery is used.",
+                                                        "properties": {
+                                                          "assumeRole": {
+                                                            "description": "AWS STS AssumeRole settings to use before signing backend requests.\nAmbient AWS credentials are used as the source credentials for STS.",
+                                                            "properties": {
+                                                              "roleArn": {
+                                                                "description": "AWS IAM role ARN to assume.",
+                                                                "minLength": 1,
+                                                                "pattern": "^arn:aws[a-z-]*:iam::[0-9]{12}:role/.+$",
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "roleArn"
+                                                            ],
+                                                            "type": "object",
+                                                            "additionalProperties": false
+                                                          },
+                                                          "secretRef": {
+                                                            "description": "Credential source, defaulting to a Kubernetes\n`Secret`, containing the AWS credentials. When using the default Secret\nresolver, the `Secret` must have keys `accessKey`, `secretKey`, and\noptionally `sessionToken`.",
+                                                            "properties": {
+                                                              "group": {
+                                                                "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                                                                "type": "string"
+                                                              },
+                                                              "kind": {
+                                                                "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                                                                "type": "string"
+                                                              },
+                                                              "name": {
+                                                                "description": "The name of the referenced credential.",
+                                                                "maxLength": 253,
+                                                                "minLength": 1,
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "name"
+                                                            ],
+                                                            "type": "object",
+                                                            "x-kubernetes-map-type": "atomic",
+                                                            "x-kubernetes-validations": [
+                                                              {
+                                                                "message": "custom credential refs must set both group and kind",
+                                                                "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                                                              }
+                                                            ],
+                                                            "additionalProperties": false
+                                                          },
+                                                          "serviceName": {
+                                                            "description": "AWS SigV4 signing service name, for example\n`bedrock`, `bedrock-agentcore`, or `execute-api`). If unset, typed AWS\nbackends may provide this automatically.",
+                                                            "maxLength": 256,
+                                                            "minLength": 1,
+                                                            "type": "string"
+                                                          }
+                                                        },
+                                                        "type": "object",
+                                                        "x-kubernetes-validations": [
+                                                          {
+                                                            "message": "secretRef and assumeRole are mutually exclusive",
+                                                            "rule": "!(has(self.secretRef) && has(self.assumeRole))"
+                                                          }
+                                                        ],
+                                                        "additionalProperties": false
+                                                      },
+                                                      "azure": {
+                                                        "description": "Azure authentication method for the backend.",
+                                                        "properties": {
+                                                          "managedIdentity": {
+                                                            "description": "Managed identity authentication settings.",
+                                                            "properties": {
+                                                              "clientId": {
+                                                                "type": "string"
+                                                              },
+                                                              "objectId": {
+                                                                "type": "string"
+                                                              },
+                                                              "resourceId": {
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "clientId",
+                                                              "objectId",
+                                                              "resourceId"
+                                                            ],
+                                                            "type": "object",
+                                                            "additionalProperties": false
+                                                          },
+                                                          "secretRef": {
+                                                            "description": "Credential source, defaulting to a Kubernetes\n`Secret`, containing the Azure credentials. When using the default Secret\nresolver, the `Secret` must have keys `clientID`, `tenantID`, and\n`clientSecret`.",
+                                                            "properties": {
+                                                              "group": {
+                                                                "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                                                                "type": "string"
+                                                              },
+                                                              "kind": {
+                                                                "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                                                                "type": "string"
+                                                              },
+                                                              "name": {
+                                                                "description": "The name of the referenced credential.",
+                                                                "maxLength": 253,
+                                                                "minLength": 1,
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "name"
+                                                            ],
+                                                            "type": "object",
+                                                            "x-kubernetes-map-type": "atomic",
+                                                            "x-kubernetes-validations": [
+                                                              {
+                                                                "message": "custom credential refs must set both group and kind",
+                                                                "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                                                              }
+                                                            ],
+                                                            "additionalProperties": false
+                                                          }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                      },
+                                                      "gcp": {
+                                                        "description": "Google authentication method for the backend.\nWhen omitted, default Google credential discovery is used.",
+                                                        "properties": {
+                                                          "audience": {
+                                                            "description": "Explicit `aud` value for the ID token. Only\nvalid with `IdToken` type. If not set, the `aud` is automatically\nderived from the backend hostname.",
+                                                            "maxLength": 256,
+                                                            "minLength": 1,
+                                                            "type": "string"
+                                                          },
+                                                          "secretRef": {
+                                                            "description": "Credential source, defaulting to a Kubernetes\n`Secret`, containing ADC-compatible Google credential JSON. When using\nthe default Secret resolver, this must be stored in the `credentials.json`\nkey. When omitted, ambient credentials are used.",
+                                                            "properties": {
+                                                              "group": {
+                                                                "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                                                                "type": "string"
+                                                              },
+                                                              "kind": {
+                                                                "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                                                                "type": "string"
+                                                              },
+                                                              "name": {
+                                                                "description": "The name of the referenced credential.",
+                                                                "maxLength": 253,
+                                                                "minLength": 1,
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "name"
+                                                            ],
+                                                            "type": "object",
+                                                            "x-kubernetes-map-type": "atomic",
+                                                            "x-kubernetes-validations": [
+                                                              {
+                                                                "message": "custom credential refs must set both group and kind",
+                                                                "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                                                              }
+                                                            ],
+                                                            "additionalProperties": false
+                                                          },
+                                                          "type": {
+                                                            "description": "The type of token to generate. To authenticate to GCP services,\ngenerally an `AccessToken` is used. To authenticate to Cloud Run, an\n`IdToken` is used.",
+                                                            "enum": [
+                                                              "AccessToken",
+                                                              "IdToken"
+                                                            ],
+                                                            "type": "string"
+                                                          }
+                                                        },
+                                                        "type": "object",
+                                                        "x-kubernetes-validations": [
+                                                          {
+                                                            "message": "audience is only valid with IdToken",
+                                                            "rule": "has(self.audience) ? self.type == 'IdToken' : true"
+                                                          }
+                                                        ],
+                                                        "additionalProperties": false
+                                                      },
+                                                      "key": {
+                                                        "description": "Inline key to use as the value of the\n`Authorization` header. This option is the least secure; usage of a\n`Secret` is preferred.",
+                                                        "maxLength": 2048,
+                                                        "type": "string"
+                                                      },
+                                                      "location": {
+                                                        "description": "Where backend credentials are inserted.\nIf omitted, credentials are written to the `Authorization` header with the `Bearer ` prefix.\nThis applies to `key`, `secretRef`, and `passthrough`.",
+                                                        "properties": {
+                                                          "cookie": {
+                                                            "properties": {
+                                                              "name": {
+                                                                "maxLength": 256,
+                                                                "minLength": 1,
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "name"
+                                                            ],
+                                                            "type": "object",
+                                                            "additionalProperties": false
+                                                          },
+                                                          "header": {
+                                                            "properties": {
+                                                              "name": {
+                                                                "description": "HTTPHeaderName is the name of an HTTP header.\n\nValid values include:\n\n* \"Authorization\"\n* \"Set-Cookie\"\n\nInvalid values include:\n\n  - \":method\" - \":\" is an invalid character. This means that HTTP/2 pseudo\n    headers are not currently supported by this type.\n  - \"/invalid\" - \"/ \" is an invalid character",
+                                                                "maxLength": 256,
+                                                                "minLength": 1,
+                                                                "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                                                                "type": "string"
+                                                              },
+                                                              "prefix": {
+                                                                "maxLength": 256,
+                                                                "minLength": 1,
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "name"
+                                                            ],
+                                                            "type": "object",
+                                                            "additionalProperties": false
+                                                          },
+                                                          "queryParameter": {
+                                                            "properties": {
+                                                              "name": {
+                                                                "maxLength": 256,
+                                                                "minLength": 1,
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "name"
+                                                            ],
+                                                            "type": "object",
+                                                            "additionalProperties": false
+                                                          }
+                                                        },
+                                                        "type": "object",
+                                                        "x-kubernetes-validations": [
+                                                          {
+                                                            "message": "exactly one of the fields in [header queryParameter cookie] must be set",
+                                                            "rule": "[has(self.header),has(self.queryParameter),has(self.cookie)].filter(x,x==true).size() == 1"
+                                                          }
+                                                        ],
+                                                        "additionalProperties": false
+                                                      },
+                                                      "passthrough": {
+                                                        "description": "Passes through an existing token that has been sent by the\nclient and validated. Other policies, like JWT and API key\nauthentication, will strip the original client credentials. Passthrough backend authentication\ncauses the original token to be added back into the request. If there are no client authentication policies on the\nrequest, the original token would be unchanged, so this would have no effect.",
+                                                        "type": "object"
+                                                      },
+                                                      "secretRef": {
+                                                        "description": "Credential source, defaulting to a Kubernetes\n`Secret`, storing the key to use as the authorization value. When using\nthe default Secret resolver, this must be stored in the `Authorization`\nkey.",
+                                                        "properties": {
+                                                          "group": {
+                                                            "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                                                            "type": "string"
+                                                          },
+                                                          "kind": {
+                                                            "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                                                            "type": "string"
+                                                          },
+                                                          "name": {
+                                                            "description": "The name of the referenced credential.",
+                                                            "maxLength": 253,
+                                                            "minLength": 1,
+                                                            "type": "string"
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "name"
+                                                        ],
+                                                        "type": "object",
+                                                        "x-kubernetes-map-type": "atomic",
+                                                        "x-kubernetes-validations": [
+                                                          {
+                                                            "message": "custom credential refs must set both group and kind",
+                                                            "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                                                          }
+                                                        ],
+                                                        "additionalProperties": false
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "x-kubernetes-validations": [
+                                                      {
+                                                        "message": "location may only be set for key or passthrough auth",
+                                                        "rule": "has(self.location) ? has(self.key) || has(self.secretRef) || has(self.passthrough) : true"
+                                                      },
+                                                      {
+                                                        "message": "exactly one of the fields in [key secretRef passthrough aws azure gcp] must be set",
+                                                        "rule": "[has(self.key),has(self.secretRef),has(self.passthrough),has(self.aws),has(self.azure),has(self.gcp)].filter(x,x==true).size() == 1"
+                                                      }
+                                                    ],
+                                                    "additionalProperties": false
+                                                  },
+                                                  "http": {
+                                                    "description": "Settings for managing HTTP requests to the backend.",
+                                                    "properties": {
+                                                      "requestTimeout": {
+                                                        "description": "Deadline for receiving a response from the backend.",
+                                                        "type": "string",
+                                                        "x-kubernetes-validations": [
+                                                          {
+                                                            "message": "invalid duration value",
+                                                            "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                                          },
+                                                          {
+                                                            "message": "requestTimeout must be at least 1ms",
+                                                            "rule": "duration(self) >= duration('1ms')"
+                                                          }
+                                                        ]
+                                                      },
+                                                      "version": {
+                                                        "description": "HTTP protocol version to use when connecting to\nthe backend.\nIf not specified, the version is automatically determined:\n* `Service` types can specify it with `appProtocol` on the `Service`\n  port.\n* If traffic is identified as gRPC, `HTTP2` is used.\n* If the incoming traffic was plaintext HTTP, the original protocol will\n  be used.\n* If the incoming traffic was HTTPS, `HTTP1` will be used. This is\n  because most clients will transparently upgrade HTTPS traffic to\n  `HTTP2`, even if the backend doesn't support it.",
+                                                        "enum": [
+                                                          "HTTP1",
+                                                          "HTTP2"
+                                                        ],
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "tcp": {
+                                                    "description": "Settings for managing TCP connections to the backend.",
+                                                    "properties": {
+                                                      "connectTimeout": {
+                                                        "description": "Deadline for establishing a connection to\nthe destination.",
+                                                        "type": "string",
+                                                        "x-kubernetes-validations": [
+                                                          {
+                                                            "message": "invalid duration value",
+                                                            "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                                          },
+                                                          {
+                                                            "message": "connectTimeout must be at least 100ms",
+                                                            "rule": "duration(self) >= duration('100ms')"
+                                                          }
+                                                        ]
+                                                      },
+                                                      "keepalive": {
+                                                        "description": "Settings for enabling TCP keepalives on the\nconnection.",
+                                                        "properties": {
+                                                          "interval": {
+                                                            "description": "Time between keepalive probes.\nIf unset, this defaults to 180s.",
+                                                            "type": "string",
+                                                            "x-kubernetes-validations": [
+                                                              {
+                                                                "message": "invalid duration value",
+                                                                "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                                              },
+                                                              {
+                                                                "message": "interval must be at least 1 second",
+                                                                "rule": "duration(self) >= duration('1s')"
+                                                              }
+                                                            ]
+                                                          },
+                                                          "retries": {
+                                                            "description": "Maximum number of keepalive probes to send before dropping the connection.\nIf unset, this defaults to 9.",
+                                                            "format": "int32",
+                                                            "maximum": 64,
+                                                            "minimum": 1,
+                                                            "type": "integer"
+                                                          },
+                                                          "time": {
+                                                            "description": "Time a connection needs to be idle before keepalive probes start being sent.\nIf unset, this defaults to 180s.",
+                                                            "type": "string",
+                                                            "x-kubernetes-validations": [
+                                                              {
+                                                                "message": "invalid duration value",
+                                                                "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                                              },
+                                                              {
+                                                                "message": "time must be at least 1 second",
+                                                                "rule": "duration(self) >= duration('1s')"
+                                                              }
+                                                            ]
+                                                          }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "tls": {
+                                                    "description": "Settings for managing TLS connections to the backend.\n\nIf this field is set, TLS will be initiated to the backend; the system trusted CA certificates will be used to\nvalidate the server, and the SNI will automatically be set based on the destination.",
+                                                    "properties": {
+                                                      "alpnProtocols": {
+                                                        "description": "Application-Layer Protocol Negotiation (`ALPN`)\nvalue to use in the TLS handshake.\n\nIf not present, defaults to `[\"h2\", \"http/1.1\"]`.",
+                                                        "items": {
+                                                          "maxLength": 64,
+                                                          "minLength": 1,
+                                                          "type": "string"
+                                                        },
+                                                        "maxItems": 16,
+                                                        "minItems": 1,
+                                                        "type": "array"
+                                                      },
+                                                      "caCertificateRefs": {
+                                                        "description": "CA certificate `ConfigMap` to use to\nverify the server certificate.\nIf unset, the system's trusted certificates are used.",
+                                                        "items": {
+                                                          "description": "LocalObjectReference contains enough information to let you locate the\nreferenced object inside the same namespace.",
+                                                          "properties": {
+                                                            "name": {
+                                                              "default": "",
+                                                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                                              "type": "string"
+                                                            }
+                                                          },
+                                                          "type": "object",
+                                                          "x-kubernetes-map-type": "atomic",
+                                                          "additionalProperties": false
+                                                        },
+                                                        "maxItems": 1,
+                                                        "type": "array",
+                                                        "x-kubernetes-list-type": "atomic"
+                                                      },
+                                                      "insecureSkipVerify": {
+                                                        "description": "Originates TLS but skips verification of the backend's certificate.\nWARNING: This is an insecure option that should only be used if the risks are understood.\n\nThere are two modes:\n* `All` disables all TLS verification.\n* `Hostname` verifies the CA certificate is trusted, but ignores any\n  mismatch of hostname or SANs. Note that this method is still insecure;\n  prefer setting `verifySubjectAltNames` to customize the valid hostnames\n  if possible.",
+                                                        "enum": [
+                                                          "All",
+                                                          "Hostname"
+                                                        ],
+                                                        "type": "string"
+                                                      },
+                                                      "keyExchangeGroups": {
+                                                        "description": "Ordered list of key exchange groups for a TLS connection.\nFor example: `X25519_MLKEM768,X25519`.",
+                                                        "items": {
+                                                          "enum": [
+                                                            "P-256",
+                                                            "P-384",
+                                                            "X25519",
+                                                            "X25519_MLKEM768"
+                                                          ],
+                                                          "type": "string"
+                                                        },
+                                                        "type": "array"
+                                                      },
+                                                      "mtlsCertificateRef": {
+                                                        "description": "Enables mutual TLS to the backend, using the\nspecified key (`tls.key`) and cert (`tls.crt`) from the referenced\ncredential source, defaulting to a Kubernetes `Secret`.\n\nAn optional `ca.cert` field, if present, will be used to verify the\nserver certificate. If `caCertificateRefs` is also specified, the\n`caCertificateRefs` field takes priority.\n\nIf unspecified, no client certificate will be used.",
+                                                        "items": {
+                                                          "description": "References a same-namespace credential.\nSet only `name` to reference a Kubernetes Secret.",
+                                                          "properties": {
+                                                            "group": {
+                                                              "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                                                              "type": "string"
+                                                            },
+                                                            "kind": {
+                                                              "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                                                              "type": "string"
+                                                            },
+                                                            "name": {
+                                                              "description": "The name of the referenced credential.",
+                                                              "maxLength": 253,
+                                                              "minLength": 1,
+                                                              "type": "string"
+                                                            }
+                                                          },
+                                                          "required": [
+                                                            "name"
+                                                          ],
+                                                          "type": "object",
+                                                          "x-kubernetes-map-type": "atomic",
+                                                          "x-kubernetes-validations": [
+                                                            {
+                                                              "message": "custom credential refs must set both group and kind",
+                                                              "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                                                            }
+                                                          ],
+                                                          "additionalProperties": false
+                                                        },
+                                                        "maxItems": 1,
+                                                        "type": "array",
+                                                        "x-kubernetes-list-type": "atomic"
+                                                      },
+                                                      "sni": {
+                                                        "description": "Server Name Indicator (`SNI`) to use in the TLS\nhandshake. If unset, the `SNI` is automatically set based on the\ndestination hostname.",
+                                                        "maxLength": 253,
+                                                        "minLength": 1,
+                                                        "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                                                        "type": "string"
+                                                      },
+                                                      "verifySubjectAltNames": {
+                                                        "description": "Subject Alternative Names (`SAN`)\nto verify in the server certificate.\nIf not present, the destination hostname is automatically used.",
+                                                        "items": {
+                                                          "maxLength": 256,
+                                                          "minLength": 1,
+                                                          "type": "string"
+                                                        },
+                                                        "maxItems": 16,
+                                                        "minItems": 1,
+                                                        "type": "array"
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "x-kubernetes-validations": [
+                                                      {
+                                                        "message": "insecureSkipVerify All and caCertificateRefs may not be set together",
+                                                        "rule": "has(self.insecureSkipVerify) && self.insecureSkipVerify == 'All' ? !has(self.caCertificateRefs) : true"
+                                                      },
+                                                      {
+                                                        "message": "insecureSkipVerify and verifySubjectAltNames may not be set together",
+                                                        "rule": "has(self.insecureSkipVerify) ? !has(self.verifySubjectAltNames) : true"
+                                                      },
+                                                      {
+                                                        "message": "at most one of the fields in [verifySubjectAltNames insecureSkipVerify] may be set",
+                                                        "rule": "[has(self.verifySubjectAltNames),has(self.insecureSkipVerify)].filter(x,x==true).size() <= 1"
+                                                      }
+                                                    ],
+                                                    "additionalProperties": false
+                                                  },
+                                                  "tunnel": {
+                                                    "description": "Settings for managing tunnel connections, with behavior like `HTTPS_PROXY`, to the backend.",
+                                                    "properties": {
+                                                      "backendRef": {
+                                                        "description": "Proxy server to reach.\nSupported types: `Service` and `Backend`.",
+                                                        "properties": {
+                                                          "group": {
+                                                            "default": "",
+                                                            "description": "Group is the group of the referent. For example, \"gateway.networking.k8s.io\".\nWhen unspecified or empty string, core API group is inferred.",
+                                                            "maxLength": 253,
+                                                            "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                                                            "type": "string"
+                                                          },
+                                                          "kind": {
+                                                            "default": "Service",
+                                                            "description": "Kind is the Kubernetes resource kind of the referent. For example\n\"Service\".\n\nDefaults to \"Service\" when not specified.\n\nExternalName services can refer to CNAME DNS records that may live\noutside of the cluster and as such are difficult to reason about in\nterms of conformance. They also may not be safe to forward to (see\nCVE-2021-25740 for more information). Implementations SHOULD NOT\nsupport ExternalName Services.\n\nSupport: Core (Services with a type other than ExternalName)\n\nSupport: Implementation-specific (Services with type ExternalName)",
+                                                            "maxLength": 63,
+                                                            "minLength": 1,
+                                                            "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
+                                                            "type": "string"
+                                                          },
+                                                          "name": {
+                                                            "description": "Name is the name of the referent.",
+                                                            "maxLength": 253,
+                                                            "minLength": 1,
+                                                            "type": "string"
+                                                          },
+                                                          "namespace": {
+                                                            "description": "Namespace is the namespace of the backend. When unspecified, the local\nnamespace is inferred.\n\nNote that when a namespace different than the local namespace is specified,\na ReferenceGrant object is required in the referent namespace to allow that\nnamespace's owner to accept the reference. See the ReferenceGrant\ndocumentation for details.\n\nSupport: Core",
+                                                            "maxLength": 63,
+                                                            "minLength": 1,
+                                                            "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                                                            "type": "string"
+                                                          },
+                                                          "port": {
+                                                            "description": "Port specifies the destination port number to use for this resource.\nPort is required when the referent is a Kubernetes Service. In this\ncase, the port number is the service port number, not the target port.\nFor other resources, destination port might be derived from the referent\nresource or this field.",
+                                                            "format": "int32",
+                                                            "maximum": 65535,
+                                                            "minimum": 1,
+                                                            "type": "integer"
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "name"
+                                                        ],
+                                                        "type": "object",
+                                                        "x-kubernetes-validations": [
+                                                          {
+                                                            "message": "Must have port for Service reference",
+                                                            "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
+                                                          }
+                                                        ],
+                                                        "additionalProperties": false
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "backendRef"
+                                                    ],
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "regex": {
+                                            "description": "Regular expression (regex) matching for prompt guards and data masking.",
+                                            "properties": {
+                                              "action": {
+                                                "default": "Mask",
+                                                "description": "The action to take if a regex pattern is matched in a request or response.\nThis setting applies only to request matches. `PromptguardResponse`\nmatches are always masked by default.\nDefaults to `Mask`.",
+                                                "enum": [
+                                                  "Mask",
+                                                  "Reject"
+                                                ],
+                                                "type": "string"
+                                              },
+                                              "builtins": {
+                                                "description": "Built-in regex patterns to match against the request or response.\nMatches and built-ins are additive.",
+                                                "items": {
+                                                  "description": "Built-in regex patterns for specific types of strings in prompts.\nFor example, if you specify `CreditCard`, any credit card numbers\nin the request or response are matched.",
+                                                  "enum": [
+                                                    "CaSin",
+                                                    "CreditCard",
+                                                    "Email",
+                                                    "PhoneNumber",
+                                                    "Ssn"
+                                                  ],
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              },
+                                              "matches": {
+                                                "description": "Regex patterns to match against the request or response.\nMatches and built-ins are additive.",
+                                                "items": {
+                                                  "maxLength": 1024,
+                                                  "minLength": 1,
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "response": {
+                                            "description": "Custom response message to return to the client. If not specified, defaults to\n`The request was rejected due to inappropriate content`.",
+                                            "properties": {
+                                              "message": {
+                                                "default": "The request was rejected due to inappropriate content",
+                                                "description": "Custom response message to return to the client. If not specified, defaults to\n`The request was rejected due to inappropriate content`.",
+                                                "type": "string"
+                                              },
+                                              "statusCode": {
+                                                "default": 403,
+                                                "description": "Status code to return to the client. Defaults to 403.",
+                                                "format": "int32",
+                                                "maximum": 599,
+                                                "minimum": 200,
+                                                "type": "integer"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "x-kubernetes-validations": [
+                                              {
+                                                "message": "at least one of the fields in [message statusCode] must be set",
+                                                "rule": "[has(self.message),has(self.statusCode)].filter(x,x==true).size() >= 1"
+                                              }
+                                            ],
+                                            "additionalProperties": false
+                                          },
+                                          "webhook": {
+                                            "description": "Webhook that receives requests for prompt guarding.",
+                                            "properties": {
+                                              "backendRef": {
+                                                "description": "Webhook server to reach.\n\nSupported types: Service and Backend.",
+                                                "properties": {
+                                                  "group": {
+                                                    "default": "",
+                                                    "description": "Group is the group of the referent. For example, \"gateway.networking.k8s.io\".\nWhen unspecified or empty string, core API group is inferred.",
+                                                    "maxLength": 253,
+                                                    "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                                                    "type": "string"
+                                                  },
+                                                  "kind": {
+                                                    "default": "Service",
+                                                    "description": "Kind is the Kubernetes resource kind of the referent. For example\n\"Service\".\n\nDefaults to \"Service\" when not specified.\n\nExternalName services can refer to CNAME DNS records that may live\noutside of the cluster and as such are difficult to reason about in\nterms of conformance. They also may not be safe to forward to (see\nCVE-2021-25740 for more information). Implementations SHOULD NOT\nsupport ExternalName Services.\n\nSupport: Core (Services with a type other than ExternalName)\n\nSupport: Implementation-specific (Services with type ExternalName)",
+                                                    "maxLength": 63,
+                                                    "minLength": 1,
+                                                    "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "description": "Name is the name of the referent.",
+                                                    "maxLength": 253,
+                                                    "minLength": 1,
+                                                    "type": "string"
+                                                  },
+                                                  "namespace": {
+                                                    "description": "Namespace is the namespace of the backend. When unspecified, the local\nnamespace is inferred.\n\nNote that when a namespace different than the local namespace is specified,\na ReferenceGrant object is required in the referent namespace to allow that\nnamespace's owner to accept the reference. See the ReferenceGrant\ndocumentation for details.\n\nSupport: Core",
+                                                    "maxLength": 63,
+                                                    "minLength": 1,
+                                                    "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                                                    "type": "string"
+                                                  },
+                                                  "port": {
+                                                    "description": "Port specifies the destination port number to use for this resource.\nPort is required when the referent is a Kubernetes Service. In this\ncase, the port number is the service port number, not the target port.\nFor other resources, destination port might be derived from the referent\nresource or this field.",
+                                                    "format": "int32",
+                                                    "maximum": 65535,
+                                                    "minimum": 1,
+                                                    "type": "integer"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "name"
+                                                ],
+                                                "type": "object",
+                                                "x-kubernetes-validations": [
+                                                  {
+                                                    "message": "Must have port for Service reference",
+                                                    "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
+                                                  }
+                                                ],
+                                                "additionalProperties": false
+                                              },
+                                              "failureMode": {
+                                                "description": "Behavior when the webhook guardrail is unavailable\nor returns an error. `FailOpen` allows the request to continue.\n`FailClosed` (default) rejects the request.",
+                                                "enum": [
+                                                  "FailClosed",
+                                                  "FailOpen"
+                                                ],
+                                                "type": "string"
+                                              },
+                                              "forwardHeaderMatches": {
+                                                "description": "HTTP header matches used to select the headers to forward to the webhook.\nRequest headers are used when forwarding requests and response headers\nare used when forwarding responses.\nBy default, no headers are forwarded.",
+                                                "items": {
+                                                  "description": "HTTPHeaderMatch describes how to select a HTTP route by matching HTTP request\nheaders.",
+                                                  "properties": {
+                                                    "name": {
+                                                      "description": "Name is the name of the HTTP Header to be matched. Name matching MUST be\ncase-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).\n\nIf multiple entries specify equivalent header names, only the first\nentry with an equivalent name MUST be considered for a match. Subsequent\nentries with an equivalent header name MUST be ignored. Due to the\ncase-insensitivity of header names, \"foo\" and \"Foo\" are considered\nequivalent.\n\nWhen a header is repeated in an HTTP request, it is\nimplementation-specific behavior as to how this is represented.\nGenerally, proxies should follow the guidance from the RFC:\nhttps://www.rfc-editor.org/rfc/rfc7230.html#section-3.2.2 regarding\nprocessing a repeated header, with special handling for \"Set-Cookie\".",
+                                                      "maxLength": 256,
+                                                      "minLength": 1,
+                                                      "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                                                      "type": "string"
+                                                    },
+                                                    "type": {
+                                                      "default": "Exact",
+                                                      "description": "Type specifies how to match against the value of the header.\n\nSupport: Core (Exact)\n\nSupport: Implementation-specific (RegularExpression)\n\nSince RegularExpression HeaderMatchType has implementation-specific\nconformance, implementations can support POSIX, PCRE or any other dialects\nof regular expressions. Please read the implementation's documentation to\ndetermine the supported dialect.",
+                                                      "enum": [
+                                                        "Exact",
+                                                        "RegularExpression"
+                                                      ],
+                                                      "type": "string"
+                                                    },
+                                                    "value": {
+                                                      "description": "Value is the value of HTTP Header to be matched.\n<gateway:experimental:description>\nMust consist of printable US-ASCII characters, optionally separated\nby single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2\n</gateway:experimental:description>\n\n<gateway:experimental:validation:Pattern=`^[!-~]+([\\t ]?[!-~]+)*$`>",
+                                                      "maxLength": 4096,
+                                                      "minLength": 1,
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "name",
+                                                    "value"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              }
+                                            },
+                                            "required": [
+                                              "backendRef"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          }
+                                        },
+                                        "type": "object",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "exactly one of the fields in [regex webhook openAIModeration bedrockGuardrails googleModelArmor] must be set",
+                                            "rule": "[has(self.regex),has(self.webhook),has(self.openAIModeration),has(self.bedrockGuardrails),has(self.googleModelArmor)].filter(x,x==true).size() == 1"
+                                          }
+                                        ],
+                                        "additionalProperties": false
+                                      },
+                                      "maxItems": 8,
+                                      "minItems": 1,
+                                      "type": "array"
+                                    },
+                                    "response": {
+                                      "description": "Prompt guards to apply to responses returned by the LLM provider.",
+                                      "items": {
+                                        "description": "Prompt guards to apply to responses returned by the LLM provider.",
+                                        "properties": {
+                                          "bedrockGuardrails": {
+                                            "description": "AWS Bedrock Guardrails settings for prompt\nguarding.",
+                                            "properties": {
+                                              "identifier": {
+                                                "description": "Identifier of the Guardrail policy to use for the backend.",
+                                                "maxLength": 256,
+                                                "minLength": 1,
+                                                "type": "string"
+                                              },
+                                              "policies": {
+                                                "description": "Policies for communicating with AWS Bedrock Guardrails.",
+                                                "properties": {
+                                                  "auth": {
+                                                    "description": "Settings for managing authentication to the backend.",
+                                                    "properties": {
+                                                      "aws": {
+                                                        "description": "Explicit AWS authentication method for the backend.\nWhen omitted, default AWS SDK credential discovery is used.",
+                                                        "properties": {
+                                                          "assumeRole": {
+                                                            "description": "AWS STS AssumeRole settings to use before signing backend requests.\nAmbient AWS credentials are used as the source credentials for STS.",
+                                                            "properties": {
+                                                              "roleArn": {
+                                                                "description": "AWS IAM role ARN to assume.",
+                                                                "minLength": 1,
+                                                                "pattern": "^arn:aws[a-z-]*:iam::[0-9]{12}:role/.+$",
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "roleArn"
+                                                            ],
+                                                            "type": "object",
+                                                            "additionalProperties": false
+                                                          },
+                                                          "secretRef": {
+                                                            "description": "Credential source, defaulting to a Kubernetes\n`Secret`, containing the AWS credentials. When using the default Secret\nresolver, the `Secret` must have keys `accessKey`, `secretKey`, and\noptionally `sessionToken`.",
+                                                            "properties": {
+                                                              "group": {
+                                                                "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                                                                "type": "string"
+                                                              },
+                                                              "kind": {
+                                                                "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                                                                "type": "string"
+                                                              },
+                                                              "name": {
+                                                                "description": "The name of the referenced credential.",
+                                                                "maxLength": 253,
+                                                                "minLength": 1,
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "name"
+                                                            ],
+                                                            "type": "object",
+                                                            "x-kubernetes-map-type": "atomic",
+                                                            "x-kubernetes-validations": [
+                                                              {
+                                                                "message": "custom credential refs must set both group and kind",
+                                                                "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                                                              }
+                                                            ],
+                                                            "additionalProperties": false
+                                                          },
+                                                          "serviceName": {
+                                                            "description": "AWS SigV4 signing service name, for example\n`bedrock`, `bedrock-agentcore`, or `execute-api`). If unset, typed AWS\nbackends may provide this automatically.",
+                                                            "maxLength": 256,
+                                                            "minLength": 1,
+                                                            "type": "string"
+                                                          }
+                                                        },
+                                                        "type": "object",
+                                                        "x-kubernetes-validations": [
+                                                          {
+                                                            "message": "secretRef and assumeRole are mutually exclusive",
+                                                            "rule": "!(has(self.secretRef) && has(self.assumeRole))"
+                                                          }
+                                                        ],
+                                                        "additionalProperties": false
+                                                      },
+                                                      "azure": {
+                                                        "description": "Azure authentication method for the backend.",
+                                                        "properties": {
+                                                          "managedIdentity": {
+                                                            "description": "Managed identity authentication settings.",
+                                                            "properties": {
+                                                              "clientId": {
+                                                                "type": "string"
+                                                              },
+                                                              "objectId": {
+                                                                "type": "string"
+                                                              },
+                                                              "resourceId": {
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "clientId",
+                                                              "objectId",
+                                                              "resourceId"
+                                                            ],
+                                                            "type": "object",
+                                                            "additionalProperties": false
+                                                          },
+                                                          "secretRef": {
+                                                            "description": "Credential source, defaulting to a Kubernetes\n`Secret`, containing the Azure credentials. When using the default Secret\nresolver, the `Secret` must have keys `clientID`, `tenantID`, and\n`clientSecret`.",
+                                                            "properties": {
+                                                              "group": {
+                                                                "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                                                                "type": "string"
+                                                              },
+                                                              "kind": {
+                                                                "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                                                                "type": "string"
+                                                              },
+                                                              "name": {
+                                                                "description": "The name of the referenced credential.",
+                                                                "maxLength": 253,
+                                                                "minLength": 1,
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "name"
+                                                            ],
+                                                            "type": "object",
+                                                            "x-kubernetes-map-type": "atomic",
+                                                            "x-kubernetes-validations": [
+                                                              {
+                                                                "message": "custom credential refs must set both group and kind",
+                                                                "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                                                              }
+                                                            ],
+                                                            "additionalProperties": false
+                                                          }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                      },
+                                                      "gcp": {
+                                                        "description": "Google authentication method for the backend.\nWhen omitted, default Google credential discovery is used.",
+                                                        "properties": {
+                                                          "audience": {
+                                                            "description": "Explicit `aud` value for the ID token. Only\nvalid with `IdToken` type. If not set, the `aud` is automatically\nderived from the backend hostname.",
+                                                            "maxLength": 256,
+                                                            "minLength": 1,
+                                                            "type": "string"
+                                                          },
+                                                          "secretRef": {
+                                                            "description": "Credential source, defaulting to a Kubernetes\n`Secret`, containing ADC-compatible Google credential JSON. When using\nthe default Secret resolver, this must be stored in the `credentials.json`\nkey. When omitted, ambient credentials are used.",
+                                                            "properties": {
+                                                              "group": {
+                                                                "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                                                                "type": "string"
+                                                              },
+                                                              "kind": {
+                                                                "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                                                                "type": "string"
+                                                              },
+                                                              "name": {
+                                                                "description": "The name of the referenced credential.",
+                                                                "maxLength": 253,
+                                                                "minLength": 1,
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "name"
+                                                            ],
+                                                            "type": "object",
+                                                            "x-kubernetes-map-type": "atomic",
+                                                            "x-kubernetes-validations": [
+                                                              {
+                                                                "message": "custom credential refs must set both group and kind",
+                                                                "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                                                              }
+                                                            ],
+                                                            "additionalProperties": false
+                                                          },
+                                                          "type": {
+                                                            "description": "The type of token to generate. To authenticate to GCP services,\ngenerally an `AccessToken` is used. To authenticate to Cloud Run, an\n`IdToken` is used.",
+                                                            "enum": [
+                                                              "AccessToken",
+                                                              "IdToken"
+                                                            ],
+                                                            "type": "string"
+                                                          }
+                                                        },
+                                                        "type": "object",
+                                                        "x-kubernetes-validations": [
+                                                          {
+                                                            "message": "audience is only valid with IdToken",
+                                                            "rule": "has(self.audience) ? self.type == 'IdToken' : true"
+                                                          }
+                                                        ],
+                                                        "additionalProperties": false
+                                                      },
+                                                      "key": {
+                                                        "description": "Inline key to use as the value of the\n`Authorization` header. This option is the least secure; usage of a\n`Secret` is preferred.",
+                                                        "maxLength": 2048,
+                                                        "type": "string"
+                                                      },
+                                                      "location": {
+                                                        "description": "Where backend credentials are inserted.\nIf omitted, credentials are written to the `Authorization` header with the `Bearer ` prefix.\nThis applies to `key`, `secretRef`, and `passthrough`.",
+                                                        "properties": {
+                                                          "cookie": {
+                                                            "properties": {
+                                                              "name": {
+                                                                "maxLength": 256,
+                                                                "minLength": 1,
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "name"
+                                                            ],
+                                                            "type": "object",
+                                                            "additionalProperties": false
+                                                          },
+                                                          "header": {
+                                                            "properties": {
+                                                              "name": {
+                                                                "description": "HTTPHeaderName is the name of an HTTP header.\n\nValid values include:\n\n* \"Authorization\"\n* \"Set-Cookie\"\n\nInvalid values include:\n\n  - \":method\" - \":\" is an invalid character. This means that HTTP/2 pseudo\n    headers are not currently supported by this type.\n  - \"/invalid\" - \"/ \" is an invalid character",
+                                                                "maxLength": 256,
+                                                                "minLength": 1,
+                                                                "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                                                                "type": "string"
+                                                              },
+                                                              "prefix": {
+                                                                "maxLength": 256,
+                                                                "minLength": 1,
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "name"
+                                                            ],
+                                                            "type": "object",
+                                                            "additionalProperties": false
+                                                          },
+                                                          "queryParameter": {
+                                                            "properties": {
+                                                              "name": {
+                                                                "maxLength": 256,
+                                                                "minLength": 1,
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "name"
+                                                            ],
+                                                            "type": "object",
+                                                            "additionalProperties": false
+                                                          }
+                                                        },
+                                                        "type": "object",
+                                                        "x-kubernetes-validations": [
+                                                          {
+                                                            "message": "exactly one of the fields in [header queryParameter cookie] must be set",
+                                                            "rule": "[has(self.header),has(self.queryParameter),has(self.cookie)].filter(x,x==true).size() == 1"
+                                                          }
+                                                        ],
+                                                        "additionalProperties": false
+                                                      },
+                                                      "passthrough": {
+                                                        "description": "Passes through an existing token that has been sent by the\nclient and validated. Other policies, like JWT and API key\nauthentication, will strip the original client credentials. Passthrough backend authentication\ncauses the original token to be added back into the request. If there are no client authentication policies on the\nrequest, the original token would be unchanged, so this would have no effect.",
+                                                        "type": "object"
+                                                      },
+                                                      "secretRef": {
+                                                        "description": "Credential source, defaulting to a Kubernetes\n`Secret`, storing the key to use as the authorization value. When using\nthe default Secret resolver, this must be stored in the `Authorization`\nkey.",
+                                                        "properties": {
+                                                          "group": {
+                                                            "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                                                            "type": "string"
+                                                          },
+                                                          "kind": {
+                                                            "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                                                            "type": "string"
+                                                          },
+                                                          "name": {
+                                                            "description": "The name of the referenced credential.",
+                                                            "maxLength": 253,
+                                                            "minLength": 1,
+                                                            "type": "string"
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "name"
+                                                        ],
+                                                        "type": "object",
+                                                        "x-kubernetes-map-type": "atomic",
+                                                        "x-kubernetes-validations": [
+                                                          {
+                                                            "message": "custom credential refs must set both group and kind",
+                                                            "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                                                          }
+                                                        ],
+                                                        "additionalProperties": false
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "x-kubernetes-validations": [
+                                                      {
+                                                        "message": "location may only be set for key or passthrough auth",
+                                                        "rule": "has(self.location) ? has(self.key) || has(self.secretRef) || has(self.passthrough) : true"
+                                                      },
+                                                      {
+                                                        "message": "exactly one of the fields in [key secretRef passthrough aws azure gcp] must be set",
+                                                        "rule": "[has(self.key),has(self.secretRef),has(self.passthrough),has(self.aws),has(self.azure),has(self.gcp)].filter(x,x==true).size() == 1"
+                                                      }
+                                                    ],
+                                                    "additionalProperties": false
+                                                  },
+                                                  "http": {
+                                                    "description": "Settings for managing HTTP requests to the backend.",
+                                                    "properties": {
+                                                      "requestTimeout": {
+                                                        "description": "Deadline for receiving a response from the backend.",
+                                                        "type": "string",
+                                                        "x-kubernetes-validations": [
+                                                          {
+                                                            "message": "invalid duration value",
+                                                            "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                                          },
+                                                          {
+                                                            "message": "requestTimeout must be at least 1ms",
+                                                            "rule": "duration(self) >= duration('1ms')"
+                                                          }
+                                                        ]
+                                                      },
+                                                      "version": {
+                                                        "description": "HTTP protocol version to use when connecting to\nthe backend.\nIf not specified, the version is automatically determined:\n* `Service` types can specify it with `appProtocol` on the `Service`\n  port.\n* If traffic is identified as gRPC, `HTTP2` is used.\n* If the incoming traffic was plaintext HTTP, the original protocol will\n  be used.\n* If the incoming traffic was HTTPS, `HTTP1` will be used. This is\n  because most clients will transparently upgrade HTTPS traffic to\n  `HTTP2`, even if the backend doesn't support it.",
+                                                        "enum": [
+                                                          "HTTP1",
+                                                          "HTTP2"
+                                                        ],
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "tcp": {
+                                                    "description": "Settings for managing TCP connections to the backend.",
+                                                    "properties": {
+                                                      "connectTimeout": {
+                                                        "description": "Deadline for establishing a connection to\nthe destination.",
+                                                        "type": "string",
+                                                        "x-kubernetes-validations": [
+                                                          {
+                                                            "message": "invalid duration value",
+                                                            "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                                          },
+                                                          {
+                                                            "message": "connectTimeout must be at least 100ms",
+                                                            "rule": "duration(self) >= duration('100ms')"
+                                                          }
+                                                        ]
+                                                      },
+                                                      "keepalive": {
+                                                        "description": "Settings for enabling TCP keepalives on the\nconnection.",
+                                                        "properties": {
+                                                          "interval": {
+                                                            "description": "Time between keepalive probes.\nIf unset, this defaults to 180s.",
+                                                            "type": "string",
+                                                            "x-kubernetes-validations": [
+                                                              {
+                                                                "message": "invalid duration value",
+                                                                "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                                              },
+                                                              {
+                                                                "message": "interval must be at least 1 second",
+                                                                "rule": "duration(self) >= duration('1s')"
+                                                              }
+                                                            ]
+                                                          },
+                                                          "retries": {
+                                                            "description": "Maximum number of keepalive probes to send before dropping the connection.\nIf unset, this defaults to 9.",
+                                                            "format": "int32",
+                                                            "maximum": 64,
+                                                            "minimum": 1,
+                                                            "type": "integer"
+                                                          },
+                                                          "time": {
+                                                            "description": "Time a connection needs to be idle before keepalive probes start being sent.\nIf unset, this defaults to 180s.",
+                                                            "type": "string",
+                                                            "x-kubernetes-validations": [
+                                                              {
+                                                                "message": "invalid duration value",
+                                                                "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                                              },
+                                                              {
+                                                                "message": "time must be at least 1 second",
+                                                                "rule": "duration(self) >= duration('1s')"
+                                                              }
+                                                            ]
+                                                          }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "tls": {
+                                                    "description": "Settings for managing TLS connections to the backend.\n\nIf this field is set, TLS will be initiated to the backend; the system trusted CA certificates will be used to\nvalidate the server, and the SNI will automatically be set based on the destination.",
+                                                    "properties": {
+                                                      "alpnProtocols": {
+                                                        "description": "Application-Layer Protocol Negotiation (`ALPN`)\nvalue to use in the TLS handshake.\n\nIf not present, defaults to `[\"h2\", \"http/1.1\"]`.",
+                                                        "items": {
+                                                          "maxLength": 64,
+                                                          "minLength": 1,
+                                                          "type": "string"
+                                                        },
+                                                        "maxItems": 16,
+                                                        "minItems": 1,
+                                                        "type": "array"
+                                                      },
+                                                      "caCertificateRefs": {
+                                                        "description": "CA certificate `ConfigMap` to use to\nverify the server certificate.\nIf unset, the system's trusted certificates are used.",
+                                                        "items": {
+                                                          "description": "LocalObjectReference contains enough information to let you locate the\nreferenced object inside the same namespace.",
+                                                          "properties": {
+                                                            "name": {
+                                                              "default": "",
+                                                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                                              "type": "string"
+                                                            }
+                                                          },
+                                                          "type": "object",
+                                                          "x-kubernetes-map-type": "atomic",
+                                                          "additionalProperties": false
+                                                        },
+                                                        "maxItems": 1,
+                                                        "type": "array",
+                                                        "x-kubernetes-list-type": "atomic"
+                                                      },
+                                                      "insecureSkipVerify": {
+                                                        "description": "Originates TLS but skips verification of the backend's certificate.\nWARNING: This is an insecure option that should only be used if the risks are understood.\n\nThere are two modes:\n* `All` disables all TLS verification.\n* `Hostname` verifies the CA certificate is trusted, but ignores any\n  mismatch of hostname or SANs. Note that this method is still insecure;\n  prefer setting `verifySubjectAltNames` to customize the valid hostnames\n  if possible.",
+                                                        "enum": [
+                                                          "All",
+                                                          "Hostname"
+                                                        ],
+                                                        "type": "string"
+                                                      },
+                                                      "keyExchangeGroups": {
+                                                        "description": "Ordered list of key exchange groups for a TLS connection.\nFor example: `X25519_MLKEM768,X25519`.",
+                                                        "items": {
+                                                          "enum": [
+                                                            "P-256",
+                                                            "P-384",
+                                                            "X25519",
+                                                            "X25519_MLKEM768"
+                                                          ],
+                                                          "type": "string"
+                                                        },
+                                                        "type": "array"
+                                                      },
+                                                      "mtlsCertificateRef": {
+                                                        "description": "Enables mutual TLS to the backend, using the\nspecified key (`tls.key`) and cert (`tls.crt`) from the referenced\ncredential source, defaulting to a Kubernetes `Secret`.\n\nAn optional `ca.cert` field, if present, will be used to verify the\nserver certificate. If `caCertificateRefs` is also specified, the\n`caCertificateRefs` field takes priority.\n\nIf unspecified, no client certificate will be used.",
+                                                        "items": {
+                                                          "description": "References a same-namespace credential.\nSet only `name` to reference a Kubernetes Secret.",
+                                                          "properties": {
+                                                            "group": {
+                                                              "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                                                              "type": "string"
+                                                            },
+                                                            "kind": {
+                                                              "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                                                              "type": "string"
+                                                            },
+                                                            "name": {
+                                                              "description": "The name of the referenced credential.",
+                                                              "maxLength": 253,
+                                                              "minLength": 1,
+                                                              "type": "string"
+                                                            }
+                                                          },
+                                                          "required": [
+                                                            "name"
+                                                          ],
+                                                          "type": "object",
+                                                          "x-kubernetes-map-type": "atomic",
+                                                          "x-kubernetes-validations": [
+                                                            {
+                                                              "message": "custom credential refs must set both group and kind",
+                                                              "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                                                            }
+                                                          ],
+                                                          "additionalProperties": false
+                                                        },
+                                                        "maxItems": 1,
+                                                        "type": "array",
+                                                        "x-kubernetes-list-type": "atomic"
+                                                      },
+                                                      "sni": {
+                                                        "description": "Server Name Indicator (`SNI`) to use in the TLS\nhandshake. If unset, the `SNI` is automatically set based on the\ndestination hostname.",
+                                                        "maxLength": 253,
+                                                        "minLength": 1,
+                                                        "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                                                        "type": "string"
+                                                      },
+                                                      "verifySubjectAltNames": {
+                                                        "description": "Subject Alternative Names (`SAN`)\nto verify in the server certificate.\nIf not present, the destination hostname is automatically used.",
+                                                        "items": {
+                                                          "maxLength": 256,
+                                                          "minLength": 1,
+                                                          "type": "string"
+                                                        },
+                                                        "maxItems": 16,
+                                                        "minItems": 1,
+                                                        "type": "array"
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "x-kubernetes-validations": [
+                                                      {
+                                                        "message": "insecureSkipVerify All and caCertificateRefs may not be set together",
+                                                        "rule": "has(self.insecureSkipVerify) && self.insecureSkipVerify == 'All' ? !has(self.caCertificateRefs) : true"
+                                                      },
+                                                      {
+                                                        "message": "insecureSkipVerify and verifySubjectAltNames may not be set together",
+                                                        "rule": "has(self.insecureSkipVerify) ? !has(self.verifySubjectAltNames) : true"
+                                                      },
+                                                      {
+                                                        "message": "at most one of the fields in [verifySubjectAltNames insecureSkipVerify] may be set",
+                                                        "rule": "[has(self.verifySubjectAltNames),has(self.insecureSkipVerify)].filter(x,x==true).size() <= 1"
+                                                      }
+                                                    ],
+                                                    "additionalProperties": false
+                                                  },
+                                                  "tunnel": {
+                                                    "description": "Settings for managing tunnel connections, with behavior like `HTTPS_PROXY`, to the backend.",
+                                                    "properties": {
+                                                      "backendRef": {
+                                                        "description": "Proxy server to reach.\nSupported types: `Service` and `Backend`.",
+                                                        "properties": {
+                                                          "group": {
+                                                            "default": "",
+                                                            "description": "Group is the group of the referent. For example, \"gateway.networking.k8s.io\".\nWhen unspecified or empty string, core API group is inferred.",
+                                                            "maxLength": 253,
+                                                            "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                                                            "type": "string"
+                                                          },
+                                                          "kind": {
+                                                            "default": "Service",
+                                                            "description": "Kind is the Kubernetes resource kind of the referent. For example\n\"Service\".\n\nDefaults to \"Service\" when not specified.\n\nExternalName services can refer to CNAME DNS records that may live\noutside of the cluster and as such are difficult to reason about in\nterms of conformance. They also may not be safe to forward to (see\nCVE-2021-25740 for more information). Implementations SHOULD NOT\nsupport ExternalName Services.\n\nSupport: Core (Services with a type other than ExternalName)\n\nSupport: Implementation-specific (Services with type ExternalName)",
+                                                            "maxLength": 63,
+                                                            "minLength": 1,
+                                                            "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
+                                                            "type": "string"
+                                                          },
+                                                          "name": {
+                                                            "description": "Name is the name of the referent.",
+                                                            "maxLength": 253,
+                                                            "minLength": 1,
+                                                            "type": "string"
+                                                          },
+                                                          "namespace": {
+                                                            "description": "Namespace is the namespace of the backend. When unspecified, the local\nnamespace is inferred.\n\nNote that when a namespace different than the local namespace is specified,\na ReferenceGrant object is required in the referent namespace to allow that\nnamespace's owner to accept the reference. See the ReferenceGrant\ndocumentation for details.\n\nSupport: Core",
+                                                            "maxLength": 63,
+                                                            "minLength": 1,
+                                                            "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                                                            "type": "string"
+                                                          },
+                                                          "port": {
+                                                            "description": "Port specifies the destination port number to use for this resource.\nPort is required when the referent is a Kubernetes Service. In this\ncase, the port number is the service port number, not the target port.\nFor other resources, destination port might be derived from the referent\nresource or this field.",
+                                                            "format": "int32",
+                                                            "maximum": 65535,
+                                                            "minimum": 1,
+                                                            "type": "integer"
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "name"
+                                                        ],
+                                                        "type": "object",
+                                                        "x-kubernetes-validations": [
+                                                          {
+                                                            "message": "Must have port for Service reference",
+                                                            "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
+                                                          }
+                                                        ],
+                                                        "additionalProperties": false
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "backendRef"
+                                                    ],
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "region": {
+                                                "description": "AWS region where the guardrail is deployed, for example\n`us-west-2`).",
+                                                "maxLength": 256,
+                                                "minLength": 1,
+                                                "type": "string"
+                                              },
+                                              "version": {
+                                                "description": "Version of the Guardrail policy to use for the backend.",
+                                                "maxLength": 256,
+                                                "minLength": 1,
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "identifier",
+                                              "region",
+                                              "version"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "googleModelArmor": {
+                                            "description": "Google Model Armor settings for prompt guarding.",
+                                            "properties": {
+                                              "location": {
+                                                "default": "us-central1",
+                                                "description": "Google Cloud location, for example `us-central1`.\nDefaults to `us-central1` if not specified.",
+                                                "maxLength": 256,
+                                                "minLength": 1,
+                                                "type": "string"
+                                              },
+                                              "policies": {
+                                                "description": "Policies for communicating with Google Model Armor.",
+                                                "properties": {
+                                                  "auth": {
+                                                    "description": "Settings for managing authentication to the backend.",
+                                                    "properties": {
+                                                      "aws": {
+                                                        "description": "Explicit AWS authentication method for the backend.\nWhen omitted, default AWS SDK credential discovery is used.",
+                                                        "properties": {
+                                                          "assumeRole": {
+                                                            "description": "AWS STS AssumeRole settings to use before signing backend requests.\nAmbient AWS credentials are used as the source credentials for STS.",
+                                                            "properties": {
+                                                              "roleArn": {
+                                                                "description": "AWS IAM role ARN to assume.",
+                                                                "minLength": 1,
+                                                                "pattern": "^arn:aws[a-z-]*:iam::[0-9]{12}:role/.+$",
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "roleArn"
+                                                            ],
+                                                            "type": "object",
+                                                            "additionalProperties": false
+                                                          },
+                                                          "secretRef": {
+                                                            "description": "Credential source, defaulting to a Kubernetes\n`Secret`, containing the AWS credentials. When using the default Secret\nresolver, the `Secret` must have keys `accessKey`, `secretKey`, and\noptionally `sessionToken`.",
+                                                            "properties": {
+                                                              "group": {
+                                                                "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                                                                "type": "string"
+                                                              },
+                                                              "kind": {
+                                                                "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                                                                "type": "string"
+                                                              },
+                                                              "name": {
+                                                                "description": "The name of the referenced credential.",
+                                                                "maxLength": 253,
+                                                                "minLength": 1,
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "name"
+                                                            ],
+                                                            "type": "object",
+                                                            "x-kubernetes-map-type": "atomic",
+                                                            "x-kubernetes-validations": [
+                                                              {
+                                                                "message": "custom credential refs must set both group and kind",
+                                                                "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                                                              }
+                                                            ],
+                                                            "additionalProperties": false
+                                                          },
+                                                          "serviceName": {
+                                                            "description": "AWS SigV4 signing service name, for example\n`bedrock`, `bedrock-agentcore`, or `execute-api`). If unset, typed AWS\nbackends may provide this automatically.",
+                                                            "maxLength": 256,
+                                                            "minLength": 1,
+                                                            "type": "string"
+                                                          }
+                                                        },
+                                                        "type": "object",
+                                                        "x-kubernetes-validations": [
+                                                          {
+                                                            "message": "secretRef and assumeRole are mutually exclusive",
+                                                            "rule": "!(has(self.secretRef) && has(self.assumeRole))"
+                                                          }
+                                                        ],
+                                                        "additionalProperties": false
+                                                      },
+                                                      "azure": {
+                                                        "description": "Azure authentication method for the backend.",
+                                                        "properties": {
+                                                          "managedIdentity": {
+                                                            "description": "Managed identity authentication settings.",
+                                                            "properties": {
+                                                              "clientId": {
+                                                                "type": "string"
+                                                              },
+                                                              "objectId": {
+                                                                "type": "string"
+                                                              },
+                                                              "resourceId": {
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "clientId",
+                                                              "objectId",
+                                                              "resourceId"
+                                                            ],
+                                                            "type": "object",
+                                                            "additionalProperties": false
+                                                          },
+                                                          "secretRef": {
+                                                            "description": "Credential source, defaulting to a Kubernetes\n`Secret`, containing the Azure credentials. When using the default Secret\nresolver, the `Secret` must have keys `clientID`, `tenantID`, and\n`clientSecret`.",
+                                                            "properties": {
+                                                              "group": {
+                                                                "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                                                                "type": "string"
+                                                              },
+                                                              "kind": {
+                                                                "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                                                                "type": "string"
+                                                              },
+                                                              "name": {
+                                                                "description": "The name of the referenced credential.",
+                                                                "maxLength": 253,
+                                                                "minLength": 1,
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "name"
+                                                            ],
+                                                            "type": "object",
+                                                            "x-kubernetes-map-type": "atomic",
+                                                            "x-kubernetes-validations": [
+                                                              {
+                                                                "message": "custom credential refs must set both group and kind",
+                                                                "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                                                              }
+                                                            ],
+                                                            "additionalProperties": false
+                                                          }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                      },
+                                                      "gcp": {
+                                                        "description": "Google authentication method for the backend.\nWhen omitted, default Google credential discovery is used.",
+                                                        "properties": {
+                                                          "audience": {
+                                                            "description": "Explicit `aud` value for the ID token. Only\nvalid with `IdToken` type. If not set, the `aud` is automatically\nderived from the backend hostname.",
+                                                            "maxLength": 256,
+                                                            "minLength": 1,
+                                                            "type": "string"
+                                                          },
+                                                          "secretRef": {
+                                                            "description": "Credential source, defaulting to a Kubernetes\n`Secret`, containing ADC-compatible Google credential JSON. When using\nthe default Secret resolver, this must be stored in the `credentials.json`\nkey. When omitted, ambient credentials are used.",
+                                                            "properties": {
+                                                              "group": {
+                                                                "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                                                                "type": "string"
+                                                              },
+                                                              "kind": {
+                                                                "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                                                                "type": "string"
+                                                              },
+                                                              "name": {
+                                                                "description": "The name of the referenced credential.",
+                                                                "maxLength": 253,
+                                                                "minLength": 1,
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "name"
+                                                            ],
+                                                            "type": "object",
+                                                            "x-kubernetes-map-type": "atomic",
+                                                            "x-kubernetes-validations": [
+                                                              {
+                                                                "message": "custom credential refs must set both group and kind",
+                                                                "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                                                              }
+                                                            ],
+                                                            "additionalProperties": false
+                                                          },
+                                                          "type": {
+                                                            "description": "The type of token to generate. To authenticate to GCP services,\ngenerally an `AccessToken` is used. To authenticate to Cloud Run, an\n`IdToken` is used.",
+                                                            "enum": [
+                                                              "AccessToken",
+                                                              "IdToken"
+                                                            ],
+                                                            "type": "string"
+                                                          }
+                                                        },
+                                                        "type": "object",
+                                                        "x-kubernetes-validations": [
+                                                          {
+                                                            "message": "audience is only valid with IdToken",
+                                                            "rule": "has(self.audience) ? self.type == 'IdToken' : true"
+                                                          }
+                                                        ],
+                                                        "additionalProperties": false
+                                                      },
+                                                      "key": {
+                                                        "description": "Inline key to use as the value of the\n`Authorization` header. This option is the least secure; usage of a\n`Secret` is preferred.",
+                                                        "maxLength": 2048,
+                                                        "type": "string"
+                                                      },
+                                                      "location": {
+                                                        "description": "Where backend credentials are inserted.\nIf omitted, credentials are written to the `Authorization` header with the `Bearer ` prefix.\nThis applies to `key`, `secretRef`, and `passthrough`.",
+                                                        "properties": {
+                                                          "cookie": {
+                                                            "properties": {
+                                                              "name": {
+                                                                "maxLength": 256,
+                                                                "minLength": 1,
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "name"
+                                                            ],
+                                                            "type": "object",
+                                                            "additionalProperties": false
+                                                          },
+                                                          "header": {
+                                                            "properties": {
+                                                              "name": {
+                                                                "description": "HTTPHeaderName is the name of an HTTP header.\n\nValid values include:\n\n* \"Authorization\"\n* \"Set-Cookie\"\n\nInvalid values include:\n\n  - \":method\" - \":\" is an invalid character. This means that HTTP/2 pseudo\n    headers are not currently supported by this type.\n  - \"/invalid\" - \"/ \" is an invalid character",
+                                                                "maxLength": 256,
+                                                                "minLength": 1,
+                                                                "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                                                                "type": "string"
+                                                              },
+                                                              "prefix": {
+                                                                "maxLength": 256,
+                                                                "minLength": 1,
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "name"
+                                                            ],
+                                                            "type": "object",
+                                                            "additionalProperties": false
+                                                          },
+                                                          "queryParameter": {
+                                                            "properties": {
+                                                              "name": {
+                                                                "maxLength": 256,
+                                                                "minLength": 1,
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "name"
+                                                            ],
+                                                            "type": "object",
+                                                            "additionalProperties": false
+                                                          }
+                                                        },
+                                                        "type": "object",
+                                                        "x-kubernetes-validations": [
+                                                          {
+                                                            "message": "exactly one of the fields in [header queryParameter cookie] must be set",
+                                                            "rule": "[has(self.header),has(self.queryParameter),has(self.cookie)].filter(x,x==true).size() == 1"
+                                                          }
+                                                        ],
+                                                        "additionalProperties": false
+                                                      },
+                                                      "passthrough": {
+                                                        "description": "Passes through an existing token that has been sent by the\nclient and validated. Other policies, like JWT and API key\nauthentication, will strip the original client credentials. Passthrough backend authentication\ncauses the original token to be added back into the request. If there are no client authentication policies on the\nrequest, the original token would be unchanged, so this would have no effect.",
+                                                        "type": "object"
+                                                      },
+                                                      "secretRef": {
+                                                        "description": "Credential source, defaulting to a Kubernetes\n`Secret`, storing the key to use as the authorization value. When using\nthe default Secret resolver, this must be stored in the `Authorization`\nkey.",
+                                                        "properties": {
+                                                          "group": {
+                                                            "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                                                            "type": "string"
+                                                          },
+                                                          "kind": {
+                                                            "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                                                            "type": "string"
+                                                          },
+                                                          "name": {
+                                                            "description": "The name of the referenced credential.",
+                                                            "maxLength": 253,
+                                                            "minLength": 1,
+                                                            "type": "string"
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "name"
+                                                        ],
+                                                        "type": "object",
+                                                        "x-kubernetes-map-type": "atomic",
+                                                        "x-kubernetes-validations": [
+                                                          {
+                                                            "message": "custom credential refs must set both group and kind",
+                                                            "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                                                          }
+                                                        ],
+                                                        "additionalProperties": false
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "x-kubernetes-validations": [
+                                                      {
+                                                        "message": "location may only be set for key or passthrough auth",
+                                                        "rule": "has(self.location) ? has(self.key) || has(self.secretRef) || has(self.passthrough) : true"
+                                                      },
+                                                      {
+                                                        "message": "exactly one of the fields in [key secretRef passthrough aws azure gcp] must be set",
+                                                        "rule": "[has(self.key),has(self.secretRef),has(self.passthrough),has(self.aws),has(self.azure),has(self.gcp)].filter(x,x==true).size() == 1"
+                                                      }
+                                                    ],
+                                                    "additionalProperties": false
+                                                  },
+                                                  "http": {
+                                                    "description": "Settings for managing HTTP requests to the backend.",
+                                                    "properties": {
+                                                      "requestTimeout": {
+                                                        "description": "Deadline for receiving a response from the backend.",
+                                                        "type": "string",
+                                                        "x-kubernetes-validations": [
+                                                          {
+                                                            "message": "invalid duration value",
+                                                            "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                                          },
+                                                          {
+                                                            "message": "requestTimeout must be at least 1ms",
+                                                            "rule": "duration(self) >= duration('1ms')"
+                                                          }
+                                                        ]
+                                                      },
+                                                      "version": {
+                                                        "description": "HTTP protocol version to use when connecting to\nthe backend.\nIf not specified, the version is automatically determined:\n* `Service` types can specify it with `appProtocol` on the `Service`\n  port.\n* If traffic is identified as gRPC, `HTTP2` is used.\n* If the incoming traffic was plaintext HTTP, the original protocol will\n  be used.\n* If the incoming traffic was HTTPS, `HTTP1` will be used. This is\n  because most clients will transparently upgrade HTTPS traffic to\n  `HTTP2`, even if the backend doesn't support it.",
+                                                        "enum": [
+                                                          "HTTP1",
+                                                          "HTTP2"
+                                                        ],
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "tcp": {
+                                                    "description": "Settings for managing TCP connections to the backend.",
+                                                    "properties": {
+                                                      "connectTimeout": {
+                                                        "description": "Deadline for establishing a connection to\nthe destination.",
+                                                        "type": "string",
+                                                        "x-kubernetes-validations": [
+                                                          {
+                                                            "message": "invalid duration value",
+                                                            "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                                          },
+                                                          {
+                                                            "message": "connectTimeout must be at least 100ms",
+                                                            "rule": "duration(self) >= duration('100ms')"
+                                                          }
+                                                        ]
+                                                      },
+                                                      "keepalive": {
+                                                        "description": "Settings for enabling TCP keepalives on the\nconnection.",
+                                                        "properties": {
+                                                          "interval": {
+                                                            "description": "Time between keepalive probes.\nIf unset, this defaults to 180s.",
+                                                            "type": "string",
+                                                            "x-kubernetes-validations": [
+                                                              {
+                                                                "message": "invalid duration value",
+                                                                "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                                              },
+                                                              {
+                                                                "message": "interval must be at least 1 second",
+                                                                "rule": "duration(self) >= duration('1s')"
+                                                              }
+                                                            ]
+                                                          },
+                                                          "retries": {
+                                                            "description": "Maximum number of keepalive probes to send before dropping the connection.\nIf unset, this defaults to 9.",
+                                                            "format": "int32",
+                                                            "maximum": 64,
+                                                            "minimum": 1,
+                                                            "type": "integer"
+                                                          },
+                                                          "time": {
+                                                            "description": "Time a connection needs to be idle before keepalive probes start being sent.\nIf unset, this defaults to 180s.",
+                                                            "type": "string",
+                                                            "x-kubernetes-validations": [
+                                                              {
+                                                                "message": "invalid duration value",
+                                                                "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                                              },
+                                                              {
+                                                                "message": "time must be at least 1 second",
+                                                                "rule": "duration(self) >= duration('1s')"
+                                                              }
+                                                            ]
+                                                          }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "tls": {
+                                                    "description": "Settings for managing TLS connections to the backend.\n\nIf this field is set, TLS will be initiated to the backend; the system trusted CA certificates will be used to\nvalidate the server, and the SNI will automatically be set based on the destination.",
+                                                    "properties": {
+                                                      "alpnProtocols": {
+                                                        "description": "Application-Layer Protocol Negotiation (`ALPN`)\nvalue to use in the TLS handshake.\n\nIf not present, defaults to `[\"h2\", \"http/1.1\"]`.",
+                                                        "items": {
+                                                          "maxLength": 64,
+                                                          "minLength": 1,
+                                                          "type": "string"
+                                                        },
+                                                        "maxItems": 16,
+                                                        "minItems": 1,
+                                                        "type": "array"
+                                                      },
+                                                      "caCertificateRefs": {
+                                                        "description": "CA certificate `ConfigMap` to use to\nverify the server certificate.\nIf unset, the system's trusted certificates are used.",
+                                                        "items": {
+                                                          "description": "LocalObjectReference contains enough information to let you locate the\nreferenced object inside the same namespace.",
+                                                          "properties": {
+                                                            "name": {
+                                                              "default": "",
+                                                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                                              "type": "string"
+                                                            }
+                                                          },
+                                                          "type": "object",
+                                                          "x-kubernetes-map-type": "atomic",
+                                                          "additionalProperties": false
+                                                        },
+                                                        "maxItems": 1,
+                                                        "type": "array",
+                                                        "x-kubernetes-list-type": "atomic"
+                                                      },
+                                                      "insecureSkipVerify": {
+                                                        "description": "Originates TLS but skips verification of the backend's certificate.\nWARNING: This is an insecure option that should only be used if the risks are understood.\n\nThere are two modes:\n* `All` disables all TLS verification.\n* `Hostname` verifies the CA certificate is trusted, but ignores any\n  mismatch of hostname or SANs. Note that this method is still insecure;\n  prefer setting `verifySubjectAltNames` to customize the valid hostnames\n  if possible.",
+                                                        "enum": [
+                                                          "All",
+                                                          "Hostname"
+                                                        ],
+                                                        "type": "string"
+                                                      },
+                                                      "keyExchangeGroups": {
+                                                        "description": "Ordered list of key exchange groups for a TLS connection.\nFor example: `X25519_MLKEM768,X25519`.",
+                                                        "items": {
+                                                          "enum": [
+                                                            "P-256",
+                                                            "P-384",
+                                                            "X25519",
+                                                            "X25519_MLKEM768"
+                                                          ],
+                                                          "type": "string"
+                                                        },
+                                                        "type": "array"
+                                                      },
+                                                      "mtlsCertificateRef": {
+                                                        "description": "Enables mutual TLS to the backend, using the\nspecified key (`tls.key`) and cert (`tls.crt`) from the referenced\ncredential source, defaulting to a Kubernetes `Secret`.\n\nAn optional `ca.cert` field, if present, will be used to verify the\nserver certificate. If `caCertificateRefs` is also specified, the\n`caCertificateRefs` field takes priority.\n\nIf unspecified, no client certificate will be used.",
+                                                        "items": {
+                                                          "description": "References a same-namespace credential.\nSet only `name` to reference a Kubernetes Secret.",
+                                                          "properties": {
+                                                            "group": {
+                                                              "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                                                              "type": "string"
+                                                            },
+                                                            "kind": {
+                                                              "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                                                              "type": "string"
+                                                            },
+                                                            "name": {
+                                                              "description": "The name of the referenced credential.",
+                                                              "maxLength": 253,
+                                                              "minLength": 1,
+                                                              "type": "string"
+                                                            }
+                                                          },
+                                                          "required": [
+                                                            "name"
+                                                          ],
+                                                          "type": "object",
+                                                          "x-kubernetes-map-type": "atomic",
+                                                          "x-kubernetes-validations": [
+                                                            {
+                                                              "message": "custom credential refs must set both group and kind",
+                                                              "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                                                            }
+                                                          ],
+                                                          "additionalProperties": false
+                                                        },
+                                                        "maxItems": 1,
+                                                        "type": "array",
+                                                        "x-kubernetes-list-type": "atomic"
+                                                      },
+                                                      "sni": {
+                                                        "description": "Server Name Indicator (`SNI`) to use in the TLS\nhandshake. If unset, the `SNI` is automatically set based on the\ndestination hostname.",
+                                                        "maxLength": 253,
+                                                        "minLength": 1,
+                                                        "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                                                        "type": "string"
+                                                      },
+                                                      "verifySubjectAltNames": {
+                                                        "description": "Subject Alternative Names (`SAN`)\nto verify in the server certificate.\nIf not present, the destination hostname is automatically used.",
+                                                        "items": {
+                                                          "maxLength": 256,
+                                                          "minLength": 1,
+                                                          "type": "string"
+                                                        },
+                                                        "maxItems": 16,
+                                                        "minItems": 1,
+                                                        "type": "array"
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "x-kubernetes-validations": [
+                                                      {
+                                                        "message": "insecureSkipVerify All and caCertificateRefs may not be set together",
+                                                        "rule": "has(self.insecureSkipVerify) && self.insecureSkipVerify == 'All' ? !has(self.caCertificateRefs) : true"
+                                                      },
+                                                      {
+                                                        "message": "insecureSkipVerify and verifySubjectAltNames may not be set together",
+                                                        "rule": "has(self.insecureSkipVerify) ? !has(self.verifySubjectAltNames) : true"
+                                                      },
+                                                      {
+                                                        "message": "at most one of the fields in [verifySubjectAltNames insecureSkipVerify] may be set",
+                                                        "rule": "[has(self.verifySubjectAltNames),has(self.insecureSkipVerify)].filter(x,x==true).size() <= 1"
+                                                      }
+                                                    ],
+                                                    "additionalProperties": false
+                                                  },
+                                                  "tunnel": {
+                                                    "description": "Settings for managing tunnel connections, with behavior like `HTTPS_PROXY`, to the backend.",
+                                                    "properties": {
+                                                      "backendRef": {
+                                                        "description": "Proxy server to reach.\nSupported types: `Service` and `Backend`.",
+                                                        "properties": {
+                                                          "group": {
+                                                            "default": "",
+                                                            "description": "Group is the group of the referent. For example, \"gateway.networking.k8s.io\".\nWhen unspecified or empty string, core API group is inferred.",
+                                                            "maxLength": 253,
+                                                            "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                                                            "type": "string"
+                                                          },
+                                                          "kind": {
+                                                            "default": "Service",
+                                                            "description": "Kind is the Kubernetes resource kind of the referent. For example\n\"Service\".\n\nDefaults to \"Service\" when not specified.\n\nExternalName services can refer to CNAME DNS records that may live\noutside of the cluster and as such are difficult to reason about in\nterms of conformance. They also may not be safe to forward to (see\nCVE-2021-25740 for more information). Implementations SHOULD NOT\nsupport ExternalName Services.\n\nSupport: Core (Services with a type other than ExternalName)\n\nSupport: Implementation-specific (Services with type ExternalName)",
+                                                            "maxLength": 63,
+                                                            "minLength": 1,
+                                                            "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
+                                                            "type": "string"
+                                                          },
+                                                          "name": {
+                                                            "description": "Name is the name of the referent.",
+                                                            "maxLength": 253,
+                                                            "minLength": 1,
+                                                            "type": "string"
+                                                          },
+                                                          "namespace": {
+                                                            "description": "Namespace is the namespace of the backend. When unspecified, the local\nnamespace is inferred.\n\nNote that when a namespace different than the local namespace is specified,\na ReferenceGrant object is required in the referent namespace to allow that\nnamespace's owner to accept the reference. See the ReferenceGrant\ndocumentation for details.\n\nSupport: Core",
+                                                            "maxLength": 63,
+                                                            "minLength": 1,
+                                                            "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                                                            "type": "string"
+                                                          },
+                                                          "port": {
+                                                            "description": "Port specifies the destination port number to use for this resource.\nPort is required when the referent is a Kubernetes Service. In this\ncase, the port number is the service port number, not the target port.\nFor other resources, destination port might be derived from the referent\nresource or this field.",
+                                                            "format": "int32",
+                                                            "maximum": 65535,
+                                                            "minimum": 1,
+                                                            "type": "integer"
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "name"
+                                                        ],
+                                                        "type": "object",
+                                                        "x-kubernetes-validations": [
+                                                          {
+                                                            "message": "Must have port for Service reference",
+                                                            "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
+                                                          }
+                                                        ],
+                                                        "additionalProperties": false
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "backendRef"
+                                                    ],
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "projectId": {
+                                                "description": "Google Cloud project ID.",
+                                                "maxLength": 256,
+                                                "minLength": 1,
+                                                "type": "string"
+                                              },
+                                              "templateId": {
+                                                "description": "Template ID for Google Model Armor.",
+                                                "maxLength": 256,
+                                                "minLength": 1,
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "projectId",
+                                              "templateId"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "regex": {
+                                            "description": "Regular expression (regex) matching for prompt guards and data masking.",
+                                            "properties": {
+                                              "action": {
+                                                "default": "Mask",
+                                                "description": "The action to take if a regex pattern is matched in a request or response.\nThis setting applies only to request matches. `PromptguardResponse`\nmatches are always masked by default.\nDefaults to `Mask`.",
+                                                "enum": [
+                                                  "Mask",
+                                                  "Reject"
+                                                ],
+                                                "type": "string"
+                                              },
+                                              "builtins": {
+                                                "description": "Built-in regex patterns to match against the request or response.\nMatches and built-ins are additive.",
+                                                "items": {
+                                                  "description": "Built-in regex patterns for specific types of strings in prompts.\nFor example, if you specify `CreditCard`, any credit card numbers\nin the request or response are matched.",
+                                                  "enum": [
+                                                    "CaSin",
+                                                    "CreditCard",
+                                                    "Email",
+                                                    "PhoneNumber",
+                                                    "Ssn"
+                                                  ],
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              },
+                                              "matches": {
+                                                "description": "Regex patterns to match against the request or response.\nMatches and built-ins are additive.",
+                                                "items": {
+                                                  "maxLength": 1024,
+                                                  "minLength": 1,
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "response": {
+                                            "description": "Custom response message to return to the client. If not specified, defaults to\n`The response was rejected due to inappropriate content`.",
+                                            "properties": {
+                                              "message": {
+                                                "default": "The request was rejected due to inappropriate content",
+                                                "description": "Custom response message to return to the client. If not specified, defaults to\n`The request was rejected due to inappropriate content`.",
+                                                "type": "string"
+                                              },
+                                              "statusCode": {
+                                                "default": 403,
+                                                "description": "Status code to return to the client. Defaults to 403.",
+                                                "format": "int32",
+                                                "maximum": 599,
+                                                "minimum": 200,
+                                                "type": "integer"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "x-kubernetes-validations": [
+                                              {
+                                                "message": "at least one of the fields in [message statusCode] must be set",
+                                                "rule": "[has(self.message),has(self.statusCode)].filter(x,x==true).size() >= 1"
+                                              }
+                                            ],
+                                            "additionalProperties": false
+                                          },
+                                          "webhook": {
+                                            "description": "Webhook that receives responses for prompt guarding.",
+                                            "properties": {
+                                              "backendRef": {
+                                                "description": "Webhook server to reach.\n\nSupported types: Service and Backend.",
+                                                "properties": {
+                                                  "group": {
+                                                    "default": "",
+                                                    "description": "Group is the group of the referent. For example, \"gateway.networking.k8s.io\".\nWhen unspecified or empty string, core API group is inferred.",
+                                                    "maxLength": 253,
+                                                    "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                                                    "type": "string"
+                                                  },
+                                                  "kind": {
+                                                    "default": "Service",
+                                                    "description": "Kind is the Kubernetes resource kind of the referent. For example\n\"Service\".\n\nDefaults to \"Service\" when not specified.\n\nExternalName services can refer to CNAME DNS records that may live\noutside of the cluster and as such are difficult to reason about in\nterms of conformance. They also may not be safe to forward to (see\nCVE-2021-25740 for more information). Implementations SHOULD NOT\nsupport ExternalName Services.\n\nSupport: Core (Services with a type other than ExternalName)\n\nSupport: Implementation-specific (Services with type ExternalName)",
+                                                    "maxLength": 63,
+                                                    "minLength": 1,
+                                                    "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "description": "Name is the name of the referent.",
+                                                    "maxLength": 253,
+                                                    "minLength": 1,
+                                                    "type": "string"
+                                                  },
+                                                  "namespace": {
+                                                    "description": "Namespace is the namespace of the backend. When unspecified, the local\nnamespace is inferred.\n\nNote that when a namespace different than the local namespace is specified,\na ReferenceGrant object is required in the referent namespace to allow that\nnamespace's owner to accept the reference. See the ReferenceGrant\ndocumentation for details.\n\nSupport: Core",
+                                                    "maxLength": 63,
+                                                    "minLength": 1,
+                                                    "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                                                    "type": "string"
+                                                  },
+                                                  "port": {
+                                                    "description": "Port specifies the destination port number to use for this resource.\nPort is required when the referent is a Kubernetes Service. In this\ncase, the port number is the service port number, not the target port.\nFor other resources, destination port might be derived from the referent\nresource or this field.",
+                                                    "format": "int32",
+                                                    "maximum": 65535,
+                                                    "minimum": 1,
+                                                    "type": "integer"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "name"
+                                                ],
+                                                "type": "object",
+                                                "x-kubernetes-validations": [
+                                                  {
+                                                    "message": "Must have port for Service reference",
+                                                    "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
+                                                  }
+                                                ],
+                                                "additionalProperties": false
+                                              },
+                                              "failureMode": {
+                                                "description": "Behavior when the webhook guardrail is unavailable\nor returns an error. `FailOpen` allows the request to continue.\n`FailClosed` (default) rejects the request.",
+                                                "enum": [
+                                                  "FailClosed",
+                                                  "FailOpen"
+                                                ],
+                                                "type": "string"
+                                              },
+                                              "forwardHeaderMatches": {
+                                                "description": "HTTP header matches used to select the headers to forward to the webhook.\nRequest headers are used when forwarding requests and response headers\nare used when forwarding responses.\nBy default, no headers are forwarded.",
+                                                "items": {
+                                                  "description": "HTTPHeaderMatch describes how to select a HTTP route by matching HTTP request\nheaders.",
+                                                  "properties": {
+                                                    "name": {
+                                                      "description": "Name is the name of the HTTP Header to be matched. Name matching MUST be\ncase-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).\n\nIf multiple entries specify equivalent header names, only the first\nentry with an equivalent name MUST be considered for a match. Subsequent\nentries with an equivalent header name MUST be ignored. Due to the\ncase-insensitivity of header names, \"foo\" and \"Foo\" are considered\nequivalent.\n\nWhen a header is repeated in an HTTP request, it is\nimplementation-specific behavior as to how this is represented.\nGenerally, proxies should follow the guidance from the RFC:\nhttps://www.rfc-editor.org/rfc/rfc7230.html#section-3.2.2 regarding\nprocessing a repeated header, with special handling for \"Set-Cookie\".",
+                                                      "maxLength": 256,
+                                                      "minLength": 1,
+                                                      "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                                                      "type": "string"
+                                                    },
+                                                    "type": {
+                                                      "default": "Exact",
+                                                      "description": "Type specifies how to match against the value of the header.\n\nSupport: Core (Exact)\n\nSupport: Implementation-specific (RegularExpression)\n\nSince RegularExpression HeaderMatchType has implementation-specific\nconformance, implementations can support POSIX, PCRE or any other dialects\nof regular expressions. Please read the implementation's documentation to\ndetermine the supported dialect.",
+                                                      "enum": [
+                                                        "Exact",
+                                                        "RegularExpression"
+                                                      ],
+                                                      "type": "string"
+                                                    },
+                                                    "value": {
+                                                      "description": "Value is the value of HTTP Header to be matched.\n<gateway:experimental:description>\nMust consist of printable US-ASCII characters, optionally separated\nby single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2\n</gateway:experimental:description>\n\n<gateway:experimental:validation:Pattern=`^[!-~]+([\\t ]?[!-~]+)*$`>",
+                                                      "maxLength": 4096,
+                                                      "minLength": 1,
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "name",
+                                                    "value"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              }
+                                            },
+                                            "required": [
+                                              "backendRef"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          }
+                                        },
+                                        "type": "object",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "exactly one of the fields in [regex webhook bedrockGuardrails googleModelArmor] must be set",
+                                            "rule": "[has(self.regex),has(self.webhook),has(self.bedrockGuardrails),has(self.googleModelArmor)].filter(x,x==true).size() == 1"
+                                          }
+                                        ],
+                                        "additionalProperties": false
+                                      },
+                                      "maxItems": 8,
+                                      "minItems": 1,
+                                      "type": "array"
+                                    },
+                                    "streaming": {
+                                      "description": "Apply prompt guards to streaming responses and realtime websocket messages.\nDefaults to disabled to preserve streaming throughput unless explicitly enabled.",
+                                      "enum": [
+                                        "Enabled"
+                                      ],
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "x-kubernetes-validations": [
+                                    {
+                                      "message": "at least one of the fields in [request response] must be set",
+                                      "rule": "[has(self.request),has(self.response)].filter(x,x==true).size() >= 1"
+                                    }
+                                  ],
+                                  "additionalProperties": false
+                                },
+                                "routes": {
+                                  "additionalProperties": {
+                                    "description": "How the AI gateway should process incoming requests\nbased on the URL path and the API format expected.",
+                                    "enum": [
+                                      "AnthropicTokenCount",
+                                      "Completions",
+                                      "Detect",
+                                      "Embeddings",
+                                      "Messages",
+                                      "Models",
+                                      "Passthrough",
+                                      "Realtime",
+                                      "Rerank",
+                                      "Responses"
+                                    ],
+                                    "type": "string"
+                                  },
+                                  "description": "Rules for identifying the type of traffic to handle.\nThe keys are URL path suffixes matched using ends-with comparison, for\nexample `\"/v1/chat/completions\"`.\nThe special `*` wildcard matches any path.\nIf not specified, all traffic defaults to `completions` type.",
+                                  "type": "object"
+                                },
+                                "transformations": {
+                                  "description": "CEL transformations to compute and set fields in the request body.\nThe expression result overwrites any existing value for that field.\nThis has a higher priority than `overrides` if both are set for the same\nkey.",
+                                  "items": {
+                                    "description": "Maps a request JSON field to a CEL expression.\nThe expression is evaluated against the current request body and its result\nis assigned to the configured field.",
+                                    "properties": {
+                                      "expression": {
+                                        "description": "CEL expression used to compute the field value.",
+                                        "maxLength": 16384,
+                                        "minLength": 1,
+                                        "type": "string"
+                                      },
+                                      "field": {
+                                        "allOf": [
+                                          {
+                                            "minLength": 1
+                                          },
+                                          {
+                                            "minLength": 1
+                                          }
+                                        ],
+                                        "description": "Name of the field to set.",
+                                        "maxLength": 256,
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "expression",
+                                      "field"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "maxItems": 64,
+                                  "minItems": 1,
+                                  "type": "array"
+                                }
+                              },
+                              "type": "object",
+                              "x-kubernetes-validations": [
+                                {
+                                  "message": "at least one of the fields in [defaults modelAliases overrides prompt promptCaching promptGuard routes transformations] must be set",
+                                  "rule": "[has(self.defaults),has(self.modelAliases),has(self.overrides),has(self.prompt),has(self.promptCaching),has(self.promptGuard),has(self.routes),has(self.transformations)].filter(x,x==true).size() >= 1"
+                                }
+                              ],
+                              "additionalProperties": false
+                            },
+                            "auth": {
+                              "description": "Settings for managing authentication to the backend.",
+                              "properties": {
+                                "aws": {
+                                  "description": "Explicit AWS authentication method for the backend.\nWhen omitted, default AWS SDK credential discovery is used.",
+                                  "properties": {
+                                    "assumeRole": {
+                                      "description": "AWS STS AssumeRole settings to use before signing backend requests.\nAmbient AWS credentials are used as the source credentials for STS.",
+                                      "properties": {
+                                        "roleArn": {
+                                          "description": "AWS IAM role ARN to assume.",
+                                          "minLength": 1,
+                                          "pattern": "^arn:aws[a-z-]*:iam::[0-9]{12}:role/.+$",
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "roleArn"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "secretRef": {
+                                      "description": "Credential source, defaulting to a Kubernetes\n`Secret`, containing the AWS credentials. When using the default Secret\nresolver, the `Secret` must have keys `accessKey`, `secretKey`, and\noptionally `sessionToken`.",
+                                      "properties": {
+                                        "group": {
+                                          "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                                          "type": "string"
+                                        },
+                                        "kind": {
+                                          "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "description": "The name of the referenced credential.",
+                                          "maxLength": 253,
+                                          "minLength": 1,
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "name"
+                                      ],
+                                      "type": "object",
+                                      "x-kubernetes-map-type": "atomic",
+                                      "x-kubernetes-validations": [
+                                        {
+                                          "message": "custom credential refs must set both group and kind",
+                                          "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                                        }
+                                      ],
+                                      "additionalProperties": false
+                                    },
+                                    "serviceName": {
+                                      "description": "AWS SigV4 signing service name, for example\n`bedrock`, `bedrock-agentcore`, or `execute-api`). If unset, typed AWS\nbackends may provide this automatically.",
+                                      "maxLength": 256,
+                                      "minLength": 1,
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "x-kubernetes-validations": [
+                                    {
+                                      "message": "secretRef and assumeRole are mutually exclusive",
+                                      "rule": "!(has(self.secretRef) && has(self.assumeRole))"
+                                    }
+                                  ],
+                                  "additionalProperties": false
+                                },
+                                "azure": {
+                                  "description": "Azure authentication method for the backend.",
+                                  "properties": {
+                                    "managedIdentity": {
+                                      "description": "Managed identity authentication settings.",
+                                      "properties": {
+                                        "clientId": {
+                                          "type": "string"
+                                        },
+                                        "objectId": {
+                                          "type": "string"
+                                        },
+                                        "resourceId": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "clientId",
+                                        "objectId",
+                                        "resourceId"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "secretRef": {
+                                      "description": "Credential source, defaulting to a Kubernetes\n`Secret`, containing the Azure credentials. When using the default Secret\nresolver, the `Secret` must have keys `clientID`, `tenantID`, and\n`clientSecret`.",
+                                      "properties": {
+                                        "group": {
+                                          "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                                          "type": "string"
+                                        },
+                                        "kind": {
+                                          "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "description": "The name of the referenced credential.",
+                                          "maxLength": 253,
+                                          "minLength": 1,
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "name"
+                                      ],
+                                      "type": "object",
+                                      "x-kubernetes-map-type": "atomic",
+                                      "x-kubernetes-validations": [
+                                        {
+                                          "message": "custom credential refs must set both group and kind",
+                                          "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                                        }
+                                      ],
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "gcp": {
+                                  "description": "Google authentication method for the backend.\nWhen omitted, default Google credential discovery is used.",
+                                  "properties": {
+                                    "audience": {
+                                      "description": "Explicit `aud` value for the ID token. Only\nvalid with `IdToken` type. If not set, the `aud` is automatically\nderived from the backend hostname.",
+                                      "maxLength": 256,
+                                      "minLength": 1,
+                                      "type": "string"
+                                    },
+                                    "secretRef": {
+                                      "description": "Credential source, defaulting to a Kubernetes\n`Secret`, containing ADC-compatible Google credential JSON. When using\nthe default Secret resolver, this must be stored in the `credentials.json`\nkey. When omitted, ambient credentials are used.",
+                                      "properties": {
+                                        "group": {
+                                          "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                                          "type": "string"
+                                        },
+                                        "kind": {
+                                          "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "description": "The name of the referenced credential.",
+                                          "maxLength": 253,
+                                          "minLength": 1,
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "name"
+                                      ],
+                                      "type": "object",
+                                      "x-kubernetes-map-type": "atomic",
+                                      "x-kubernetes-validations": [
+                                        {
+                                          "message": "custom credential refs must set both group and kind",
+                                          "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                                        }
+                                      ],
+                                      "additionalProperties": false
+                                    },
+                                    "type": {
+                                      "description": "The type of token to generate. To authenticate to GCP services,\ngenerally an `AccessToken` is used. To authenticate to Cloud Run, an\n`IdToken` is used.",
+                                      "enum": [
+                                        "AccessToken",
+                                        "IdToken"
+                                      ],
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "x-kubernetes-validations": [
+                                    {
+                                      "message": "audience is only valid with IdToken",
+                                      "rule": "has(self.audience) ? self.type == 'IdToken' : true"
+                                    }
+                                  ],
+                                  "additionalProperties": false
+                                },
+                                "key": {
+                                  "description": "Inline key to use as the value of the\n`Authorization` header. This option is the least secure; usage of a\n`Secret` is preferred.",
+                                  "maxLength": 2048,
+                                  "type": "string"
+                                },
+                                "location": {
+                                  "description": "Where backend credentials are inserted.\nIf omitted, credentials are written to the `Authorization` header with the `Bearer ` prefix.\nThis applies to `key`, `secretRef`, and `passthrough`.",
+                                  "properties": {
+                                    "cookie": {
+                                      "properties": {
+                                        "name": {
+                                          "maxLength": 256,
+                                          "minLength": 1,
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "name"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "header": {
+                                      "properties": {
+                                        "name": {
+                                          "description": "HTTPHeaderName is the name of an HTTP header.\n\nValid values include:\n\n* \"Authorization\"\n* \"Set-Cookie\"\n\nInvalid values include:\n\n  - \":method\" - \":\" is an invalid character. This means that HTTP/2 pseudo\n    headers are not currently supported by this type.\n  - \"/invalid\" - \"/ \" is an invalid character",
+                                          "maxLength": 256,
+                                          "minLength": 1,
+                                          "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                                          "type": "string"
+                                        },
+                                        "prefix": {
+                                          "maxLength": 256,
+                                          "minLength": 1,
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "name"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "queryParameter": {
+                                      "properties": {
+                                        "name": {
+                                          "maxLength": 256,
+                                          "minLength": 1,
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "name"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "x-kubernetes-validations": [
+                                    {
+                                      "message": "exactly one of the fields in [header queryParameter cookie] must be set",
+                                      "rule": "[has(self.header),has(self.queryParameter),has(self.cookie)].filter(x,x==true).size() == 1"
+                                    }
+                                  ],
+                                  "additionalProperties": false
+                                },
+                                "passthrough": {
+                                  "description": "Passes through an existing token that has been sent by the\nclient and validated. Other policies, like JWT and API key\nauthentication, will strip the original client credentials. Passthrough backend authentication\ncauses the original token to be added back into the request. If there are no client authentication policies on the\nrequest, the original token would be unchanged, so this would have no effect.",
+                                  "type": "object"
+                                },
+                                "secretRef": {
+                                  "description": "Credential source, defaulting to a Kubernetes\n`Secret`, storing the key to use as the authorization value. When using\nthe default Secret resolver, this must be stored in the `Authorization`\nkey.",
+                                  "properties": {
+                                    "group": {
+                                      "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                                      "type": "string"
+                                    },
+                                    "kind": {
+                                      "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "description": "The name of the referenced credential.",
+                                      "maxLength": 253,
+                                      "minLength": 1,
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "name"
+                                  ],
+                                  "type": "object",
+                                  "x-kubernetes-map-type": "atomic",
+                                  "x-kubernetes-validations": [
+                                    {
+                                      "message": "custom credential refs must set both group and kind",
+                                      "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                                    }
+                                  ],
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "x-kubernetes-validations": [
+                                {
+                                  "message": "location may only be set for key or passthrough auth",
+                                  "rule": "has(self.location) ? has(self.key) || has(self.secretRef) || has(self.passthrough) : true"
+                                },
+                                {
+                                  "message": "exactly one of the fields in [key secretRef passthrough aws azure gcp] must be set",
+                                  "rule": "[has(self.key),has(self.secretRef),has(self.passthrough),has(self.aws),has(self.azure),has(self.gcp)].filter(x,x==true).size() == 1"
+                                }
+                              ],
+                              "additionalProperties": false
+                            },
+                            "health": {
+                              "description": "Settings for passive and active health checking.",
+                              "properties": {
+                                "eviction": {
+                                  "description": "Settings for evicting unhealthy backends.",
+                                  "properties": {
+                                    "consecutiveFailures": {
+                                      "description": "Number of consecutive unhealthy responses required before the backend is evicted.\nFor example, a value of 5 means the backend must receive 5 unhealthy responses in a row before being evicted.\nWhen both consecutiveFailures and healthThreshold are set, the backend is evicted when either condition is met.\nWhen neither is set, a single unhealthy response can trigger eviction.",
+                                      "format": "int32",
+                                      "minimum": 0,
+                                      "type": "integer"
+                                    },
+                                    "duration": {
+                                      "default": "3s",
+                                      "description": "Base time a backend should be evicted after being marked unhealthy.\nSubsequent evictions use multiplicative backoff (duration * times_evicted).\nIf all endpoints are evicted, the load balancer falls back to returning evicted endpoints\nrather than failing entirely.\nIf unset, defaults to `3s`.",
+                                      "type": "string",
+                                      "x-kubernetes-validations": [
+                                        {
+                                          "message": "invalid duration value",
+                                          "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                        },
+                                        {
+                                          "message": "evictionDuration must be at least 1 second",
+                                          "rule": "duration(self) >= duration('1s')"
+                                        }
+                                      ]
+                                    },
+                                    "healthThreshold": {
+                                      "description": "EWMA health score threshold, expressed as 0 to 100.\nWhen set, a backend is only evicted if its computed health drops below this value after an unhealthy response.\nFor example, 50 means the backend is evicted when its EWMA health falls below 50% following failures.\nUnlike consecutiveFailures (which counts consecutive failures), this uses a sliding-window average\nso a single success in a stream of failures can delay eviction.\nWhen both consecutiveFailures and healthThreshold are set, the backend is evicted when either condition is met.\nWhen neither is set, a single unhealthy response triggers eviction.",
+                                      "format": "int32",
+                                      "maximum": 100,
+                                      "minimum": 0,
+                                      "type": "integer"
+                                    },
+                                    "restoreHealth": {
+                                      "description": "Health score from 0 to 100 assigned to a backend when it returns from eviction.\nFor gradual recovery, set below 100; for full recovery immediately, set 100.\nIf unset, the backend resumes with the health it had when evicted.",
+                                      "format": "int32",
+                                      "maximum": 100,
+                                      "minimum": 0,
+                                      "type": "integer"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "unhealthyCondition": {
+                                  "description": "CEL expression that determines whether a response indicates an unhealthy backend.\nWhen the expression evaluates to true, the backend is considered unhealthy and may be evicted.\n\nFor example, to evict on 5xx responses: `response.code >= 500`.\n\nWhen unset, any 5xx response, or a connection failure, is treated as unhealthy.\nThis default lowers the backend's health score but does not trigger eviction on its own.",
+                                  "maxLength": 16384,
+                                  "minLength": 1,
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "http": {
+                              "description": "Settings for managing HTTP requests to the backend.",
+                              "properties": {
+                                "requestTimeout": {
+                                  "description": "Deadline for receiving a response from the backend.",
+                                  "type": "string",
+                                  "x-kubernetes-validations": [
+                                    {
+                                      "message": "invalid duration value",
+                                      "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                    },
+                                    {
+                                      "message": "requestTimeout must be at least 1ms",
+                                      "rule": "duration(self) >= duration('1ms')"
+                                    }
+                                  ]
+                                },
+                                "version": {
+                                  "description": "HTTP protocol version to use when connecting to\nthe backend.\nIf not specified, the version is automatically determined:\n* `Service` types can specify it with `appProtocol` on the `Service`\n  port.\n* If traffic is identified as gRPC, `HTTP2` is used.\n* If the incoming traffic was plaintext HTTP, the original protocol will\n  be used.\n* If the incoming traffic was HTTPS, `HTTP1` will be used. This is\n  because most clients will transparently upgrade HTTPS traffic to\n  `HTTP2`, even if the backend doesn't support it.",
+                                  "enum": [
+                                    "HTTP1",
+                                    "HTTP2"
+                                  ],
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "tcp": {
+                              "description": "Settings for managing TCP connections to the backend.",
+                              "properties": {
+                                "connectTimeout": {
+                                  "description": "Deadline for establishing a connection to\nthe destination.",
+                                  "type": "string",
+                                  "x-kubernetes-validations": [
+                                    {
+                                      "message": "invalid duration value",
+                                      "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                    },
+                                    {
+                                      "message": "connectTimeout must be at least 100ms",
+                                      "rule": "duration(self) >= duration('100ms')"
+                                    }
+                                  ]
+                                },
+                                "keepalive": {
+                                  "description": "Settings for enabling TCP keepalives on the\nconnection.",
+                                  "properties": {
+                                    "interval": {
+                                      "description": "Time between keepalive probes.\nIf unset, this defaults to 180s.",
+                                      "type": "string",
+                                      "x-kubernetes-validations": [
+                                        {
+                                          "message": "invalid duration value",
+                                          "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                        },
+                                        {
+                                          "message": "interval must be at least 1 second",
+                                          "rule": "duration(self) >= duration('1s')"
+                                        }
+                                      ]
+                                    },
+                                    "retries": {
+                                      "description": "Maximum number of keepalive probes to send before dropping the connection.\nIf unset, this defaults to 9.",
+                                      "format": "int32",
+                                      "maximum": 64,
+                                      "minimum": 1,
+                                      "type": "integer"
+                                    },
+                                    "time": {
+                                      "description": "Time a connection needs to be idle before keepalive probes start being sent.\nIf unset, this defaults to 180s.",
+                                      "type": "string",
+                                      "x-kubernetes-validations": [
+                                        {
+                                          "message": "invalid duration value",
+                                          "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                        },
+                                        {
+                                          "message": "time must be at least 1 second",
+                                          "rule": "duration(self) >= duration('1s')"
+                                        }
+                                      ]
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "tls": {
+                              "description": "Settings for managing TLS connections to the backend.\n\nIf this field is set, TLS will be initiated to the backend; the system trusted CA certificates will be used to\nvalidate the server, and the SNI will automatically be set based on the destination.",
+                              "properties": {
+                                "alpnProtocols": {
+                                  "description": "Application-Layer Protocol Negotiation (`ALPN`)\nvalue to use in the TLS handshake.\n\nIf not present, defaults to `[\"h2\", \"http/1.1\"]`.",
+                                  "items": {
+                                    "maxLength": 64,
+                                    "minLength": 1,
+                                    "type": "string"
+                                  },
+                                  "maxItems": 16,
+                                  "minItems": 1,
+                                  "type": "array"
+                                },
+                                "caCertificateRefs": {
+                                  "description": "CA certificate `ConfigMap` to use to\nverify the server certificate.\nIf unset, the system's trusted certificates are used.",
+                                  "items": {
+                                    "description": "LocalObjectReference contains enough information to let you locate the\nreferenced object inside the same namespace.",
+                                    "properties": {
+                                      "name": {
+                                        "default": "",
+                                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "x-kubernetes-map-type": "atomic",
+                                    "additionalProperties": false
+                                  },
+                                  "maxItems": 1,
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
+                                },
+                                "insecureSkipVerify": {
+                                  "description": "Originates TLS but skips verification of the backend's certificate.\nWARNING: This is an insecure option that should only be used if the risks are understood.\n\nThere are two modes:\n* `All` disables all TLS verification.\n* `Hostname` verifies the CA certificate is trusted, but ignores any\n  mismatch of hostname or SANs. Note that this method is still insecure;\n  prefer setting `verifySubjectAltNames` to customize the valid hostnames\n  if possible.",
+                                  "enum": [
+                                    "All",
+                                    "Hostname"
+                                  ],
+                                  "type": "string"
+                                },
+                                "keyExchangeGroups": {
+                                  "description": "Ordered list of key exchange groups for a TLS connection.\nFor example: `X25519_MLKEM768,X25519`.",
+                                  "items": {
+                                    "enum": [
+                                      "P-256",
+                                      "P-384",
+                                      "X25519",
+                                      "X25519_MLKEM768"
+                                    ],
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "mtlsCertificateRef": {
+                                  "description": "Enables mutual TLS to the backend, using the\nspecified key (`tls.key`) and cert (`tls.crt`) from the referenced\ncredential source, defaulting to a Kubernetes `Secret`.\n\nAn optional `ca.cert` field, if present, will be used to verify the\nserver certificate. If `caCertificateRefs` is also specified, the\n`caCertificateRefs` field takes priority.\n\nIf unspecified, no client certificate will be used.",
+                                  "items": {
+                                    "description": "References a same-namespace credential.\nSet only `name` to reference a Kubernetes Secret.",
+                                    "properties": {
+                                      "group": {
+                                        "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                                        "type": "string"
+                                      },
+                                      "kind": {
+                                        "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "description": "The name of the referenced credential.",
+                                        "maxLength": 253,
+                                        "minLength": 1,
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "name"
+                                    ],
+                                    "type": "object",
+                                    "x-kubernetes-map-type": "atomic",
+                                    "x-kubernetes-validations": [
+                                      {
+                                        "message": "custom credential refs must set both group and kind",
+                                        "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                                      }
+                                    ],
+                                    "additionalProperties": false
+                                  },
+                                  "maxItems": 1,
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
+                                },
+                                "sni": {
+                                  "description": "Server Name Indicator (`SNI`) to use in the TLS\nhandshake. If unset, the `SNI` is automatically set based on the\ndestination hostname.",
+                                  "maxLength": 253,
+                                  "minLength": 1,
+                                  "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                                  "type": "string"
+                                },
+                                "verifySubjectAltNames": {
+                                  "description": "Subject Alternative Names (`SAN`)\nto verify in the server certificate.\nIf not present, the destination hostname is automatically used.",
+                                  "items": {
+                                    "maxLength": 256,
+                                    "minLength": 1,
+                                    "type": "string"
+                                  },
+                                  "maxItems": 16,
+                                  "minItems": 1,
+                                  "type": "array"
+                                }
+                              },
+                              "type": "object",
+                              "x-kubernetes-validations": [
+                                {
+                                  "message": "insecureSkipVerify All and caCertificateRefs may not be set together",
+                                  "rule": "has(self.insecureSkipVerify) && self.insecureSkipVerify == 'All' ? !has(self.caCertificateRefs) : true"
+                                },
+                                {
+                                  "message": "insecureSkipVerify and verifySubjectAltNames may not be set together",
+                                  "rule": "has(self.insecureSkipVerify) ? !has(self.verifySubjectAltNames) : true"
+                                },
+                                {
+                                  "message": "at most one of the fields in [verifySubjectAltNames insecureSkipVerify] may be set",
+                                  "rule": "[has(self.verifySubjectAltNames),has(self.insecureSkipVerify)].filter(x,x==true).size() <= 1"
+                                }
+                              ],
+                              "additionalProperties": false
+                            },
+                            "transformation": {
+                              "description": "Mutates and transforms requests and responses sent to and from the backend.",
+                              "properties": {
+                                "request": {
+                                  "description": "Request transformation settings.",
+                                  "properties": {
+                                    "add": {
+                                      "description": "Headers to add to the request and what each value\nshould be set to. If there is already a header with these values then\nappend the value as an extra entry.",
+                                      "items": {
+                                        "properties": {
+                                          "name": {
+                                            "description": "The name of the header to add.",
+                                            "maxLength": 256,
+                                            "minLength": 1,
+                                            "pattern": "^:?[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                                            "type": "string",
+                                            "x-kubernetes-validations": [
+                                              {
+                                                "message": "pseudo-headers must be one of :authority, :method, :path, :scheme, or :status",
+                                                "rule": "!self.startsWith(':') || self in [':authority', ':method', ':path', ':scheme', ':status']"
+                                              }
+                                            ]
+                                          },
+                                          "value": {
+                                            "description": "CEL expression that generates the output value for\nthe header.",
+                                            "maxLength": 16384,
+                                            "minLength": 1,
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "name",
+                                          "value"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "maxItems": 16,
+                                      "minItems": 1,
+                                      "type": "array",
+                                      "x-kubernetes-list-map-keys": [
+                                        "name"
+                                      ],
+                                      "x-kubernetes-list-type": "map"
+                                    },
+                                    "body": {
+                                      "description": "HTTP body transformation.",
+                                      "maxLength": 16384,
+                                      "minLength": 1,
+                                      "type": "string"
+                                    },
+                                    "metadata": {
+                                      "additionalProperties": {
+                                        "description": "A Common Expression Language (CEL) expression.",
+                                        "maxLength": 16384,
+                                        "minLength": 1,
+                                        "type": "string"
+                                      },
+                                      "description": "Stores CEL-evaluated values under the `metadata` CEL variable\nfor subsequent policy evaluations. `metadata` is evaluated before header\nor body transformations.",
+                                      "maxProperties": 16,
+                                      "minProperties": 1,
+                                      "type": "object"
+                                    },
+                                    "remove": {
+                                      "description": "Header names to remove from the request or\nresponse.",
+                                      "items": {
+                                        "description": "HTTP header name.",
+                                        "maxLength": 256,
+                                        "minLength": 1,
+                                        "pattern": "^:?[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                                        "type": "string",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "pseudo-headers must be one of :authority, :method, :path, :scheme, or :status",
+                                            "rule": "!self.startsWith(':') || self in [':authority', ':method', ':path', ':scheme', ':status']"
+                                          }
+                                        ]
+                                      },
+                                      "maxItems": 16,
+                                      "minItems": 1,
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "set"
+                                    },
+                                    "set": {
+                                      "description": "Headers to set and the values to use.",
+                                      "items": {
+                                        "properties": {
+                                          "name": {
+                                            "description": "The name of the header to add.",
+                                            "maxLength": 256,
+                                            "minLength": 1,
+                                            "pattern": "^:?[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                                            "type": "string",
+                                            "x-kubernetes-validations": [
+                                              {
+                                                "message": "pseudo-headers must be one of :authority, :method, :path, :scheme, or :status",
+                                                "rule": "!self.startsWith(':') || self in [':authority', ':method', ':path', ':scheme', ':status']"
+                                              }
+                                            ]
+                                          },
+                                          "value": {
+                                            "description": "CEL expression that generates the output value for\nthe header.",
+                                            "maxLength": 16384,
+                                            "minLength": 1,
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "name",
+                                          "value"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "maxItems": 16,
+                                      "minItems": 1,
+                                      "type": "array",
+                                      "x-kubernetes-list-map-keys": [
+                                        "name"
+                                      ],
+                                      "x-kubernetes-list-type": "map"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "x-kubernetes-validations": [
+                                    {
+                                      "message": "at least one of the fields in [add body metadata remove set] must be set",
+                                      "rule": "[has(self.add),has(self.body),has(self.metadata),has(self.remove),has(self.set)].filter(x,x==true).size() >= 1"
+                                    }
+                                  ],
+                                  "additionalProperties": false
+                                },
+                                "response": {
+                                  "description": "Response transformation settings.",
+                                  "properties": {
+                                    "add": {
+                                      "description": "Headers to add to the request and what each value\nshould be set to. If there is already a header with these values then\nappend the value as an extra entry.",
+                                      "items": {
+                                        "properties": {
+                                          "name": {
+                                            "description": "The name of the header to add.",
+                                            "maxLength": 256,
+                                            "minLength": 1,
+                                            "pattern": "^:?[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                                            "type": "string",
+                                            "x-kubernetes-validations": [
+                                              {
+                                                "message": "pseudo-headers must be one of :authority, :method, :path, :scheme, or :status",
+                                                "rule": "!self.startsWith(':') || self in [':authority', ':method', ':path', ':scheme', ':status']"
+                                              }
+                                            ]
+                                          },
+                                          "value": {
+                                            "description": "CEL expression that generates the output value for\nthe header.",
+                                            "maxLength": 16384,
+                                            "minLength": 1,
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "name",
+                                          "value"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "maxItems": 16,
+                                      "minItems": 1,
+                                      "type": "array",
+                                      "x-kubernetes-list-map-keys": [
+                                        "name"
+                                      ],
+                                      "x-kubernetes-list-type": "map"
+                                    },
+                                    "body": {
+                                      "description": "HTTP body transformation.",
+                                      "maxLength": 16384,
+                                      "minLength": 1,
+                                      "type": "string"
+                                    },
+                                    "metadata": {
+                                      "additionalProperties": {
+                                        "description": "A Common Expression Language (CEL) expression.",
+                                        "maxLength": 16384,
+                                        "minLength": 1,
+                                        "type": "string"
+                                      },
+                                      "description": "Stores CEL-evaluated values under the `metadata` CEL variable\nfor subsequent policy evaluations. `metadata` is evaluated before header\nor body transformations.",
+                                      "maxProperties": 16,
+                                      "minProperties": 1,
+                                      "type": "object"
+                                    },
+                                    "remove": {
+                                      "description": "Header names to remove from the request or\nresponse.",
+                                      "items": {
+                                        "description": "HTTP header name.",
+                                        "maxLength": 256,
+                                        "minLength": 1,
+                                        "pattern": "^:?[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                                        "type": "string",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "pseudo-headers must be one of :authority, :method, :path, :scheme, or :status",
+                                            "rule": "!self.startsWith(':') || self in [':authority', ':method', ':path', ':scheme', ':status']"
+                                          }
+                                        ]
+                                      },
+                                      "maxItems": 16,
+                                      "minItems": 1,
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "set"
+                                    },
+                                    "set": {
+                                      "description": "Headers to set and the values to use.",
+                                      "items": {
+                                        "properties": {
+                                          "name": {
+                                            "description": "The name of the header to add.",
+                                            "maxLength": 256,
+                                            "minLength": 1,
+                                            "pattern": "^:?[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                                            "type": "string",
+                                            "x-kubernetes-validations": [
+                                              {
+                                                "message": "pseudo-headers must be one of :authority, :method, :path, :scheme, or :status",
+                                                "rule": "!self.startsWith(':') || self in [':authority', ':method', ':path', ':scheme', ':status']"
+                                              }
+                                            ]
+                                          },
+                                          "value": {
+                                            "description": "CEL expression that generates the output value for\nthe header.",
+                                            "maxLength": 16384,
+                                            "minLength": 1,
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "name",
+                                          "value"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "maxItems": 16,
+                                      "minItems": 1,
+                                      "type": "array",
+                                      "x-kubernetes-list-map-keys": [
+                                        "name"
+                                      ],
+                                      "x-kubernetes-list-type": "map"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "x-kubernetes-validations": [
+                                    {
+                                      "message": "at least one of the fields in [add body metadata remove set] must be set",
+                                      "rule": "[has(self.add),has(self.body),has(self.metadata),has(self.remove),has(self.set)].filter(x,x==true).size() >= 1"
+                                    }
+                                  ],
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "x-kubernetes-validations": [
+                                {
+                                  "message": "at least one of the fields in [request response] must be set",
+                                  "rule": "[has(self.request),has(self.response)].filter(x,x==true).size() >= 1"
+                                }
+                              ],
+                              "additionalProperties": false
+                            },
+                            "tunnel": {
+                              "description": "Settings for managing tunnel connections, with behavior like `HTTPS_PROXY`, to the backend.",
+                              "properties": {
+                                "backendRef": {
+                                  "description": "Proxy server to reach.\nSupported types: `Service` and `Backend`.",
+                                  "properties": {
+                                    "group": {
+                                      "default": "",
+                                      "description": "Group is the group of the referent. For example, \"gateway.networking.k8s.io\".\nWhen unspecified or empty string, core API group is inferred.",
+                                      "maxLength": 253,
+                                      "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                                      "type": "string"
+                                    },
+                                    "kind": {
+                                      "default": "Service",
+                                      "description": "Kind is the Kubernetes resource kind of the referent. For example\n\"Service\".\n\nDefaults to \"Service\" when not specified.\n\nExternalName services can refer to CNAME DNS records that may live\noutside of the cluster and as such are difficult to reason about in\nterms of conformance. They also may not be safe to forward to (see\nCVE-2021-25740 for more information). Implementations SHOULD NOT\nsupport ExternalName Services.\n\nSupport: Core (Services with a type other than ExternalName)\n\nSupport: Implementation-specific (Services with type ExternalName)",
+                                      "maxLength": 63,
+                                      "minLength": 1,
+                                      "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "description": "Name is the name of the referent.",
+                                      "maxLength": 253,
+                                      "minLength": 1,
+                                      "type": "string"
+                                    },
+                                    "namespace": {
+                                      "description": "Namespace is the namespace of the backend. When unspecified, the local\nnamespace is inferred.\n\nNote that when a namespace different than the local namespace is specified,\na ReferenceGrant object is required in the referent namespace to allow that\nnamespace's owner to accept the reference. See the ReferenceGrant\ndocumentation for details.\n\nSupport: Core",
+                                      "maxLength": 63,
+                                      "minLength": 1,
+                                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                                      "type": "string"
+                                    },
+                                    "port": {
+                                      "description": "Port specifies the destination port number to use for this resource.\nPort is required when the referent is a Kubernetes Service. In this\ncase, the port number is the service port number, not the target port.\nFor other resources, destination port might be derived from the referent\nresource or this field.",
+                                      "format": "int32",
+                                      "maximum": 65535,
+                                      "minimum": 1,
+                                      "type": "integer"
+                                    }
+                                  },
+                                  "required": [
+                                    "name"
+                                  ],
+                                  "type": "object",
+                                  "x-kubernetes-validations": [
+                                    {
+                                      "message": "Must have port for Service reference",
+                                      "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
+                                    }
+                                  ],
+                                  "additionalProperties": false
+                                }
+                              },
+                              "required": [
+                                "backendRef"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "x-kubernetes-validations": [
+                            {
+                              "message": "at least one of the fields in [ai auth health http tcp tls transformation tunnel] must be set",
+                              "rule": "[has(self.ai),has(self.auth),has(self.health),has(self.http),has(self.tcp),has(self.tls),has(self.transformation),has(self.tunnel)].filter(x,x==true).size() >= 1"
+                            }
+                          ],
+                          "additionalProperties": false
+                        },
+                        "port": {
+                          "description": "Port to send requests to.",
+                          "format": "int32",
+                          "maximum": 65535,
+                          "minimum": 1,
+                          "type": "integer"
+                        },
+                        "vertexai": {
+                          "description": "Vertex AI provider settings.",
+                          "properties": {
+                            "model": {
+                              "description": "Model name override, such as `gpt-4o-mini`.\nIf unset, the model name is taken from the request.",
+                              "maxLength": 256,
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "projectId": {
+                              "description": "The ID of the Google Cloud Project that you use for the Vertex AI.",
+                              "maxLength": 64,
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "region": {
+                              "default": "global",
+                              "description": "The location of the Google Cloud Project that you use for the Vertex AI.\nSpecial values: `global` uses the global endpoint, while `us` and `eu` use restricted\nmulti-region endpoints. Other values are treated as regional locations.\nDefaults to `global` if not specified.",
+                              "maxLength": 64,
+                              "minLength": 1,
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "projectId"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "name"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-validations": [
+                        {
+                          "message": "both host and port must be set together",
+                          "rule": "has(self.host) || has(self.port) ? has(self.host) && has(self.port) : true"
+                        },
+                        {
+                          "message": "custom providers must specify exactly one of backendRef or host and port",
+                          "rule": "has(self.custom) ? has(self.custom.backendRef) != has(self.host) : true"
+                        },
+                        {
+                          "message": "path and pathPrefix are mutually exclusive",
+                          "rule": "!(has(self.path) && has(self.pathPrefix))"
+                        },
+                        {
+                          "message": "path, pathPrefix, and custom format paths are mutually exclusive",
+                          "rule": "!(has(self.custom) && self.custom.formats.exists(f, has(f.path)) && (has(self.path) || has(self.pathPrefix)))"
+                        },
+                        {
+                          "message": "pathPrefix requires host to be set",
+                          "rule": "has(self.pathPrefix) ? has(self.host) : true"
+                        },
+                        {
+                          "message": "exactly one of the fields in [openai azureopenai azure anthropic gemini vertexai bedrock custom] must be set",
+                          "rule": "[has(self.openai),has(self.azureopenai),has(self.azure),has(self.anthropic),has(self.gemini),has(self.vertexai),has(self.bedrock),has(self.custom)].filter(x,x==true).size() == 1"
+                        }
+                      ],
+                      "additionalProperties": false
+                    },
+                    "maxItems": 16,
+                    "minItems": 1,
+                    "type": "array",
+                    "x-kubernetes-validations": [
+                      {
+                        "message": "provider names must be unique within a group",
+                        "rule": "self.all(p1, self.exists_one(p2, p1.name == p2.name))"
+                      }
+                    ]
+                  }
+                },
+                "required": [
+                  "providers"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "maxItems": 8,
+              "minItems": 1,
+              "type": "array"
+            },
+            "provider": {
+              "description": "Configuration for how to reach the configured LLM\nprovider.",
+              "properties": {
+                "anthropic": {
+                  "description": "Anthropic provider settings.",
+                  "properties": {
+                    "model": {
+                      "description": "Model name override, such as `gpt-4o-mini`.\nIf unset, the model name is taken from the request.",
+                      "maxLength": 256,
+                      "minLength": 1,
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "azure": {
+                  "description": "Azure provider with resource-based configuration.\nSupports both Azure OpenAI and Azure AI Foundry resource types.",
+                  "properties": {
+                    "apiVersion": {
+                      "description": "The version of the Azure OpenAI API to use.\nIf unset, defaults to `v1`.",
+                      "maxLength": 64,
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "model": {
+                      "description": "Model name override, such as `gpt-4o-mini`.\nIf unset, the model name is taken from the request.",
+                      "maxLength": 256,
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "projectName": {
+                      "description": "The Foundry project name, required when `resourceType` is `Foundry`.\nUsed to construct paths: /api/projects/{projectName}/openai/v1/...",
+                      "maxLength": 256,
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "resourceName": {
+                      "description": "The Azure resource name used to construct the endpoint host.\nFor OpenAI: {resourceName}.openai.azure.com\nFor Foundry: {resourceName}.services.ai.azure.com\nNote: when the Azure portal \"Foundry legacy\" template was used, the\ngenerated resource name may end in \"-resource\" (e.g. \"myproject-resource\");\nthat suffix is part of the resource name as the user configured it, not\npart of the hostname suffix agentgateway should append.",
+                      "maxLength": 256,
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "resourceType": {
+                      "description": "The type of Azure endpoint. Determines the host suffix.",
+                      "enum": [
+                        "Foundry",
+                        "OpenAI"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "resourceName",
+                    "resourceType"
+                  ],
+                  "type": "object",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "projectName is required when resourceType is Foundry",
+                      "rule": "self.resourceType != 'Foundry' || has(self.projectName)"
+                    }
+                  ],
+                  "additionalProperties": false
+                },
+                "azureopenai": {
+                  "description": "Azure OpenAI provider settings.",
+                  "properties": {
+                    "apiVersion": {
+                      "description": "The version of the Azure OpenAI API to use.\nFor more information, see the [Azure OpenAI API version reference](https://learn.microsoft.com/en-us/azure/foundry/openai/reference).\nIf unset, defaults to `v1`.",
+                      "maxLength": 64,
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "deploymentName": {
+                      "description": "The name of the Azure OpenAI model deployment to use.\nFor more information, see the [Azure OpenAI model docs](https://learn.microsoft.com/en-us/azure/foundry/foundry-models/concepts/models-sold-directly-by-azure?view=foundry-classic).\nThis is required if `apiVersion` is not `v1`. For `v1`, the model can be\nset in the request.",
+                      "maxLength": 256,
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "endpoint": {
+                      "description": "The endpoint for the Azure OpenAI API to use, such as `my-endpoint.openai.azure.com`.\nIf the scheme is included, it is stripped.",
+                      "maxLength": 256,
+                      "minLength": 1,
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "endpoint"
+                  ],
+                  "type": "object",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "deploymentName is required for this apiVersion",
+                      "rule": "!has(self.apiVersion) || self.apiVersion == 'v1' ? true : has(self.deploymentName)"
+                    }
+                  ],
+                  "additionalProperties": false
+                },
+                "bedrock": {
+                  "description": "Bedrock provider settings.",
+                  "properties": {
+                    "guardrail": {
+                      "description": "Guardrail policy to use for the backend. See\n<https://docs.aws.amazon.com/bedrock/latest/userguide/guardrails.html>.\nIf not specified, the AWS Guardrail policy will not be used.",
+                      "properties": {
+                        "identifier": {
+                          "description": "Identifier of the Guardrail policy to use for the backend.",
+                          "maxLength": 256,
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "version": {
+                          "description": "Version of the Guardrail policy to use for the backend.",
+                          "maxLength": 256,
+                          "minLength": 1,
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "identifier",
+                        "version"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "model": {
+                      "description": "Model name override, such as `gpt-4o-mini`.\nIf unset, the model name is taken from the request.",
+                      "maxLength": 256,
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "region": {
+                      "default": "us-east-1",
+                      "description": "AWS region to use for the backend.\nDefaults to `us-east-1` if not specified.",
+                      "maxLength": 63,
+                      "minLength": 1,
+                      "pattern": "^[a-z0-9-]+$",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "custom": {
+                  "description": "Custom provider configures a non-managed or self-hosted LLM provider.\nUse this when the provider target and API formats should be declared\nexplicitly instead of inferred from a managed provider such as OpenAI or\nAnthropic.",
+                  "properties": {
+                    "backendRef": {
+                      "description": "Kubernetes backend that serves this provider.\n`backendRef` may target only a namespace-local Service or InferencePool.\nIf unset, host and port must be set on the parent provider.",
+                      "properties": {
+                        "group": {
+                          "default": "",
+                          "description": "API group of the referenced resource. For example, `gateway.networking.k8s.io`.\nWhen unspecified or empty string, core API group is inferred.",
+                          "maxLength": 253,
+                          "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                          "type": "string"
+                        },
+                        "kind": {
+                          "default": "Service",
+                          "description": "Kind of the referenced resource. For example, `Service`.\nDefaults to \"Service\" when not specified.",
+                          "maxLength": 63,
+                          "minLength": 1,
+                          "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
+                          "type": "string"
+                        },
+                        "name": {
+                          "description": "Name of the referenced resource.",
+                          "maxLength": 253,
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "port": {
+                          "description": "Destination port number to use for this resource.\nRequired when the referenced resource is a Kubernetes Service.",
+                          "format": "int32",
+                          "maximum": 65535,
+                          "minimum": 1,
+                          "type": "integer"
+                        }
+                      },
+                      "required": [
+                        "name"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-validations": [
+                        {
+                          "message": "Must have port for Service reference",
+                          "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
+                        }
+                      ],
+                      "additionalProperties": false
+                    },
+                    "formats": {
+                      "description": "Provider-native API formats this provider supports.",
+                      "items": {
+                        "description": "Provider-native LLM API format settings.",
+                        "properties": {
+                          "path": {
+                            "description": "Default upstream path override for this format.\nIf unset, agentgateway uses the default path for the format.",
+                            "maxLength": 1024,
+                            "minLength": 1,
+                            "type": "string"
+                          },
+                          "type": {
+                            "description": "Provider-native API format.",
+                            "enum": [
+                              "AnthropicTokenCount",
+                              "Completions",
+                              "Embeddings",
+                              "Messages",
+                              "Realtime",
+                              "Rerank",
+                              "Responses"
+                            ],
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "type"
+                        ],
+                        "type": "object",
+                        "x-kubernetes-validations": [
+                          {
+                            "message": "path must start with /",
+                            "rule": "!has(self.path) || self.path.startsWith('/')"
+                          }
+                        ],
+                        "additionalProperties": false
+                      },
+                      "maxItems": 6,
+                      "minItems": 1,
+                      "type": "array",
+                      "x-kubernetes-list-map-keys": [
+                        "type"
+                      ],
+                      "x-kubernetes-list-type": "map"
+                    },
+                    "model": {
+                      "description": "Model name override, such as `gpt-oss`.\nIf unset, the model name is taken from the request.",
+                      "maxLength": 256,
+                      "minLength": 1,
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "formats"
+                  ],
+                  "type": "object",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "custom provider backendRef may target only Service or InferencePool",
+                      "rule": "!has(self.backendRef) || (((!has(self.backendRef.group) || self.backendRef.group == \"\") && (!has(self.backendRef.kind) || self.backendRef.kind == 'Service')) || (has(self.backendRef.group) && self.backendRef.group == 'inference.networking.k8s.io' && has(self.backendRef.kind) && self.backendRef.kind == 'InferencePool'))"
+                    }
+                  ],
+                  "additionalProperties": false
+                },
+                "gemini": {
+                  "description": "Gemini provider settings.",
+                  "properties": {
+                    "model": {
+                      "description": "Model name override, such as `gemini-2.5-pro`.\nIf unset, the model name is taken from the request.",
+                      "maxLength": 256,
+                      "minLength": 1,
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "host": {
+                  "description": "Hostname to send requests to.\nFor custom providers without backendRef, host and port specify the target.\nFor managed providers, host and port override the provider default.",
+                  "maxLength": 256,
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "openai": {
+                  "description": "OpenAI provider settings.",
+                  "properties": {
+                    "model": {
+                      "description": "Model name override, such as `gpt-4o-mini`.\nIf unset, the model name is taken from the request.",
+                      "maxLength": 256,
+                      "minLength": 1,
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "path": {
+                  "description": "URL path to use for LLM provider API requests.\nThis is useful when you need to route requests to a different API endpoint while maintaining\ncompatibility with the original provider's API structure.\nIf not specified, the default path for the provider is used.",
+                  "maxLength": 1024,
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "pathPrefix": {
+                  "description": "Overrides the default base path prefix, such as `/v1`, for upstream requests.\nPath translation for cross-format requests still applies using this prefix.\nOnly supported for OpenAI and Anthropic providers.",
+                  "maxLength": 1024,
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "port": {
+                  "description": "Port to send requests to.",
+                  "format": "int32",
+                  "maximum": 65535,
+                  "minimum": 1,
+                  "type": "integer"
+                },
+                "vertexai": {
+                  "description": "Vertex AI provider settings.",
+                  "properties": {
+                    "model": {
+                      "description": "Model name override, such as `gpt-4o-mini`.\nIf unset, the model name is taken from the request.",
+                      "maxLength": 256,
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "projectId": {
+                      "description": "The ID of the Google Cloud Project that you use for the Vertex AI.",
+                      "maxLength": 64,
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "region": {
+                      "default": "global",
+                      "description": "The location of the Google Cloud Project that you use for the Vertex AI.\nSpecial values: `global` uses the global endpoint, while `us` and `eu` use restricted\nmulti-region endpoints. Other values are treated as regional locations.\nDefaults to `global` if not specified.",
+                      "maxLength": 64,
+                      "minLength": 1,
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "projectId"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "x-kubernetes-validations": [
+                {
+                  "message": "both host and port must be set together",
+                  "rule": "has(self.host) || has(self.port) ? has(self.host) && has(self.port) : true"
+                },
+                {
+                  "message": "custom providers must specify exactly one of backendRef or host and port",
+                  "rule": "has(self.custom) ? has(self.custom.backendRef) != has(self.host) : true"
+                },
+                {
+                  "message": "path and pathPrefix are mutually exclusive",
+                  "rule": "!(has(self.path) && has(self.pathPrefix))"
+                },
+                {
+                  "message": "path, pathPrefix, and custom format paths are mutually exclusive",
+                  "rule": "!(has(self.custom) && self.custom.formats.exists(f, has(f.path)) && (has(self.path) || has(self.pathPrefix)))"
+                },
+                {
+                  "message": "pathPrefix requires host to be set",
+                  "rule": "has(self.pathPrefix) ? has(self.host) : true"
+                },
+                {
+                  "message": "exactly one of the fields in [openai azureopenai azure anthropic gemini vertexai bedrock custom] must be set",
+                  "rule": "[has(self.openai),has(self.azureopenai),has(self.azure),has(self.anthropic),has(self.gemini),has(self.vertexai),has(self.bedrock),has(self.custom)].filter(x,x==true).size() == 1"
+                }
+              ],
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "x-kubernetes-validations": [
+            {
+              "message": "exactly one of the fields in [provider groups] must be set",
+              "rule": "[has(self.provider),has(self.groups)].filter(x,x==true).size() == 1"
+            }
+          ],
+          "additionalProperties": false
+        },
+        "aws": {
+          "description": "AWS service backend, such as AgentCore.",
+          "properties": {
+            "agentCore": {
+              "description": "Amazon Bedrock AgentCore backend settings.",
+              "properties": {
+                "agentRuntimeArn": {
+                  "description": "ARN of the AgentCore runtime.",
+                  "type": "string"
+                },
+                "qualifier": {
+                  "description": "Alias or version qualifier.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "agentRuntimeArn"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "x-kubernetes-validations": [
+            {
+              "message": "exactly one of the fields in [agentCore] must be set",
+              "rule": "[has(self.agentCore)].filter(x,x==true).size() == 1"
+            }
+          ],
+          "additionalProperties": false
+        },
+        "dynamicForwardProxy": {
+          "description": "Dynamically sends requests to the destination based on the incoming\nrequest HTTP host header, or TLS SNI for TLS traffic.\n\nWarning: this backend type can send requests to arbitrary destinations. Proper\naccess controls must be put in place when using this backend type.",
+          "type": "object"
+        },
+        "mcp": {
+          "description": "MCP backend.",
+          "properties": {
+            "failureMode": {
+              "description": "Behavior when MCP targets fail to initialize or\nbecome unavailable at runtime. `FailOpen` skips failed targets and\ncontinues serving from healthy ones. `FailClosed` (default) fails the\nentire session if any target fails.",
+              "enum": [
+                "FailClosed",
+                "FailOpen"
+              ],
+              "type": "string"
+            },
+            "sessionRouting": {
+              "description": "MCP session routing behavior.\nDefaults to `Stateful` if not set.",
+              "enum": [
+                "Stateful",
+                "Stateless"
+              ],
+              "type": "string"
+            },
+            "targets": {
+              "description": "MCP targets to use for this backend. Policies\ntargeting MCP targets must use `targetRefs[].sectionName` to select\nthe target by name.",
+              "items": {
+                "description": "MCP target selection for this backend.",
+                "properties": {
+                  "name": {
+                    "description": "Name of the MCP target.",
+                    "maxLength": 253,
+                    "minLength": 1,
+                    "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                    "type": "string"
+                  },
+                  "selector": {
+                    "description": "Label selector used to select `Service` resources.\nIf policies are needed on a per-service basis, `AgentgatewayPolicy` can\ntarget the desired `Service`.",
+                    "properties": {
+                      "namespaces": {
+                        "description": "`namespace` is the label selector for namespaces that `Service`\nresources should be selected from. If unset, only the namespace of the\n`AgentgatewayBackend` is searched.",
+                        "properties": {
+                          "matchExpressions": {
+                            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                            "items": {
+                              "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                              "properties": {
+                                "key": {
+                                  "description": "key is the label key that the selector applies to.",
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                  "type": "string"
+                                },
+                                "values": {
+                                  "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
+                                }
+                              },
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "matchLabels": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "services": {
+                        "description": "`services` is the label selector for which `Service` resources should be\nselected.",
+                        "properties": {
+                          "matchExpressions": {
+                            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                            "items": {
+                              "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                              "properties": {
+                                "key": {
+                                  "description": "key is the label key that the selector applies to.",
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                  "type": "string"
+                                },
+                                "values": {
+                                  "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
+                                }
+                              },
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "matchLabels": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "x-kubernetes-validations": [
+                      {
+                        "message": "at least one of the fields in [namespaces services] must be set",
+                        "rule": "[has(self.namespaces),has(self.services)].filter(x,x==true).size() >= 1"
+                      }
+                    ],
+                    "additionalProperties": false
+                  },
+                  "static": {
+                    "description": "Static MCP destination. When connecting to\nin-cluster `Service` resources, it is recommended to use `selector`\ninstead.",
+                    "properties": {
+                      "backendRef": {
+                        "description": "Namespace-local `Service` resource by name.\nWhen set, this replaces `host` only; `port`, `path`, and `protocol`\nremain configured on this target.",
+                        "properties": {
+                          "name": {
+                            "default": "",
+                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "host": {
+                        "description": "Hostname or IP address of the MCP target.",
+                        "maxLength": 256,
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "path": {
+                        "description": "URL path of the MCP target endpoint.\nDefaults to `\"/sse\"` for the `SSE` protocol or `\"/mcp\"` for the\n`StreamableHTTP` protocol if not specified.",
+                        "maxLength": 1024,
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "policies": {
+                        "description": "Policies for communicating with this backend.\nPolicies may also be set in `AgentgatewayPolicy`, or in the top-level\n`AgentgatewayBackend`. Policies are merged on a field-level basis, with\norder: `AgentgatewayPolicy` < `AgentgatewayBackend` < `AgentgatewayBackend` MCP (this field).\nThis field may only be used with host-based static targets, not\n`backendRef`.",
+                        "properties": {
+                          "auth": {
+                            "description": "Settings for managing authentication to the backend.",
+                            "properties": {
+                              "aws": {
+                                "description": "Explicit AWS authentication method for the backend.\nWhen omitted, default AWS SDK credential discovery is used.",
+                                "properties": {
+                                  "assumeRole": {
+                                    "description": "AWS STS AssumeRole settings to use before signing backend requests.\nAmbient AWS credentials are used as the source credentials for STS.",
+                                    "properties": {
+                                      "roleArn": {
+                                        "description": "AWS IAM role ARN to assume.",
+                                        "minLength": 1,
+                                        "pattern": "^arn:aws[a-z-]*:iam::[0-9]{12}:role/.+$",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "roleArn"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "secretRef": {
+                                    "description": "Credential source, defaulting to a Kubernetes\n`Secret`, containing the AWS credentials. When using the default Secret\nresolver, the `Secret` must have keys `accessKey`, `secretKey`, and\noptionally `sessionToken`.",
+                                    "properties": {
+                                      "group": {
+                                        "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                                        "type": "string"
+                                      },
+                                      "kind": {
+                                        "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "description": "The name of the referenced credential.",
+                                        "maxLength": 253,
+                                        "minLength": 1,
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "name"
+                                    ],
+                                    "type": "object",
+                                    "x-kubernetes-map-type": "atomic",
+                                    "x-kubernetes-validations": [
+                                      {
+                                        "message": "custom credential refs must set both group and kind",
+                                        "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                                      }
+                                    ],
+                                    "additionalProperties": false
+                                  },
+                                  "serviceName": {
+                                    "description": "AWS SigV4 signing service name, for example\n`bedrock`, `bedrock-agentcore`, or `execute-api`). If unset, typed AWS\nbackends may provide this automatically.",
+                                    "maxLength": 256,
+                                    "minLength": 1,
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "x-kubernetes-validations": [
+                                  {
+                                    "message": "secretRef and assumeRole are mutually exclusive",
+                                    "rule": "!(has(self.secretRef) && has(self.assumeRole))"
+                                  }
+                                ],
+                                "additionalProperties": false
+                              },
+                              "azure": {
+                                "description": "Azure authentication method for the backend.",
+                                "properties": {
+                                  "managedIdentity": {
+                                    "description": "Managed identity authentication settings.",
+                                    "properties": {
+                                      "clientId": {
+                                        "type": "string"
+                                      },
+                                      "objectId": {
+                                        "type": "string"
+                                      },
+                                      "resourceId": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "clientId",
+                                      "objectId",
+                                      "resourceId"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "secretRef": {
+                                    "description": "Credential source, defaulting to a Kubernetes\n`Secret`, containing the Azure credentials. When using the default Secret\nresolver, the `Secret` must have keys `clientID`, `tenantID`, and\n`clientSecret`.",
+                                    "properties": {
+                                      "group": {
+                                        "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                                        "type": "string"
+                                      },
+                                      "kind": {
+                                        "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "description": "The name of the referenced credential.",
+                                        "maxLength": 253,
+                                        "minLength": 1,
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "name"
+                                    ],
+                                    "type": "object",
+                                    "x-kubernetes-map-type": "atomic",
+                                    "x-kubernetes-validations": [
+                                      {
+                                        "message": "custom credential refs must set both group and kind",
+                                        "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                                      }
+                                    ],
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "gcp": {
+                                "description": "Google authentication method for the backend.\nWhen omitted, default Google credential discovery is used.",
+                                "properties": {
+                                  "audience": {
+                                    "description": "Explicit `aud` value for the ID token. Only\nvalid with `IdToken` type. If not set, the `aud` is automatically\nderived from the backend hostname.",
+                                    "maxLength": 256,
+                                    "minLength": 1,
+                                    "type": "string"
+                                  },
+                                  "secretRef": {
+                                    "description": "Credential source, defaulting to a Kubernetes\n`Secret`, containing ADC-compatible Google credential JSON. When using\nthe default Secret resolver, this must be stored in the `credentials.json`\nkey. When omitted, ambient credentials are used.",
+                                    "properties": {
+                                      "group": {
+                                        "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                                        "type": "string"
+                                      },
+                                      "kind": {
+                                        "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "description": "The name of the referenced credential.",
+                                        "maxLength": 253,
+                                        "minLength": 1,
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "name"
+                                    ],
+                                    "type": "object",
+                                    "x-kubernetes-map-type": "atomic",
+                                    "x-kubernetes-validations": [
+                                      {
+                                        "message": "custom credential refs must set both group and kind",
+                                        "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                                      }
+                                    ],
+                                    "additionalProperties": false
+                                  },
+                                  "type": {
+                                    "description": "The type of token to generate. To authenticate to GCP services,\ngenerally an `AccessToken` is used. To authenticate to Cloud Run, an\n`IdToken` is used.",
+                                    "enum": [
+                                      "AccessToken",
+                                      "IdToken"
+                                    ],
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "x-kubernetes-validations": [
+                                  {
+                                    "message": "audience is only valid with IdToken",
+                                    "rule": "has(self.audience) ? self.type == 'IdToken' : true"
+                                  }
+                                ],
+                                "additionalProperties": false
+                              },
+                              "key": {
+                                "description": "Inline key to use as the value of the\n`Authorization` header. This option is the least secure; usage of a\n`Secret` is preferred.",
+                                "maxLength": 2048,
+                                "type": "string"
+                              },
+                              "location": {
+                                "description": "Where backend credentials are inserted.\nIf omitted, credentials are written to the `Authorization` header with the `Bearer ` prefix.\nThis applies to `key`, `secretRef`, and `passthrough`.",
+                                "properties": {
+                                  "cookie": {
+                                    "properties": {
+                                      "name": {
+                                        "maxLength": 256,
+                                        "minLength": 1,
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "name"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "header": {
+                                    "properties": {
+                                      "name": {
+                                        "description": "HTTPHeaderName is the name of an HTTP header.\n\nValid values include:\n\n* \"Authorization\"\n* \"Set-Cookie\"\n\nInvalid values include:\n\n  - \":method\" - \":\" is an invalid character. This means that HTTP/2 pseudo\n    headers are not currently supported by this type.\n  - \"/invalid\" - \"/ \" is an invalid character",
+                                        "maxLength": 256,
+                                        "minLength": 1,
+                                        "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                                        "type": "string"
+                                      },
+                                      "prefix": {
+                                        "maxLength": 256,
+                                        "minLength": 1,
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "name"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "queryParameter": {
+                                    "properties": {
+                                      "name": {
+                                        "maxLength": 256,
+                                        "minLength": 1,
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "name"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "x-kubernetes-validations": [
+                                  {
+                                    "message": "exactly one of the fields in [header queryParameter cookie] must be set",
+                                    "rule": "[has(self.header),has(self.queryParameter),has(self.cookie)].filter(x,x==true).size() == 1"
+                                  }
+                                ],
+                                "additionalProperties": false
+                              },
+                              "passthrough": {
+                                "description": "Passes through an existing token that has been sent by the\nclient and validated. Other policies, like JWT and API key\nauthentication, will strip the original client credentials. Passthrough backend authentication\ncauses the original token to be added back into the request. If there are no client authentication policies on the\nrequest, the original token would be unchanged, so this would have no effect.",
+                                "type": "object"
+                              },
+                              "secretRef": {
+                                "description": "Credential source, defaulting to a Kubernetes\n`Secret`, storing the key to use as the authorization value. When using\nthe default Secret resolver, this must be stored in the `Authorization`\nkey.",
+                                "properties": {
+                                  "group": {
+                                    "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                                    "type": "string"
+                                  },
+                                  "kind": {
+                                    "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "description": "The name of the referenced credential.",
+                                    "maxLength": 253,
+                                    "minLength": 1,
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "name"
+                                ],
+                                "type": "object",
+                                "x-kubernetes-map-type": "atomic",
+                                "x-kubernetes-validations": [
+                                  {
+                                    "message": "custom credential refs must set both group and kind",
+                                    "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                                  }
+                                ],
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-validations": [
+                              {
+                                "message": "location may only be set for key or passthrough auth",
+                                "rule": "has(self.location) ? has(self.key) || has(self.secretRef) || has(self.passthrough) : true"
+                              },
+                              {
+                                "message": "exactly one of the fields in [key secretRef passthrough aws azure gcp] must be set",
+                                "rule": "[has(self.key),has(self.secretRef),has(self.passthrough),has(self.aws),has(self.azure),has(self.gcp)].filter(x,x==true).size() == 1"
+                              }
+                            ],
+                            "additionalProperties": false
+                          },
+                          "http": {
+                            "description": "Settings for managing HTTP requests to the backend.",
+                            "properties": {
+                              "requestTimeout": {
+                                "description": "Deadline for receiving a response from the backend.",
+                                "type": "string",
+                                "x-kubernetes-validations": [
+                                  {
+                                    "message": "invalid duration value",
+                                    "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                  },
+                                  {
+                                    "message": "requestTimeout must be at least 1ms",
+                                    "rule": "duration(self) >= duration('1ms')"
+                                  }
+                                ]
+                              },
+                              "version": {
+                                "description": "HTTP protocol version to use when connecting to\nthe backend.\nIf not specified, the version is automatically determined:\n* `Service` types can specify it with `appProtocol` on the `Service`\n  port.\n* If traffic is identified as gRPC, `HTTP2` is used.\n* If the incoming traffic was plaintext HTTP, the original protocol will\n  be used.\n* If the incoming traffic was HTTPS, `HTTP1` will be used. This is\n  because most clients will transparently upgrade HTTPS traffic to\n  `HTTP2`, even if the backend doesn't support it.",
+                                "enum": [
+                                  "HTTP1",
+                                  "HTTP2"
+                                ],
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "tcp": {
+                            "description": "Settings for managing TCP connections to the backend.",
+                            "properties": {
+                              "connectTimeout": {
+                                "description": "Deadline for establishing a connection to\nthe destination.",
+                                "type": "string",
+                                "x-kubernetes-validations": [
+                                  {
+                                    "message": "invalid duration value",
+                                    "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                  },
+                                  {
+                                    "message": "connectTimeout must be at least 100ms",
+                                    "rule": "duration(self) >= duration('100ms')"
+                                  }
+                                ]
+                              },
+                              "keepalive": {
+                                "description": "Settings for enabling TCP keepalives on the\nconnection.",
+                                "properties": {
+                                  "interval": {
+                                    "description": "Time between keepalive probes.\nIf unset, this defaults to 180s.",
+                                    "type": "string",
+                                    "x-kubernetes-validations": [
+                                      {
+                                        "message": "invalid duration value",
+                                        "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                      },
+                                      {
+                                        "message": "interval must be at least 1 second",
+                                        "rule": "duration(self) >= duration('1s')"
+                                      }
+                                    ]
+                                  },
+                                  "retries": {
+                                    "description": "Maximum number of keepalive probes to send before dropping the connection.\nIf unset, this defaults to 9.",
+                                    "format": "int32",
+                                    "maximum": 64,
+                                    "minimum": 1,
+                                    "type": "integer"
+                                  },
+                                  "time": {
+                                    "description": "Time a connection needs to be idle before keepalive probes start being sent.\nIf unset, this defaults to 180s.",
+                                    "type": "string",
+                                    "x-kubernetes-validations": [
+                                      {
+                                        "message": "invalid duration value",
+                                        "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                      },
+                                      {
+                                        "message": "time must be at least 1 second",
+                                        "rule": "duration(self) >= duration('1s')"
+                                      }
+                                    ]
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "tls": {
+                            "description": "Settings for managing TLS connections to the backend.\n\nIf this field is set, TLS will be initiated to the backend; the system trusted CA certificates will be used to\nvalidate the server, and the SNI will automatically be set based on the destination.",
+                            "properties": {
+                              "alpnProtocols": {
+                                "description": "Application-Layer Protocol Negotiation (`ALPN`)\nvalue to use in the TLS handshake.\n\nIf not present, defaults to `[\"h2\", \"http/1.1\"]`.",
+                                "items": {
+                                  "maxLength": 64,
+                                  "minLength": 1,
+                                  "type": "string"
+                                },
+                                "maxItems": 16,
+                                "minItems": 1,
+                                "type": "array"
+                              },
+                              "caCertificateRefs": {
+                                "description": "CA certificate `ConfigMap` to use to\nverify the server certificate.\nIf unset, the system's trusted certificates are used.",
+                                "items": {
+                                  "description": "LocalObjectReference contains enough information to let you locate the\nreferenced object inside the same namespace.",
+                                  "properties": {
+                                    "name": {
+                                      "default": "",
+                                      "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "x-kubernetes-map-type": "atomic",
+                                  "additionalProperties": false
+                                },
+                                "maxItems": 1,
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
+                              },
+                              "insecureSkipVerify": {
+                                "description": "Originates TLS but skips verification of the backend's certificate.\nWARNING: This is an insecure option that should only be used if the risks are understood.\n\nThere are two modes:\n* `All` disables all TLS verification.\n* `Hostname` verifies the CA certificate is trusted, but ignores any\n  mismatch of hostname or SANs. Note that this method is still insecure;\n  prefer setting `verifySubjectAltNames` to customize the valid hostnames\n  if possible.",
+                                "enum": [
+                                  "All",
+                                  "Hostname"
+                                ],
+                                "type": "string"
+                              },
+                              "keyExchangeGroups": {
+                                "description": "Ordered list of key exchange groups for a TLS connection.\nFor example: `X25519_MLKEM768,X25519`.",
+                                "items": {
+                                  "enum": [
+                                    "P-256",
+                                    "P-384",
+                                    "X25519",
+                                    "X25519_MLKEM768"
+                                  ],
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "mtlsCertificateRef": {
+                                "description": "Enables mutual TLS to the backend, using the\nspecified key (`tls.key`) and cert (`tls.crt`) from the referenced\ncredential source, defaulting to a Kubernetes `Secret`.\n\nAn optional `ca.cert` field, if present, will be used to verify the\nserver certificate. If `caCertificateRefs` is also specified, the\n`caCertificateRefs` field takes priority.\n\nIf unspecified, no client certificate will be used.",
+                                "items": {
+                                  "description": "References a same-namespace credential.\nSet only `name` to reference a Kubernetes Secret.",
+                                  "properties": {
+                                    "group": {
+                                      "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                                      "type": "string"
+                                    },
+                                    "kind": {
+                                      "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "description": "The name of the referenced credential.",
+                                      "maxLength": 253,
+                                      "minLength": 1,
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "name"
+                                  ],
+                                  "type": "object",
+                                  "x-kubernetes-map-type": "atomic",
+                                  "x-kubernetes-validations": [
+                                    {
+                                      "message": "custom credential refs must set both group and kind",
+                                      "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                                    }
+                                  ],
+                                  "additionalProperties": false
+                                },
+                                "maxItems": 1,
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
+                              },
+                              "sni": {
+                                "description": "Server Name Indicator (`SNI`) to use in the TLS\nhandshake. If unset, the `SNI` is automatically set based on the\ndestination hostname.",
+                                "maxLength": 253,
+                                "minLength": 1,
+                                "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                                "type": "string"
+                              },
+                              "verifySubjectAltNames": {
+                                "description": "Subject Alternative Names (`SAN`)\nto verify in the server certificate.\nIf not present, the destination hostname is automatically used.",
+                                "items": {
+                                  "maxLength": 256,
+                                  "minLength": 1,
+                                  "type": "string"
+                                },
+                                "maxItems": 16,
+                                "minItems": 1,
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-validations": [
+                              {
+                                "message": "insecureSkipVerify All and caCertificateRefs may not be set together",
+                                "rule": "has(self.insecureSkipVerify) && self.insecureSkipVerify == 'All' ? !has(self.caCertificateRefs) : true"
+                              },
+                              {
+                                "message": "insecureSkipVerify and verifySubjectAltNames may not be set together",
+                                "rule": "has(self.insecureSkipVerify) ? !has(self.verifySubjectAltNames) : true"
+                              },
+                              {
+                                "message": "at most one of the fields in [verifySubjectAltNames insecureSkipVerify] may be set",
+                                "rule": "[has(self.verifySubjectAltNames),has(self.insecureSkipVerify)].filter(x,x==true).size() <= 1"
+                              }
+                            ],
+                            "additionalProperties": false
+                          },
+                          "tunnel": {
+                            "description": "Settings for managing tunnel connections, with behavior like `HTTPS_PROXY`, to the backend.",
+                            "properties": {
+                              "backendRef": {
+                                "description": "Proxy server to reach.\nSupported types: `Service` and `Backend`.",
+                                "properties": {
+                                  "group": {
+                                    "default": "",
+                                    "description": "Group is the group of the referent. For example, \"gateway.networking.k8s.io\".\nWhen unspecified or empty string, core API group is inferred.",
+                                    "maxLength": 253,
+                                    "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                                    "type": "string"
+                                  },
+                                  "kind": {
+                                    "default": "Service",
+                                    "description": "Kind is the Kubernetes resource kind of the referent. For example\n\"Service\".\n\nDefaults to \"Service\" when not specified.\n\nExternalName services can refer to CNAME DNS records that may live\noutside of the cluster and as such are difficult to reason about in\nterms of conformance. They also may not be safe to forward to (see\nCVE-2021-25740 for more information). Implementations SHOULD NOT\nsupport ExternalName Services.\n\nSupport: Core (Services with a type other than ExternalName)\n\nSupport: Implementation-specific (Services with type ExternalName)",
+                                    "maxLength": 63,
+                                    "minLength": 1,
+                                    "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "description": "Name is the name of the referent.",
+                                    "maxLength": 253,
+                                    "minLength": 1,
+                                    "type": "string"
+                                  },
+                                  "namespace": {
+                                    "description": "Namespace is the namespace of the backend. When unspecified, the local\nnamespace is inferred.\n\nNote that when a namespace different than the local namespace is specified,\na ReferenceGrant object is required in the referent namespace to allow that\nnamespace's owner to accept the reference. See the ReferenceGrant\ndocumentation for details.\n\nSupport: Core",
+                                    "maxLength": 63,
+                                    "minLength": 1,
+                                    "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "description": "Port specifies the destination port number to use for this resource.\nPort is required when the referent is a Kubernetes Service. In this\ncase, the port number is the service port number, not the target port.\nFor other resources, destination port might be derived from the referent\nresource or this field.",
+                                    "format": "int32",
+                                    "maximum": 65535,
+                                    "minimum": 1,
+                                    "type": "integer"
+                                  }
+                                },
+                                "required": [
+                                  "name"
+                                ],
+                                "type": "object",
+                                "x-kubernetes-validations": [
+                                  {
+                                    "message": "Must have port for Service reference",
+                                    "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
+                                  }
+                                ],
+                                "additionalProperties": false
+                              }
+                            },
+                            "required": [
+                              "backendRef"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "port": {
+                        "description": "Port number of the MCP target.",
+                        "format": "int32",
+                        "maximum": 65535,
+                        "minimum": 1,
+                        "type": "integer"
+                      },
+                      "protocol": {
+                        "description": "Protocol to use for the connection to the MCP\ntarget.",
+                        "enum": [
+                          "SSE",
+                          "StreamableHTTP"
+                        ],
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "port"
+                    ],
+                    "type": "object",
+                    "x-kubernetes-validations": [
+                      {
+                        "message": "mcp target policies may not be used with backendRef",
+                        "rule": "!has(self.backendRef) || !has(self.policies)"
+                      },
+                      {
+                        "message": "exactly one of the fields in [host backendRef] must be set",
+                        "rule": "[has(self.host),has(self.backendRef)].filter(x,x==true).size() == 1"
+                      }
+                    ],
+                    "additionalProperties": false
+                  }
+                },
+                "required": [
+                  "name"
+                ],
+                "type": "object",
+                "x-kubernetes-validations": [
+                  {
+                    "message": "exactly one of the fields in [selector static] must be set",
+                    "rule": "[has(self.selector),has(self.static)].filter(x,x==true).size() == 1"
+                  }
+                ],
+                "additionalProperties": false
+              },
+              "maxItems": 32,
+              "minItems": 1,
+              "type": "array",
+              "x-kubernetes-list-map-keys": [
+                "name"
+              ],
+              "x-kubernetes-list-type": "map",
+              "x-kubernetes-validations": [
+                {
+                  "message": "target names must be unique",
+                  "rule": "self.all(t1, self.exists_one(t2, t1.name == t2.name))"
+                }
+              ]
+            }
+          },
+          "required": [
+            "targets"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "policies": {
+          "description": "Policies for communicating with this backend. Policies may also be set\nwith AgentgatewayPolicy. Backend policies take precedence over policy\nresources when they set the same field.",
+          "properties": {
+            "ai": {
+              "description": "Settings for AI workloads. This is only applicable when\nconnecting to a `Backend` of type `ai`.",
+              "properties": {
+                "defaults": {
+                  "description": "Defaults to merge with user input fields. If the field is already set, the field in the request is used.",
+                  "items": {
+                    "description": "Default value for a field in the JSON request body sent to the LLM provider.\nThese defaults are merged with the user-provided request to ensure missing fields are populated.\n\nUser input fields here refer to the fields in the JSON request body that a client sends when making a request to the LLM provider.\nDefaults set here do _not_ override those user-provided values unless you explicitly set `override` to `true`.\n\nExample: Setting a default system field for Anthropic, which does not support system role messages:\n\n\tdefaults:\n\t  - field: \"system\"\n\t    value: \"answer all questions in French\"\n\nExample: Setting a default temperature and overriding `max_tokens`:\n\n\tdefaults:\n\t  - field: \"temperature\"\n\t    value: \"0.5\"\n\t  - field: \"max_tokens\"\n\t    value: \"100\"\n\t    override: true\n\nExample: Setting custom lists fields:\n\n\tdefaults:\n\t  - field: \"custom_integer_list\"\n\t    value: [1,2,3]\n\n\toverrides:\n\t  - field: \"custom_string_list\"\n\t    value: [\"one\",\"two\",\"three\"]\n\nNote: The `field` values correspond to keys in the JSON request body, not fields in this CRD.",
+                    "properties": {
+                      "field": {
+                        "allOf": [
+                          {
+                            "minLength": 1
+                          },
+                          {
+                            "minLength": 1
+                          }
+                        ],
+                        "description": "Name of the field.",
+                        "maxLength": 256,
+                        "type": "string"
+                      },
+                      "value": {
+                        "description": "Default value for the field. This can be any JSON data type.",
+                        "x-kubernetes-preserve-unknown-fields": true
+                      }
+                    },
+                    "required": [
+                      "field",
+                      "value"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "maxItems": 64,
+                  "minItems": 1,
+                  "type": "array"
+                },
+                "modelAliases": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "Maps friendly model names to actual provider model names.\nExample: `{\"fast\": \"gpt-3.5-turbo\", \"smart\": \"gpt-4-turbo\"}`.\nNote: This field is only applicable when using the agentgateway data plane.",
+                  "maxProperties": 64,
+                  "type": "object"
+                },
+                "overrides": {
+                  "description": "Overrides to merge with user input fields. If the field is already set, the field is overwritten.",
+                  "items": {
+                    "description": "Default value for a field in the JSON request body sent to the LLM provider.\nThese defaults are merged with the user-provided request to ensure missing fields are populated.\n\nUser input fields here refer to the fields in the JSON request body that a client sends when making a request to the LLM provider.\nDefaults set here do _not_ override those user-provided values unless you explicitly set `override` to `true`.\n\nExample: Setting a default system field for Anthropic, which does not support system role messages:\n\n\tdefaults:\n\t  - field: \"system\"\n\t    value: \"answer all questions in French\"\n\nExample: Setting a default temperature and overriding `max_tokens`:\n\n\tdefaults:\n\t  - field: \"temperature\"\n\t    value: \"0.5\"\n\t  - field: \"max_tokens\"\n\t    value: \"100\"\n\t    override: true\n\nExample: Setting custom lists fields:\n\n\tdefaults:\n\t  - field: \"custom_integer_list\"\n\t    value: [1,2,3]\n\n\toverrides:\n\t  - field: \"custom_string_list\"\n\t    value: [\"one\",\"two\",\"three\"]\n\nNote: The `field` values correspond to keys in the JSON request body, not fields in this CRD.",
+                    "properties": {
+                      "field": {
+                        "allOf": [
+                          {
+                            "minLength": 1
+                          },
+                          {
+                            "minLength": 1
+                          }
+                        ],
+                        "description": "Name of the field.",
+                        "maxLength": 256,
+                        "type": "string"
+                      },
+                      "value": {
+                        "description": "Default value for the field. This can be any JSON data type.",
+                        "x-kubernetes-preserve-unknown-fields": true
+                      }
+                    },
+                    "required": [
+                      "field",
+                      "value"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "maxItems": 64,
+                  "minItems": 1,
+                  "type": "array"
+                },
+                "prompt": {
+                  "description": "Enriches requests sent to the LLM provider by appending and prepending system prompts. This can be configured only for\nLLM providers that use the `CHAT` or `CHAT_STREAMING` API route type.",
+                  "properties": {
+                    "append": {
+                      "description": "Messages to append to the prompt sent by the client.",
+                      "items": {
+                        "description": "An entry for a message to prepend or append to each prompt.",
+                        "properties": {
+                          "content": {
+                            "description": "String content of the message.",
+                            "type": "string"
+                          },
+                          "role": {
+                            "description": "Role of the message. The available roles depend on the backend\nLLM provider model, such as `SYSTEM` or `USER` in the OpenAI API.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "content",
+                          "role"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "prepend": {
+                      "description": "Messages to prepend to the prompt sent by the client.",
+                      "items": {
+                        "description": "An entry for a message to prepend or append to each prompt.",
+                        "properties": {
+                          "content": {
+                            "description": "String content of the message.",
+                            "type": "string"
+                          },
+                          "role": {
+                            "description": "Role of the message. The available roles depend on the backend\nLLM provider model, such as `SYSTEM` or `USER` in the OpenAI API.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "content",
+                          "role"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "promptCaching": {
+                  "description": "Automatic prompt caching for supported\nproviders, currently AWS Bedrock.\nReduces API costs by caching static content like system prompts and tool definitions.\nOnly applicable for Bedrock Claude 3+ and Nova models.",
+                  "properties": {
+                    "cacheMessageOffset": {
+                      "default": 0,
+                      "description": "Shifts the message cache point further back in the\nconversation. 0 (default) places it at the second-to-last message.\nHigher values move it N additional messages towards the start, clamped\nto bounds.",
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "cacheMessages": {
+                      "default": true,
+                      "description": "Enables caching for conversation messages.\nCaches all messages in the conversation for cost savings.",
+                      "type": "boolean"
+                    },
+                    "cacheSystem": {
+                      "default": true,
+                      "description": "Enables caching for system prompts.\nInserts a cache point after all system messages.",
+                      "type": "boolean"
+                    },
+                    "cacheTools": {
+                      "default": false,
+                      "description": "Enables caching for tool definitions.\nInserts a cache point after all tool specifications.",
+                      "type": "boolean"
+                    },
+                    "minTokens": {
+                      "default": 1024,
+                      "description": "Minimum estimated token count\nbefore caching is enabled. Uses rough heuristic (word count \u00d7 1.3) to estimate tokens.\nBedrock requires at least 1,024 tokens for caching to be effective.",
+                      "minimum": 0,
+                      "type": "integer"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "promptGuard": {
+                  "description": "Guardrails for LLM requests and responses.",
+                  "properties": {
+                    "request": {
+                      "description": "Prompt guards to apply to requests sent by the client.",
+                      "items": {
+                        "description": "Prompt guards to apply to requests sent by the client.",
+                        "properties": {
+                          "bedrockGuardrails": {
+                            "description": "AWS Bedrock Guardrails settings for prompt\nguarding.",
+                            "properties": {
+                              "identifier": {
+                                "description": "Identifier of the Guardrail policy to use for the backend.",
+                                "maxLength": 256,
+                                "minLength": 1,
+                                "type": "string"
+                              },
+                              "policies": {
+                                "description": "Policies for communicating with AWS Bedrock Guardrails.",
+                                "properties": {
+                                  "auth": {
+                                    "description": "Settings for managing authentication to the backend.",
+                                    "properties": {
+                                      "aws": {
+                                        "description": "Explicit AWS authentication method for the backend.\nWhen omitted, default AWS SDK credential discovery is used.",
+                                        "properties": {
+                                          "assumeRole": {
+                                            "description": "AWS STS AssumeRole settings to use before signing backend requests.\nAmbient AWS credentials are used as the source credentials for STS.",
+                                            "properties": {
+                                              "roleArn": {
+                                                "description": "AWS IAM role ARN to assume.",
+                                                "minLength": 1,
+                                                "pattern": "^arn:aws[a-z-]*:iam::[0-9]{12}:role/.+$",
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "roleArn"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "secretRef": {
+                                            "description": "Credential source, defaulting to a Kubernetes\n`Secret`, containing the AWS credentials. When using the default Secret\nresolver, the `Secret` must have keys `accessKey`, `secretKey`, and\noptionally `sessionToken`.",
+                                            "properties": {
+                                              "group": {
+                                                "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                                                "type": "string"
+                                              },
+                                              "kind": {
+                                                "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "description": "The name of the referenced credential.",
+                                                "maxLength": 253,
+                                                "minLength": 1,
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name"
+                                            ],
+                                            "type": "object",
+                                            "x-kubernetes-map-type": "atomic",
+                                            "x-kubernetes-validations": [
+                                              {
+                                                "message": "custom credential refs must set both group and kind",
+                                                "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                                              }
+                                            ],
+                                            "additionalProperties": false
+                                          },
+                                          "serviceName": {
+                                            "description": "AWS SigV4 signing service name, for example\n`bedrock`, `bedrock-agentcore`, or `execute-api`). If unset, typed AWS\nbackends may provide this automatically.",
+                                            "maxLength": 256,
+                                            "minLength": 1,
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "secretRef and assumeRole are mutually exclusive",
+                                            "rule": "!(has(self.secretRef) && has(self.assumeRole))"
+                                          }
+                                        ],
+                                        "additionalProperties": false
+                                      },
+                                      "azure": {
+                                        "description": "Azure authentication method for the backend.",
+                                        "properties": {
+                                          "managedIdentity": {
+                                            "description": "Managed identity authentication settings.",
+                                            "properties": {
+                                              "clientId": {
+                                                "type": "string"
+                                              },
+                                              "objectId": {
+                                                "type": "string"
+                                              },
+                                              "resourceId": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "clientId",
+                                              "objectId",
+                                              "resourceId"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "secretRef": {
+                                            "description": "Credential source, defaulting to a Kubernetes\n`Secret`, containing the Azure credentials. When using the default Secret\nresolver, the `Secret` must have keys `clientID`, `tenantID`, and\n`clientSecret`.",
+                                            "properties": {
+                                              "group": {
+                                                "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                                                "type": "string"
+                                              },
+                                              "kind": {
+                                                "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "description": "The name of the referenced credential.",
+                                                "maxLength": 253,
+                                                "minLength": 1,
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name"
+                                            ],
+                                            "type": "object",
+                                            "x-kubernetes-map-type": "atomic",
+                                            "x-kubernetes-validations": [
+                                              {
+                                                "message": "custom credential refs must set both group and kind",
+                                                "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                                              }
+                                            ],
+                                            "additionalProperties": false
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "gcp": {
+                                        "description": "Google authentication method for the backend.\nWhen omitted, default Google credential discovery is used.",
+                                        "properties": {
+                                          "audience": {
+                                            "description": "Explicit `aud` value for the ID token. Only\nvalid with `IdToken` type. If not set, the `aud` is automatically\nderived from the backend hostname.",
+                                            "maxLength": 256,
+                                            "minLength": 1,
+                                            "type": "string"
+                                          },
+                                          "secretRef": {
+                                            "description": "Credential source, defaulting to a Kubernetes\n`Secret`, containing ADC-compatible Google credential JSON. When using\nthe default Secret resolver, this must be stored in the `credentials.json`\nkey. When omitted, ambient credentials are used.",
+                                            "properties": {
+                                              "group": {
+                                                "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                                                "type": "string"
+                                              },
+                                              "kind": {
+                                                "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "description": "The name of the referenced credential.",
+                                                "maxLength": 253,
+                                                "minLength": 1,
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name"
+                                            ],
+                                            "type": "object",
+                                            "x-kubernetes-map-type": "atomic",
+                                            "x-kubernetes-validations": [
+                                              {
+                                                "message": "custom credential refs must set both group and kind",
+                                                "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                                              }
+                                            ],
+                                            "additionalProperties": false
+                                          },
+                                          "type": {
+                                            "description": "The type of token to generate. To authenticate to GCP services,\ngenerally an `AccessToken` is used. To authenticate to Cloud Run, an\n`IdToken` is used.",
+                                            "enum": [
+                                              "AccessToken",
+                                              "IdToken"
+                                            ],
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "audience is only valid with IdToken",
+                                            "rule": "has(self.audience) ? self.type == 'IdToken' : true"
+                                          }
+                                        ],
+                                        "additionalProperties": false
+                                      },
+                                      "key": {
+                                        "description": "Inline key to use as the value of the\n`Authorization` header. This option is the least secure; usage of a\n`Secret` is preferred.",
+                                        "maxLength": 2048,
+                                        "type": "string"
+                                      },
+                                      "location": {
+                                        "description": "Where backend credentials are inserted.\nIf omitted, credentials are written to the `Authorization` header with the `Bearer ` prefix.\nThis applies to `key`, `secretRef`, and `passthrough`.",
+                                        "properties": {
+                                          "cookie": {
+                                            "properties": {
+                                              "name": {
+                                                "maxLength": 256,
+                                                "minLength": 1,
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "header": {
+                                            "properties": {
+                                              "name": {
+                                                "description": "HTTPHeaderName is the name of an HTTP header.\n\nValid values include:\n\n* \"Authorization\"\n* \"Set-Cookie\"\n\nInvalid values include:\n\n  - \":method\" - \":\" is an invalid character. This means that HTTP/2 pseudo\n    headers are not currently supported by this type.\n  - \"/invalid\" - \"/ \" is an invalid character",
+                                                "maxLength": 256,
+                                                "minLength": 1,
+                                                "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                                                "type": "string"
+                                              },
+                                              "prefix": {
+                                                "maxLength": 256,
+                                                "minLength": 1,
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "queryParameter": {
+                                            "properties": {
+                                              "name": {
+                                                "maxLength": 256,
+                                                "minLength": 1,
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          }
+                                        },
+                                        "type": "object",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "exactly one of the fields in [header queryParameter cookie] must be set",
+                                            "rule": "[has(self.header),has(self.queryParameter),has(self.cookie)].filter(x,x==true).size() == 1"
+                                          }
+                                        ],
+                                        "additionalProperties": false
+                                      },
+                                      "passthrough": {
+                                        "description": "Passes through an existing token that has been sent by the\nclient and validated. Other policies, like JWT and API key\nauthentication, will strip the original client credentials. Passthrough backend authentication\ncauses the original token to be added back into the request. If there are no client authentication policies on the\nrequest, the original token would be unchanged, so this would have no effect.",
+                                        "type": "object"
+                                      },
+                                      "secretRef": {
+                                        "description": "Credential source, defaulting to a Kubernetes\n`Secret`, storing the key to use as the authorization value. When using\nthe default Secret resolver, this must be stored in the `Authorization`\nkey.",
+                                        "properties": {
+                                          "group": {
+                                            "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                                            "type": "string"
+                                          },
+                                          "kind": {
+                                            "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "description": "The name of the referenced credential.",
+                                            "maxLength": 253,
+                                            "minLength": 1,
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "name"
+                                        ],
+                                        "type": "object",
+                                        "x-kubernetes-map-type": "atomic",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "custom credential refs must set both group and kind",
+                                            "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                                          }
+                                        ],
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "x-kubernetes-validations": [
+                                      {
+                                        "message": "location may only be set for key or passthrough auth",
+                                        "rule": "has(self.location) ? has(self.key) || has(self.secretRef) || has(self.passthrough) : true"
+                                      },
+                                      {
+                                        "message": "exactly one of the fields in [key secretRef passthrough aws azure gcp] must be set",
+                                        "rule": "[has(self.key),has(self.secretRef),has(self.passthrough),has(self.aws),has(self.azure),has(self.gcp)].filter(x,x==true).size() == 1"
+                                      }
+                                    ],
+                                    "additionalProperties": false
+                                  },
+                                  "http": {
+                                    "description": "Settings for managing HTTP requests to the backend.",
+                                    "properties": {
+                                      "requestTimeout": {
+                                        "description": "Deadline for receiving a response from the backend.",
+                                        "type": "string",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "invalid duration value",
+                                            "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                          },
+                                          {
+                                            "message": "requestTimeout must be at least 1ms",
+                                            "rule": "duration(self) >= duration('1ms')"
+                                          }
+                                        ]
+                                      },
+                                      "version": {
+                                        "description": "HTTP protocol version to use when connecting to\nthe backend.\nIf not specified, the version is automatically determined:\n* `Service` types can specify it with `appProtocol` on the `Service`\n  port.\n* If traffic is identified as gRPC, `HTTP2` is used.\n* If the incoming traffic was plaintext HTTP, the original protocol will\n  be used.\n* If the incoming traffic was HTTPS, `HTTP1` will be used. This is\n  because most clients will transparently upgrade HTTPS traffic to\n  `HTTP2`, even if the backend doesn't support it.",
+                                        "enum": [
+                                          "HTTP1",
+                                          "HTTP2"
+                                        ],
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "tcp": {
+                                    "description": "Settings for managing TCP connections to the backend.",
+                                    "properties": {
+                                      "connectTimeout": {
+                                        "description": "Deadline for establishing a connection to\nthe destination.",
+                                        "type": "string",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "invalid duration value",
+                                            "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                          },
+                                          {
+                                            "message": "connectTimeout must be at least 100ms",
+                                            "rule": "duration(self) >= duration('100ms')"
+                                          }
+                                        ]
+                                      },
+                                      "keepalive": {
+                                        "description": "Settings for enabling TCP keepalives on the\nconnection.",
+                                        "properties": {
+                                          "interval": {
+                                            "description": "Time between keepalive probes.\nIf unset, this defaults to 180s.",
+                                            "type": "string",
+                                            "x-kubernetes-validations": [
+                                              {
+                                                "message": "invalid duration value",
+                                                "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                              },
+                                              {
+                                                "message": "interval must be at least 1 second",
+                                                "rule": "duration(self) >= duration('1s')"
+                                              }
+                                            ]
+                                          },
+                                          "retries": {
+                                            "description": "Maximum number of keepalive probes to send before dropping the connection.\nIf unset, this defaults to 9.",
+                                            "format": "int32",
+                                            "maximum": 64,
+                                            "minimum": 1,
+                                            "type": "integer"
+                                          },
+                                          "time": {
+                                            "description": "Time a connection needs to be idle before keepalive probes start being sent.\nIf unset, this defaults to 180s.",
+                                            "type": "string",
+                                            "x-kubernetes-validations": [
+                                              {
+                                                "message": "invalid duration value",
+                                                "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                              },
+                                              {
+                                                "message": "time must be at least 1 second",
+                                                "rule": "duration(self) >= duration('1s')"
+                                              }
+                                            ]
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "tls": {
+                                    "description": "Settings for managing TLS connections to the backend.\n\nIf this field is set, TLS will be initiated to the backend; the system trusted CA certificates will be used to\nvalidate the server, and the SNI will automatically be set based on the destination.",
+                                    "properties": {
+                                      "alpnProtocols": {
+                                        "description": "Application-Layer Protocol Negotiation (`ALPN`)\nvalue to use in the TLS handshake.\n\nIf not present, defaults to `[\"h2\", \"http/1.1\"]`.",
+                                        "items": {
+                                          "maxLength": 64,
+                                          "minLength": 1,
+                                          "type": "string"
+                                        },
+                                        "maxItems": 16,
+                                        "minItems": 1,
+                                        "type": "array"
+                                      },
+                                      "caCertificateRefs": {
+                                        "description": "CA certificate `ConfigMap` to use to\nverify the server certificate.\nIf unset, the system's trusted certificates are used.",
+                                        "items": {
+                                          "description": "LocalObjectReference contains enough information to let you locate the\nreferenced object inside the same namespace.",
+                                          "properties": {
+                                            "name": {
+                                              "default": "",
+                                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "x-kubernetes-map-type": "atomic",
+                                          "additionalProperties": false
+                                        },
+                                        "maxItems": 1,
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
+                                      },
+                                      "insecureSkipVerify": {
+                                        "description": "Originates TLS but skips verification of the backend's certificate.\nWARNING: This is an insecure option that should only be used if the risks are understood.\n\nThere are two modes:\n* `All` disables all TLS verification.\n* `Hostname` verifies the CA certificate is trusted, but ignores any\n  mismatch of hostname or SANs. Note that this method is still insecure;\n  prefer setting `verifySubjectAltNames` to customize the valid hostnames\n  if possible.",
+                                        "enum": [
+                                          "All",
+                                          "Hostname"
+                                        ],
+                                        "type": "string"
+                                      },
+                                      "keyExchangeGroups": {
+                                        "description": "Ordered list of key exchange groups for a TLS connection.\nFor example: `X25519_MLKEM768,X25519`.",
+                                        "items": {
+                                          "enum": [
+                                            "P-256",
+                                            "P-384",
+                                            "X25519",
+                                            "X25519_MLKEM768"
+                                          ],
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "mtlsCertificateRef": {
+                                        "description": "Enables mutual TLS to the backend, using the\nspecified key (`tls.key`) and cert (`tls.crt`) from the referenced\ncredential source, defaulting to a Kubernetes `Secret`.\n\nAn optional `ca.cert` field, if present, will be used to verify the\nserver certificate. If `caCertificateRefs` is also specified, the\n`caCertificateRefs` field takes priority.\n\nIf unspecified, no client certificate will be used.",
+                                        "items": {
+                                          "description": "References a same-namespace credential.\nSet only `name` to reference a Kubernetes Secret.",
+                                          "properties": {
+                                            "group": {
+                                              "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                                              "type": "string"
+                                            },
+                                            "kind": {
+                                              "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "description": "The name of the referenced credential.",
+                                              "maxLength": 253,
+                                              "minLength": 1,
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "name"
+                                          ],
+                                          "type": "object",
+                                          "x-kubernetes-map-type": "atomic",
+                                          "x-kubernetes-validations": [
+                                            {
+                                              "message": "custom credential refs must set both group and kind",
+                                              "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                                            }
+                                          ],
+                                          "additionalProperties": false
+                                        },
+                                        "maxItems": 1,
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
+                                      },
+                                      "sni": {
+                                        "description": "Server Name Indicator (`SNI`) to use in the TLS\nhandshake. If unset, the `SNI` is automatically set based on the\ndestination hostname.",
+                                        "maxLength": 253,
+                                        "minLength": 1,
+                                        "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                                        "type": "string"
+                                      },
+                                      "verifySubjectAltNames": {
+                                        "description": "Subject Alternative Names (`SAN`)\nto verify in the server certificate.\nIf not present, the destination hostname is automatically used.",
+                                        "items": {
+                                          "maxLength": 256,
+                                          "minLength": 1,
+                                          "type": "string"
+                                        },
+                                        "maxItems": 16,
+                                        "minItems": 1,
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "x-kubernetes-validations": [
+                                      {
+                                        "message": "insecureSkipVerify All and caCertificateRefs may not be set together",
+                                        "rule": "has(self.insecureSkipVerify) && self.insecureSkipVerify == 'All' ? !has(self.caCertificateRefs) : true"
+                                      },
+                                      {
+                                        "message": "insecureSkipVerify and verifySubjectAltNames may not be set together",
+                                        "rule": "has(self.insecureSkipVerify) ? !has(self.verifySubjectAltNames) : true"
+                                      },
+                                      {
+                                        "message": "at most one of the fields in [verifySubjectAltNames insecureSkipVerify] may be set",
+                                        "rule": "[has(self.verifySubjectAltNames),has(self.insecureSkipVerify)].filter(x,x==true).size() <= 1"
+                                      }
+                                    ],
+                                    "additionalProperties": false
+                                  },
+                                  "tunnel": {
+                                    "description": "Settings for managing tunnel connections, with behavior like `HTTPS_PROXY`, to the backend.",
+                                    "properties": {
+                                      "backendRef": {
+                                        "description": "Proxy server to reach.\nSupported types: `Service` and `Backend`.",
+                                        "properties": {
+                                          "group": {
+                                            "default": "",
+                                            "description": "Group is the group of the referent. For example, \"gateway.networking.k8s.io\".\nWhen unspecified or empty string, core API group is inferred.",
+                                            "maxLength": 253,
+                                            "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                                            "type": "string"
+                                          },
+                                          "kind": {
+                                            "default": "Service",
+                                            "description": "Kind is the Kubernetes resource kind of the referent. For example\n\"Service\".\n\nDefaults to \"Service\" when not specified.\n\nExternalName services can refer to CNAME DNS records that may live\noutside of the cluster and as such are difficult to reason about in\nterms of conformance. They also may not be safe to forward to (see\nCVE-2021-25740 for more information). Implementations SHOULD NOT\nsupport ExternalName Services.\n\nSupport: Core (Services with a type other than ExternalName)\n\nSupport: Implementation-specific (Services with type ExternalName)",
+                                            "maxLength": 63,
+                                            "minLength": 1,
+                                            "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "description": "Name is the name of the referent.",
+                                            "maxLength": 253,
+                                            "minLength": 1,
+                                            "type": "string"
+                                          },
+                                          "namespace": {
+                                            "description": "Namespace is the namespace of the backend. When unspecified, the local\nnamespace is inferred.\n\nNote that when a namespace different than the local namespace is specified,\na ReferenceGrant object is required in the referent namespace to allow that\nnamespace's owner to accept the reference. See the ReferenceGrant\ndocumentation for details.\n\nSupport: Core",
+                                            "maxLength": 63,
+                                            "minLength": 1,
+                                            "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "description": "Port specifies the destination port number to use for this resource.\nPort is required when the referent is a Kubernetes Service. In this\ncase, the port number is the service port number, not the target port.\nFor other resources, destination port might be derived from the referent\nresource or this field.",
+                                            "format": "int32",
+                                            "maximum": 65535,
+                                            "minimum": 1,
+                                            "type": "integer"
+                                          }
+                                        },
+                                        "required": [
+                                          "name"
+                                        ],
+                                        "type": "object",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "Must have port for Service reference",
+                                            "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
+                                          }
+                                        ],
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "required": [
+                                      "backendRef"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "region": {
+                                "description": "AWS region where the guardrail is deployed, for example\n`us-west-2`).",
+                                "maxLength": 256,
+                                "minLength": 1,
+                                "type": "string"
+                              },
+                              "version": {
+                                "description": "Version of the Guardrail policy to use for the backend.",
+                                "maxLength": 256,
+                                "minLength": 1,
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "identifier",
+                              "region",
+                              "version"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "googleModelArmor": {
+                            "description": "Google Model Armor settings for prompt guarding.",
+                            "properties": {
+                              "location": {
+                                "default": "us-central1",
+                                "description": "Google Cloud location, for example `us-central1`.\nDefaults to `us-central1` if not specified.",
+                                "maxLength": 256,
+                                "minLength": 1,
+                                "type": "string"
+                              },
+                              "policies": {
+                                "description": "Policies for communicating with Google Model Armor.",
+                                "properties": {
+                                  "auth": {
+                                    "description": "Settings for managing authentication to the backend.",
+                                    "properties": {
+                                      "aws": {
+                                        "description": "Explicit AWS authentication method for the backend.\nWhen omitted, default AWS SDK credential discovery is used.",
+                                        "properties": {
+                                          "assumeRole": {
+                                            "description": "AWS STS AssumeRole settings to use before signing backend requests.\nAmbient AWS credentials are used as the source credentials for STS.",
+                                            "properties": {
+                                              "roleArn": {
+                                                "description": "AWS IAM role ARN to assume.",
+                                                "minLength": 1,
+                                                "pattern": "^arn:aws[a-z-]*:iam::[0-9]{12}:role/.+$",
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "roleArn"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "secretRef": {
+                                            "description": "Credential source, defaulting to a Kubernetes\n`Secret`, containing the AWS credentials. When using the default Secret\nresolver, the `Secret` must have keys `accessKey`, `secretKey`, and\noptionally `sessionToken`.",
+                                            "properties": {
+                                              "group": {
+                                                "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                                                "type": "string"
+                                              },
+                                              "kind": {
+                                                "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "description": "The name of the referenced credential.",
+                                                "maxLength": 253,
+                                                "minLength": 1,
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name"
+                                            ],
+                                            "type": "object",
+                                            "x-kubernetes-map-type": "atomic",
+                                            "x-kubernetes-validations": [
+                                              {
+                                                "message": "custom credential refs must set both group and kind",
+                                                "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                                              }
+                                            ],
+                                            "additionalProperties": false
+                                          },
+                                          "serviceName": {
+                                            "description": "AWS SigV4 signing service name, for example\n`bedrock`, `bedrock-agentcore`, or `execute-api`). If unset, typed AWS\nbackends may provide this automatically.",
+                                            "maxLength": 256,
+                                            "minLength": 1,
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "secretRef and assumeRole are mutually exclusive",
+                                            "rule": "!(has(self.secretRef) && has(self.assumeRole))"
+                                          }
+                                        ],
+                                        "additionalProperties": false
+                                      },
+                                      "azure": {
+                                        "description": "Azure authentication method for the backend.",
+                                        "properties": {
+                                          "managedIdentity": {
+                                            "description": "Managed identity authentication settings.",
+                                            "properties": {
+                                              "clientId": {
+                                                "type": "string"
+                                              },
+                                              "objectId": {
+                                                "type": "string"
+                                              },
+                                              "resourceId": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "clientId",
+                                              "objectId",
+                                              "resourceId"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "secretRef": {
+                                            "description": "Credential source, defaulting to a Kubernetes\n`Secret`, containing the Azure credentials. When using the default Secret\nresolver, the `Secret` must have keys `clientID`, `tenantID`, and\n`clientSecret`.",
+                                            "properties": {
+                                              "group": {
+                                                "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                                                "type": "string"
+                                              },
+                                              "kind": {
+                                                "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "description": "The name of the referenced credential.",
+                                                "maxLength": 253,
+                                                "minLength": 1,
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name"
+                                            ],
+                                            "type": "object",
+                                            "x-kubernetes-map-type": "atomic",
+                                            "x-kubernetes-validations": [
+                                              {
+                                                "message": "custom credential refs must set both group and kind",
+                                                "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                                              }
+                                            ],
+                                            "additionalProperties": false
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "gcp": {
+                                        "description": "Google authentication method for the backend.\nWhen omitted, default Google credential discovery is used.",
+                                        "properties": {
+                                          "audience": {
+                                            "description": "Explicit `aud` value for the ID token. Only\nvalid with `IdToken` type. If not set, the `aud` is automatically\nderived from the backend hostname.",
+                                            "maxLength": 256,
+                                            "minLength": 1,
+                                            "type": "string"
+                                          },
+                                          "secretRef": {
+                                            "description": "Credential source, defaulting to a Kubernetes\n`Secret`, containing ADC-compatible Google credential JSON. When using\nthe default Secret resolver, this must be stored in the `credentials.json`\nkey. When omitted, ambient credentials are used.",
+                                            "properties": {
+                                              "group": {
+                                                "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                                                "type": "string"
+                                              },
+                                              "kind": {
+                                                "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "description": "The name of the referenced credential.",
+                                                "maxLength": 253,
+                                                "minLength": 1,
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name"
+                                            ],
+                                            "type": "object",
+                                            "x-kubernetes-map-type": "atomic",
+                                            "x-kubernetes-validations": [
+                                              {
+                                                "message": "custom credential refs must set both group and kind",
+                                                "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                                              }
+                                            ],
+                                            "additionalProperties": false
+                                          },
+                                          "type": {
+                                            "description": "The type of token to generate. To authenticate to GCP services,\ngenerally an `AccessToken` is used. To authenticate to Cloud Run, an\n`IdToken` is used.",
+                                            "enum": [
+                                              "AccessToken",
+                                              "IdToken"
+                                            ],
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "audience is only valid with IdToken",
+                                            "rule": "has(self.audience) ? self.type == 'IdToken' : true"
+                                          }
+                                        ],
+                                        "additionalProperties": false
+                                      },
+                                      "key": {
+                                        "description": "Inline key to use as the value of the\n`Authorization` header. This option is the least secure; usage of a\n`Secret` is preferred.",
+                                        "maxLength": 2048,
+                                        "type": "string"
+                                      },
+                                      "location": {
+                                        "description": "Where backend credentials are inserted.\nIf omitted, credentials are written to the `Authorization` header with the `Bearer ` prefix.\nThis applies to `key`, `secretRef`, and `passthrough`.",
+                                        "properties": {
+                                          "cookie": {
+                                            "properties": {
+                                              "name": {
+                                                "maxLength": 256,
+                                                "minLength": 1,
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "header": {
+                                            "properties": {
+                                              "name": {
+                                                "description": "HTTPHeaderName is the name of an HTTP header.\n\nValid values include:\n\n* \"Authorization\"\n* \"Set-Cookie\"\n\nInvalid values include:\n\n  - \":method\" - \":\" is an invalid character. This means that HTTP/2 pseudo\n    headers are not currently supported by this type.\n  - \"/invalid\" - \"/ \" is an invalid character",
+                                                "maxLength": 256,
+                                                "minLength": 1,
+                                                "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                                                "type": "string"
+                                              },
+                                              "prefix": {
+                                                "maxLength": 256,
+                                                "minLength": 1,
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "queryParameter": {
+                                            "properties": {
+                                              "name": {
+                                                "maxLength": 256,
+                                                "minLength": 1,
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          }
+                                        },
+                                        "type": "object",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "exactly one of the fields in [header queryParameter cookie] must be set",
+                                            "rule": "[has(self.header),has(self.queryParameter),has(self.cookie)].filter(x,x==true).size() == 1"
+                                          }
+                                        ],
+                                        "additionalProperties": false
+                                      },
+                                      "passthrough": {
+                                        "description": "Passes through an existing token that has been sent by the\nclient and validated. Other policies, like JWT and API key\nauthentication, will strip the original client credentials. Passthrough backend authentication\ncauses the original token to be added back into the request. If there are no client authentication policies on the\nrequest, the original token would be unchanged, so this would have no effect.",
+                                        "type": "object"
+                                      },
+                                      "secretRef": {
+                                        "description": "Credential source, defaulting to a Kubernetes\n`Secret`, storing the key to use as the authorization value. When using\nthe default Secret resolver, this must be stored in the `Authorization`\nkey.",
+                                        "properties": {
+                                          "group": {
+                                            "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                                            "type": "string"
+                                          },
+                                          "kind": {
+                                            "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "description": "The name of the referenced credential.",
+                                            "maxLength": 253,
+                                            "minLength": 1,
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "name"
+                                        ],
+                                        "type": "object",
+                                        "x-kubernetes-map-type": "atomic",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "custom credential refs must set both group and kind",
+                                            "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                                          }
+                                        ],
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "x-kubernetes-validations": [
+                                      {
+                                        "message": "location may only be set for key or passthrough auth",
+                                        "rule": "has(self.location) ? has(self.key) || has(self.secretRef) || has(self.passthrough) : true"
+                                      },
+                                      {
+                                        "message": "exactly one of the fields in [key secretRef passthrough aws azure gcp] must be set",
+                                        "rule": "[has(self.key),has(self.secretRef),has(self.passthrough),has(self.aws),has(self.azure),has(self.gcp)].filter(x,x==true).size() == 1"
+                                      }
+                                    ],
+                                    "additionalProperties": false
+                                  },
+                                  "http": {
+                                    "description": "Settings for managing HTTP requests to the backend.",
+                                    "properties": {
+                                      "requestTimeout": {
+                                        "description": "Deadline for receiving a response from the backend.",
+                                        "type": "string",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "invalid duration value",
+                                            "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                          },
+                                          {
+                                            "message": "requestTimeout must be at least 1ms",
+                                            "rule": "duration(self) >= duration('1ms')"
+                                          }
+                                        ]
+                                      },
+                                      "version": {
+                                        "description": "HTTP protocol version to use when connecting to\nthe backend.\nIf not specified, the version is automatically determined:\n* `Service` types can specify it with `appProtocol` on the `Service`\n  port.\n* If traffic is identified as gRPC, `HTTP2` is used.\n* If the incoming traffic was plaintext HTTP, the original protocol will\n  be used.\n* If the incoming traffic was HTTPS, `HTTP1` will be used. This is\n  because most clients will transparently upgrade HTTPS traffic to\n  `HTTP2`, even if the backend doesn't support it.",
+                                        "enum": [
+                                          "HTTP1",
+                                          "HTTP2"
+                                        ],
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "tcp": {
+                                    "description": "Settings for managing TCP connections to the backend.",
+                                    "properties": {
+                                      "connectTimeout": {
+                                        "description": "Deadline for establishing a connection to\nthe destination.",
+                                        "type": "string",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "invalid duration value",
+                                            "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                          },
+                                          {
+                                            "message": "connectTimeout must be at least 100ms",
+                                            "rule": "duration(self) >= duration('100ms')"
+                                          }
+                                        ]
+                                      },
+                                      "keepalive": {
+                                        "description": "Settings for enabling TCP keepalives on the\nconnection.",
+                                        "properties": {
+                                          "interval": {
+                                            "description": "Time between keepalive probes.\nIf unset, this defaults to 180s.",
+                                            "type": "string",
+                                            "x-kubernetes-validations": [
+                                              {
+                                                "message": "invalid duration value",
+                                                "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                              },
+                                              {
+                                                "message": "interval must be at least 1 second",
+                                                "rule": "duration(self) >= duration('1s')"
+                                              }
+                                            ]
+                                          },
+                                          "retries": {
+                                            "description": "Maximum number of keepalive probes to send before dropping the connection.\nIf unset, this defaults to 9.",
+                                            "format": "int32",
+                                            "maximum": 64,
+                                            "minimum": 1,
+                                            "type": "integer"
+                                          },
+                                          "time": {
+                                            "description": "Time a connection needs to be idle before keepalive probes start being sent.\nIf unset, this defaults to 180s.",
+                                            "type": "string",
+                                            "x-kubernetes-validations": [
+                                              {
+                                                "message": "invalid duration value",
+                                                "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                              },
+                                              {
+                                                "message": "time must be at least 1 second",
+                                                "rule": "duration(self) >= duration('1s')"
+                                              }
+                                            ]
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "tls": {
+                                    "description": "Settings for managing TLS connections to the backend.\n\nIf this field is set, TLS will be initiated to the backend; the system trusted CA certificates will be used to\nvalidate the server, and the SNI will automatically be set based on the destination.",
+                                    "properties": {
+                                      "alpnProtocols": {
+                                        "description": "Application-Layer Protocol Negotiation (`ALPN`)\nvalue to use in the TLS handshake.\n\nIf not present, defaults to `[\"h2\", \"http/1.1\"]`.",
+                                        "items": {
+                                          "maxLength": 64,
+                                          "minLength": 1,
+                                          "type": "string"
+                                        },
+                                        "maxItems": 16,
+                                        "minItems": 1,
+                                        "type": "array"
+                                      },
+                                      "caCertificateRefs": {
+                                        "description": "CA certificate `ConfigMap` to use to\nverify the server certificate.\nIf unset, the system's trusted certificates are used.",
+                                        "items": {
+                                          "description": "LocalObjectReference contains enough information to let you locate the\nreferenced object inside the same namespace.",
+                                          "properties": {
+                                            "name": {
+                                              "default": "",
+                                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "x-kubernetes-map-type": "atomic",
+                                          "additionalProperties": false
+                                        },
+                                        "maxItems": 1,
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
+                                      },
+                                      "insecureSkipVerify": {
+                                        "description": "Originates TLS but skips verification of the backend's certificate.\nWARNING: This is an insecure option that should only be used if the risks are understood.\n\nThere are two modes:\n* `All` disables all TLS verification.\n* `Hostname` verifies the CA certificate is trusted, but ignores any\n  mismatch of hostname or SANs. Note that this method is still insecure;\n  prefer setting `verifySubjectAltNames` to customize the valid hostnames\n  if possible.",
+                                        "enum": [
+                                          "All",
+                                          "Hostname"
+                                        ],
+                                        "type": "string"
+                                      },
+                                      "keyExchangeGroups": {
+                                        "description": "Ordered list of key exchange groups for a TLS connection.\nFor example: `X25519_MLKEM768,X25519`.",
+                                        "items": {
+                                          "enum": [
+                                            "P-256",
+                                            "P-384",
+                                            "X25519",
+                                            "X25519_MLKEM768"
+                                          ],
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "mtlsCertificateRef": {
+                                        "description": "Enables mutual TLS to the backend, using the\nspecified key (`tls.key`) and cert (`tls.crt`) from the referenced\ncredential source, defaulting to a Kubernetes `Secret`.\n\nAn optional `ca.cert` field, if present, will be used to verify the\nserver certificate. If `caCertificateRefs` is also specified, the\n`caCertificateRefs` field takes priority.\n\nIf unspecified, no client certificate will be used.",
+                                        "items": {
+                                          "description": "References a same-namespace credential.\nSet only `name` to reference a Kubernetes Secret.",
+                                          "properties": {
+                                            "group": {
+                                              "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                                              "type": "string"
+                                            },
+                                            "kind": {
+                                              "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "description": "The name of the referenced credential.",
+                                              "maxLength": 253,
+                                              "minLength": 1,
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "name"
+                                          ],
+                                          "type": "object",
+                                          "x-kubernetes-map-type": "atomic",
+                                          "x-kubernetes-validations": [
+                                            {
+                                              "message": "custom credential refs must set both group and kind",
+                                              "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                                            }
+                                          ],
+                                          "additionalProperties": false
+                                        },
+                                        "maxItems": 1,
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
+                                      },
+                                      "sni": {
+                                        "description": "Server Name Indicator (`SNI`) to use in the TLS\nhandshake. If unset, the `SNI` is automatically set based on the\ndestination hostname.",
+                                        "maxLength": 253,
+                                        "minLength": 1,
+                                        "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                                        "type": "string"
+                                      },
+                                      "verifySubjectAltNames": {
+                                        "description": "Subject Alternative Names (`SAN`)\nto verify in the server certificate.\nIf not present, the destination hostname is automatically used.",
+                                        "items": {
+                                          "maxLength": 256,
+                                          "minLength": 1,
+                                          "type": "string"
+                                        },
+                                        "maxItems": 16,
+                                        "minItems": 1,
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "x-kubernetes-validations": [
+                                      {
+                                        "message": "insecureSkipVerify All and caCertificateRefs may not be set together",
+                                        "rule": "has(self.insecureSkipVerify) && self.insecureSkipVerify == 'All' ? !has(self.caCertificateRefs) : true"
+                                      },
+                                      {
+                                        "message": "insecureSkipVerify and verifySubjectAltNames may not be set together",
+                                        "rule": "has(self.insecureSkipVerify) ? !has(self.verifySubjectAltNames) : true"
+                                      },
+                                      {
+                                        "message": "at most one of the fields in [verifySubjectAltNames insecureSkipVerify] may be set",
+                                        "rule": "[has(self.verifySubjectAltNames),has(self.insecureSkipVerify)].filter(x,x==true).size() <= 1"
+                                      }
+                                    ],
+                                    "additionalProperties": false
+                                  },
+                                  "tunnel": {
+                                    "description": "Settings for managing tunnel connections, with behavior like `HTTPS_PROXY`, to the backend.",
+                                    "properties": {
+                                      "backendRef": {
+                                        "description": "Proxy server to reach.\nSupported types: `Service` and `Backend`.",
+                                        "properties": {
+                                          "group": {
+                                            "default": "",
+                                            "description": "Group is the group of the referent. For example, \"gateway.networking.k8s.io\".\nWhen unspecified or empty string, core API group is inferred.",
+                                            "maxLength": 253,
+                                            "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                                            "type": "string"
+                                          },
+                                          "kind": {
+                                            "default": "Service",
+                                            "description": "Kind is the Kubernetes resource kind of the referent. For example\n\"Service\".\n\nDefaults to \"Service\" when not specified.\n\nExternalName services can refer to CNAME DNS records that may live\noutside of the cluster and as such are difficult to reason about in\nterms of conformance. They also may not be safe to forward to (see\nCVE-2021-25740 for more information). Implementations SHOULD NOT\nsupport ExternalName Services.\n\nSupport: Core (Services with a type other than ExternalName)\n\nSupport: Implementation-specific (Services with type ExternalName)",
+                                            "maxLength": 63,
+                                            "minLength": 1,
+                                            "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "description": "Name is the name of the referent.",
+                                            "maxLength": 253,
+                                            "minLength": 1,
+                                            "type": "string"
+                                          },
+                                          "namespace": {
+                                            "description": "Namespace is the namespace of the backend. When unspecified, the local\nnamespace is inferred.\n\nNote that when a namespace different than the local namespace is specified,\na ReferenceGrant object is required in the referent namespace to allow that\nnamespace's owner to accept the reference. See the ReferenceGrant\ndocumentation for details.\n\nSupport: Core",
+                                            "maxLength": 63,
+                                            "minLength": 1,
+                                            "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "description": "Port specifies the destination port number to use for this resource.\nPort is required when the referent is a Kubernetes Service. In this\ncase, the port number is the service port number, not the target port.\nFor other resources, destination port might be derived from the referent\nresource or this field.",
+                                            "format": "int32",
+                                            "maximum": 65535,
+                                            "minimum": 1,
+                                            "type": "integer"
+                                          }
+                                        },
+                                        "required": [
+                                          "name"
+                                        ],
+                                        "type": "object",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "Must have port for Service reference",
+                                            "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
+                                          }
+                                        ],
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "required": [
+                                      "backendRef"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "projectId": {
+                                "description": "Google Cloud project ID.",
+                                "maxLength": 256,
+                                "minLength": 1,
+                                "type": "string"
+                              },
+                              "templateId": {
+                                "description": "Template ID for Google Model Armor.",
+                                "maxLength": 256,
+                                "minLength": 1,
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "projectId",
+                              "templateId"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "openAIModeration": {
+                            "description": "Passes prompt data through the OpenAI Moderations\nendpoint.\nSee https://developers.openai.com/api/reference/resources/moderations for more information.",
+                            "properties": {
+                              "model": {
+                                "description": "Moderation model to use. For example,\n`omni-moderation`.",
+                                "type": "string"
+                              },
+                              "policies": {
+                                "description": "Policies for communicating with OpenAI.",
+                                "properties": {
+                                  "auth": {
+                                    "description": "Settings for managing authentication to the backend.",
+                                    "properties": {
+                                      "aws": {
+                                        "description": "Explicit AWS authentication method for the backend.\nWhen omitted, default AWS SDK credential discovery is used.",
+                                        "properties": {
+                                          "assumeRole": {
+                                            "description": "AWS STS AssumeRole settings to use before signing backend requests.\nAmbient AWS credentials are used as the source credentials for STS.",
+                                            "properties": {
+                                              "roleArn": {
+                                                "description": "AWS IAM role ARN to assume.",
+                                                "minLength": 1,
+                                                "pattern": "^arn:aws[a-z-]*:iam::[0-9]{12}:role/.+$",
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "roleArn"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "secretRef": {
+                                            "description": "Credential source, defaulting to a Kubernetes\n`Secret`, containing the AWS credentials. When using the default Secret\nresolver, the `Secret` must have keys `accessKey`, `secretKey`, and\noptionally `sessionToken`.",
+                                            "properties": {
+                                              "group": {
+                                                "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                                                "type": "string"
+                                              },
+                                              "kind": {
+                                                "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "description": "The name of the referenced credential.",
+                                                "maxLength": 253,
+                                                "minLength": 1,
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name"
+                                            ],
+                                            "type": "object",
+                                            "x-kubernetes-map-type": "atomic",
+                                            "x-kubernetes-validations": [
+                                              {
+                                                "message": "custom credential refs must set both group and kind",
+                                                "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                                              }
+                                            ],
+                                            "additionalProperties": false
+                                          },
+                                          "serviceName": {
+                                            "description": "AWS SigV4 signing service name, for example\n`bedrock`, `bedrock-agentcore`, or `execute-api`). If unset, typed AWS\nbackends may provide this automatically.",
+                                            "maxLength": 256,
+                                            "minLength": 1,
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "secretRef and assumeRole are mutually exclusive",
+                                            "rule": "!(has(self.secretRef) && has(self.assumeRole))"
+                                          }
+                                        ],
+                                        "additionalProperties": false
+                                      },
+                                      "azure": {
+                                        "description": "Azure authentication method for the backend.",
+                                        "properties": {
+                                          "managedIdentity": {
+                                            "description": "Managed identity authentication settings.",
+                                            "properties": {
+                                              "clientId": {
+                                                "type": "string"
+                                              },
+                                              "objectId": {
+                                                "type": "string"
+                                              },
+                                              "resourceId": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "clientId",
+                                              "objectId",
+                                              "resourceId"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "secretRef": {
+                                            "description": "Credential source, defaulting to a Kubernetes\n`Secret`, containing the Azure credentials. When using the default Secret\nresolver, the `Secret` must have keys `clientID`, `tenantID`, and\n`clientSecret`.",
+                                            "properties": {
+                                              "group": {
+                                                "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                                                "type": "string"
+                                              },
+                                              "kind": {
+                                                "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "description": "The name of the referenced credential.",
+                                                "maxLength": 253,
+                                                "minLength": 1,
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name"
+                                            ],
+                                            "type": "object",
+                                            "x-kubernetes-map-type": "atomic",
+                                            "x-kubernetes-validations": [
+                                              {
+                                                "message": "custom credential refs must set both group and kind",
+                                                "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                                              }
+                                            ],
+                                            "additionalProperties": false
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "gcp": {
+                                        "description": "Google authentication method for the backend.\nWhen omitted, default Google credential discovery is used.",
+                                        "properties": {
+                                          "audience": {
+                                            "description": "Explicit `aud` value for the ID token. Only\nvalid with `IdToken` type. If not set, the `aud` is automatically\nderived from the backend hostname.",
+                                            "maxLength": 256,
+                                            "minLength": 1,
+                                            "type": "string"
+                                          },
+                                          "secretRef": {
+                                            "description": "Credential source, defaulting to a Kubernetes\n`Secret`, containing ADC-compatible Google credential JSON. When using\nthe default Secret resolver, this must be stored in the `credentials.json`\nkey. When omitted, ambient credentials are used.",
+                                            "properties": {
+                                              "group": {
+                                                "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                                                "type": "string"
+                                              },
+                                              "kind": {
+                                                "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "description": "The name of the referenced credential.",
+                                                "maxLength": 253,
+                                                "minLength": 1,
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name"
+                                            ],
+                                            "type": "object",
+                                            "x-kubernetes-map-type": "atomic",
+                                            "x-kubernetes-validations": [
+                                              {
+                                                "message": "custom credential refs must set both group and kind",
+                                                "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                                              }
+                                            ],
+                                            "additionalProperties": false
+                                          },
+                                          "type": {
+                                            "description": "The type of token to generate. To authenticate to GCP services,\ngenerally an `AccessToken` is used. To authenticate to Cloud Run, an\n`IdToken` is used.",
+                                            "enum": [
+                                              "AccessToken",
+                                              "IdToken"
+                                            ],
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "audience is only valid with IdToken",
+                                            "rule": "has(self.audience) ? self.type == 'IdToken' : true"
+                                          }
+                                        ],
+                                        "additionalProperties": false
+                                      },
+                                      "key": {
+                                        "description": "Inline key to use as the value of the\n`Authorization` header. This option is the least secure; usage of a\n`Secret` is preferred.",
+                                        "maxLength": 2048,
+                                        "type": "string"
+                                      },
+                                      "location": {
+                                        "description": "Where backend credentials are inserted.\nIf omitted, credentials are written to the `Authorization` header with the `Bearer ` prefix.\nThis applies to `key`, `secretRef`, and `passthrough`.",
+                                        "properties": {
+                                          "cookie": {
+                                            "properties": {
+                                              "name": {
+                                                "maxLength": 256,
+                                                "minLength": 1,
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "header": {
+                                            "properties": {
+                                              "name": {
+                                                "description": "HTTPHeaderName is the name of an HTTP header.\n\nValid values include:\n\n* \"Authorization\"\n* \"Set-Cookie\"\n\nInvalid values include:\n\n  - \":method\" - \":\" is an invalid character. This means that HTTP/2 pseudo\n    headers are not currently supported by this type.\n  - \"/invalid\" - \"/ \" is an invalid character",
+                                                "maxLength": 256,
+                                                "minLength": 1,
+                                                "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                                                "type": "string"
+                                              },
+                                              "prefix": {
+                                                "maxLength": 256,
+                                                "minLength": 1,
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "queryParameter": {
+                                            "properties": {
+                                              "name": {
+                                                "maxLength": 256,
+                                                "minLength": 1,
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          }
+                                        },
+                                        "type": "object",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "exactly one of the fields in [header queryParameter cookie] must be set",
+                                            "rule": "[has(self.header),has(self.queryParameter),has(self.cookie)].filter(x,x==true).size() == 1"
+                                          }
+                                        ],
+                                        "additionalProperties": false
+                                      },
+                                      "passthrough": {
+                                        "description": "Passes through an existing token that has been sent by the\nclient and validated. Other policies, like JWT and API key\nauthentication, will strip the original client credentials. Passthrough backend authentication\ncauses the original token to be added back into the request. If there are no client authentication policies on the\nrequest, the original token would be unchanged, so this would have no effect.",
+                                        "type": "object"
+                                      },
+                                      "secretRef": {
+                                        "description": "Credential source, defaulting to a Kubernetes\n`Secret`, storing the key to use as the authorization value. When using\nthe default Secret resolver, this must be stored in the `Authorization`\nkey.",
+                                        "properties": {
+                                          "group": {
+                                            "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                                            "type": "string"
+                                          },
+                                          "kind": {
+                                            "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "description": "The name of the referenced credential.",
+                                            "maxLength": 253,
+                                            "minLength": 1,
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "name"
+                                        ],
+                                        "type": "object",
+                                        "x-kubernetes-map-type": "atomic",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "custom credential refs must set both group and kind",
+                                            "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                                          }
+                                        ],
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "x-kubernetes-validations": [
+                                      {
+                                        "message": "location may only be set for key or passthrough auth",
+                                        "rule": "has(self.location) ? has(self.key) || has(self.secretRef) || has(self.passthrough) : true"
+                                      },
+                                      {
+                                        "message": "exactly one of the fields in [key secretRef passthrough aws azure gcp] must be set",
+                                        "rule": "[has(self.key),has(self.secretRef),has(self.passthrough),has(self.aws),has(self.azure),has(self.gcp)].filter(x,x==true).size() == 1"
+                                      }
+                                    ],
+                                    "additionalProperties": false
+                                  },
+                                  "http": {
+                                    "description": "Settings for managing HTTP requests to the backend.",
+                                    "properties": {
+                                      "requestTimeout": {
+                                        "description": "Deadline for receiving a response from the backend.",
+                                        "type": "string",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "invalid duration value",
+                                            "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                          },
+                                          {
+                                            "message": "requestTimeout must be at least 1ms",
+                                            "rule": "duration(self) >= duration('1ms')"
+                                          }
+                                        ]
+                                      },
+                                      "version": {
+                                        "description": "HTTP protocol version to use when connecting to\nthe backend.\nIf not specified, the version is automatically determined:\n* `Service` types can specify it with `appProtocol` on the `Service`\n  port.\n* If traffic is identified as gRPC, `HTTP2` is used.\n* If the incoming traffic was plaintext HTTP, the original protocol will\n  be used.\n* If the incoming traffic was HTTPS, `HTTP1` will be used. This is\n  because most clients will transparently upgrade HTTPS traffic to\n  `HTTP2`, even if the backend doesn't support it.",
+                                        "enum": [
+                                          "HTTP1",
+                                          "HTTP2"
+                                        ],
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "tcp": {
+                                    "description": "Settings for managing TCP connections to the backend.",
+                                    "properties": {
+                                      "connectTimeout": {
+                                        "description": "Deadline for establishing a connection to\nthe destination.",
+                                        "type": "string",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "invalid duration value",
+                                            "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                          },
+                                          {
+                                            "message": "connectTimeout must be at least 100ms",
+                                            "rule": "duration(self) >= duration('100ms')"
+                                          }
+                                        ]
+                                      },
+                                      "keepalive": {
+                                        "description": "Settings for enabling TCP keepalives on the\nconnection.",
+                                        "properties": {
+                                          "interval": {
+                                            "description": "Time between keepalive probes.\nIf unset, this defaults to 180s.",
+                                            "type": "string",
+                                            "x-kubernetes-validations": [
+                                              {
+                                                "message": "invalid duration value",
+                                                "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                              },
+                                              {
+                                                "message": "interval must be at least 1 second",
+                                                "rule": "duration(self) >= duration('1s')"
+                                              }
+                                            ]
+                                          },
+                                          "retries": {
+                                            "description": "Maximum number of keepalive probes to send before dropping the connection.\nIf unset, this defaults to 9.",
+                                            "format": "int32",
+                                            "maximum": 64,
+                                            "minimum": 1,
+                                            "type": "integer"
+                                          },
+                                          "time": {
+                                            "description": "Time a connection needs to be idle before keepalive probes start being sent.\nIf unset, this defaults to 180s.",
+                                            "type": "string",
+                                            "x-kubernetes-validations": [
+                                              {
+                                                "message": "invalid duration value",
+                                                "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                              },
+                                              {
+                                                "message": "time must be at least 1 second",
+                                                "rule": "duration(self) >= duration('1s')"
+                                              }
+                                            ]
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "tls": {
+                                    "description": "Settings for managing TLS connections to the backend.\n\nIf this field is set, TLS will be initiated to the backend; the system trusted CA certificates will be used to\nvalidate the server, and the SNI will automatically be set based on the destination.",
+                                    "properties": {
+                                      "alpnProtocols": {
+                                        "description": "Application-Layer Protocol Negotiation (`ALPN`)\nvalue to use in the TLS handshake.\n\nIf not present, defaults to `[\"h2\", \"http/1.1\"]`.",
+                                        "items": {
+                                          "maxLength": 64,
+                                          "minLength": 1,
+                                          "type": "string"
+                                        },
+                                        "maxItems": 16,
+                                        "minItems": 1,
+                                        "type": "array"
+                                      },
+                                      "caCertificateRefs": {
+                                        "description": "CA certificate `ConfigMap` to use to\nverify the server certificate.\nIf unset, the system's trusted certificates are used.",
+                                        "items": {
+                                          "description": "LocalObjectReference contains enough information to let you locate the\nreferenced object inside the same namespace.",
+                                          "properties": {
+                                            "name": {
+                                              "default": "",
+                                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "x-kubernetes-map-type": "atomic",
+                                          "additionalProperties": false
+                                        },
+                                        "maxItems": 1,
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
+                                      },
+                                      "insecureSkipVerify": {
+                                        "description": "Originates TLS but skips verification of the backend's certificate.\nWARNING: This is an insecure option that should only be used if the risks are understood.\n\nThere are two modes:\n* `All` disables all TLS verification.\n* `Hostname` verifies the CA certificate is trusted, but ignores any\n  mismatch of hostname or SANs. Note that this method is still insecure;\n  prefer setting `verifySubjectAltNames` to customize the valid hostnames\n  if possible.",
+                                        "enum": [
+                                          "All",
+                                          "Hostname"
+                                        ],
+                                        "type": "string"
+                                      },
+                                      "keyExchangeGroups": {
+                                        "description": "Ordered list of key exchange groups for a TLS connection.\nFor example: `X25519_MLKEM768,X25519`.",
+                                        "items": {
+                                          "enum": [
+                                            "P-256",
+                                            "P-384",
+                                            "X25519",
+                                            "X25519_MLKEM768"
+                                          ],
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "mtlsCertificateRef": {
+                                        "description": "Enables mutual TLS to the backend, using the\nspecified key (`tls.key`) and cert (`tls.crt`) from the referenced\ncredential source, defaulting to a Kubernetes `Secret`.\n\nAn optional `ca.cert` field, if present, will be used to verify the\nserver certificate. If `caCertificateRefs` is also specified, the\n`caCertificateRefs` field takes priority.\n\nIf unspecified, no client certificate will be used.",
+                                        "items": {
+                                          "description": "References a same-namespace credential.\nSet only `name` to reference a Kubernetes Secret.",
+                                          "properties": {
+                                            "group": {
+                                              "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                                              "type": "string"
+                                            },
+                                            "kind": {
+                                              "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "description": "The name of the referenced credential.",
+                                              "maxLength": 253,
+                                              "minLength": 1,
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "name"
+                                          ],
+                                          "type": "object",
+                                          "x-kubernetes-map-type": "atomic",
+                                          "x-kubernetes-validations": [
+                                            {
+                                              "message": "custom credential refs must set both group and kind",
+                                              "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                                            }
+                                          ],
+                                          "additionalProperties": false
+                                        },
+                                        "maxItems": 1,
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
+                                      },
+                                      "sni": {
+                                        "description": "Server Name Indicator (`SNI`) to use in the TLS\nhandshake. If unset, the `SNI` is automatically set based on the\ndestination hostname.",
+                                        "maxLength": 253,
+                                        "minLength": 1,
+                                        "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                                        "type": "string"
+                                      },
+                                      "verifySubjectAltNames": {
+                                        "description": "Subject Alternative Names (`SAN`)\nto verify in the server certificate.\nIf not present, the destination hostname is automatically used.",
+                                        "items": {
+                                          "maxLength": 256,
+                                          "minLength": 1,
+                                          "type": "string"
+                                        },
+                                        "maxItems": 16,
+                                        "minItems": 1,
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "x-kubernetes-validations": [
+                                      {
+                                        "message": "insecureSkipVerify All and caCertificateRefs may not be set together",
+                                        "rule": "has(self.insecureSkipVerify) && self.insecureSkipVerify == 'All' ? !has(self.caCertificateRefs) : true"
+                                      },
+                                      {
+                                        "message": "insecureSkipVerify and verifySubjectAltNames may not be set together",
+                                        "rule": "has(self.insecureSkipVerify) ? !has(self.verifySubjectAltNames) : true"
+                                      },
+                                      {
+                                        "message": "at most one of the fields in [verifySubjectAltNames insecureSkipVerify] may be set",
+                                        "rule": "[has(self.verifySubjectAltNames),has(self.insecureSkipVerify)].filter(x,x==true).size() <= 1"
+                                      }
+                                    ],
+                                    "additionalProperties": false
+                                  },
+                                  "tunnel": {
+                                    "description": "Settings for managing tunnel connections, with behavior like `HTTPS_PROXY`, to the backend.",
+                                    "properties": {
+                                      "backendRef": {
+                                        "description": "Proxy server to reach.\nSupported types: `Service` and `Backend`.",
+                                        "properties": {
+                                          "group": {
+                                            "default": "",
+                                            "description": "Group is the group of the referent. For example, \"gateway.networking.k8s.io\".\nWhen unspecified or empty string, core API group is inferred.",
+                                            "maxLength": 253,
+                                            "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                                            "type": "string"
+                                          },
+                                          "kind": {
+                                            "default": "Service",
+                                            "description": "Kind is the Kubernetes resource kind of the referent. For example\n\"Service\".\n\nDefaults to \"Service\" when not specified.\n\nExternalName services can refer to CNAME DNS records that may live\noutside of the cluster and as such are difficult to reason about in\nterms of conformance. They also may not be safe to forward to (see\nCVE-2021-25740 for more information). Implementations SHOULD NOT\nsupport ExternalName Services.\n\nSupport: Core (Services with a type other than ExternalName)\n\nSupport: Implementation-specific (Services with type ExternalName)",
+                                            "maxLength": 63,
+                                            "minLength": 1,
+                                            "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "description": "Name is the name of the referent.",
+                                            "maxLength": 253,
+                                            "minLength": 1,
+                                            "type": "string"
+                                          },
+                                          "namespace": {
+                                            "description": "Namespace is the namespace of the backend. When unspecified, the local\nnamespace is inferred.\n\nNote that when a namespace different than the local namespace is specified,\na ReferenceGrant object is required in the referent namespace to allow that\nnamespace's owner to accept the reference. See the ReferenceGrant\ndocumentation for details.\n\nSupport: Core",
+                                            "maxLength": 63,
+                                            "minLength": 1,
+                                            "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "description": "Port specifies the destination port number to use for this resource.\nPort is required when the referent is a Kubernetes Service. In this\ncase, the port number is the service port number, not the target port.\nFor other resources, destination port might be derived from the referent\nresource or this field.",
+                                            "format": "int32",
+                                            "maximum": 65535,
+                                            "minimum": 1,
+                                            "type": "integer"
+                                          }
+                                        },
+                                        "required": [
+                                          "name"
+                                        ],
+                                        "type": "object",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "Must have port for Service reference",
+                                            "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
+                                          }
+                                        ],
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "required": [
+                                      "backendRef"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "regex": {
+                            "description": "Regular expression (regex) matching for prompt guards and data masking.",
+                            "properties": {
+                              "action": {
+                                "default": "Mask",
+                                "description": "The action to take if a regex pattern is matched in a request or response.\nThis setting applies only to request matches. `PromptguardResponse`\nmatches are always masked by default.\nDefaults to `Mask`.",
+                                "enum": [
+                                  "Mask",
+                                  "Reject"
+                                ],
+                                "type": "string"
+                              },
+                              "builtins": {
+                                "description": "Built-in regex patterns to match against the request or response.\nMatches and built-ins are additive.",
+                                "items": {
+                                  "description": "Built-in regex patterns for specific types of strings in prompts.\nFor example, if you specify `CreditCard`, any credit card numbers\nin the request or response are matched.",
+                                  "enum": [
+                                    "CaSin",
+                                    "CreditCard",
+                                    "Email",
+                                    "PhoneNumber",
+                                    "Ssn"
+                                  ],
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "matches": {
+                                "description": "Regex patterns to match against the request or response.\nMatches and built-ins are additive.",
+                                "items": {
+                                  "maxLength": 1024,
+                                  "minLength": 1,
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "response": {
+                            "description": "Custom response message to return to the client. If not specified, defaults to\n`The request was rejected due to inappropriate content`.",
+                            "properties": {
+                              "message": {
+                                "default": "The request was rejected due to inappropriate content",
+                                "description": "Custom response message to return to the client. If not specified, defaults to\n`The request was rejected due to inappropriate content`.",
+                                "type": "string"
+                              },
+                              "statusCode": {
+                                "default": 403,
+                                "description": "Status code to return to the client. Defaults to 403.",
+                                "format": "int32",
+                                "maximum": 599,
+                                "minimum": 200,
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-validations": [
+                              {
+                                "message": "at least one of the fields in [message statusCode] must be set",
+                                "rule": "[has(self.message),has(self.statusCode)].filter(x,x==true).size() >= 1"
+                              }
+                            ],
+                            "additionalProperties": false
+                          },
+                          "webhook": {
+                            "description": "Webhook that receives requests for prompt guarding.",
+                            "properties": {
+                              "backendRef": {
+                                "description": "Webhook server to reach.\n\nSupported types: Service and Backend.",
+                                "properties": {
+                                  "group": {
+                                    "default": "",
+                                    "description": "Group is the group of the referent. For example, \"gateway.networking.k8s.io\".\nWhen unspecified or empty string, core API group is inferred.",
+                                    "maxLength": 253,
+                                    "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                                    "type": "string"
+                                  },
+                                  "kind": {
+                                    "default": "Service",
+                                    "description": "Kind is the Kubernetes resource kind of the referent. For example\n\"Service\".\n\nDefaults to \"Service\" when not specified.\n\nExternalName services can refer to CNAME DNS records that may live\noutside of the cluster and as such are difficult to reason about in\nterms of conformance. They also may not be safe to forward to (see\nCVE-2021-25740 for more information). Implementations SHOULD NOT\nsupport ExternalName Services.\n\nSupport: Core (Services with a type other than ExternalName)\n\nSupport: Implementation-specific (Services with type ExternalName)",
+                                    "maxLength": 63,
+                                    "minLength": 1,
+                                    "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "description": "Name is the name of the referent.",
+                                    "maxLength": 253,
+                                    "minLength": 1,
+                                    "type": "string"
+                                  },
+                                  "namespace": {
+                                    "description": "Namespace is the namespace of the backend. When unspecified, the local\nnamespace is inferred.\n\nNote that when a namespace different than the local namespace is specified,\na ReferenceGrant object is required in the referent namespace to allow that\nnamespace's owner to accept the reference. See the ReferenceGrant\ndocumentation for details.\n\nSupport: Core",
+                                    "maxLength": 63,
+                                    "minLength": 1,
+                                    "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "description": "Port specifies the destination port number to use for this resource.\nPort is required when the referent is a Kubernetes Service. In this\ncase, the port number is the service port number, not the target port.\nFor other resources, destination port might be derived from the referent\nresource or this field.",
+                                    "format": "int32",
+                                    "maximum": 65535,
+                                    "minimum": 1,
+                                    "type": "integer"
+                                  }
+                                },
+                                "required": [
+                                  "name"
+                                ],
+                                "type": "object",
+                                "x-kubernetes-validations": [
+                                  {
+                                    "message": "Must have port for Service reference",
+                                    "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
+                                  }
+                                ],
+                                "additionalProperties": false
+                              },
+                              "failureMode": {
+                                "description": "Behavior when the webhook guardrail is unavailable\nor returns an error. `FailOpen` allows the request to continue.\n`FailClosed` (default) rejects the request.",
+                                "enum": [
+                                  "FailClosed",
+                                  "FailOpen"
+                                ],
+                                "type": "string"
+                              },
+                              "forwardHeaderMatches": {
+                                "description": "HTTP header matches used to select the headers to forward to the webhook.\nRequest headers are used when forwarding requests and response headers\nare used when forwarding responses.\nBy default, no headers are forwarded.",
+                                "items": {
+                                  "description": "HTTPHeaderMatch describes how to select a HTTP route by matching HTTP request\nheaders.",
+                                  "properties": {
+                                    "name": {
+                                      "description": "Name is the name of the HTTP Header to be matched. Name matching MUST be\ncase-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).\n\nIf multiple entries specify equivalent header names, only the first\nentry with an equivalent name MUST be considered for a match. Subsequent\nentries with an equivalent header name MUST be ignored. Due to the\ncase-insensitivity of header names, \"foo\" and \"Foo\" are considered\nequivalent.\n\nWhen a header is repeated in an HTTP request, it is\nimplementation-specific behavior as to how this is represented.\nGenerally, proxies should follow the guidance from the RFC:\nhttps://www.rfc-editor.org/rfc/rfc7230.html#section-3.2.2 regarding\nprocessing a repeated header, with special handling for \"Set-Cookie\".",
+                                      "maxLength": 256,
+                                      "minLength": 1,
+                                      "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                                      "type": "string"
+                                    },
+                                    "type": {
+                                      "default": "Exact",
+                                      "description": "Type specifies how to match against the value of the header.\n\nSupport: Core (Exact)\n\nSupport: Implementation-specific (RegularExpression)\n\nSince RegularExpression HeaderMatchType has implementation-specific\nconformance, implementations can support POSIX, PCRE or any other dialects\nof regular expressions. Please read the implementation's documentation to\ndetermine the supported dialect.",
+                                      "enum": [
+                                        "Exact",
+                                        "RegularExpression"
+                                      ],
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "description": "Value is the value of HTTP Header to be matched.\n<gateway:experimental:description>\nMust consist of printable US-ASCII characters, optionally separated\nby single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2\n</gateway:experimental:description>\n\n<gateway:experimental:validation:Pattern=`^[!-~]+([\\t ]?[!-~]+)*$`>",
+                                      "maxLength": 4096,
+                                      "minLength": 1,
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "name",
+                                    "value"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "required": [
+                              "backendRef"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-validations": [
+                          {
+                            "message": "exactly one of the fields in [regex webhook openAIModeration bedrockGuardrails googleModelArmor] must be set",
+                            "rule": "[has(self.regex),has(self.webhook),has(self.openAIModeration),has(self.bedrockGuardrails),has(self.googleModelArmor)].filter(x,x==true).size() == 1"
+                          }
+                        ],
+                        "additionalProperties": false
+                      },
+                      "maxItems": 8,
+                      "minItems": 1,
+                      "type": "array"
+                    },
+                    "response": {
+                      "description": "Prompt guards to apply to responses returned by the LLM provider.",
+                      "items": {
+                        "description": "Prompt guards to apply to responses returned by the LLM provider.",
+                        "properties": {
+                          "bedrockGuardrails": {
+                            "description": "AWS Bedrock Guardrails settings for prompt\nguarding.",
+                            "properties": {
+                              "identifier": {
+                                "description": "Identifier of the Guardrail policy to use for the backend.",
+                                "maxLength": 256,
+                                "minLength": 1,
+                                "type": "string"
+                              },
+                              "policies": {
+                                "description": "Policies for communicating with AWS Bedrock Guardrails.",
+                                "properties": {
+                                  "auth": {
+                                    "description": "Settings for managing authentication to the backend.",
+                                    "properties": {
+                                      "aws": {
+                                        "description": "Explicit AWS authentication method for the backend.\nWhen omitted, default AWS SDK credential discovery is used.",
+                                        "properties": {
+                                          "assumeRole": {
+                                            "description": "AWS STS AssumeRole settings to use before signing backend requests.\nAmbient AWS credentials are used as the source credentials for STS.",
+                                            "properties": {
+                                              "roleArn": {
+                                                "description": "AWS IAM role ARN to assume.",
+                                                "minLength": 1,
+                                                "pattern": "^arn:aws[a-z-]*:iam::[0-9]{12}:role/.+$",
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "roleArn"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "secretRef": {
+                                            "description": "Credential source, defaulting to a Kubernetes\n`Secret`, containing the AWS credentials. When using the default Secret\nresolver, the `Secret` must have keys `accessKey`, `secretKey`, and\noptionally `sessionToken`.",
+                                            "properties": {
+                                              "group": {
+                                                "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                                                "type": "string"
+                                              },
+                                              "kind": {
+                                                "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "description": "The name of the referenced credential.",
+                                                "maxLength": 253,
+                                                "minLength": 1,
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name"
+                                            ],
+                                            "type": "object",
+                                            "x-kubernetes-map-type": "atomic",
+                                            "x-kubernetes-validations": [
+                                              {
+                                                "message": "custom credential refs must set both group and kind",
+                                                "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                                              }
+                                            ],
+                                            "additionalProperties": false
+                                          },
+                                          "serviceName": {
+                                            "description": "AWS SigV4 signing service name, for example\n`bedrock`, `bedrock-agentcore`, or `execute-api`). If unset, typed AWS\nbackends may provide this automatically.",
+                                            "maxLength": 256,
+                                            "minLength": 1,
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "secretRef and assumeRole are mutually exclusive",
+                                            "rule": "!(has(self.secretRef) && has(self.assumeRole))"
+                                          }
+                                        ],
+                                        "additionalProperties": false
+                                      },
+                                      "azure": {
+                                        "description": "Azure authentication method for the backend.",
+                                        "properties": {
+                                          "managedIdentity": {
+                                            "description": "Managed identity authentication settings.",
+                                            "properties": {
+                                              "clientId": {
+                                                "type": "string"
+                                              },
+                                              "objectId": {
+                                                "type": "string"
+                                              },
+                                              "resourceId": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "clientId",
+                                              "objectId",
+                                              "resourceId"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "secretRef": {
+                                            "description": "Credential source, defaulting to a Kubernetes\n`Secret`, containing the Azure credentials. When using the default Secret\nresolver, the `Secret` must have keys `clientID`, `tenantID`, and\n`clientSecret`.",
+                                            "properties": {
+                                              "group": {
+                                                "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                                                "type": "string"
+                                              },
+                                              "kind": {
+                                                "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "description": "The name of the referenced credential.",
+                                                "maxLength": 253,
+                                                "minLength": 1,
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name"
+                                            ],
+                                            "type": "object",
+                                            "x-kubernetes-map-type": "atomic",
+                                            "x-kubernetes-validations": [
+                                              {
+                                                "message": "custom credential refs must set both group and kind",
+                                                "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                                              }
+                                            ],
+                                            "additionalProperties": false
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "gcp": {
+                                        "description": "Google authentication method for the backend.\nWhen omitted, default Google credential discovery is used.",
+                                        "properties": {
+                                          "audience": {
+                                            "description": "Explicit `aud` value for the ID token. Only\nvalid with `IdToken` type. If not set, the `aud` is automatically\nderived from the backend hostname.",
+                                            "maxLength": 256,
+                                            "minLength": 1,
+                                            "type": "string"
+                                          },
+                                          "secretRef": {
+                                            "description": "Credential source, defaulting to a Kubernetes\n`Secret`, containing ADC-compatible Google credential JSON. When using\nthe default Secret resolver, this must be stored in the `credentials.json`\nkey. When omitted, ambient credentials are used.",
+                                            "properties": {
+                                              "group": {
+                                                "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                                                "type": "string"
+                                              },
+                                              "kind": {
+                                                "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "description": "The name of the referenced credential.",
+                                                "maxLength": 253,
+                                                "minLength": 1,
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name"
+                                            ],
+                                            "type": "object",
+                                            "x-kubernetes-map-type": "atomic",
+                                            "x-kubernetes-validations": [
+                                              {
+                                                "message": "custom credential refs must set both group and kind",
+                                                "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                                              }
+                                            ],
+                                            "additionalProperties": false
+                                          },
+                                          "type": {
+                                            "description": "The type of token to generate. To authenticate to GCP services,\ngenerally an `AccessToken` is used. To authenticate to Cloud Run, an\n`IdToken` is used.",
+                                            "enum": [
+                                              "AccessToken",
+                                              "IdToken"
+                                            ],
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "audience is only valid with IdToken",
+                                            "rule": "has(self.audience) ? self.type == 'IdToken' : true"
+                                          }
+                                        ],
+                                        "additionalProperties": false
+                                      },
+                                      "key": {
+                                        "description": "Inline key to use as the value of the\n`Authorization` header. This option is the least secure; usage of a\n`Secret` is preferred.",
+                                        "maxLength": 2048,
+                                        "type": "string"
+                                      },
+                                      "location": {
+                                        "description": "Where backend credentials are inserted.\nIf omitted, credentials are written to the `Authorization` header with the `Bearer ` prefix.\nThis applies to `key`, `secretRef`, and `passthrough`.",
+                                        "properties": {
+                                          "cookie": {
+                                            "properties": {
+                                              "name": {
+                                                "maxLength": 256,
+                                                "minLength": 1,
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "header": {
+                                            "properties": {
+                                              "name": {
+                                                "description": "HTTPHeaderName is the name of an HTTP header.\n\nValid values include:\n\n* \"Authorization\"\n* \"Set-Cookie\"\n\nInvalid values include:\n\n  - \":method\" - \":\" is an invalid character. This means that HTTP/2 pseudo\n    headers are not currently supported by this type.\n  - \"/invalid\" - \"/ \" is an invalid character",
+                                                "maxLength": 256,
+                                                "minLength": 1,
+                                                "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                                                "type": "string"
+                                              },
+                                              "prefix": {
+                                                "maxLength": 256,
+                                                "minLength": 1,
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "queryParameter": {
+                                            "properties": {
+                                              "name": {
+                                                "maxLength": 256,
+                                                "minLength": 1,
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          }
+                                        },
+                                        "type": "object",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "exactly one of the fields in [header queryParameter cookie] must be set",
+                                            "rule": "[has(self.header),has(self.queryParameter),has(self.cookie)].filter(x,x==true).size() == 1"
+                                          }
+                                        ],
+                                        "additionalProperties": false
+                                      },
+                                      "passthrough": {
+                                        "description": "Passes through an existing token that has been sent by the\nclient and validated. Other policies, like JWT and API key\nauthentication, will strip the original client credentials. Passthrough backend authentication\ncauses the original token to be added back into the request. If there are no client authentication policies on the\nrequest, the original token would be unchanged, so this would have no effect.",
+                                        "type": "object"
+                                      },
+                                      "secretRef": {
+                                        "description": "Credential source, defaulting to a Kubernetes\n`Secret`, storing the key to use as the authorization value. When using\nthe default Secret resolver, this must be stored in the `Authorization`\nkey.",
+                                        "properties": {
+                                          "group": {
+                                            "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                                            "type": "string"
+                                          },
+                                          "kind": {
+                                            "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "description": "The name of the referenced credential.",
+                                            "maxLength": 253,
+                                            "minLength": 1,
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "name"
+                                        ],
+                                        "type": "object",
+                                        "x-kubernetes-map-type": "atomic",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "custom credential refs must set both group and kind",
+                                            "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                                          }
+                                        ],
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "x-kubernetes-validations": [
+                                      {
+                                        "message": "location may only be set for key or passthrough auth",
+                                        "rule": "has(self.location) ? has(self.key) || has(self.secretRef) || has(self.passthrough) : true"
+                                      },
+                                      {
+                                        "message": "exactly one of the fields in [key secretRef passthrough aws azure gcp] must be set",
+                                        "rule": "[has(self.key),has(self.secretRef),has(self.passthrough),has(self.aws),has(self.azure),has(self.gcp)].filter(x,x==true).size() == 1"
+                                      }
+                                    ],
+                                    "additionalProperties": false
+                                  },
+                                  "http": {
+                                    "description": "Settings for managing HTTP requests to the backend.",
+                                    "properties": {
+                                      "requestTimeout": {
+                                        "description": "Deadline for receiving a response from the backend.",
+                                        "type": "string",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "invalid duration value",
+                                            "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                          },
+                                          {
+                                            "message": "requestTimeout must be at least 1ms",
+                                            "rule": "duration(self) >= duration('1ms')"
+                                          }
+                                        ]
+                                      },
+                                      "version": {
+                                        "description": "HTTP protocol version to use when connecting to\nthe backend.\nIf not specified, the version is automatically determined:\n* `Service` types can specify it with `appProtocol` on the `Service`\n  port.\n* If traffic is identified as gRPC, `HTTP2` is used.\n* If the incoming traffic was plaintext HTTP, the original protocol will\n  be used.\n* If the incoming traffic was HTTPS, `HTTP1` will be used. This is\n  because most clients will transparently upgrade HTTPS traffic to\n  `HTTP2`, even if the backend doesn't support it.",
+                                        "enum": [
+                                          "HTTP1",
+                                          "HTTP2"
+                                        ],
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "tcp": {
+                                    "description": "Settings for managing TCP connections to the backend.",
+                                    "properties": {
+                                      "connectTimeout": {
+                                        "description": "Deadline for establishing a connection to\nthe destination.",
+                                        "type": "string",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "invalid duration value",
+                                            "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                          },
+                                          {
+                                            "message": "connectTimeout must be at least 100ms",
+                                            "rule": "duration(self) >= duration('100ms')"
+                                          }
+                                        ]
+                                      },
+                                      "keepalive": {
+                                        "description": "Settings for enabling TCP keepalives on the\nconnection.",
+                                        "properties": {
+                                          "interval": {
+                                            "description": "Time between keepalive probes.\nIf unset, this defaults to 180s.",
+                                            "type": "string",
+                                            "x-kubernetes-validations": [
+                                              {
+                                                "message": "invalid duration value",
+                                                "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                              },
+                                              {
+                                                "message": "interval must be at least 1 second",
+                                                "rule": "duration(self) >= duration('1s')"
+                                              }
+                                            ]
+                                          },
+                                          "retries": {
+                                            "description": "Maximum number of keepalive probes to send before dropping the connection.\nIf unset, this defaults to 9.",
+                                            "format": "int32",
+                                            "maximum": 64,
+                                            "minimum": 1,
+                                            "type": "integer"
+                                          },
+                                          "time": {
+                                            "description": "Time a connection needs to be idle before keepalive probes start being sent.\nIf unset, this defaults to 180s.",
+                                            "type": "string",
+                                            "x-kubernetes-validations": [
+                                              {
+                                                "message": "invalid duration value",
+                                                "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                              },
+                                              {
+                                                "message": "time must be at least 1 second",
+                                                "rule": "duration(self) >= duration('1s')"
+                                              }
+                                            ]
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "tls": {
+                                    "description": "Settings for managing TLS connections to the backend.\n\nIf this field is set, TLS will be initiated to the backend; the system trusted CA certificates will be used to\nvalidate the server, and the SNI will automatically be set based on the destination.",
+                                    "properties": {
+                                      "alpnProtocols": {
+                                        "description": "Application-Layer Protocol Negotiation (`ALPN`)\nvalue to use in the TLS handshake.\n\nIf not present, defaults to `[\"h2\", \"http/1.1\"]`.",
+                                        "items": {
+                                          "maxLength": 64,
+                                          "minLength": 1,
+                                          "type": "string"
+                                        },
+                                        "maxItems": 16,
+                                        "minItems": 1,
+                                        "type": "array"
+                                      },
+                                      "caCertificateRefs": {
+                                        "description": "CA certificate `ConfigMap` to use to\nverify the server certificate.\nIf unset, the system's trusted certificates are used.",
+                                        "items": {
+                                          "description": "LocalObjectReference contains enough information to let you locate the\nreferenced object inside the same namespace.",
+                                          "properties": {
+                                            "name": {
+                                              "default": "",
+                                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "x-kubernetes-map-type": "atomic",
+                                          "additionalProperties": false
+                                        },
+                                        "maxItems": 1,
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
+                                      },
+                                      "insecureSkipVerify": {
+                                        "description": "Originates TLS but skips verification of the backend's certificate.\nWARNING: This is an insecure option that should only be used if the risks are understood.\n\nThere are two modes:\n* `All` disables all TLS verification.\n* `Hostname` verifies the CA certificate is trusted, but ignores any\n  mismatch of hostname or SANs. Note that this method is still insecure;\n  prefer setting `verifySubjectAltNames` to customize the valid hostnames\n  if possible.",
+                                        "enum": [
+                                          "All",
+                                          "Hostname"
+                                        ],
+                                        "type": "string"
+                                      },
+                                      "keyExchangeGroups": {
+                                        "description": "Ordered list of key exchange groups for a TLS connection.\nFor example: `X25519_MLKEM768,X25519`.",
+                                        "items": {
+                                          "enum": [
+                                            "P-256",
+                                            "P-384",
+                                            "X25519",
+                                            "X25519_MLKEM768"
+                                          ],
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "mtlsCertificateRef": {
+                                        "description": "Enables mutual TLS to the backend, using the\nspecified key (`tls.key`) and cert (`tls.crt`) from the referenced\ncredential source, defaulting to a Kubernetes `Secret`.\n\nAn optional `ca.cert` field, if present, will be used to verify the\nserver certificate. If `caCertificateRefs` is also specified, the\n`caCertificateRefs` field takes priority.\n\nIf unspecified, no client certificate will be used.",
+                                        "items": {
+                                          "description": "References a same-namespace credential.\nSet only `name` to reference a Kubernetes Secret.",
+                                          "properties": {
+                                            "group": {
+                                              "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                                              "type": "string"
+                                            },
+                                            "kind": {
+                                              "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "description": "The name of the referenced credential.",
+                                              "maxLength": 253,
+                                              "minLength": 1,
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "name"
+                                          ],
+                                          "type": "object",
+                                          "x-kubernetes-map-type": "atomic",
+                                          "x-kubernetes-validations": [
+                                            {
+                                              "message": "custom credential refs must set both group and kind",
+                                              "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                                            }
+                                          ],
+                                          "additionalProperties": false
+                                        },
+                                        "maxItems": 1,
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
+                                      },
+                                      "sni": {
+                                        "description": "Server Name Indicator (`SNI`) to use in the TLS\nhandshake. If unset, the `SNI` is automatically set based on the\ndestination hostname.",
+                                        "maxLength": 253,
+                                        "minLength": 1,
+                                        "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                                        "type": "string"
+                                      },
+                                      "verifySubjectAltNames": {
+                                        "description": "Subject Alternative Names (`SAN`)\nto verify in the server certificate.\nIf not present, the destination hostname is automatically used.",
+                                        "items": {
+                                          "maxLength": 256,
+                                          "minLength": 1,
+                                          "type": "string"
+                                        },
+                                        "maxItems": 16,
+                                        "minItems": 1,
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "x-kubernetes-validations": [
+                                      {
+                                        "message": "insecureSkipVerify All and caCertificateRefs may not be set together",
+                                        "rule": "has(self.insecureSkipVerify) && self.insecureSkipVerify == 'All' ? !has(self.caCertificateRefs) : true"
+                                      },
+                                      {
+                                        "message": "insecureSkipVerify and verifySubjectAltNames may not be set together",
+                                        "rule": "has(self.insecureSkipVerify) ? !has(self.verifySubjectAltNames) : true"
+                                      },
+                                      {
+                                        "message": "at most one of the fields in [verifySubjectAltNames insecureSkipVerify] may be set",
+                                        "rule": "[has(self.verifySubjectAltNames),has(self.insecureSkipVerify)].filter(x,x==true).size() <= 1"
+                                      }
+                                    ],
+                                    "additionalProperties": false
+                                  },
+                                  "tunnel": {
+                                    "description": "Settings for managing tunnel connections, with behavior like `HTTPS_PROXY`, to the backend.",
+                                    "properties": {
+                                      "backendRef": {
+                                        "description": "Proxy server to reach.\nSupported types: `Service` and `Backend`.",
+                                        "properties": {
+                                          "group": {
+                                            "default": "",
+                                            "description": "Group is the group of the referent. For example, \"gateway.networking.k8s.io\".\nWhen unspecified or empty string, core API group is inferred.",
+                                            "maxLength": 253,
+                                            "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                                            "type": "string"
+                                          },
+                                          "kind": {
+                                            "default": "Service",
+                                            "description": "Kind is the Kubernetes resource kind of the referent. For example\n\"Service\".\n\nDefaults to \"Service\" when not specified.\n\nExternalName services can refer to CNAME DNS records that may live\noutside of the cluster and as such are difficult to reason about in\nterms of conformance. They also may not be safe to forward to (see\nCVE-2021-25740 for more information). Implementations SHOULD NOT\nsupport ExternalName Services.\n\nSupport: Core (Services with a type other than ExternalName)\n\nSupport: Implementation-specific (Services with type ExternalName)",
+                                            "maxLength": 63,
+                                            "minLength": 1,
+                                            "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "description": "Name is the name of the referent.",
+                                            "maxLength": 253,
+                                            "minLength": 1,
+                                            "type": "string"
+                                          },
+                                          "namespace": {
+                                            "description": "Namespace is the namespace of the backend. When unspecified, the local\nnamespace is inferred.\n\nNote that when a namespace different than the local namespace is specified,\na ReferenceGrant object is required in the referent namespace to allow that\nnamespace's owner to accept the reference. See the ReferenceGrant\ndocumentation for details.\n\nSupport: Core",
+                                            "maxLength": 63,
+                                            "minLength": 1,
+                                            "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "description": "Port specifies the destination port number to use for this resource.\nPort is required when the referent is a Kubernetes Service. In this\ncase, the port number is the service port number, not the target port.\nFor other resources, destination port might be derived from the referent\nresource or this field.",
+                                            "format": "int32",
+                                            "maximum": 65535,
+                                            "minimum": 1,
+                                            "type": "integer"
+                                          }
+                                        },
+                                        "required": [
+                                          "name"
+                                        ],
+                                        "type": "object",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "Must have port for Service reference",
+                                            "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
+                                          }
+                                        ],
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "required": [
+                                      "backendRef"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "region": {
+                                "description": "AWS region where the guardrail is deployed, for example\n`us-west-2`).",
+                                "maxLength": 256,
+                                "minLength": 1,
+                                "type": "string"
+                              },
+                              "version": {
+                                "description": "Version of the Guardrail policy to use for the backend.",
+                                "maxLength": 256,
+                                "minLength": 1,
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "identifier",
+                              "region",
+                              "version"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "googleModelArmor": {
+                            "description": "Google Model Armor settings for prompt guarding.",
+                            "properties": {
+                              "location": {
+                                "default": "us-central1",
+                                "description": "Google Cloud location, for example `us-central1`.\nDefaults to `us-central1` if not specified.",
+                                "maxLength": 256,
+                                "minLength": 1,
+                                "type": "string"
+                              },
+                              "policies": {
+                                "description": "Policies for communicating with Google Model Armor.",
+                                "properties": {
+                                  "auth": {
+                                    "description": "Settings for managing authentication to the backend.",
+                                    "properties": {
+                                      "aws": {
+                                        "description": "Explicit AWS authentication method for the backend.\nWhen omitted, default AWS SDK credential discovery is used.",
+                                        "properties": {
+                                          "assumeRole": {
+                                            "description": "AWS STS AssumeRole settings to use before signing backend requests.\nAmbient AWS credentials are used as the source credentials for STS.",
+                                            "properties": {
+                                              "roleArn": {
+                                                "description": "AWS IAM role ARN to assume.",
+                                                "minLength": 1,
+                                                "pattern": "^arn:aws[a-z-]*:iam::[0-9]{12}:role/.+$",
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "roleArn"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "secretRef": {
+                                            "description": "Credential source, defaulting to a Kubernetes\n`Secret`, containing the AWS credentials. When using the default Secret\nresolver, the `Secret` must have keys `accessKey`, `secretKey`, and\noptionally `sessionToken`.",
+                                            "properties": {
+                                              "group": {
+                                                "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                                                "type": "string"
+                                              },
+                                              "kind": {
+                                                "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "description": "The name of the referenced credential.",
+                                                "maxLength": 253,
+                                                "minLength": 1,
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name"
+                                            ],
+                                            "type": "object",
+                                            "x-kubernetes-map-type": "atomic",
+                                            "x-kubernetes-validations": [
+                                              {
+                                                "message": "custom credential refs must set both group and kind",
+                                                "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                                              }
+                                            ],
+                                            "additionalProperties": false
+                                          },
+                                          "serviceName": {
+                                            "description": "AWS SigV4 signing service name, for example\n`bedrock`, `bedrock-agentcore`, or `execute-api`). If unset, typed AWS\nbackends may provide this automatically.",
+                                            "maxLength": 256,
+                                            "minLength": 1,
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "secretRef and assumeRole are mutually exclusive",
+                                            "rule": "!(has(self.secretRef) && has(self.assumeRole))"
+                                          }
+                                        ],
+                                        "additionalProperties": false
+                                      },
+                                      "azure": {
+                                        "description": "Azure authentication method for the backend.",
+                                        "properties": {
+                                          "managedIdentity": {
+                                            "description": "Managed identity authentication settings.",
+                                            "properties": {
+                                              "clientId": {
+                                                "type": "string"
+                                              },
+                                              "objectId": {
+                                                "type": "string"
+                                              },
+                                              "resourceId": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "clientId",
+                                              "objectId",
+                                              "resourceId"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "secretRef": {
+                                            "description": "Credential source, defaulting to a Kubernetes\n`Secret`, containing the Azure credentials. When using the default Secret\nresolver, the `Secret` must have keys `clientID`, `tenantID`, and\n`clientSecret`.",
+                                            "properties": {
+                                              "group": {
+                                                "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                                                "type": "string"
+                                              },
+                                              "kind": {
+                                                "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "description": "The name of the referenced credential.",
+                                                "maxLength": 253,
+                                                "minLength": 1,
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name"
+                                            ],
+                                            "type": "object",
+                                            "x-kubernetes-map-type": "atomic",
+                                            "x-kubernetes-validations": [
+                                              {
+                                                "message": "custom credential refs must set both group and kind",
+                                                "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                                              }
+                                            ],
+                                            "additionalProperties": false
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "gcp": {
+                                        "description": "Google authentication method for the backend.\nWhen omitted, default Google credential discovery is used.",
+                                        "properties": {
+                                          "audience": {
+                                            "description": "Explicit `aud` value for the ID token. Only\nvalid with `IdToken` type. If not set, the `aud` is automatically\nderived from the backend hostname.",
+                                            "maxLength": 256,
+                                            "minLength": 1,
+                                            "type": "string"
+                                          },
+                                          "secretRef": {
+                                            "description": "Credential source, defaulting to a Kubernetes\n`Secret`, containing ADC-compatible Google credential JSON. When using\nthe default Secret resolver, this must be stored in the `credentials.json`\nkey. When omitted, ambient credentials are used.",
+                                            "properties": {
+                                              "group": {
+                                                "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                                                "type": "string"
+                                              },
+                                              "kind": {
+                                                "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "description": "The name of the referenced credential.",
+                                                "maxLength": 253,
+                                                "minLength": 1,
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name"
+                                            ],
+                                            "type": "object",
+                                            "x-kubernetes-map-type": "atomic",
+                                            "x-kubernetes-validations": [
+                                              {
+                                                "message": "custom credential refs must set both group and kind",
+                                                "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                                              }
+                                            ],
+                                            "additionalProperties": false
+                                          },
+                                          "type": {
+                                            "description": "The type of token to generate. To authenticate to GCP services,\ngenerally an `AccessToken` is used. To authenticate to Cloud Run, an\n`IdToken` is used.",
+                                            "enum": [
+                                              "AccessToken",
+                                              "IdToken"
+                                            ],
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "audience is only valid with IdToken",
+                                            "rule": "has(self.audience) ? self.type == 'IdToken' : true"
+                                          }
+                                        ],
+                                        "additionalProperties": false
+                                      },
+                                      "key": {
+                                        "description": "Inline key to use as the value of the\n`Authorization` header. This option is the least secure; usage of a\n`Secret` is preferred.",
+                                        "maxLength": 2048,
+                                        "type": "string"
+                                      },
+                                      "location": {
+                                        "description": "Where backend credentials are inserted.\nIf omitted, credentials are written to the `Authorization` header with the `Bearer ` prefix.\nThis applies to `key`, `secretRef`, and `passthrough`.",
+                                        "properties": {
+                                          "cookie": {
+                                            "properties": {
+                                              "name": {
+                                                "maxLength": 256,
+                                                "minLength": 1,
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "header": {
+                                            "properties": {
+                                              "name": {
+                                                "description": "HTTPHeaderName is the name of an HTTP header.\n\nValid values include:\n\n* \"Authorization\"\n* \"Set-Cookie\"\n\nInvalid values include:\n\n  - \":method\" - \":\" is an invalid character. This means that HTTP/2 pseudo\n    headers are not currently supported by this type.\n  - \"/invalid\" - \"/ \" is an invalid character",
+                                                "maxLength": 256,
+                                                "minLength": 1,
+                                                "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                                                "type": "string"
+                                              },
+                                              "prefix": {
+                                                "maxLength": 256,
+                                                "minLength": 1,
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "queryParameter": {
+                                            "properties": {
+                                              "name": {
+                                                "maxLength": 256,
+                                                "minLength": 1,
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          }
+                                        },
+                                        "type": "object",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "exactly one of the fields in [header queryParameter cookie] must be set",
+                                            "rule": "[has(self.header),has(self.queryParameter),has(self.cookie)].filter(x,x==true).size() == 1"
+                                          }
+                                        ],
+                                        "additionalProperties": false
+                                      },
+                                      "passthrough": {
+                                        "description": "Passes through an existing token that has been sent by the\nclient and validated. Other policies, like JWT and API key\nauthentication, will strip the original client credentials. Passthrough backend authentication\ncauses the original token to be added back into the request. If there are no client authentication policies on the\nrequest, the original token would be unchanged, so this would have no effect.",
+                                        "type": "object"
+                                      },
+                                      "secretRef": {
+                                        "description": "Credential source, defaulting to a Kubernetes\n`Secret`, storing the key to use as the authorization value. When using\nthe default Secret resolver, this must be stored in the `Authorization`\nkey.",
+                                        "properties": {
+                                          "group": {
+                                            "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                                            "type": "string"
+                                          },
+                                          "kind": {
+                                            "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "description": "The name of the referenced credential.",
+                                            "maxLength": 253,
+                                            "minLength": 1,
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "name"
+                                        ],
+                                        "type": "object",
+                                        "x-kubernetes-map-type": "atomic",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "custom credential refs must set both group and kind",
+                                            "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                                          }
+                                        ],
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "x-kubernetes-validations": [
+                                      {
+                                        "message": "location may only be set for key or passthrough auth",
+                                        "rule": "has(self.location) ? has(self.key) || has(self.secretRef) || has(self.passthrough) : true"
+                                      },
+                                      {
+                                        "message": "exactly one of the fields in [key secretRef passthrough aws azure gcp] must be set",
+                                        "rule": "[has(self.key),has(self.secretRef),has(self.passthrough),has(self.aws),has(self.azure),has(self.gcp)].filter(x,x==true).size() == 1"
+                                      }
+                                    ],
+                                    "additionalProperties": false
+                                  },
+                                  "http": {
+                                    "description": "Settings for managing HTTP requests to the backend.",
+                                    "properties": {
+                                      "requestTimeout": {
+                                        "description": "Deadline for receiving a response from the backend.",
+                                        "type": "string",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "invalid duration value",
+                                            "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                          },
+                                          {
+                                            "message": "requestTimeout must be at least 1ms",
+                                            "rule": "duration(self) >= duration('1ms')"
+                                          }
+                                        ]
+                                      },
+                                      "version": {
+                                        "description": "HTTP protocol version to use when connecting to\nthe backend.\nIf not specified, the version is automatically determined:\n* `Service` types can specify it with `appProtocol` on the `Service`\n  port.\n* If traffic is identified as gRPC, `HTTP2` is used.\n* If the incoming traffic was plaintext HTTP, the original protocol will\n  be used.\n* If the incoming traffic was HTTPS, `HTTP1` will be used. This is\n  because most clients will transparently upgrade HTTPS traffic to\n  `HTTP2`, even if the backend doesn't support it.",
+                                        "enum": [
+                                          "HTTP1",
+                                          "HTTP2"
+                                        ],
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "tcp": {
+                                    "description": "Settings for managing TCP connections to the backend.",
+                                    "properties": {
+                                      "connectTimeout": {
+                                        "description": "Deadline for establishing a connection to\nthe destination.",
+                                        "type": "string",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "invalid duration value",
+                                            "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                          },
+                                          {
+                                            "message": "connectTimeout must be at least 100ms",
+                                            "rule": "duration(self) >= duration('100ms')"
+                                          }
+                                        ]
+                                      },
+                                      "keepalive": {
+                                        "description": "Settings for enabling TCP keepalives on the\nconnection.",
+                                        "properties": {
+                                          "interval": {
+                                            "description": "Time between keepalive probes.\nIf unset, this defaults to 180s.",
+                                            "type": "string",
+                                            "x-kubernetes-validations": [
+                                              {
+                                                "message": "invalid duration value",
+                                                "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                              },
+                                              {
+                                                "message": "interval must be at least 1 second",
+                                                "rule": "duration(self) >= duration('1s')"
+                                              }
+                                            ]
+                                          },
+                                          "retries": {
+                                            "description": "Maximum number of keepalive probes to send before dropping the connection.\nIf unset, this defaults to 9.",
+                                            "format": "int32",
+                                            "maximum": 64,
+                                            "minimum": 1,
+                                            "type": "integer"
+                                          },
+                                          "time": {
+                                            "description": "Time a connection needs to be idle before keepalive probes start being sent.\nIf unset, this defaults to 180s.",
+                                            "type": "string",
+                                            "x-kubernetes-validations": [
+                                              {
+                                                "message": "invalid duration value",
+                                                "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                              },
+                                              {
+                                                "message": "time must be at least 1 second",
+                                                "rule": "duration(self) >= duration('1s')"
+                                              }
+                                            ]
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "tls": {
+                                    "description": "Settings for managing TLS connections to the backend.\n\nIf this field is set, TLS will be initiated to the backend; the system trusted CA certificates will be used to\nvalidate the server, and the SNI will automatically be set based on the destination.",
+                                    "properties": {
+                                      "alpnProtocols": {
+                                        "description": "Application-Layer Protocol Negotiation (`ALPN`)\nvalue to use in the TLS handshake.\n\nIf not present, defaults to `[\"h2\", \"http/1.1\"]`.",
+                                        "items": {
+                                          "maxLength": 64,
+                                          "minLength": 1,
+                                          "type": "string"
+                                        },
+                                        "maxItems": 16,
+                                        "minItems": 1,
+                                        "type": "array"
+                                      },
+                                      "caCertificateRefs": {
+                                        "description": "CA certificate `ConfigMap` to use to\nverify the server certificate.\nIf unset, the system's trusted certificates are used.",
+                                        "items": {
+                                          "description": "LocalObjectReference contains enough information to let you locate the\nreferenced object inside the same namespace.",
+                                          "properties": {
+                                            "name": {
+                                              "default": "",
+                                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "x-kubernetes-map-type": "atomic",
+                                          "additionalProperties": false
+                                        },
+                                        "maxItems": 1,
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
+                                      },
+                                      "insecureSkipVerify": {
+                                        "description": "Originates TLS but skips verification of the backend's certificate.\nWARNING: This is an insecure option that should only be used if the risks are understood.\n\nThere are two modes:\n* `All` disables all TLS verification.\n* `Hostname` verifies the CA certificate is trusted, but ignores any\n  mismatch of hostname or SANs. Note that this method is still insecure;\n  prefer setting `verifySubjectAltNames` to customize the valid hostnames\n  if possible.",
+                                        "enum": [
+                                          "All",
+                                          "Hostname"
+                                        ],
+                                        "type": "string"
+                                      },
+                                      "keyExchangeGroups": {
+                                        "description": "Ordered list of key exchange groups for a TLS connection.\nFor example: `X25519_MLKEM768,X25519`.",
+                                        "items": {
+                                          "enum": [
+                                            "P-256",
+                                            "P-384",
+                                            "X25519",
+                                            "X25519_MLKEM768"
+                                          ],
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "mtlsCertificateRef": {
+                                        "description": "Enables mutual TLS to the backend, using the\nspecified key (`tls.key`) and cert (`tls.crt`) from the referenced\ncredential source, defaulting to a Kubernetes `Secret`.\n\nAn optional `ca.cert` field, if present, will be used to verify the\nserver certificate. If `caCertificateRefs` is also specified, the\n`caCertificateRefs` field takes priority.\n\nIf unspecified, no client certificate will be used.",
+                                        "items": {
+                                          "description": "References a same-namespace credential.\nSet only `name` to reference a Kubernetes Secret.",
+                                          "properties": {
+                                            "group": {
+                                              "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                                              "type": "string"
+                                            },
+                                            "kind": {
+                                              "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "description": "The name of the referenced credential.",
+                                              "maxLength": 253,
+                                              "minLength": 1,
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "name"
+                                          ],
+                                          "type": "object",
+                                          "x-kubernetes-map-type": "atomic",
+                                          "x-kubernetes-validations": [
+                                            {
+                                              "message": "custom credential refs must set both group and kind",
+                                              "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                                            }
+                                          ],
+                                          "additionalProperties": false
+                                        },
+                                        "maxItems": 1,
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
+                                      },
+                                      "sni": {
+                                        "description": "Server Name Indicator (`SNI`) to use in the TLS\nhandshake. If unset, the `SNI` is automatically set based on the\ndestination hostname.",
+                                        "maxLength": 253,
+                                        "minLength": 1,
+                                        "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                                        "type": "string"
+                                      },
+                                      "verifySubjectAltNames": {
+                                        "description": "Subject Alternative Names (`SAN`)\nto verify in the server certificate.\nIf not present, the destination hostname is automatically used.",
+                                        "items": {
+                                          "maxLength": 256,
+                                          "minLength": 1,
+                                          "type": "string"
+                                        },
+                                        "maxItems": 16,
+                                        "minItems": 1,
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "x-kubernetes-validations": [
+                                      {
+                                        "message": "insecureSkipVerify All and caCertificateRefs may not be set together",
+                                        "rule": "has(self.insecureSkipVerify) && self.insecureSkipVerify == 'All' ? !has(self.caCertificateRefs) : true"
+                                      },
+                                      {
+                                        "message": "insecureSkipVerify and verifySubjectAltNames may not be set together",
+                                        "rule": "has(self.insecureSkipVerify) ? !has(self.verifySubjectAltNames) : true"
+                                      },
+                                      {
+                                        "message": "at most one of the fields in [verifySubjectAltNames insecureSkipVerify] may be set",
+                                        "rule": "[has(self.verifySubjectAltNames),has(self.insecureSkipVerify)].filter(x,x==true).size() <= 1"
+                                      }
+                                    ],
+                                    "additionalProperties": false
+                                  },
+                                  "tunnel": {
+                                    "description": "Settings for managing tunnel connections, with behavior like `HTTPS_PROXY`, to the backend.",
+                                    "properties": {
+                                      "backendRef": {
+                                        "description": "Proxy server to reach.\nSupported types: `Service` and `Backend`.",
+                                        "properties": {
+                                          "group": {
+                                            "default": "",
+                                            "description": "Group is the group of the referent. For example, \"gateway.networking.k8s.io\".\nWhen unspecified or empty string, core API group is inferred.",
+                                            "maxLength": 253,
+                                            "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                                            "type": "string"
+                                          },
+                                          "kind": {
+                                            "default": "Service",
+                                            "description": "Kind is the Kubernetes resource kind of the referent. For example\n\"Service\".\n\nDefaults to \"Service\" when not specified.\n\nExternalName services can refer to CNAME DNS records that may live\noutside of the cluster and as such are difficult to reason about in\nterms of conformance. They also may not be safe to forward to (see\nCVE-2021-25740 for more information). Implementations SHOULD NOT\nsupport ExternalName Services.\n\nSupport: Core (Services with a type other than ExternalName)\n\nSupport: Implementation-specific (Services with type ExternalName)",
+                                            "maxLength": 63,
+                                            "minLength": 1,
+                                            "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "description": "Name is the name of the referent.",
+                                            "maxLength": 253,
+                                            "minLength": 1,
+                                            "type": "string"
+                                          },
+                                          "namespace": {
+                                            "description": "Namespace is the namespace of the backend. When unspecified, the local\nnamespace is inferred.\n\nNote that when a namespace different than the local namespace is specified,\na ReferenceGrant object is required in the referent namespace to allow that\nnamespace's owner to accept the reference. See the ReferenceGrant\ndocumentation for details.\n\nSupport: Core",
+                                            "maxLength": 63,
+                                            "minLength": 1,
+                                            "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "description": "Port specifies the destination port number to use for this resource.\nPort is required when the referent is a Kubernetes Service. In this\ncase, the port number is the service port number, not the target port.\nFor other resources, destination port might be derived from the referent\nresource or this field.",
+                                            "format": "int32",
+                                            "maximum": 65535,
+                                            "minimum": 1,
+                                            "type": "integer"
+                                          }
+                                        },
+                                        "required": [
+                                          "name"
+                                        ],
+                                        "type": "object",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "Must have port for Service reference",
+                                            "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
+                                          }
+                                        ],
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "required": [
+                                      "backendRef"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "projectId": {
+                                "description": "Google Cloud project ID.",
+                                "maxLength": 256,
+                                "minLength": 1,
+                                "type": "string"
+                              },
+                              "templateId": {
+                                "description": "Template ID for Google Model Armor.",
+                                "maxLength": 256,
+                                "minLength": 1,
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "projectId",
+                              "templateId"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "regex": {
+                            "description": "Regular expression (regex) matching for prompt guards and data masking.",
+                            "properties": {
+                              "action": {
+                                "default": "Mask",
+                                "description": "The action to take if a regex pattern is matched in a request or response.\nThis setting applies only to request matches. `PromptguardResponse`\nmatches are always masked by default.\nDefaults to `Mask`.",
+                                "enum": [
+                                  "Mask",
+                                  "Reject"
+                                ],
+                                "type": "string"
+                              },
+                              "builtins": {
+                                "description": "Built-in regex patterns to match against the request or response.\nMatches and built-ins are additive.",
+                                "items": {
+                                  "description": "Built-in regex patterns for specific types of strings in prompts.\nFor example, if you specify `CreditCard`, any credit card numbers\nin the request or response are matched.",
+                                  "enum": [
+                                    "CaSin",
+                                    "CreditCard",
+                                    "Email",
+                                    "PhoneNumber",
+                                    "Ssn"
+                                  ],
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "matches": {
+                                "description": "Regex patterns to match against the request or response.\nMatches and built-ins are additive.",
+                                "items": {
+                                  "maxLength": 1024,
+                                  "minLength": 1,
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "response": {
+                            "description": "Custom response message to return to the client. If not specified, defaults to\n`The response was rejected due to inappropriate content`.",
+                            "properties": {
+                              "message": {
+                                "default": "The request was rejected due to inappropriate content",
+                                "description": "Custom response message to return to the client. If not specified, defaults to\n`The request was rejected due to inappropriate content`.",
+                                "type": "string"
+                              },
+                              "statusCode": {
+                                "default": 403,
+                                "description": "Status code to return to the client. Defaults to 403.",
+                                "format": "int32",
+                                "maximum": 599,
+                                "minimum": 200,
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-validations": [
+                              {
+                                "message": "at least one of the fields in [message statusCode] must be set",
+                                "rule": "[has(self.message),has(self.statusCode)].filter(x,x==true).size() >= 1"
+                              }
+                            ],
+                            "additionalProperties": false
+                          },
+                          "webhook": {
+                            "description": "Webhook that receives responses for prompt guarding.",
+                            "properties": {
+                              "backendRef": {
+                                "description": "Webhook server to reach.\n\nSupported types: Service and Backend.",
+                                "properties": {
+                                  "group": {
+                                    "default": "",
+                                    "description": "Group is the group of the referent. For example, \"gateway.networking.k8s.io\".\nWhen unspecified or empty string, core API group is inferred.",
+                                    "maxLength": 253,
+                                    "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                                    "type": "string"
+                                  },
+                                  "kind": {
+                                    "default": "Service",
+                                    "description": "Kind is the Kubernetes resource kind of the referent. For example\n\"Service\".\n\nDefaults to \"Service\" when not specified.\n\nExternalName services can refer to CNAME DNS records that may live\noutside of the cluster and as such are difficult to reason about in\nterms of conformance. They also may not be safe to forward to (see\nCVE-2021-25740 for more information). Implementations SHOULD NOT\nsupport ExternalName Services.\n\nSupport: Core (Services with a type other than ExternalName)\n\nSupport: Implementation-specific (Services with type ExternalName)",
+                                    "maxLength": 63,
+                                    "minLength": 1,
+                                    "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "description": "Name is the name of the referent.",
+                                    "maxLength": 253,
+                                    "minLength": 1,
+                                    "type": "string"
+                                  },
+                                  "namespace": {
+                                    "description": "Namespace is the namespace of the backend. When unspecified, the local\nnamespace is inferred.\n\nNote that when a namespace different than the local namespace is specified,\na ReferenceGrant object is required in the referent namespace to allow that\nnamespace's owner to accept the reference. See the ReferenceGrant\ndocumentation for details.\n\nSupport: Core",
+                                    "maxLength": 63,
+                                    "minLength": 1,
+                                    "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "description": "Port specifies the destination port number to use for this resource.\nPort is required when the referent is a Kubernetes Service. In this\ncase, the port number is the service port number, not the target port.\nFor other resources, destination port might be derived from the referent\nresource or this field.",
+                                    "format": "int32",
+                                    "maximum": 65535,
+                                    "minimum": 1,
+                                    "type": "integer"
+                                  }
+                                },
+                                "required": [
+                                  "name"
+                                ],
+                                "type": "object",
+                                "x-kubernetes-validations": [
+                                  {
+                                    "message": "Must have port for Service reference",
+                                    "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
+                                  }
+                                ],
+                                "additionalProperties": false
+                              },
+                              "failureMode": {
+                                "description": "Behavior when the webhook guardrail is unavailable\nor returns an error. `FailOpen` allows the request to continue.\n`FailClosed` (default) rejects the request.",
+                                "enum": [
+                                  "FailClosed",
+                                  "FailOpen"
+                                ],
+                                "type": "string"
+                              },
+                              "forwardHeaderMatches": {
+                                "description": "HTTP header matches used to select the headers to forward to the webhook.\nRequest headers are used when forwarding requests and response headers\nare used when forwarding responses.\nBy default, no headers are forwarded.",
+                                "items": {
+                                  "description": "HTTPHeaderMatch describes how to select a HTTP route by matching HTTP request\nheaders.",
+                                  "properties": {
+                                    "name": {
+                                      "description": "Name is the name of the HTTP Header to be matched. Name matching MUST be\ncase-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).\n\nIf multiple entries specify equivalent header names, only the first\nentry with an equivalent name MUST be considered for a match. Subsequent\nentries with an equivalent header name MUST be ignored. Due to the\ncase-insensitivity of header names, \"foo\" and \"Foo\" are considered\nequivalent.\n\nWhen a header is repeated in an HTTP request, it is\nimplementation-specific behavior as to how this is represented.\nGenerally, proxies should follow the guidance from the RFC:\nhttps://www.rfc-editor.org/rfc/rfc7230.html#section-3.2.2 regarding\nprocessing a repeated header, with special handling for \"Set-Cookie\".",
+                                      "maxLength": 256,
+                                      "minLength": 1,
+                                      "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                                      "type": "string"
+                                    },
+                                    "type": {
+                                      "default": "Exact",
+                                      "description": "Type specifies how to match against the value of the header.\n\nSupport: Core (Exact)\n\nSupport: Implementation-specific (RegularExpression)\n\nSince RegularExpression HeaderMatchType has implementation-specific\nconformance, implementations can support POSIX, PCRE or any other dialects\nof regular expressions. Please read the implementation's documentation to\ndetermine the supported dialect.",
+                                      "enum": [
+                                        "Exact",
+                                        "RegularExpression"
+                                      ],
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "description": "Value is the value of HTTP Header to be matched.\n<gateway:experimental:description>\nMust consist of printable US-ASCII characters, optionally separated\nby single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2\n</gateway:experimental:description>\n\n<gateway:experimental:validation:Pattern=`^[!-~]+([\\t ]?[!-~]+)*$`>",
+                                      "maxLength": 4096,
+                                      "minLength": 1,
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "name",
+                                    "value"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "required": [
+                              "backendRef"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-validations": [
+                          {
+                            "message": "exactly one of the fields in [regex webhook bedrockGuardrails googleModelArmor] must be set",
+                            "rule": "[has(self.regex),has(self.webhook),has(self.bedrockGuardrails),has(self.googleModelArmor)].filter(x,x==true).size() == 1"
+                          }
+                        ],
+                        "additionalProperties": false
+                      },
+                      "maxItems": 8,
+                      "minItems": 1,
+                      "type": "array"
+                    },
+                    "streaming": {
+                      "description": "Apply prompt guards to streaming responses and realtime websocket messages.\nDefaults to disabled to preserve streaming throughput unless explicitly enabled.",
+                      "enum": [
+                        "Enabled"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "at least one of the fields in [request response] must be set",
+                      "rule": "[has(self.request),has(self.response)].filter(x,x==true).size() >= 1"
+                    }
+                  ],
+                  "additionalProperties": false
+                },
+                "routes": {
+                  "additionalProperties": {
+                    "description": "How the AI gateway should process incoming requests\nbased on the URL path and the API format expected.",
+                    "enum": [
+                      "AnthropicTokenCount",
+                      "Completions",
+                      "Detect",
+                      "Embeddings",
+                      "Messages",
+                      "Models",
+                      "Passthrough",
+                      "Realtime",
+                      "Rerank",
+                      "Responses"
+                    ],
+                    "type": "string"
+                  },
+                  "description": "Rules for identifying the type of traffic to handle.\nThe keys are URL path suffixes matched using ends-with comparison, for\nexample `\"/v1/chat/completions\"`.\nThe special `*` wildcard matches any path.\nIf not specified, all traffic defaults to `completions` type.",
+                  "type": "object"
+                },
+                "transformations": {
+                  "description": "CEL transformations to compute and set fields in the request body.\nThe expression result overwrites any existing value for that field.\nThis has a higher priority than `overrides` if both are set for the same\nkey.",
+                  "items": {
+                    "description": "Maps a request JSON field to a CEL expression.\nThe expression is evaluated against the current request body and its result\nis assigned to the configured field.",
+                    "properties": {
+                      "expression": {
+                        "description": "CEL expression used to compute the field value.",
+                        "maxLength": 16384,
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "field": {
+                        "allOf": [
+                          {
+                            "minLength": 1
+                          },
+                          {
+                            "minLength": 1
+                          }
+                        ],
+                        "description": "Name of the field to set.",
+                        "maxLength": 256,
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "expression",
+                      "field"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "maxItems": 64,
+                  "minItems": 1,
+                  "type": "array"
+                }
+              },
+              "type": "object",
+              "x-kubernetes-validations": [
+                {
+                  "message": "at least one of the fields in [defaults modelAliases overrides prompt promptCaching promptGuard routes transformations] must be set",
+                  "rule": "[has(self.defaults),has(self.modelAliases),has(self.overrides),has(self.prompt),has(self.promptCaching),has(self.promptGuard),has(self.routes),has(self.transformations)].filter(x,x==true).size() >= 1"
+                }
+              ],
+              "additionalProperties": false
+            },
+            "auth": {
+              "description": "Settings for managing authentication to the backend.",
+              "properties": {
+                "aws": {
+                  "description": "Explicit AWS authentication method for the backend.\nWhen omitted, default AWS SDK credential discovery is used.",
+                  "properties": {
+                    "assumeRole": {
+                      "description": "AWS STS AssumeRole settings to use before signing backend requests.\nAmbient AWS credentials are used as the source credentials for STS.",
+                      "properties": {
+                        "roleArn": {
+                          "description": "AWS IAM role ARN to assume.",
+                          "minLength": 1,
+                          "pattern": "^arn:aws[a-z-]*:iam::[0-9]{12}:role/.+$",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "roleArn"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "secretRef": {
+                      "description": "Credential source, defaulting to a Kubernetes\n`Secret`, containing the AWS credentials. When using the default Secret\nresolver, the `Secret` must have keys `accessKey`, `secretKey`, and\noptionally `sessionToken`.",
+                      "properties": {
+                        "group": {
+                          "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                          "type": "string"
+                        },
+                        "kind": {
+                          "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "description": "The name of the referenced credential.",
+                          "maxLength": 253,
+                          "minLength": 1,
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "x-kubernetes-validations": [
+                        {
+                          "message": "custom credential refs must set both group and kind",
+                          "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                        }
+                      ],
+                      "additionalProperties": false
+                    },
+                    "serviceName": {
+                      "description": "AWS SigV4 signing service name, for example\n`bedrock`, `bedrock-agentcore`, or `execute-api`). If unset, typed AWS\nbackends may provide this automatically.",
+                      "maxLength": 256,
+                      "minLength": 1,
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "secretRef and assumeRole are mutually exclusive",
+                      "rule": "!(has(self.secretRef) && has(self.assumeRole))"
+                    }
+                  ],
+                  "additionalProperties": false
+                },
+                "azure": {
+                  "description": "Azure authentication method for the backend.",
+                  "properties": {
+                    "managedIdentity": {
+                      "description": "Managed identity authentication settings.",
+                      "properties": {
+                        "clientId": {
+                          "type": "string"
+                        },
+                        "objectId": {
+                          "type": "string"
+                        },
+                        "resourceId": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "clientId",
+                        "objectId",
+                        "resourceId"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "secretRef": {
+                      "description": "Credential source, defaulting to a Kubernetes\n`Secret`, containing the Azure credentials. When using the default Secret\nresolver, the `Secret` must have keys `clientID`, `tenantID`, and\n`clientSecret`.",
+                      "properties": {
+                        "group": {
+                          "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                          "type": "string"
+                        },
+                        "kind": {
+                          "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "description": "The name of the referenced credential.",
+                          "maxLength": 253,
+                          "minLength": 1,
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "x-kubernetes-validations": [
+                        {
+                          "message": "custom credential refs must set both group and kind",
+                          "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                        }
+                      ],
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "gcp": {
+                  "description": "Google authentication method for the backend.\nWhen omitted, default Google credential discovery is used.",
+                  "properties": {
+                    "audience": {
+                      "description": "Explicit `aud` value for the ID token. Only\nvalid with `IdToken` type. If not set, the `aud` is automatically\nderived from the backend hostname.",
+                      "maxLength": 256,
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "secretRef": {
+                      "description": "Credential source, defaulting to a Kubernetes\n`Secret`, containing ADC-compatible Google credential JSON. When using\nthe default Secret resolver, this must be stored in the `credentials.json`\nkey. When omitted, ambient credentials are used.",
+                      "properties": {
+                        "group": {
+                          "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                          "type": "string"
+                        },
+                        "kind": {
+                          "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "description": "The name of the referenced credential.",
+                          "maxLength": 253,
+                          "minLength": 1,
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "x-kubernetes-validations": [
+                        {
+                          "message": "custom credential refs must set both group and kind",
+                          "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                        }
+                      ],
+                      "additionalProperties": false
+                    },
+                    "type": {
+                      "description": "The type of token to generate. To authenticate to GCP services,\ngenerally an `AccessToken` is used. To authenticate to Cloud Run, an\n`IdToken` is used.",
+                      "enum": [
+                        "AccessToken",
+                        "IdToken"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "audience is only valid with IdToken",
+                      "rule": "has(self.audience) ? self.type == 'IdToken' : true"
+                    }
+                  ],
+                  "additionalProperties": false
+                },
+                "key": {
+                  "description": "Inline key to use as the value of the\n`Authorization` header. This option is the least secure; usage of a\n`Secret` is preferred.",
+                  "maxLength": 2048,
+                  "type": "string"
+                },
+                "location": {
+                  "description": "Where backend credentials are inserted.\nIf omitted, credentials are written to the `Authorization` header with the `Bearer ` prefix.\nThis applies to `key`, `secretRef`, and `passthrough`.",
+                  "properties": {
+                    "cookie": {
+                      "properties": {
+                        "name": {
+                          "maxLength": 256,
+                          "minLength": 1,
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "header": {
+                      "properties": {
+                        "name": {
+                          "description": "HTTPHeaderName is the name of an HTTP header.\n\nValid values include:\n\n* \"Authorization\"\n* \"Set-Cookie\"\n\nInvalid values include:\n\n  - \":method\" - \":\" is an invalid character. This means that HTTP/2 pseudo\n    headers are not currently supported by this type.\n  - \"/invalid\" - \"/ \" is an invalid character",
+                          "maxLength": 256,
+                          "minLength": 1,
+                          "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                          "type": "string"
+                        },
+                        "prefix": {
+                          "maxLength": 256,
+                          "minLength": 1,
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "queryParameter": {
+                      "properties": {
+                        "name": {
+                          "maxLength": 256,
+                          "minLength": 1,
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "exactly one of the fields in [header queryParameter cookie] must be set",
+                      "rule": "[has(self.header),has(self.queryParameter),has(self.cookie)].filter(x,x==true).size() == 1"
+                    }
+                  ],
+                  "additionalProperties": false
+                },
+                "passthrough": {
+                  "description": "Passes through an existing token that has been sent by the\nclient and validated. Other policies, like JWT and API key\nauthentication, will strip the original client credentials. Passthrough backend authentication\ncauses the original token to be added back into the request. If there are no client authentication policies on the\nrequest, the original token would be unchanged, so this would have no effect.",
+                  "type": "object"
+                },
+                "secretRef": {
+                  "description": "Credential source, defaulting to a Kubernetes\n`Secret`, storing the key to use as the authorization value. When using\nthe default Secret resolver, this must be stored in the `Authorization`\nkey.",
+                  "properties": {
+                    "group": {
+                      "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                      "type": "string"
+                    },
+                    "kind": {
+                      "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                      "type": "string"
+                    },
+                    "name": {
+                      "description": "The name of the referenced credential.",
+                      "maxLength": 253,
+                      "minLength": 1,
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "name"
+                  ],
+                  "type": "object",
+                  "x-kubernetes-map-type": "atomic",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "custom credential refs must set both group and kind",
+                      "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                    }
+                  ],
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "x-kubernetes-validations": [
+                {
+                  "message": "location may only be set for key or passthrough auth",
+                  "rule": "has(self.location) ? has(self.key) || has(self.secretRef) || has(self.passthrough) : true"
+                },
+                {
+                  "message": "exactly one of the fields in [key secretRef passthrough aws azure gcp] must be set",
+                  "rule": "[has(self.key),has(self.secretRef),has(self.passthrough),has(self.aws),has(self.azure),has(self.gcp)].filter(x,x==true).size() == 1"
+                }
+              ],
+              "additionalProperties": false
+            },
+            "extAuth": {
+              "description": "External authentication configuration for requests\nsent to this backend.",
+              "properties": {
+                "backendRef": {
+                  "description": "External Authorization server to reach.\n\nSupported types: `Service` and `Backend`.",
+                  "properties": {
+                    "group": {
+                      "default": "",
+                      "description": "Group is the group of the referent. For example, \"gateway.networking.k8s.io\".\nWhen unspecified or empty string, core API group is inferred.",
+                      "maxLength": 253,
+                      "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                      "type": "string"
+                    },
+                    "kind": {
+                      "default": "Service",
+                      "description": "Kind is the Kubernetes resource kind of the referent. For example\n\"Service\".\n\nDefaults to \"Service\" when not specified.\n\nExternalName services can refer to CNAME DNS records that may live\noutside of the cluster and as such are difficult to reason about in\nterms of conformance. They also may not be safe to forward to (see\nCVE-2021-25740 for more information). Implementations SHOULD NOT\nsupport ExternalName Services.\n\nSupport: Core (Services with a type other than ExternalName)\n\nSupport: Implementation-specific (Services with type ExternalName)",
+                      "maxLength": 63,
+                      "minLength": 1,
+                      "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
+                      "type": "string"
+                    },
+                    "name": {
+                      "description": "Name is the name of the referent.",
+                      "maxLength": 253,
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "namespace": {
+                      "description": "Namespace is the namespace of the backend. When unspecified, the local\nnamespace is inferred.\n\nNote that when a namespace different than the local namespace is specified,\na ReferenceGrant object is required in the referent namespace to allow that\nnamespace's owner to accept the reference. See the ReferenceGrant\ndocumentation for details.\n\nSupport: Core",
+                      "maxLength": 63,
+                      "minLength": 1,
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                      "type": "string"
+                    },
+                    "port": {
+                      "description": "Port specifies the destination port number to use for this resource.\nPort is required when the referent is a Kubernetes Service. In this\ncase, the port number is the service port number, not the target port.\nFor other resources, destination port might be derived from the referent\nresource or this field.",
+                      "format": "int32",
+                      "maximum": 65535,
+                      "minimum": 1,
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "name"
+                  ],
+                  "type": "object",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "Must have port for Service reference",
+                      "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
+                    }
+                  ],
+                  "additionalProperties": false
+                },
+                "cache": {
+                  "description": "Caches gRPC authorization results.\n\nWARNING: the safety of this feature depends on the cache key accurately\ncapturing every request property that the authorization service uses to\nmake a decision. For example, if the service returns different results\nbased on both path and authorization header, both must be included in\n`key`; otherwise, one request may incorrectly reuse another request's\nauthorization result.\n\nIf any key expression fails to evaluate or produces an unsupported value,\nthe request is still sent to the authorization service, but its result is\nnot read from or written to the cache.",
+                  "properties": {
+                    "key": {
+                      "description": "Ordered list of CEL expressions evaluated against the request\nto construct the cache key.",
+                      "items": {
+                        "description": "A Common Expression Language (CEL) expression.",
+                        "maxLength": 16384,
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "maxItems": 16,
+                      "minItems": 1,
+                      "type": "array"
+                    },
+                    "maxEntries": {
+                      "description": "Maximum number of authorization results to keep in\nthe cache. If unset, this defaults to 10000.",
+                      "format": "int32",
+                      "minimum": 1,
+                      "type": "integer"
+                    },
+                    "ttl": {
+                      "description": "Duration string, such as `5m`, or a CEL expression that\nreturns the duration that cached authorization results may be reused, or a\ntimestamp when the cached authorization result expires. The expression is\nevaluated after the authorization response has been applied to the request.",
+                      "maxLength": 16384,
+                      "minLength": 1,
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "key",
+                    "ttl"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "failureMode": {
+                  "description": "Behavior when the external authorization service is\nunavailable or returns an error. \"FailOpen\" allows the request to continue.\n\"FailClosed\" (default) denies the request.",
+                  "enum": [
+                    "FailClosed",
+                    "FailOpen"
+                  ],
+                  "type": "string"
+                },
+                "forwardBody": {
+                  "description": "Whether to include the HTTP body in the authorization request.\nIf enabled, the request body will be buffered.",
+                  "properties": {
+                    "maxSize": {
+                      "anyOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ],
+                      "description": "Largest body, in bytes, that will be buffered\nand sent to the authorization server. If the body size is larger than\n`maxSize`, then the request will be rejected with a response.",
+                      "maxLength": 32,
+                      "minLength": 1,
+                      "pattern": "^[+-]?([0-9]+(\\.[0-9]*)?|\\.[0-9]+)(([KMGTPE]i)|[numkMGTPE]|[eE](\\+?0*([0-9]|1[0-8])|-0*[0-9]))?$",
+                      "x-kubernetes-int-or-string": true,
+                      "x-kubernetes-validations": [
+                        {
+                          "message": "value must be at least 1 byte and fit within uint32",
+                          "rule": "(self >= 1 && self <= 4294967295) || self.size() > 0"
+                        }
+                      ]
+                    }
+                  },
+                  "required": [
+                    "maxSize"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "grpc": {
+                  "description": "Uses the gRPC External Authorization\n[protocol](https://www.envoyproxy.io/docs/envoy/latest/api-v3/service/auth/v3/external_auth.proto) should be used.",
+                  "properties": {
+                    "contextExtensions": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "Additional arbitrary key-value pairs to\nsend to the authorization server in the `context_extensions` field.",
+                      "maxProperties": 64,
+                      "type": "object"
+                    },
+                    "requestMetadata": {
+                      "additionalProperties": {
+                        "description": "A Common Expression Language (CEL) expression.",
+                        "maxLength": 16384,
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "description": "Metadata to send to the authorization\nserver. This maps to the `metadata_context.filter_metadata` field of the\nrequest, and allows dynamic CEL expressions. If unset, by default the\n`envoy.filters.http.jwt_authn` key is set if the JWT policy is used as\nwell, for compatibility.",
+                      "maxProperties": 64,
+                      "type": "object"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "http": {
+                  "description": "Uses HTTP to connect to\nthe authorization server. The authorization server must return a `200`\nstatus code, otherwise the request is considered an authorization\nfailure.",
+                  "properties": {
+                    "addRequestHeaders": {
+                      "additionalProperties": {
+                        "description": "A Common Expression Language (CEL) expression.",
+                        "maxLength": 16384,
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "description": "Additional headers to add to the\nrequest to the authorization server. While `allowedRequestHeaders` just\npasses the original headers through, `addRequestHeaders` allows defining\ncustom headers based on CEL expressions.",
+                      "maxProperties": 64,
+                      "type": "object"
+                    },
+                    "allowedRequestHeaders": {
+                      "description": "Additional headers from the client request that\nwill be sent to the authorization server.\n\nIf unset, the following headers are sent by default: `Authorization`.",
+                      "items": {
+                        "maxLength": 256,
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "maxItems": 64,
+                      "type": "array"
+                    },
+                    "allowedResponseHeaders": {
+                      "description": "Headers from the authorization response that\nwill be copied into the request to the backend.",
+                      "items": {
+                        "maxLength": 256,
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "maxItems": 64,
+                      "type": "array"
+                    },
+                    "path": {
+                      "description": "Path to send to the authorization server. If\nunset, this defaults to the original request path.\nThis is a CEL expression, which allows customizing the path based on the\nincoming request. For example, to add a prefix, use\n`\"/prefix/\" + request.path`.",
+                      "maxLength": 16384,
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "redirect": {
+                      "description": "Optional expression that determines a path to\nredirect to on authorization failure. This is useful to redirect to a\nsign-in page.",
+                      "maxLength": 16384,
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "responseMetadata": {
+                      "additionalProperties": {
+                        "description": "A Common Expression Language (CEL) expression.",
+                        "maxLength": 16384,
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "description": "Metadata fields to construct\nfrom the authorization response. These will be included under the\n`extauthz` variable in future CEL expressions. Setting this is useful\nfor things like logging usernames, without needing to include them as\nheaders to the backend, as `allowedResponseHeaders` would.",
+                      "maxProperties": 64,
+                      "type": "object"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "x-kubernetes-validations": [
+                {
+                  "message": "cache requires grpc",
+                  "rule": "!has(self.cache) || has(self.grpc)"
+                }
+              ],
+              "additionalProperties": false
+            },
+            "health": {
+              "description": "Settings for passive and active health checking.",
+              "properties": {
+                "eviction": {
+                  "description": "Settings for evicting unhealthy backends.",
+                  "properties": {
+                    "consecutiveFailures": {
+                      "description": "Number of consecutive unhealthy responses required before the backend is evicted.\nFor example, a value of 5 means the backend must receive 5 unhealthy responses in a row before being evicted.\nWhen both consecutiveFailures and healthThreshold are set, the backend is evicted when either condition is met.\nWhen neither is set, a single unhealthy response can trigger eviction.",
+                      "format": "int32",
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "duration": {
+                      "default": "3s",
+                      "description": "Base time a backend should be evicted after being marked unhealthy.\nSubsequent evictions use multiplicative backoff (duration * times_evicted).\nIf all endpoints are evicted, the load balancer falls back to returning evicted endpoints\nrather than failing entirely.\nIf unset, defaults to `3s`.",
+                      "type": "string",
+                      "x-kubernetes-validations": [
+                        {
+                          "message": "invalid duration value",
+                          "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                        },
+                        {
+                          "message": "evictionDuration must be at least 1 second",
+                          "rule": "duration(self) >= duration('1s')"
+                        }
+                      ]
+                    },
+                    "healthThreshold": {
+                      "description": "EWMA health score threshold, expressed as 0 to 100.\nWhen set, a backend is only evicted if its computed health drops below this value after an unhealthy response.\nFor example, 50 means the backend is evicted when its EWMA health falls below 50% following failures.\nUnlike consecutiveFailures (which counts consecutive failures), this uses a sliding-window average\nso a single success in a stream of failures can delay eviction.\nWhen both consecutiveFailures and healthThreshold are set, the backend is evicted when either condition is met.\nWhen neither is set, a single unhealthy response triggers eviction.",
+                      "format": "int32",
+                      "maximum": 100,
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "restoreHealth": {
+                      "description": "Health score from 0 to 100 assigned to a backend when it returns from eviction.\nFor gradual recovery, set below 100; for full recovery immediately, set 100.\nIf unset, the backend resumes with the health it had when evicted.",
+                      "format": "int32",
+                      "maximum": 100,
+                      "minimum": 0,
+                      "type": "integer"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "unhealthyCondition": {
+                  "description": "CEL expression that determines whether a response indicates an unhealthy backend.\nWhen the expression evaluates to true, the backend is considered unhealthy and may be evicted.\n\nFor example, to evict on 5xx responses: `response.code >= 500`.\n\nWhen unset, any 5xx response, or a connection failure, is treated as unhealthy.\nThis default lowers the backend's health score but does not trigger eviction on its own.",
+                  "maxLength": 16384,
+                  "minLength": 1,
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "http": {
+              "description": "Settings for managing HTTP requests to the backend.",
+              "properties": {
+                "requestTimeout": {
+                  "description": "Deadline for receiving a response from the backend.",
+                  "type": "string",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "invalid duration value",
+                      "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                    },
+                    {
+                      "message": "requestTimeout must be at least 1ms",
+                      "rule": "duration(self) >= duration('1ms')"
+                    }
+                  ]
+                },
+                "version": {
+                  "description": "HTTP protocol version to use when connecting to\nthe backend.\nIf not specified, the version is automatically determined:\n* `Service` types can specify it with `appProtocol` on the `Service`\n  port.\n* If traffic is identified as gRPC, `HTTP2` is used.\n* If the incoming traffic was plaintext HTTP, the original protocol will\n  be used.\n* If the incoming traffic was HTTPS, `HTTP1` will be used. This is\n  because most clients will transparently upgrade HTTPS traffic to\n  `HTTP2`, even if the backend doesn't support it.",
+                  "enum": [
+                    "HTTP1",
+                    "HTTP2"
+                  ],
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "mcp": {
+              "description": "Settings for MCP workloads. This is only applicable when\nconnecting to a `Backend` of type `mcp`.",
+              "properties": {
+                "authentication": {
+                  "description": "MCP backend-specific authentication rules.\n\nThis field is deprecated; prefer to use traffic policy `jwtAuthentication.mcp`, which ensures authentication runs before\nother policies such as transformation and rate limiting.",
+                  "properties": {
+                    "audiences": {
+                      "description": "Allowed audiences that are allowed\naccess. This corresponds to the `aud` claim\n([RFC 7519 \u00a74.1.3](https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.3)).\nIf unset, any audience is allowed.",
+                      "items": {
+                        "type": "string"
+                      },
+                      "maxItems": 64,
+                      "minItems": 1,
+                      "type": "array"
+                    },
+                    "clientId": {
+                      "description": "Client ID to use for short-circuiting Dynamic Client Registration.\nIf set, the gateway will not proxy registration requests to the IDP and instead return this client ID.",
+                      "type": "string"
+                    },
+                    "issuer": {
+                      "description": "IdP that issued the JWT. This corresponds to the\n`iss` claim ([RFC 7519 \u00a74.1.1](https://tools.ietf.org/html/rfc7519#section-4.1.1)).",
+                      "maxLength": 256,
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "jwks": {
+                      "description": "Remote JSON Web Key used to validate the signature of\nthe JWT.",
+                      "properties": {
+                        "backendRef": {
+                          "description": "Remote JWKS server to reach.\nSupported types are `Service` and static `Backend`. An\n`AgentgatewayPolicy` containing backend TLS config can then be attached\nto the `Service` or `Backend` in order to set TLS options for a\nconnection to the remote `jwks` source.",
+                          "properties": {
+                            "group": {
+                              "default": "",
+                              "description": "Group is the group of the referent. For example, \"gateway.networking.k8s.io\".\nWhen unspecified or empty string, core API group is inferred.",
+                              "maxLength": 253,
+                              "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                              "type": "string"
+                            },
+                            "kind": {
+                              "default": "Service",
+                              "description": "Kind is the Kubernetes resource kind of the referent. For example\n\"Service\".\n\nDefaults to \"Service\" when not specified.\n\nExternalName services can refer to CNAME DNS records that may live\noutside of the cluster and as such are difficult to reason about in\nterms of conformance. They also may not be safe to forward to (see\nCVE-2021-25740 for more information). Implementations SHOULD NOT\nsupport ExternalName Services.\n\nSupport: Core (Services with a type other than ExternalName)\n\nSupport: Implementation-specific (Services with type ExternalName)",
+                              "maxLength": 63,
+                              "minLength": 1,
+                              "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
+                              "type": "string"
+                            },
+                            "name": {
+                              "description": "Name is the name of the referent.",
+                              "maxLength": 253,
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "namespace": {
+                              "description": "Namespace is the namespace of the backend. When unspecified, the local\nnamespace is inferred.\n\nNote that when a namespace different than the local namespace is specified,\na ReferenceGrant object is required in the referent namespace to allow that\nnamespace's owner to accept the reference. See the ReferenceGrant\ndocumentation for details.\n\nSupport: Core",
+                              "maxLength": 63,
+                              "minLength": 1,
+                              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                              "type": "string"
+                            },
+                            "port": {
+                              "description": "Port specifies the destination port number to use for this resource.\nPort is required when the referent is a Kubernetes Service. In this\ncase, the port number is the service port number, not the target port.\nFor other resources, destination port might be derived from the referent\nresource or this field.",
+                              "format": "int32",
+                              "maximum": 65535,
+                              "minimum": 1,
+                              "type": "integer"
+                            }
+                          },
+                          "required": [
+                            "name"
+                          ],
+                          "type": "object",
+                          "x-kubernetes-validations": [
+                            {
+                              "message": "Must have port for Service reference",
+                              "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
+                            }
+                          ],
+                          "additionalProperties": false
+                        },
+                        "cacheDuration": {
+                          "default": "5m",
+                          "type": "string",
+                          "x-kubernetes-validations": [
+                            {
+                              "message": "invalid duration value",
+                              "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                            },
+                            {
+                              "message": "cacheDuration must be at least 5m.",
+                              "rule": "duration(self) >= duration('5m')"
+                            }
+                          ]
+                        },
+                        "jwksPath": {
+                          "description": "Path to the IdP `jwks` endpoint, relative to the root, commonly\n`\".well-known/jwks.json\"`.",
+                          "maxLength": 2000,
+                          "minLength": 1,
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "backendRef",
+                        "jwksPath"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "mode": {
+                      "default": "Strict",
+                      "description": "Validation mode for JWT authentication.",
+                      "enum": [
+                        "Optional",
+                        "Permissive",
+                        "Strict"
+                      ],
+                      "type": "string"
+                    },
+                    "provider": {
+                      "description": "Identity provider to use for authentication.",
+                      "enum": [
+                        "Auth0",
+                        "Keycloak",
+                        "Okta"
+                      ],
+                      "type": "string"
+                    },
+                    "resourceMetadata": {
+                      "additionalProperties": {
+                        "x-kubernetes-preserve-unknown-fields": true
+                      },
+                      "description": "Metadata to use for MCP resources.",
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "jwks"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "authorization": {
+                  "description": "MCP backend authorization. Unlike authorization at the HTTP level, which rejects\nunauthorized requests with a `403` error, this policy works at the\n`MCPBackend` level.\n\nList operations, such as `list_tools`, will have each item evaluated.\nItems that do not meet the rule will be filtered.\n\nGet or call operations, such as `call_tool`, will evaluate the specific\nitem and reject requests that do not meet the rule.",
+                  "properties": {
+                    "action": {
+                      "default": "Allow",
+                      "description": "The effect of this rule when it matches.\nIf unspecified, defaults to `Allow`.\n`Require` rules are cumulative: all require rules must match.",
+                      "enum": [
+                        "Allow",
+                        "Deny",
+                        "Require"
+                      ],
+                      "type": "string"
+                    },
+                    "policy": {
+                      "description": "The authorization rule to evaluate.\n\n* `Allow`: any matching allow rule allows the request.\n* `Require`: every require rule must match for the request to be allowed.\n* `Deny`: any matching deny rule denies the request.\n\nA CEL expression that fails to evaluate does not match. Prefer `Require`\nfor deny-by-default behavior.\n\nIf at least one `Allow` rule is configured, requests are denied unless at\nleast one allow rule matches.",
+                      "properties": {
+                        "matchExpressions": {
+                          "description": "CEL expressions that must all evaluate to true for the rule to match.",
+                          "items": {
+                            "description": "A Common Expression Language (CEL) expression.",
+                            "maxLength": 16384,
+                            "minLength": 1,
+                            "type": "string"
+                          },
+                          "maxItems": 256,
+                          "minItems": 1,
+                          "type": "array"
+                        }
+                      },
+                      "required": [
+                        "matchExpressions"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": [
+                    "policy"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "guardrails": {
+                  "description": "`guardrails` routes selected JSON-RPC methods through a remote policy server.",
+                  "properties": {
+                    "processors": {
+                      "description": "`processors` is the ordered list of policy processors applied to matched\nmethods. Processors run in the order listed; the first to reject a request\nshort-circuits the chain.",
+                      "items": {
+                        "description": "MCPGuardrailsProcessor selects a single policy processor. Exactly one variant must be set.",
+                        "properties": {
+                          "methods": {
+                            "additionalProperties": {
+                              "description": "MCPMethodPhase controls when an MCP method is run through the guardrails pipeline.",
+                              "enum": [
+                                "Full",
+                                "Off",
+                                "Request",
+                                "Response"
+                              ],
+                              "type": "string"
+                            },
+                            "description": "`methods` is the allowlist of JSON-RPC methods (e.g. `tools/call`,\n`tools/list`) routed through this processor, keyed by method name with the\nphase it runs in. Keys may be exact, a prefix wildcard (`tools/*`), a suffix\nwildcard (`*/list`), or `*` for all methods; the most specific match wins.\nMethods matching no key, including unknown ones, bypass this processor.",
+                            "maxProperties": 64,
+                            "minProperties": 1,
+                            "type": "object",
+                            "x-kubernetes-validations": [
+                              {
+                                "message": "method wildcards must be '*', a prefix like 'tools/*', or a suffix like '*/list'",
+                                "rule": "self.all(k, !k.contains('*') || (k.indexOf('*') == k.lastIndexOf('*') && (k.indexOf('*') == 0 || k.indexOf('*') == size(k) - 1)))"
+                              }
+                            ]
+                          },
+                          "remote": {
+                            "description": "`remote` configures a gRPC policy server.",
+                            "properties": {
+                              "allowedRequestHeaders": {
+                                "description": "`allowedRequestHeaders` lists the incoming request headers forwarded to\nthe policy server in `McpRequest.headers`. If empty, all headers and\npseudo-headers (`:authority`, `:method`, ...) are forwarded. Matching is\ncase-insensitive.",
+                                "items": {
+                                  "description": "HTTP header name.",
+                                  "maxLength": 256,
+                                  "minLength": 1,
+                                  "pattern": "^:?[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                                  "type": "string",
+                                  "x-kubernetes-validations": [
+                                    {
+                                      "message": "pseudo-headers must be one of :authority, :method, :path, :scheme, or :status",
+                                      "rule": "!self.startsWith(':') || self in [':authority', ':method', ':path', ':scheme', ':status']"
+                                    }
+                                  ]
+                                },
+                                "maxItems": 64,
+                                "type": "array",
+                                "x-kubernetes-list-type": "set"
+                              },
+                              "backendRef": {
+                                "description": "`backendRef` references the remote guardrails policy server.\nSupported types: `Service` and `Backend`.",
+                                "properties": {
+                                  "group": {
+                                    "default": "",
+                                    "description": "Group is the group of the referent. For example, \"gateway.networking.k8s.io\".\nWhen unspecified or empty string, core API group is inferred.",
+                                    "maxLength": 253,
+                                    "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                                    "type": "string"
+                                  },
+                                  "kind": {
+                                    "default": "Service",
+                                    "description": "Kind is the Kubernetes resource kind of the referent. For example\n\"Service\".\n\nDefaults to \"Service\" when not specified.\n\nExternalName services can refer to CNAME DNS records that may live\noutside of the cluster and as such are difficult to reason about in\nterms of conformance. They also may not be safe to forward to (see\nCVE-2021-25740 for more information). Implementations SHOULD NOT\nsupport ExternalName Services.\n\nSupport: Core (Services with a type other than ExternalName)\n\nSupport: Implementation-specific (Services with type ExternalName)",
+                                    "maxLength": 63,
+                                    "minLength": 1,
+                                    "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "description": "Name is the name of the referent.",
+                                    "maxLength": 253,
+                                    "minLength": 1,
+                                    "type": "string"
+                                  },
+                                  "namespace": {
+                                    "description": "Namespace is the namespace of the backend. When unspecified, the local\nnamespace is inferred.\n\nNote that when a namespace different than the local namespace is specified,\na ReferenceGrant object is required in the referent namespace to allow that\nnamespace's owner to accept the reference. See the ReferenceGrant\ndocumentation for details.\n\nSupport: Core",
+                                    "maxLength": 63,
+                                    "minLength": 1,
+                                    "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "description": "Port specifies the destination port number to use for this resource.\nPort is required when the referent is a Kubernetes Service. In this\ncase, the port number is the service port number, not the target port.\nFor other resources, destination port might be derived from the referent\nresource or this field.",
+                                    "format": "int32",
+                                    "maximum": 65535,
+                                    "minimum": 1,
+                                    "type": "integer"
+                                  }
+                                },
+                                "required": [
+                                  "name"
+                                ],
+                                "type": "object",
+                                "x-kubernetes-validations": [
+                                  {
+                                    "message": "Must have port for Service reference",
+                                    "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
+                                  }
+                                ],
+                                "additionalProperties": false
+                              },
+                              "disallowedRequestHeaders": {
+                                "description": "`disallowedRequestHeaders` lists header names never forwarded to the\npolicy server, even if listed in `allowedRequestHeaders`. Matching is\ncase-insensitive.",
+                                "items": {
+                                  "description": "HTTP header name.",
+                                  "maxLength": 256,
+                                  "minLength": 1,
+                                  "pattern": "^:?[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                                  "type": "string",
+                                  "x-kubernetes-validations": [
+                                    {
+                                      "message": "pseudo-headers must be one of :authority, :method, :path, :scheme, or :status",
+                                      "rule": "!self.startsWith(':') || self in [':authority', ':method', ':path', ':scheme', ':status']"
+                                    }
+                                  ]
+                                },
+                                "maxItems": 64,
+                                "type": "array",
+                                "x-kubernetes-list-type": "set"
+                              },
+                              "failureMode": {
+                                "description": "`failureMode` controls behavior when the policy server is unreachable\nor returns an error. `FailOpen` allows the request; `FailClosed`\n(default) denies it.",
+                                "enum": [
+                                  "FailClosed",
+                                  "FailOpen"
+                                ],
+                                "type": "string"
+                              },
+                              "metadata": {
+                                "additionalProperties": {
+                                  "description": "A Common Expression Language (CEL) expression.",
+                                  "maxLength": 16384,
+                                  "minLength": 1,
+                                  "type": "string"
+                                },
+                                "description": "`metadata` is static or CEL-evaluated context surfaced to the policy\nserver as fields of the `metadata_context` google.protobuf.Struct,\nkeyed by config key. Values are CEL expressions.",
+                                "maxProperties": 64,
+                                "type": "object"
+                              }
+                            },
+                            "required": [
+                              "backendRef"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "required": [
+                          "methods"
+                        ],
+                        "type": "object",
+                        "x-kubernetes-validations": [
+                          {
+                            "message": "exactly one of the fields in [remote] must be set",
+                            "rule": "[has(self.remote)].filter(x,x==true).size() == 1"
+                          }
+                        ],
+                        "additionalProperties": false
+                      },
+                      "maxItems": 16,
+                      "minItems": 1,
+                      "type": "array"
+                    }
+                  },
+                  "required": [
+                    "processors"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "x-kubernetes-validations": [
+                {
+                  "message": "at least one of the fields in [authentication authorization guardrails] must be set",
+                  "rule": "[has(self.authentication),has(self.authorization),has(self.guardrails)].filter(x,x==true).size() >= 1"
+                }
+              ],
+              "additionalProperties": false
+            },
+            "tcp": {
+              "description": "Settings for managing TCP connections to the backend.",
+              "properties": {
+                "connectTimeout": {
+                  "description": "Deadline for establishing a connection to\nthe destination.",
+                  "type": "string",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "invalid duration value",
+                      "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                    },
+                    {
+                      "message": "connectTimeout must be at least 100ms",
+                      "rule": "duration(self) >= duration('100ms')"
+                    }
+                  ]
+                },
+                "keepalive": {
+                  "description": "Settings for enabling TCP keepalives on the\nconnection.",
+                  "properties": {
+                    "interval": {
+                      "description": "Time between keepalive probes.\nIf unset, this defaults to 180s.",
+                      "type": "string",
+                      "x-kubernetes-validations": [
+                        {
+                          "message": "invalid duration value",
+                          "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                        },
+                        {
+                          "message": "interval must be at least 1 second",
+                          "rule": "duration(self) >= duration('1s')"
+                        }
+                      ]
+                    },
+                    "retries": {
+                      "description": "Maximum number of keepalive probes to send before dropping the connection.\nIf unset, this defaults to 9.",
+                      "format": "int32",
+                      "maximum": 64,
+                      "minimum": 1,
+                      "type": "integer"
+                    },
+                    "time": {
+                      "description": "Time a connection needs to be idle before keepalive probes start being sent.\nIf unset, this defaults to 180s.",
+                      "type": "string",
+                      "x-kubernetes-validations": [
+                        {
+                          "message": "invalid duration value",
+                          "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                        },
+                        {
+                          "message": "time must be at least 1 second",
+                          "rule": "duration(self) >= duration('1s')"
+                        }
+                      ]
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "tls": {
+              "description": "Settings for managing TLS connections to the backend.\n\nIf this field is set, TLS will be initiated to the backend; the system trusted CA certificates will be used to\nvalidate the server, and the SNI will automatically be set based on the destination.",
+              "properties": {
+                "alpnProtocols": {
+                  "description": "Application-Layer Protocol Negotiation (`ALPN`)\nvalue to use in the TLS handshake.\n\nIf not present, defaults to `[\"h2\", \"http/1.1\"]`.",
+                  "items": {
+                    "maxLength": 64,
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "maxItems": 16,
+                  "minItems": 1,
+                  "type": "array"
+                },
+                "caCertificateRefs": {
+                  "description": "CA certificate `ConfigMap` to use to\nverify the server certificate.\nIf unset, the system's trusted certificates are used.",
+                  "items": {
+                    "description": "LocalObjectReference contains enough information to let you locate the\nreferenced object inside the same namespace.",
+                    "properties": {
+                      "name": {
+                        "default": "",
+                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "x-kubernetes-map-type": "atomic",
+                    "additionalProperties": false
+                  },
+                  "maxItems": 1,
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
+                },
+                "insecureSkipVerify": {
+                  "description": "Originates TLS but skips verification of the backend's certificate.\nWARNING: This is an insecure option that should only be used if the risks are understood.\n\nThere are two modes:\n* `All` disables all TLS verification.\n* `Hostname` verifies the CA certificate is trusted, but ignores any\n  mismatch of hostname or SANs. Note that this method is still insecure;\n  prefer setting `verifySubjectAltNames` to customize the valid hostnames\n  if possible.",
+                  "enum": [
+                    "All",
+                    "Hostname"
+                  ],
+                  "type": "string"
+                },
+                "keyExchangeGroups": {
+                  "description": "Ordered list of key exchange groups for a TLS connection.\nFor example: `X25519_MLKEM768,X25519`.",
+                  "items": {
+                    "enum": [
+                      "P-256",
+                      "P-384",
+                      "X25519",
+                      "X25519_MLKEM768"
+                    ],
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "mtlsCertificateRef": {
+                  "description": "Enables mutual TLS to the backend, using the\nspecified key (`tls.key`) and cert (`tls.crt`) from the referenced\ncredential source, defaulting to a Kubernetes `Secret`.\n\nAn optional `ca.cert` field, if present, will be used to verify the\nserver certificate. If `caCertificateRefs` is also specified, the\n`caCertificateRefs` field takes priority.\n\nIf unspecified, no client certificate will be used.",
+                  "items": {
+                    "description": "References a same-namespace credential.\nSet only `name` to reference a Kubernetes Secret.",
+                    "properties": {
+                      "group": {
+                        "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                        "type": "string"
+                      },
+                      "kind": {
+                        "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "The name of the referenced credential.",
+                        "maxLength": 253,
+                        "minLength": 1,
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "name"
+                    ],
+                    "type": "object",
+                    "x-kubernetes-map-type": "atomic",
+                    "x-kubernetes-validations": [
+                      {
+                        "message": "custom credential refs must set both group and kind",
+                        "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                      }
+                    ],
+                    "additionalProperties": false
+                  },
+                  "maxItems": 1,
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
+                },
+                "sni": {
+                  "description": "Server Name Indicator (`SNI`) to use in the TLS\nhandshake. If unset, the `SNI` is automatically set based on the\ndestination hostname.",
+                  "maxLength": 253,
+                  "minLength": 1,
+                  "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                  "type": "string"
+                },
+                "verifySubjectAltNames": {
+                  "description": "Subject Alternative Names (`SAN`)\nto verify in the server certificate.\nIf not present, the destination hostname is automatically used.",
+                  "items": {
+                    "maxLength": 256,
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "maxItems": 16,
+                  "minItems": 1,
+                  "type": "array"
+                }
+              },
+              "type": "object",
+              "x-kubernetes-validations": [
+                {
+                  "message": "insecureSkipVerify All and caCertificateRefs may not be set together",
+                  "rule": "has(self.insecureSkipVerify) && self.insecureSkipVerify == 'All' ? !has(self.caCertificateRefs) : true"
+                },
+                {
+                  "message": "insecureSkipVerify and verifySubjectAltNames may not be set together",
+                  "rule": "has(self.insecureSkipVerify) ? !has(self.verifySubjectAltNames) : true"
+                },
+                {
+                  "message": "at most one of the fields in [verifySubjectAltNames insecureSkipVerify] may be set",
+                  "rule": "[has(self.verifySubjectAltNames),has(self.insecureSkipVerify)].filter(x,x==true).size() <= 1"
+                }
+              ],
+              "additionalProperties": false
+            },
+            "transformation": {
+              "description": "Mutates and transforms requests and responses sent to and from the backend.",
+              "properties": {
+                "request": {
+                  "description": "Request transformation settings.",
+                  "properties": {
+                    "add": {
+                      "description": "Headers to add to the request and what each value\nshould be set to. If there is already a header with these values then\nappend the value as an extra entry.",
+                      "items": {
+                        "properties": {
+                          "name": {
+                            "description": "The name of the header to add.",
+                            "maxLength": 256,
+                            "minLength": 1,
+                            "pattern": "^:?[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                            "type": "string",
+                            "x-kubernetes-validations": [
+                              {
+                                "message": "pseudo-headers must be one of :authority, :method, :path, :scheme, or :status",
+                                "rule": "!self.startsWith(':') || self in [':authority', ':method', ':path', ':scheme', ':status']"
+                              }
+                            ]
+                          },
+                          "value": {
+                            "description": "CEL expression that generates the output value for\nthe header.",
+                            "maxLength": 16384,
+                            "minLength": 1,
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "name",
+                          "value"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "maxItems": 16,
+                      "minItems": 1,
+                      "type": "array",
+                      "x-kubernetes-list-map-keys": [
+                        "name"
+                      ],
+                      "x-kubernetes-list-type": "map"
+                    },
+                    "body": {
+                      "description": "HTTP body transformation.",
+                      "maxLength": 16384,
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "metadata": {
+                      "additionalProperties": {
+                        "description": "A Common Expression Language (CEL) expression.",
+                        "maxLength": 16384,
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "description": "Stores CEL-evaluated values under the `metadata` CEL variable\nfor subsequent policy evaluations. `metadata` is evaluated before header\nor body transformations.",
+                      "maxProperties": 16,
+                      "minProperties": 1,
+                      "type": "object"
+                    },
+                    "remove": {
+                      "description": "Header names to remove from the request or\nresponse.",
+                      "items": {
+                        "description": "HTTP header name.",
+                        "maxLength": 256,
+                        "minLength": 1,
+                        "pattern": "^:?[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                        "type": "string",
+                        "x-kubernetes-validations": [
+                          {
+                            "message": "pseudo-headers must be one of :authority, :method, :path, :scheme, or :status",
+                            "rule": "!self.startsWith(':') || self in [':authority', ':method', ':path', ':scheme', ':status']"
+                          }
+                        ]
+                      },
+                      "maxItems": 16,
+                      "minItems": 1,
+                      "type": "array",
+                      "x-kubernetes-list-type": "set"
+                    },
+                    "set": {
+                      "description": "Headers to set and the values to use.",
+                      "items": {
+                        "properties": {
+                          "name": {
+                            "description": "The name of the header to add.",
+                            "maxLength": 256,
+                            "minLength": 1,
+                            "pattern": "^:?[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                            "type": "string",
+                            "x-kubernetes-validations": [
+                              {
+                                "message": "pseudo-headers must be one of :authority, :method, :path, :scheme, or :status",
+                                "rule": "!self.startsWith(':') || self in [':authority', ':method', ':path', ':scheme', ':status']"
+                              }
+                            ]
+                          },
+                          "value": {
+                            "description": "CEL expression that generates the output value for\nthe header.",
+                            "maxLength": 16384,
+                            "minLength": 1,
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "name",
+                          "value"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "maxItems": 16,
+                      "minItems": 1,
+                      "type": "array",
+                      "x-kubernetes-list-map-keys": [
+                        "name"
+                      ],
+                      "x-kubernetes-list-type": "map"
+                    }
+                  },
+                  "type": "object",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "at least one of the fields in [add body metadata remove set] must be set",
+                      "rule": "[has(self.add),has(self.body),has(self.metadata),has(self.remove),has(self.set)].filter(x,x==true).size() >= 1"
+                    }
+                  ],
+                  "additionalProperties": false
+                },
+                "response": {
+                  "description": "Response transformation settings.",
+                  "properties": {
+                    "add": {
+                      "description": "Headers to add to the request and what each value\nshould be set to. If there is already a header with these values then\nappend the value as an extra entry.",
+                      "items": {
+                        "properties": {
+                          "name": {
+                            "description": "The name of the header to add.",
+                            "maxLength": 256,
+                            "minLength": 1,
+                            "pattern": "^:?[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                            "type": "string",
+                            "x-kubernetes-validations": [
+                              {
+                                "message": "pseudo-headers must be one of :authority, :method, :path, :scheme, or :status",
+                                "rule": "!self.startsWith(':') || self in [':authority', ':method', ':path', ':scheme', ':status']"
+                              }
+                            ]
+                          },
+                          "value": {
+                            "description": "CEL expression that generates the output value for\nthe header.",
+                            "maxLength": 16384,
+                            "minLength": 1,
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "name",
+                          "value"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "maxItems": 16,
+                      "minItems": 1,
+                      "type": "array",
+                      "x-kubernetes-list-map-keys": [
+                        "name"
+                      ],
+                      "x-kubernetes-list-type": "map"
+                    },
+                    "body": {
+                      "description": "HTTP body transformation.",
+                      "maxLength": 16384,
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "metadata": {
+                      "additionalProperties": {
+                        "description": "A Common Expression Language (CEL) expression.",
+                        "maxLength": 16384,
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "description": "Stores CEL-evaluated values under the `metadata` CEL variable\nfor subsequent policy evaluations. `metadata` is evaluated before header\nor body transformations.",
+                      "maxProperties": 16,
+                      "minProperties": 1,
+                      "type": "object"
+                    },
+                    "remove": {
+                      "description": "Header names to remove from the request or\nresponse.",
+                      "items": {
+                        "description": "HTTP header name.",
+                        "maxLength": 256,
+                        "minLength": 1,
+                        "pattern": "^:?[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                        "type": "string",
+                        "x-kubernetes-validations": [
+                          {
+                            "message": "pseudo-headers must be one of :authority, :method, :path, :scheme, or :status",
+                            "rule": "!self.startsWith(':') || self in [':authority', ':method', ':path', ':scheme', ':status']"
+                          }
+                        ]
+                      },
+                      "maxItems": 16,
+                      "minItems": 1,
+                      "type": "array",
+                      "x-kubernetes-list-type": "set"
+                    },
+                    "set": {
+                      "description": "Headers to set and the values to use.",
+                      "items": {
+                        "properties": {
+                          "name": {
+                            "description": "The name of the header to add.",
+                            "maxLength": 256,
+                            "minLength": 1,
+                            "pattern": "^:?[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                            "type": "string",
+                            "x-kubernetes-validations": [
+                              {
+                                "message": "pseudo-headers must be one of :authority, :method, :path, :scheme, or :status",
+                                "rule": "!self.startsWith(':') || self in [':authority', ':method', ':path', ':scheme', ':status']"
+                              }
+                            ]
+                          },
+                          "value": {
+                            "description": "CEL expression that generates the output value for\nthe header.",
+                            "maxLength": 16384,
+                            "minLength": 1,
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "name",
+                          "value"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "maxItems": 16,
+                      "minItems": 1,
+                      "type": "array",
+                      "x-kubernetes-list-map-keys": [
+                        "name"
+                      ],
+                      "x-kubernetes-list-type": "map"
+                    }
+                  },
+                  "type": "object",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "at least one of the fields in [add body metadata remove set] must be set",
+                      "rule": "[has(self.add),has(self.body),has(self.metadata),has(self.remove),has(self.set)].filter(x,x==true).size() >= 1"
+                    }
+                  ],
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "x-kubernetes-validations": [
+                {
+                  "message": "at least one of the fields in [request response] must be set",
+                  "rule": "[has(self.request),has(self.response)].filter(x,x==true).size() >= 1"
+                }
+              ],
+              "additionalProperties": false
+            },
+            "tunnel": {
+              "description": "Settings for managing tunnel connections, with behavior like `HTTPS_PROXY`, to the backend.",
+              "properties": {
+                "backendRef": {
+                  "description": "Proxy server to reach.\nSupported types: `Service` and `Backend`.",
+                  "properties": {
+                    "group": {
+                      "default": "",
+                      "description": "Group is the group of the referent. For example, \"gateway.networking.k8s.io\".\nWhen unspecified or empty string, core API group is inferred.",
+                      "maxLength": 253,
+                      "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                      "type": "string"
+                    },
+                    "kind": {
+                      "default": "Service",
+                      "description": "Kind is the Kubernetes resource kind of the referent. For example\n\"Service\".\n\nDefaults to \"Service\" when not specified.\n\nExternalName services can refer to CNAME DNS records that may live\noutside of the cluster and as such are difficult to reason about in\nterms of conformance. They also may not be safe to forward to (see\nCVE-2021-25740 for more information). Implementations SHOULD NOT\nsupport ExternalName Services.\n\nSupport: Core (Services with a type other than ExternalName)\n\nSupport: Implementation-specific (Services with type ExternalName)",
+                      "maxLength": 63,
+                      "minLength": 1,
+                      "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
+                      "type": "string"
+                    },
+                    "name": {
+                      "description": "Name is the name of the referent.",
+                      "maxLength": 253,
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "namespace": {
+                      "description": "Namespace is the namespace of the backend. When unspecified, the local\nnamespace is inferred.\n\nNote that when a namespace different than the local namespace is specified,\na ReferenceGrant object is required in the referent namespace to allow that\nnamespace's owner to accept the reference. See the ReferenceGrant\ndocumentation for details.\n\nSupport: Core",
+                      "maxLength": 63,
+                      "minLength": 1,
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                      "type": "string"
+                    },
+                    "port": {
+                      "description": "Port specifies the destination port number to use for this resource.\nPort is required when the referent is a Kubernetes Service. In this\ncase, the port number is the service port number, not the target port.\nFor other resources, destination port might be derived from the referent\nresource or this field.",
+                      "format": "int32",
+                      "maximum": 65535,
+                      "minimum": 1,
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "name"
+                  ],
+                  "type": "object",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "Must have port for Service reference",
+                      "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
+                    }
+                  ],
+                  "additionalProperties": false
+                }
+              },
+              "required": [
+                "backendRef"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "x-kubernetes-validations": [
+            {
+              "message": "at least one of the fields in [ai auth extAuth health http mcp tcp tls transformation tunnel] must be set",
+              "rule": "[has(self.ai),has(self.auth),has(self.extAuth),has(self.health),has(self.http),has(self.mcp),has(self.tcp),has(self.tls),has(self.transformation),has(self.tunnel)].filter(x,x==true).size() >= 1"
+            }
+          ],
+          "additionalProperties": false
+        },
+        "static": {
+          "description": "Static hostname, IP address, or Unix Domain Socket backend.",
+          "properties": {
+            "host": {
+              "description": "Host to connect to for TCP backends.",
+              "maxLength": 256,
+              "minLength": 1,
+              "type": "string"
+            },
+            "port": {
+              "description": "Port to connect to for TCP backends.",
+              "format": "int32",
+              "maximum": 65535,
+              "minimum": 1,
+              "type": "integer"
+            },
+            "unixPath": {
+              "description": "Filesystem path to a Unix Domain Socket. The gateway pod\nmust share a volume with the target (e.g., via emptyDir sidecar pattern).\nMutually exclusive with host/port.",
+              "minLength": 1,
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "x-kubernetes-validations": [
+            {
+              "message": "must specify either unixPath or both host and port",
+              "rule": "has(self.unixPath) || (has(self.host) && has(self.port))"
+            },
+            {
+              "message": "unixPath and host/port are mutually exclusive",
+              "rule": "!has(self.unixPath) || (!has(self.host) && !has(self.port))"
+            }
+          ],
+          "additionalProperties": false
+        }
+      },
+      "type": "object",
+      "x-kubernetes-validations": [
+        {
+          "message": "AI policies require AI backend",
+          "rule": "has(self.policies) && has(self.policies.ai) ? has(self.ai) : true"
+        },
+        {
+          "message": "MCP policies require MCP backend",
+          "rule": "has(self.policies) && has(self.policies.mcp) ? has(self.mcp) : true"
+        },
+        {
+          "message": "exactly one of the fields in [ai static dynamicForwardProxy mcp aws a2a] must be set",
+          "rule": "[has(self.ai),has(self.static),has(self.dynamicForwardProxy),has(self.mcp),has(self.aws),has(self.a2a)].filter(x,x==true).size() == 1"
+        }
+      ],
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "Current backend status.",
+      "properties": {
+        "conditions": {
+          "description": "Current condition state for the backend.",
+          "items": {
+            "description": "Condition contains details for one aspect of the current state of this API Resource.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "lastTransitionTime is the last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "message is a human readable message indicating details about the transition.\nThis may be an empty string.",
+                "maxLength": 32768,
+                "type": "string"
+              },
+              "observedGeneration": {
+                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon.\nFor instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date\nwith respect to the current state of the instance.",
+                "format": "int64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "reason": {
+                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition.\nProducers of specific condition types may define expected values and meanings for this field,\nand whether the values are considered a guaranteed API.\nThe value should be a CamelCase string.\nThis field may not be empty.",
+                "maxLength": 1024,
+                "minLength": 1,
+                "pattern": "^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$",
+                "type": "string"
+              },
+              "status": {
+                "description": "status of the condition, one of True, False, Unknown.",
+                "enum": [
+                  "True",
+                  "False",
+                  "Unknown"
+                ],
+                "type": "string"
+              },
+              "type": {
+                "description": "type of condition in CamelCase or in foo.example.com/CamelCase.",
+                "maxLength": 316,
+                "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$",
+                "type": "string"
+              }
+            },
+            "required": [
+              "lastTransitionTime",
+              "message",
+              "reason",
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "maxItems": 8,
+          "type": "array",
+          "x-kubernetes-list-map-keys": [
+            "type"
+          ],
+          "x-kubernetes-list-type": "map"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "required": [
+    "spec"
+  ],
+  "type": "object"
+}

--- a/agentgateway.dev/agentgatewayparameters_v1alpha1.json
+++ b/agentgateway.dev/agentgatewayparameters_v1alpha1.json
@@ -1,0 +1,570 @@
+{
+  "description": "Configures dynamic provisioning for the agentgateway data plane.\nLabels and annotations that apply to\nall resources may be specified at a higher level; see\nhttps://gateway-api.sigs.k8s.io/reference/api-spec/main/spec/#gatewayinfrastructure",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "Desired data plane provisioning settings.",
+      "properties": {
+        "deployment": {
+          "description": "Overrides for the generated\n`Deployment` resource.",
+          "properties": {
+            "metadata": {
+              "description": "`metadata` defines a subset of object metadata to be customized.\n`labels` and `annotations` are merged with existing values. If both\n`GatewayClass` and `Gateway` parameters define the same label or\nannotation key, the `Gateway` value takes precedence (applied second).",
+              "properties": {
+                "annotations": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "Annotations is an unstructured key value map stored with a resource that may be\nset by external tools to store and retrieve arbitrary metadata. They are not\nqueryable and should be preserved when modifying objects.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations",
+                  "type": "object"
+                },
+                "labels": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "Map of string keys and values that can be used to organize and categorize\n(scope and select) objects. May match selectors of replication controllers\nand services.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels",
+                  "type": "object"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "spec": {
+              "description": "`spec` provides an opaque mechanism to configure the resource spec.\nThis field accepts a complete or partial Kubernetes resource spec, such\nas `PodSpec` or `ServiceSpec`, and will be merged with the generated\nconfiguration using **Strategic Merge Patch** semantics.\n\n# Application Order\n\nOverlays are applied after all typed configuration fields from both levels.\nThe full merge order is:\n\n 1. `GatewayClass` typed configuration fields\n 2. `Gateway` typed configuration fields\n 3. `GatewayClass` overlays\n 4. `Gateway` overlays (can override all previous values)\n\n# Strategic Merge Patch & Deletion Guide\n\nThis merge strategy allows you to override individual fields, merge lists, or delete items\nwithout needing to provide the entire resource definition.\n\n**1. Replacing Values (Scalars):**\nSimple fields (strings, integers, booleans) in your config will overwrite the generated defaults.\n\n**2. Merging Lists (Append/Merge):**\nLists with \"merge keys\", like `containers` which merges on `name`, or\n`tolerations` which merges on `key`,\nwill append your items to the generated list, or update existing items if keys match.\n\n**3. Deleting Fields or List Items ($patch: delete):**\nTo remove a field or list item from the generated resource, use the\n`$patch: delete` directive. This works for both map fields and list items,\nand is the recommended approach because it works with both client-side\nand server-side apply.\n\n\tspec:\n\t  template:\n\t    spec:\n\t      # Delete pod-level securityContext\n\t      securityContext:\n\t        $patch: delete\n\t      # Delete nodeSelector\n\t      nodeSelector:\n\t        $patch: delete\n\t      containers:\n\t      # Be sure to use the correct proxy name here or you will add a\n\t      # container instead of modifying a container.\n\t      - name: proxy-name\n\t        # Delete container-level securityContext\n\t        securityContext:\n\t          $patch: delete\n\n**4. Null Values (server-side apply only):**\nSetting a field to `null` can also remove it, but this ONLY works with\n`kubectl apply --server-side` or equivalent. With regular client-side\n`kubectl apply`, null values are stripped by kubectl before reaching\nthe API server, so the deletion won't occur. Prefer `$patch: delete`\nfor consistent behavior across both apply modes.\n\n\tspec:\n\t  template:\n\t    spec:\n\t      nodeSelector: null  # Removes nodeSelector (server-side apply only!)\n\n**5. Replacing Maps Entirely ($patch: replace):**\nTo replace an entire map with your values (instead of merging), use `$patch: replace`.\nThis removes all existing keys and replaces them with only your specified keys.\n\n\tspec:\n\t  template:\n\t    spec:\n\t      nodeSelector:\n\t        $patch: replace\n\t        custom-key: custom-value\n\n**6. Replacing Lists Entirely ($patch: replace):**\nIf you want to strictly define a list and ignore all generated defaults, use `$patch: replace`.\n\n\tservice:\n\t  spec:\n\t    ports:\n\t    - $patch: replace\n\t    - name: http\n\t      port: 80\n\t      targetPort: 8080\n\t      protocol: TCP\n\t    - name: https\n\t      port: 443\n\t      targetPort: 8443\n\t      protocol: TCP",
+              "type": "object",
+              "x-kubernetes-preserve-unknown-fields": true
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "env": {
+          "description": "Container environment variables. These override any existing\nvalues. If you want to delete an environment variable entirely, use\n`$patch: delete` with an overlay instead. Note that\n[variable\nexpansion](https://kubernetes.io/docs/tasks/inject-data-application/define-interdependent-environment-variables/)\ndoes apply, but is highly discouraged -- to set dependent environment\nvariables, you can use `$(VAR_NAME)`, but it's highly discouraged.\n`$$(VAR_NAME)` avoids expansion and results in a literal\n`$(VAR_NAME)`.\n\nIf `SESSION_KEY` is specified, it takes precedence over the\ncontroller-managed per-`Gateway` session key `Secret`.",
+          "items": {
+            "description": "EnvVar represents an environment variable present in a Container.",
+            "properties": {
+              "name": {
+                "description": "Name of the environment variable.\nMay consist of any printable ASCII characters except '='.",
+                "type": "string"
+              },
+              "value": {
+                "description": "Variable references $(VAR_NAME) are expanded\nusing the previously defined environment variables in the container and\nany service environment variables. If a variable cannot be resolved,\nthe reference in the input string will be unchanged. Double $$ are reduced\nto a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.\n\"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\".\nEscaped references will never be expanded, regardless of whether the variable\nexists or not.\nDefaults to \"\".",
+                "type": "string"
+              },
+              "valueFrom": {
+                "description": "Source for the environment variable's value. Cannot be used if value is not empty.",
+                "properties": {
+                  "configMapKeyRef": {
+                    "description": "Selects a key of a ConfigMap.",
+                    "properties": {
+                      "key": {
+                        "description": "The key to select.",
+                        "type": "string"
+                      },
+                      "name": {
+                        "default": "",
+                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                        "type": "string"
+                      },
+                      "optional": {
+                        "description": "Specify whether the ConfigMap or its key must be defined",
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "key"
+                    ],
+                    "type": "object",
+                    "x-kubernetes-map-type": "atomic",
+                    "additionalProperties": false
+                  },
+                  "fieldRef": {
+                    "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,\nspec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.",
+                    "properties": {
+                      "apiVersion": {
+                        "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                        "type": "string"
+                      },
+                      "fieldPath": {
+                        "description": "Path of the field to select in the specified API version.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "fieldPath"
+                    ],
+                    "type": "object",
+                    "x-kubernetes-map-type": "atomic",
+                    "additionalProperties": false
+                  },
+                  "fileKeyRef": {
+                    "description": "FileKeyRef selects a key of the env file.\nRequires the EnvFiles feature gate to be enabled.",
+                    "properties": {
+                      "key": {
+                        "description": "The key within the env file. An invalid key will prevent the pod from starting.\nThe keys defined within a source may consist of any printable ASCII characters except '='.\nDuring Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.",
+                        "type": "string"
+                      },
+                      "optional": {
+                        "default": false,
+                        "description": "Specify whether the file or its key must be defined. If the file or key\ndoes not exist, then the env var is not published.\nIf optional is set to true and the specified key does not exist,\nthe environment variable will not be set in the Pod's containers.\n\nIf optional is set to false and the specified key does not exist,\nan error will be returned during Pod creation.",
+                        "type": "boolean"
+                      },
+                      "path": {
+                        "description": "The path within the volume from which to select the file.\nMust be relative and may not contain the '..' path or start with '..'.",
+                        "type": "string"
+                      },
+                      "volumeName": {
+                        "description": "The name of the volume mount containing the env file.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "key",
+                      "path",
+                      "volumeName"
+                    ],
+                    "type": "object",
+                    "x-kubernetes-map-type": "atomic",
+                    "additionalProperties": false
+                  },
+                  "resourceFieldRef": {
+                    "description": "Selects a resource of the container: only resources limits and requests\n(limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.",
+                    "properties": {
+                      "containerName": {
+                        "description": "Container name: required for volumes, optional for env vars",
+                        "type": "string"
+                      },
+                      "divisor": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                        "x-kubernetes-int-or-string": true
+                      },
+                      "resource": {
+                        "description": "Required: resource to select",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "resource"
+                    ],
+                    "type": "object",
+                    "x-kubernetes-map-type": "atomic",
+                    "additionalProperties": false
+                  },
+                  "secretKeyRef": {
+                    "description": "Selects a key of a secret in the pod's namespace",
+                    "properties": {
+                      "key": {
+                        "description": "The key of the secret to select from.  Must be a valid secret key.",
+                        "type": "string"
+                      },
+                      "name": {
+                        "default": "",
+                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                        "type": "string"
+                      },
+                      "optional": {
+                        "description": "Specify whether the Secret or its key must be defined",
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "key"
+                    ],
+                    "type": "object",
+                    "x-kubernetes-map-type": "atomic",
+                    "additionalProperties": false
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              }
+            },
+            "required": [
+              "name"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "horizontalPodAutoscaler": {
+          "description": "Creates a `HorizontalPodAutoscaler`\nfor the agentgateway proxy. If absent, no HPA is created. If present, an\nHPA is created with its `scaleTargetRef` automatically configured to\ntarget the agentgateway proxy `Deployment`. The `metadata` and `spec`\nfields from this overlay are applied to the generated HPA.",
+          "properties": {
+            "metadata": {
+              "description": "`metadata` defines a subset of object metadata to be customized.\n`labels` and `annotations` are merged with existing values. If both\n`GatewayClass` and `Gateway` parameters define the same label or\nannotation key, the `Gateway` value takes precedence (applied second).",
+              "properties": {
+                "annotations": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "Annotations is an unstructured key value map stored with a resource that may be\nset by external tools to store and retrieve arbitrary metadata. They are not\nqueryable and should be preserved when modifying objects.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations",
+                  "type": "object"
+                },
+                "labels": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "Map of string keys and values that can be used to organize and categorize\n(scope and select) objects. May match selectors of replication controllers\nand services.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels",
+                  "type": "object"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "spec": {
+              "description": "`spec` provides an opaque mechanism to configure the resource spec.\nThis field accepts a complete or partial Kubernetes resource spec, such\nas `PodSpec` or `ServiceSpec`, and will be merged with the generated\nconfiguration using **Strategic Merge Patch** semantics.\n\n# Application Order\n\nOverlays are applied after all typed configuration fields from both levels.\nThe full merge order is:\n\n 1. `GatewayClass` typed configuration fields\n 2. `Gateway` typed configuration fields\n 3. `GatewayClass` overlays\n 4. `Gateway` overlays (can override all previous values)\n\n# Strategic Merge Patch & Deletion Guide\n\nThis merge strategy allows you to override individual fields, merge lists, or delete items\nwithout needing to provide the entire resource definition.\n\n**1. Replacing Values (Scalars):**\nSimple fields (strings, integers, booleans) in your config will overwrite the generated defaults.\n\n**2. Merging Lists (Append/Merge):**\nLists with \"merge keys\", like `containers` which merges on `name`, or\n`tolerations` which merges on `key`,\nwill append your items to the generated list, or update existing items if keys match.\n\n**3. Deleting Fields or List Items ($patch: delete):**\nTo remove a field or list item from the generated resource, use the\n`$patch: delete` directive. This works for both map fields and list items,\nand is the recommended approach because it works with both client-side\nand server-side apply.\n\n\tspec:\n\t  template:\n\t    spec:\n\t      # Delete pod-level securityContext\n\t      securityContext:\n\t        $patch: delete\n\t      # Delete nodeSelector\n\t      nodeSelector:\n\t        $patch: delete\n\t      containers:\n\t      # Be sure to use the correct proxy name here or you will add a\n\t      # container instead of modifying a container.\n\t      - name: proxy-name\n\t        # Delete container-level securityContext\n\t        securityContext:\n\t          $patch: delete\n\n**4. Null Values (server-side apply only):**\nSetting a field to `null` can also remove it, but this ONLY works with\n`kubectl apply --server-side` or equivalent. With regular client-side\n`kubectl apply`, null values are stripped by kubectl before reaching\nthe API server, so the deletion won't occur. Prefer `$patch: delete`\nfor consistent behavior across both apply modes.\n\n\tspec:\n\t  template:\n\t    spec:\n\t      nodeSelector: null  # Removes nodeSelector (server-side apply only!)\n\n**5. Replacing Maps Entirely ($patch: replace):**\nTo replace an entire map with your values (instead of merging), use `$patch: replace`.\nThis removes all existing keys and replaces them with only your specified keys.\n\n\tspec:\n\t  template:\n\t    spec:\n\t      nodeSelector:\n\t        $patch: replace\n\t        custom-key: custom-value\n\n**6. Replacing Lists Entirely ($patch: replace):**\nIf you want to strictly define a list and ignore all generated defaults, use `$patch: replace`.\n\n\tservice:\n\t  spec:\n\t    ports:\n\t    - $patch: replace\n\t    - name: http\n\t      port: 80\n\t      targetPort: 8080\n\t      protocol: TCP\n\t    - name: https\n\t      port: 443\n\t      targetPort: 8443\n\t      protocol: TCP",
+              "type": "object",
+              "x-kubernetes-preserve-unknown-fields": true
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "image": {
+          "description": "The agentgateway container image. See\nhttps://kubernetes.io/docs/concepts/containers/images\nfor details.\n\nDefault values, which may be overridden individually:\n\n\tregistry: cr.agentgateway.dev\n\trepository: agentgateway\n\ttag: <agentgateway version>\n\tpullPolicy: <omitted, relying on Kubernetes defaults which depend on the tag>",
+          "properties": {
+            "digest": {
+              "description": "Image digest, such as `sha256:12345...`.",
+              "type": "string"
+            },
+            "pullPolicy": {
+              "description": "Image pull policy for the container. See\nhttps://kubernetes.io/docs/concepts/containers/images/#image-pull-policy\nfor details.",
+              "type": "string"
+            },
+            "registry": {
+              "description": "Image registry.",
+              "type": "string"
+            },
+            "repository": {
+              "description": "Image repository.",
+              "type": "string"
+            },
+            "tag": {
+              "description": "Image tag.",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "istio": {
+          "description": "Istio integration settings. If enabled, agentgateway can natively connect to Istio-enabled pods with mTLS.",
+          "properties": {
+            "additionalTrustDomains": {
+              "description": "Additional SPIFFE trust domains accepted on inbound HBONE connections.\nThe local trust domain is always implicitly included.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "caAddress": {
+              "description": "Address of the Istio CA. If unset, defaults to `https://istiod.istio-system.svc:15012`.",
+              "type": "string"
+            },
+            "clusterId": {
+              "description": "ID of the cluster this gateway runs in. If unset, defaults to `Kubernetes`.",
+              "type": "string"
+            },
+            "enabled": {
+              "description": "Explicitly turns Istio integration on or off for this gateway.",
+              "type": "boolean"
+            },
+            "network": {
+              "description": "Istio network this gateway runs in. If unset, defaults to the empty network.",
+              "type": "string"
+            },
+            "trustDomain": {
+              "description": "Istio trust domain. If not set, defaults to `cluster.local`, or the default\ntrust domain for the control plane's istio revision.",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "logging": {
+          "description": "Logging configuration. By default, all logs are set to\n`info` level.",
+          "properties": {
+            "format": {
+              "description": "Logging output format.",
+              "enum": [
+                "json",
+                "text"
+              ],
+              "type": "string"
+            },
+            "level": {
+              "description": "Logging level in standard `RUST_LOG` syntax, for example `info` (the\ndefault), or a comma-separated per-module setting such as\n`rmcp=warn,hickory_server::server::server_future=off,typespec_client_core::http::policies::logging=warn`.",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "modelCatalog": {
+          "description": "Model cost catalog sources. Only effective when set on a Gateway-level\nAgentgatewayParameters (via Gateway.spec.infrastructure.parametersRef);\nignored on GatewayClass-level parameters because ConfigMap references\nare resolved from the Gateway's deployment namespace.",
+          "properties": {
+            "sources": {
+              "items": {
+                "description": "ModelCatalogSource is a single source of model cost catalog data.",
+                "properties": {
+                  "configMap": {
+                    "description": "ModelCatalogConfigMapRef identifies a ConfigMap holding model cost catalog JSON.\nThe ConfigMap must be in the same namespace as the Gateway that references it.",
+                    "properties": {
+                      "key": {
+                        "description": "Data key whose value is the catalog JSON. Defaults to \"catalog.json\".",
+                        "type": "string"
+                      },
+                      "name": {
+                        "minLength": 1,
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "name"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "podDisruptionBudget": {
+          "description": "Creates a `PodDisruptionBudget` for the\nagentgateway proxy. If absent, no PDB is created. If present, a PDB is\ncreated with its selector automatically configured to target the\nagentgateway proxy `Deployment`. The `metadata` and `spec` fields from\nthis overlay are applied to the generated PDB.",
+          "properties": {
+            "metadata": {
+              "description": "`metadata` defines a subset of object metadata to be customized.\n`labels` and `annotations` are merged with existing values. If both\n`GatewayClass` and `Gateway` parameters define the same label or\nannotation key, the `Gateway` value takes precedence (applied second).",
+              "properties": {
+                "annotations": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "Annotations is an unstructured key value map stored with a resource that may be\nset by external tools to store and retrieve arbitrary metadata. They are not\nqueryable and should be preserved when modifying objects.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations",
+                  "type": "object"
+                },
+                "labels": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "Map of string keys and values that can be used to organize and categorize\n(scope and select) objects. May match selectors of replication controllers\nand services.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels",
+                  "type": "object"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "spec": {
+              "description": "`spec` provides an opaque mechanism to configure the resource spec.\nThis field accepts a complete or partial Kubernetes resource spec, such\nas `PodSpec` or `ServiceSpec`, and will be merged with the generated\nconfiguration using **Strategic Merge Patch** semantics.\n\n# Application Order\n\nOverlays are applied after all typed configuration fields from both levels.\nThe full merge order is:\n\n 1. `GatewayClass` typed configuration fields\n 2. `Gateway` typed configuration fields\n 3. `GatewayClass` overlays\n 4. `Gateway` overlays (can override all previous values)\n\n# Strategic Merge Patch & Deletion Guide\n\nThis merge strategy allows you to override individual fields, merge lists, or delete items\nwithout needing to provide the entire resource definition.\n\n**1. Replacing Values (Scalars):**\nSimple fields (strings, integers, booleans) in your config will overwrite the generated defaults.\n\n**2. Merging Lists (Append/Merge):**\nLists with \"merge keys\", like `containers` which merges on `name`, or\n`tolerations` which merges on `key`,\nwill append your items to the generated list, or update existing items if keys match.\n\n**3. Deleting Fields or List Items ($patch: delete):**\nTo remove a field or list item from the generated resource, use the\n`$patch: delete` directive. This works for both map fields and list items,\nand is the recommended approach because it works with both client-side\nand server-side apply.\n\n\tspec:\n\t  template:\n\t    spec:\n\t      # Delete pod-level securityContext\n\t      securityContext:\n\t        $patch: delete\n\t      # Delete nodeSelector\n\t      nodeSelector:\n\t        $patch: delete\n\t      containers:\n\t      # Be sure to use the correct proxy name here or you will add a\n\t      # container instead of modifying a container.\n\t      - name: proxy-name\n\t        # Delete container-level securityContext\n\t        securityContext:\n\t          $patch: delete\n\n**4. Null Values (server-side apply only):**\nSetting a field to `null` can also remove it, but this ONLY works with\n`kubectl apply --server-side` or equivalent. With regular client-side\n`kubectl apply`, null values are stripped by kubectl before reaching\nthe API server, so the deletion won't occur. Prefer `$patch: delete`\nfor consistent behavior across both apply modes.\n\n\tspec:\n\t  template:\n\t    spec:\n\t      nodeSelector: null  # Removes nodeSelector (server-side apply only!)\n\n**5. Replacing Maps Entirely ($patch: replace):**\nTo replace an entire map with your values (instead of merging), use `$patch: replace`.\nThis removes all existing keys and replaces them with only your specified keys.\n\n\tspec:\n\t  template:\n\t    spec:\n\t      nodeSelector:\n\t        $patch: replace\n\t        custom-key: custom-value\n\n**6. Replacing Lists Entirely ($patch: replace):**\nIf you want to strictly define a list and ignore all generated defaults, use `$patch: replace`.\n\n\tservice:\n\t  spec:\n\t    ports:\n\t    - $patch: replace\n\t    - name: http\n\t      port: 80\n\t      targetPort: 8080\n\t      protocol: TCP\n\t    - name: https\n\t      port: 443\n\t      targetPort: 8443\n\t      protocol: TCP",
+              "type": "object",
+              "x-kubernetes-preserve-unknown-fields": true
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "rawConfig": {
+          "description": "Raw agentgateway configuration to merge into the generated config file.\nThis is merged with\nconfiguration derived from typed fields like `logging.format`, and those\ntyped fields will take precedence.\n\nExample:\n\n\trawConfig:\n\t  binds:\n\t  - port: 3000\n\t    listeners:\n\t    - routes:\n\t      - policies:\n\t          cors:\n\t            allowOrigins:\n\t            - \"*\"\n\t            allowHeaders:\n\t            - mcp-protocol-version\n\t            - content-type\n\t            - cache-control\n\t        backends:\n\t        - mcp:\n\t            targets:\n\t            - name: everything\n\t              stdio:\n\t                cmd: npx\n\t                args: [\"@modelcontextprotocol/server-everything\"]",
+          "type": "object",
+          "x-kubernetes-preserve-unknown-fields": true
+        },
+        "resources": {
+          "description": "Compute resources required by this container. See\nhttps://kubernetes.io/docs/concepts/configuration/manage-resources-containers/\nfor details.",
+          "properties": {
+            "claims": {
+              "description": "Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.\n\nThis field depends on the\nDynamicResourceAllocation feature gate.\n\nThis field is immutable. It can only be set for containers.",
+              "items": {
+                "description": "ResourceClaim references one entry in PodSpec.ResourceClaims.",
+                "properties": {
+                  "name": {
+                    "description": "Name must match the name of one entry in pod.spec.resourceClaims of\nthe Pod where this field is used. It makes that resource available\ninside a container.",
+                    "type": "string"
+                  },
+                  "request": {
+                    "description": "Request is the name chosen for a request in the referenced claim.\nIf empty, everything from the claim is made available, otherwise\nonly the result of this request.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array",
+              "x-kubernetes-list-map-keys": [
+                "name"
+              ],
+              "x-kubernetes-list-type": "map"
+            },
+            "limits": {
+              "additionalProperties": {
+                "anyOf": [
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "string"
+                  }
+                ],
+                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                "x-kubernetes-int-or-string": true
+              },
+              "description": "Limits describes the maximum amount of compute resources allowed.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+              "type": "object"
+            },
+            "requests": {
+              "additionalProperties": {
+                "anyOf": [
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "string"
+                  }
+                ],
+                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                "x-kubernetes-int-or-string": true
+              },
+              "description": "Requests describes the minimum amount of compute resources required.\nIf Requests is omitted for a container, it defaults to Limits if that is explicitly specified,\notherwise to an implementation-defined value. Requests cannot exceed Limits.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+              "type": "object"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "service": {
+          "description": "Overrides for the generated `Service`\nresource.",
+          "properties": {
+            "metadata": {
+              "description": "`metadata` defines a subset of object metadata to be customized.\n`labels` and `annotations` are merged with existing values. If both\n`GatewayClass` and `Gateway` parameters define the same label or\nannotation key, the `Gateway` value takes precedence (applied second).",
+              "properties": {
+                "annotations": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "Annotations is an unstructured key value map stored with a resource that may be\nset by external tools to store and retrieve arbitrary metadata. They are not\nqueryable and should be preserved when modifying objects.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations",
+                  "type": "object"
+                },
+                "labels": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "Map of string keys and values that can be used to organize and categorize\n(scope and select) objects. May match selectors of replication controllers\nand services.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels",
+                  "type": "object"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "spec": {
+              "description": "`spec` provides an opaque mechanism to configure the resource spec.\nThis field accepts a complete or partial Kubernetes resource spec, such\nas `PodSpec` or `ServiceSpec`, and will be merged with the generated\nconfiguration using **Strategic Merge Patch** semantics.\n\n# Application Order\n\nOverlays are applied after all typed configuration fields from both levels.\nThe full merge order is:\n\n 1. `GatewayClass` typed configuration fields\n 2. `Gateway` typed configuration fields\n 3. `GatewayClass` overlays\n 4. `Gateway` overlays (can override all previous values)\n\n# Strategic Merge Patch & Deletion Guide\n\nThis merge strategy allows you to override individual fields, merge lists, or delete items\nwithout needing to provide the entire resource definition.\n\n**1. Replacing Values (Scalars):**\nSimple fields (strings, integers, booleans) in your config will overwrite the generated defaults.\n\n**2. Merging Lists (Append/Merge):**\nLists with \"merge keys\", like `containers` which merges on `name`, or\n`tolerations` which merges on `key`,\nwill append your items to the generated list, or update existing items if keys match.\n\n**3. Deleting Fields or List Items ($patch: delete):**\nTo remove a field or list item from the generated resource, use the\n`$patch: delete` directive. This works for both map fields and list items,\nand is the recommended approach because it works with both client-side\nand server-side apply.\n\n\tspec:\n\t  template:\n\t    spec:\n\t      # Delete pod-level securityContext\n\t      securityContext:\n\t        $patch: delete\n\t      # Delete nodeSelector\n\t      nodeSelector:\n\t        $patch: delete\n\t      containers:\n\t      # Be sure to use the correct proxy name here or you will add a\n\t      # container instead of modifying a container.\n\t      - name: proxy-name\n\t        # Delete container-level securityContext\n\t        securityContext:\n\t          $patch: delete\n\n**4. Null Values (server-side apply only):**\nSetting a field to `null` can also remove it, but this ONLY works with\n`kubectl apply --server-side` or equivalent. With regular client-side\n`kubectl apply`, null values are stripped by kubectl before reaching\nthe API server, so the deletion won't occur. Prefer `$patch: delete`\nfor consistent behavior across both apply modes.\n\n\tspec:\n\t  template:\n\t    spec:\n\t      nodeSelector: null  # Removes nodeSelector (server-side apply only!)\n\n**5. Replacing Maps Entirely ($patch: replace):**\nTo replace an entire map with your values (instead of merging), use `$patch: replace`.\nThis removes all existing keys and replaces them with only your specified keys.\n\n\tspec:\n\t  template:\n\t    spec:\n\t      nodeSelector:\n\t        $patch: replace\n\t        custom-key: custom-value\n\n**6. Replacing Lists Entirely ($patch: replace):**\nIf you want to strictly define a list and ignore all generated defaults, use `$patch: replace`.\n\n\tservice:\n\t  spec:\n\t    ports:\n\t    - $patch: replace\n\t    - name: http\n\t      port: 80\n\t      targetPort: 8080\n\t      protocol: TCP\n\t    - name: https\n\t      port: 443\n\t      targetPort: 8443\n\t      protocol: TCP",
+              "type": "object",
+              "x-kubernetes-preserve-unknown-fields": true
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "serviceAccount": {
+          "description": "Overrides for the generated\n`ServiceAccount` resource.",
+          "properties": {
+            "metadata": {
+              "description": "`metadata` defines a subset of object metadata to be customized.\n`labels` and `annotations` are merged with existing values. If both\n`GatewayClass` and `Gateway` parameters define the same label or\nannotation key, the `Gateway` value takes precedence (applied second).",
+              "properties": {
+                "annotations": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "Annotations is an unstructured key value map stored with a resource that may be\nset by external tools to store and retrieve arbitrary metadata. They are not\nqueryable and should be preserved when modifying objects.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations",
+                  "type": "object"
+                },
+                "labels": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "Map of string keys and values that can be used to organize and categorize\n(scope and select) objects. May match selectors of replication controllers\nand services.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels",
+                  "type": "object"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "spec": {
+              "description": "`spec` provides an opaque mechanism to configure the resource spec.\nThis field accepts a complete or partial Kubernetes resource spec, such\nas `PodSpec` or `ServiceSpec`, and will be merged with the generated\nconfiguration using **Strategic Merge Patch** semantics.\n\n# Application Order\n\nOverlays are applied after all typed configuration fields from both levels.\nThe full merge order is:\n\n 1. `GatewayClass` typed configuration fields\n 2. `Gateway` typed configuration fields\n 3. `GatewayClass` overlays\n 4. `Gateway` overlays (can override all previous values)\n\n# Strategic Merge Patch & Deletion Guide\n\nThis merge strategy allows you to override individual fields, merge lists, or delete items\nwithout needing to provide the entire resource definition.\n\n**1. Replacing Values (Scalars):**\nSimple fields (strings, integers, booleans) in your config will overwrite the generated defaults.\n\n**2. Merging Lists (Append/Merge):**\nLists with \"merge keys\", like `containers` which merges on `name`, or\n`tolerations` which merges on `key`,\nwill append your items to the generated list, or update existing items if keys match.\n\n**3. Deleting Fields or List Items ($patch: delete):**\nTo remove a field or list item from the generated resource, use the\n`$patch: delete` directive. This works for both map fields and list items,\nand is the recommended approach because it works with both client-side\nand server-side apply.\n\n\tspec:\n\t  template:\n\t    spec:\n\t      # Delete pod-level securityContext\n\t      securityContext:\n\t        $patch: delete\n\t      # Delete nodeSelector\n\t      nodeSelector:\n\t        $patch: delete\n\t      containers:\n\t      # Be sure to use the correct proxy name here or you will add a\n\t      # container instead of modifying a container.\n\t      - name: proxy-name\n\t        # Delete container-level securityContext\n\t        securityContext:\n\t          $patch: delete\n\n**4. Null Values (server-side apply only):**\nSetting a field to `null` can also remove it, but this ONLY works with\n`kubectl apply --server-side` or equivalent. With regular client-side\n`kubectl apply`, null values are stripped by kubectl before reaching\nthe API server, so the deletion won't occur. Prefer `$patch: delete`\nfor consistent behavior across both apply modes.\n\n\tspec:\n\t  template:\n\t    spec:\n\t      nodeSelector: null  # Removes nodeSelector (server-side apply only!)\n\n**5. Replacing Maps Entirely ($patch: replace):**\nTo replace an entire map with your values (instead of merging), use `$patch: replace`.\nThis removes all existing keys and replaces them with only your specified keys.\n\n\tspec:\n\t  template:\n\t    spec:\n\t      nodeSelector:\n\t        $patch: replace\n\t        custom-key: custom-value\n\n**6. Replacing Lists Entirely ($patch: replace):**\nIf you want to strictly define a list and ignore all generated defaults, use `$patch: replace`.\n\n\tservice:\n\t  spec:\n\t    ports:\n\t    - $patch: replace\n\t    - name: http\n\t      port: 80\n\t      targetPort: 8080\n\t      protocol: TCP\n\t    - name: https\n\t      port: 443\n\t      targetPort: 8443\n\t      protocol: TCP",
+              "type": "object",
+              "x-kubernetes-preserve-unknown-fields": true
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "shutdown": {
+          "description": "Shutdown delay configuration. How graceful planned or unplanned data\nplane changes happen is in tension with how quickly rollouts of the data\nplane complete. How long a data plane pod must wait for shutdown to be\nperfectly graceful depends on how you have configured your `Gateway`\nresources.",
+          "properties": {
+            "max": {
+              "description": "Maximum time (in seconds) to wait before allowing Agentgateway to\nterminate. Refer to the `TERMINATION_GRACE_PERIOD_SECONDS`\nenvironment variable for details.",
+              "format": "int64",
+              "maximum": 31536000,
+              "minimum": 0,
+              "type": "integer"
+            },
+            "min": {
+              "description": "Minimum time (in seconds) to wait before allowing Agentgateway to\nterminate. Refer to the `CONNECTION_MIN_TERMINATION_DEADLINE`\nenvironment variable for details.",
+              "format": "int64",
+              "maximum": 31536000,
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          "required": [
+            "max",
+            "min"
+          ],
+          "type": "object",
+          "x-kubernetes-validations": [
+            {
+              "message": "The 'min' value must be less than or equal to the 'max' value.",
+              "rule": "self.min <= self.max"
+            }
+          ],
+          "additionalProperties": false
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "Current status for these provisioning settings.",
+      "type": "object"
+    }
+  },
+  "required": [
+    "spec"
+  ],
+  "type": "object"
+}

--- a/agentgateway.dev/agentgatewaypolicy_v1alpha1.json
+++ b/agentgateway.dev/agentgatewaypolicy_v1alpha1.json
@@ -1,0 +1,9378 @@
+{
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "Desired policy configuration.",
+      "properties": {
+        "backend": {
+          "description": "Settings for how to connect to destination backends.\n\nA backend policy can target a `Gateway` (optionally, with a\n`sectionName` indicating the listener), `ListenerSet`, `Route`\n(optionally, with a `sectionName` indicating the route rule), or a\n`Service` or `Backend` (optionally, with a `sectionName` indicating the\nport for `Service`, or sub-backend for `Backend`).\n\nNote that a backend policy applies when connecting to a specific destination backend. Targeting a higher level\nresource, like `Gateway`, is just a way to easily apply a policy to a\ngroup of backends.\n\nWhen multiple policies are selected for a given request, they are merged on a field-level basis, but not a deep\nmerge. Precedence is given to more precise policies: `Gateway` <\n`Listener` < `Route` < `Route Rule` < `Backend` or `Service`. For\nexample, if a `Gateway` policy sets `tcp` and `tls`, and a `Backend`\npolicy sets `tls`, the effective policy would be `tcp` from the\n`Gateway`, and `tls` from the `Backend`.",
+          "properties": {
+            "ai": {
+              "description": "Settings for AI workloads. This is only applicable when\nconnecting to a `Backend` of type `ai`.",
+              "properties": {
+                "defaults": {
+                  "description": "Defaults to merge with user input fields. If the field is already set, the field in the request is used.",
+                  "items": {
+                    "description": "Default value for a field in the JSON request body sent to the LLM provider.\nThese defaults are merged with the user-provided request to ensure missing fields are populated.\n\nUser input fields here refer to the fields in the JSON request body that a client sends when making a request to the LLM provider.\nDefaults set here do _not_ override those user-provided values unless you explicitly set `override` to `true`.\n\nExample: Setting a default system field for Anthropic, which does not support system role messages:\n\n\tdefaults:\n\t  - field: \"system\"\n\t    value: \"answer all questions in French\"\n\nExample: Setting a default temperature and overriding `max_tokens`:\n\n\tdefaults:\n\t  - field: \"temperature\"\n\t    value: \"0.5\"\n\t  - field: \"max_tokens\"\n\t    value: \"100\"\n\t    override: true\n\nExample: Setting custom lists fields:\n\n\tdefaults:\n\t  - field: \"custom_integer_list\"\n\t    value: [1,2,3]\n\n\toverrides:\n\t  - field: \"custom_string_list\"\n\t    value: [\"one\",\"two\",\"three\"]\n\nNote: The `field` values correspond to keys in the JSON request body, not fields in this CRD.",
+                    "properties": {
+                      "field": {
+                        "allOf": [
+                          {
+                            "minLength": 1
+                          },
+                          {
+                            "minLength": 1
+                          }
+                        ],
+                        "description": "Name of the field.",
+                        "maxLength": 256,
+                        "type": "string"
+                      },
+                      "value": {
+                        "description": "Default value for the field. This can be any JSON data type.",
+                        "x-kubernetes-preserve-unknown-fields": true
+                      }
+                    },
+                    "required": [
+                      "field",
+                      "value"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "maxItems": 64,
+                  "minItems": 1,
+                  "type": "array"
+                },
+                "modelAliases": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "Maps friendly model names to actual provider model names.\nExample: `{\"fast\": \"gpt-3.5-turbo\", \"smart\": \"gpt-4-turbo\"}`.\nNote: This field is only applicable when using the agentgateway data plane.",
+                  "maxProperties": 64,
+                  "type": "object"
+                },
+                "overrides": {
+                  "description": "Overrides to merge with user input fields. If the field is already set, the field is overwritten.",
+                  "items": {
+                    "description": "Default value for a field in the JSON request body sent to the LLM provider.\nThese defaults are merged with the user-provided request to ensure missing fields are populated.\n\nUser input fields here refer to the fields in the JSON request body that a client sends when making a request to the LLM provider.\nDefaults set here do _not_ override those user-provided values unless you explicitly set `override` to `true`.\n\nExample: Setting a default system field for Anthropic, which does not support system role messages:\n\n\tdefaults:\n\t  - field: \"system\"\n\t    value: \"answer all questions in French\"\n\nExample: Setting a default temperature and overriding `max_tokens`:\n\n\tdefaults:\n\t  - field: \"temperature\"\n\t    value: \"0.5\"\n\t  - field: \"max_tokens\"\n\t    value: \"100\"\n\t    override: true\n\nExample: Setting custom lists fields:\n\n\tdefaults:\n\t  - field: \"custom_integer_list\"\n\t    value: [1,2,3]\n\n\toverrides:\n\t  - field: \"custom_string_list\"\n\t    value: [\"one\",\"two\",\"three\"]\n\nNote: The `field` values correspond to keys in the JSON request body, not fields in this CRD.",
+                    "properties": {
+                      "field": {
+                        "allOf": [
+                          {
+                            "minLength": 1
+                          },
+                          {
+                            "minLength": 1
+                          }
+                        ],
+                        "description": "Name of the field.",
+                        "maxLength": 256,
+                        "type": "string"
+                      },
+                      "value": {
+                        "description": "Default value for the field. This can be any JSON data type.",
+                        "x-kubernetes-preserve-unknown-fields": true
+                      }
+                    },
+                    "required": [
+                      "field",
+                      "value"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "maxItems": 64,
+                  "minItems": 1,
+                  "type": "array"
+                },
+                "prompt": {
+                  "description": "Enriches requests sent to the LLM provider by appending and prepending system prompts. This can be configured only for\nLLM providers that use the `CHAT` or `CHAT_STREAMING` API route type.",
+                  "properties": {
+                    "append": {
+                      "description": "Messages to append to the prompt sent by the client.",
+                      "items": {
+                        "description": "An entry for a message to prepend or append to each prompt.",
+                        "properties": {
+                          "content": {
+                            "description": "String content of the message.",
+                            "type": "string"
+                          },
+                          "role": {
+                            "description": "Role of the message. The available roles depend on the backend\nLLM provider model, such as `SYSTEM` or `USER` in the OpenAI API.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "content",
+                          "role"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "prepend": {
+                      "description": "Messages to prepend to the prompt sent by the client.",
+                      "items": {
+                        "description": "An entry for a message to prepend or append to each prompt.",
+                        "properties": {
+                          "content": {
+                            "description": "String content of the message.",
+                            "type": "string"
+                          },
+                          "role": {
+                            "description": "Role of the message. The available roles depend on the backend\nLLM provider model, such as `SYSTEM` or `USER` in the OpenAI API.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "content",
+                          "role"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "promptCaching": {
+                  "description": "Automatic prompt caching for supported\nproviders, currently AWS Bedrock.\nReduces API costs by caching static content like system prompts and tool definitions.\nOnly applicable for Bedrock Claude 3+ and Nova models.",
+                  "properties": {
+                    "cacheMessageOffset": {
+                      "default": 0,
+                      "description": "Shifts the message cache point further back in the\nconversation. 0 (default) places it at the second-to-last message.\nHigher values move it N additional messages towards the start, clamped\nto bounds.",
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "cacheMessages": {
+                      "default": true,
+                      "description": "Enables caching for conversation messages.\nCaches all messages in the conversation for cost savings.",
+                      "type": "boolean"
+                    },
+                    "cacheSystem": {
+                      "default": true,
+                      "description": "Enables caching for system prompts.\nInserts a cache point after all system messages.",
+                      "type": "boolean"
+                    },
+                    "cacheTools": {
+                      "default": false,
+                      "description": "Enables caching for tool definitions.\nInserts a cache point after all tool specifications.",
+                      "type": "boolean"
+                    },
+                    "minTokens": {
+                      "default": 1024,
+                      "description": "Minimum estimated token count\nbefore caching is enabled. Uses rough heuristic (word count \u00d7 1.3) to estimate tokens.\nBedrock requires at least 1,024 tokens for caching to be effective.",
+                      "minimum": 0,
+                      "type": "integer"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "promptGuard": {
+                  "description": "Guardrails for LLM requests and responses.",
+                  "properties": {
+                    "request": {
+                      "description": "Prompt guards to apply to requests sent by the client.",
+                      "items": {
+                        "description": "Prompt guards to apply to requests sent by the client.",
+                        "properties": {
+                          "bedrockGuardrails": {
+                            "description": "AWS Bedrock Guardrails settings for prompt\nguarding.",
+                            "properties": {
+                              "identifier": {
+                                "description": "Identifier of the Guardrail policy to use for the backend.",
+                                "maxLength": 256,
+                                "minLength": 1,
+                                "type": "string"
+                              },
+                              "policies": {
+                                "description": "Policies for communicating with AWS Bedrock Guardrails.",
+                                "properties": {
+                                  "auth": {
+                                    "description": "Settings for managing authentication to the backend.",
+                                    "properties": {
+                                      "aws": {
+                                        "description": "Explicit AWS authentication method for the backend.\nWhen omitted, default AWS SDK credential discovery is used.",
+                                        "properties": {
+                                          "assumeRole": {
+                                            "description": "AWS STS AssumeRole settings to use before signing backend requests.\nAmbient AWS credentials are used as the source credentials for STS.",
+                                            "properties": {
+                                              "roleArn": {
+                                                "description": "AWS IAM role ARN to assume.",
+                                                "minLength": 1,
+                                                "pattern": "^arn:aws[a-z-]*:iam::[0-9]{12}:role/.+$",
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "roleArn"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "secretRef": {
+                                            "description": "Credential source, defaulting to a Kubernetes\n`Secret`, containing the AWS credentials. When using the default Secret\nresolver, the `Secret` must have keys `accessKey`, `secretKey`, and\noptionally `sessionToken`.",
+                                            "properties": {
+                                              "group": {
+                                                "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                                                "type": "string"
+                                              },
+                                              "kind": {
+                                                "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "description": "The name of the referenced credential.",
+                                                "maxLength": 253,
+                                                "minLength": 1,
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name"
+                                            ],
+                                            "type": "object",
+                                            "x-kubernetes-map-type": "atomic",
+                                            "x-kubernetes-validations": [
+                                              {
+                                                "message": "custom credential refs must set both group and kind",
+                                                "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                                              }
+                                            ],
+                                            "additionalProperties": false
+                                          },
+                                          "serviceName": {
+                                            "description": "AWS SigV4 signing service name, for example\n`bedrock`, `bedrock-agentcore`, or `execute-api`). If unset, typed AWS\nbackends may provide this automatically.",
+                                            "maxLength": 256,
+                                            "minLength": 1,
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "secretRef and assumeRole are mutually exclusive",
+                                            "rule": "!(has(self.secretRef) && has(self.assumeRole))"
+                                          }
+                                        ],
+                                        "additionalProperties": false
+                                      },
+                                      "azure": {
+                                        "description": "Azure authentication method for the backend.",
+                                        "properties": {
+                                          "managedIdentity": {
+                                            "description": "Managed identity authentication settings.",
+                                            "properties": {
+                                              "clientId": {
+                                                "type": "string"
+                                              },
+                                              "objectId": {
+                                                "type": "string"
+                                              },
+                                              "resourceId": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "clientId",
+                                              "objectId",
+                                              "resourceId"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "secretRef": {
+                                            "description": "Credential source, defaulting to a Kubernetes\n`Secret`, containing the Azure credentials. When using the default Secret\nresolver, the `Secret` must have keys `clientID`, `tenantID`, and\n`clientSecret`.",
+                                            "properties": {
+                                              "group": {
+                                                "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                                                "type": "string"
+                                              },
+                                              "kind": {
+                                                "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "description": "The name of the referenced credential.",
+                                                "maxLength": 253,
+                                                "minLength": 1,
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name"
+                                            ],
+                                            "type": "object",
+                                            "x-kubernetes-map-type": "atomic",
+                                            "x-kubernetes-validations": [
+                                              {
+                                                "message": "custom credential refs must set both group and kind",
+                                                "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                                              }
+                                            ],
+                                            "additionalProperties": false
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "gcp": {
+                                        "description": "Google authentication method for the backend.\nWhen omitted, default Google credential discovery is used.",
+                                        "properties": {
+                                          "audience": {
+                                            "description": "Explicit `aud` value for the ID token. Only\nvalid with `IdToken` type. If not set, the `aud` is automatically\nderived from the backend hostname.",
+                                            "maxLength": 256,
+                                            "minLength": 1,
+                                            "type": "string"
+                                          },
+                                          "secretRef": {
+                                            "description": "Credential source, defaulting to a Kubernetes\n`Secret`, containing ADC-compatible Google credential JSON. When using\nthe default Secret resolver, this must be stored in the `credentials.json`\nkey. When omitted, ambient credentials are used.",
+                                            "properties": {
+                                              "group": {
+                                                "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                                                "type": "string"
+                                              },
+                                              "kind": {
+                                                "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "description": "The name of the referenced credential.",
+                                                "maxLength": 253,
+                                                "minLength": 1,
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name"
+                                            ],
+                                            "type": "object",
+                                            "x-kubernetes-map-type": "atomic",
+                                            "x-kubernetes-validations": [
+                                              {
+                                                "message": "custom credential refs must set both group and kind",
+                                                "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                                              }
+                                            ],
+                                            "additionalProperties": false
+                                          },
+                                          "type": {
+                                            "description": "The type of token to generate. To authenticate to GCP services,\ngenerally an `AccessToken` is used. To authenticate to Cloud Run, an\n`IdToken` is used.",
+                                            "enum": [
+                                              "AccessToken",
+                                              "IdToken"
+                                            ],
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "audience is only valid with IdToken",
+                                            "rule": "has(self.audience) ? self.type == 'IdToken' : true"
+                                          }
+                                        ],
+                                        "additionalProperties": false
+                                      },
+                                      "key": {
+                                        "description": "Inline key to use as the value of the\n`Authorization` header. This option is the least secure; usage of a\n`Secret` is preferred.",
+                                        "maxLength": 2048,
+                                        "type": "string"
+                                      },
+                                      "location": {
+                                        "description": "Where backend credentials are inserted.\nIf omitted, credentials are written to the `Authorization` header with the `Bearer ` prefix.\nThis applies to `key`, `secretRef`, and `passthrough`.",
+                                        "properties": {
+                                          "cookie": {
+                                            "properties": {
+                                              "name": {
+                                                "maxLength": 256,
+                                                "minLength": 1,
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "header": {
+                                            "properties": {
+                                              "name": {
+                                                "description": "HTTPHeaderName is the name of an HTTP header.\n\nValid values include:\n\n* \"Authorization\"\n* \"Set-Cookie\"\n\nInvalid values include:\n\n  - \":method\" - \":\" is an invalid character. This means that HTTP/2 pseudo\n    headers are not currently supported by this type.\n  - \"/invalid\" - \"/ \" is an invalid character",
+                                                "maxLength": 256,
+                                                "minLength": 1,
+                                                "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                                                "type": "string"
+                                              },
+                                              "prefix": {
+                                                "maxLength": 256,
+                                                "minLength": 1,
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "queryParameter": {
+                                            "properties": {
+                                              "name": {
+                                                "maxLength": 256,
+                                                "minLength": 1,
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          }
+                                        },
+                                        "type": "object",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "exactly one of the fields in [header queryParameter cookie] must be set",
+                                            "rule": "[has(self.header),has(self.queryParameter),has(self.cookie)].filter(x,x==true).size() == 1"
+                                          }
+                                        ],
+                                        "additionalProperties": false
+                                      },
+                                      "passthrough": {
+                                        "description": "Passes through an existing token that has been sent by the\nclient and validated. Other policies, like JWT and API key\nauthentication, will strip the original client credentials. Passthrough backend authentication\ncauses the original token to be added back into the request. If there are no client authentication policies on the\nrequest, the original token would be unchanged, so this would have no effect.",
+                                        "type": "object"
+                                      },
+                                      "secretRef": {
+                                        "description": "Credential source, defaulting to a Kubernetes\n`Secret`, storing the key to use as the authorization value. When using\nthe default Secret resolver, this must be stored in the `Authorization`\nkey.",
+                                        "properties": {
+                                          "group": {
+                                            "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                                            "type": "string"
+                                          },
+                                          "kind": {
+                                            "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "description": "The name of the referenced credential.",
+                                            "maxLength": 253,
+                                            "minLength": 1,
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "name"
+                                        ],
+                                        "type": "object",
+                                        "x-kubernetes-map-type": "atomic",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "custom credential refs must set both group and kind",
+                                            "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                                          }
+                                        ],
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "x-kubernetes-validations": [
+                                      {
+                                        "message": "location may only be set for key or passthrough auth",
+                                        "rule": "has(self.location) ? has(self.key) || has(self.secretRef) || has(self.passthrough) : true"
+                                      },
+                                      {
+                                        "message": "exactly one of the fields in [key secretRef passthrough aws azure gcp] must be set",
+                                        "rule": "[has(self.key),has(self.secretRef),has(self.passthrough),has(self.aws),has(self.azure),has(self.gcp)].filter(x,x==true).size() == 1"
+                                      }
+                                    ],
+                                    "additionalProperties": false
+                                  },
+                                  "http": {
+                                    "description": "Settings for managing HTTP requests to the backend.",
+                                    "properties": {
+                                      "requestTimeout": {
+                                        "description": "Deadline for receiving a response from the backend.",
+                                        "type": "string",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "invalid duration value",
+                                            "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                          },
+                                          {
+                                            "message": "requestTimeout must be at least 1ms",
+                                            "rule": "duration(self) >= duration('1ms')"
+                                          }
+                                        ]
+                                      },
+                                      "version": {
+                                        "description": "HTTP protocol version to use when connecting to\nthe backend.\nIf not specified, the version is automatically determined:\n* `Service` types can specify it with `appProtocol` on the `Service`\n  port.\n* If traffic is identified as gRPC, `HTTP2` is used.\n* If the incoming traffic was plaintext HTTP, the original protocol will\n  be used.\n* If the incoming traffic was HTTPS, `HTTP1` will be used. This is\n  because most clients will transparently upgrade HTTPS traffic to\n  `HTTP2`, even if the backend doesn't support it.",
+                                        "enum": [
+                                          "HTTP1",
+                                          "HTTP2"
+                                        ],
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "tcp": {
+                                    "description": "Settings for managing TCP connections to the backend.",
+                                    "properties": {
+                                      "connectTimeout": {
+                                        "description": "Deadline for establishing a connection to\nthe destination.",
+                                        "type": "string",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "invalid duration value",
+                                            "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                          },
+                                          {
+                                            "message": "connectTimeout must be at least 100ms",
+                                            "rule": "duration(self) >= duration('100ms')"
+                                          }
+                                        ]
+                                      },
+                                      "keepalive": {
+                                        "description": "Settings for enabling TCP keepalives on the\nconnection.",
+                                        "properties": {
+                                          "interval": {
+                                            "description": "Time between keepalive probes.\nIf unset, this defaults to 180s.",
+                                            "type": "string",
+                                            "x-kubernetes-validations": [
+                                              {
+                                                "message": "invalid duration value",
+                                                "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                              },
+                                              {
+                                                "message": "interval must be at least 1 second",
+                                                "rule": "duration(self) >= duration('1s')"
+                                              }
+                                            ]
+                                          },
+                                          "retries": {
+                                            "description": "Maximum number of keepalive probes to send before dropping the connection.\nIf unset, this defaults to 9.",
+                                            "format": "int32",
+                                            "maximum": 64,
+                                            "minimum": 1,
+                                            "type": "integer"
+                                          },
+                                          "time": {
+                                            "description": "Time a connection needs to be idle before keepalive probes start being sent.\nIf unset, this defaults to 180s.",
+                                            "type": "string",
+                                            "x-kubernetes-validations": [
+                                              {
+                                                "message": "invalid duration value",
+                                                "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                              },
+                                              {
+                                                "message": "time must be at least 1 second",
+                                                "rule": "duration(self) >= duration('1s')"
+                                              }
+                                            ]
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "tls": {
+                                    "description": "Settings for managing TLS connections to the backend.\n\nIf this field is set, TLS will be initiated to the backend; the system trusted CA certificates will be used to\nvalidate the server, and the SNI will automatically be set based on the destination.",
+                                    "properties": {
+                                      "alpnProtocols": {
+                                        "description": "Application-Layer Protocol Negotiation (`ALPN`)\nvalue to use in the TLS handshake.\n\nIf not present, defaults to `[\"h2\", \"http/1.1\"]`.",
+                                        "items": {
+                                          "maxLength": 64,
+                                          "minLength": 1,
+                                          "type": "string"
+                                        },
+                                        "maxItems": 16,
+                                        "minItems": 1,
+                                        "type": "array"
+                                      },
+                                      "caCertificateRefs": {
+                                        "description": "CA certificate `ConfigMap` to use to\nverify the server certificate.\nIf unset, the system's trusted certificates are used.",
+                                        "items": {
+                                          "description": "LocalObjectReference contains enough information to let you locate the\nreferenced object inside the same namespace.",
+                                          "properties": {
+                                            "name": {
+                                              "default": "",
+                                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "x-kubernetes-map-type": "atomic",
+                                          "additionalProperties": false
+                                        },
+                                        "maxItems": 1,
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
+                                      },
+                                      "insecureSkipVerify": {
+                                        "description": "Originates TLS but skips verification of the backend's certificate.\nWARNING: This is an insecure option that should only be used if the risks are understood.\n\nThere are two modes:\n* `All` disables all TLS verification.\n* `Hostname` verifies the CA certificate is trusted, but ignores any\n  mismatch of hostname or SANs. Note that this method is still insecure;\n  prefer setting `verifySubjectAltNames` to customize the valid hostnames\n  if possible.",
+                                        "enum": [
+                                          "All",
+                                          "Hostname"
+                                        ],
+                                        "type": "string"
+                                      },
+                                      "keyExchangeGroups": {
+                                        "description": "Ordered list of key exchange groups for a TLS connection.\nFor example: `X25519_MLKEM768,X25519`.",
+                                        "items": {
+                                          "enum": [
+                                            "P-256",
+                                            "P-384",
+                                            "X25519",
+                                            "X25519_MLKEM768"
+                                          ],
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "mtlsCertificateRef": {
+                                        "description": "Enables mutual TLS to the backend, using the\nspecified key (`tls.key`) and cert (`tls.crt`) from the referenced\ncredential source, defaulting to a Kubernetes `Secret`.\n\nAn optional `ca.cert` field, if present, will be used to verify the\nserver certificate. If `caCertificateRefs` is also specified, the\n`caCertificateRefs` field takes priority.\n\nIf unspecified, no client certificate will be used.",
+                                        "items": {
+                                          "description": "References a same-namespace credential.\nSet only `name` to reference a Kubernetes Secret.",
+                                          "properties": {
+                                            "group": {
+                                              "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                                              "type": "string"
+                                            },
+                                            "kind": {
+                                              "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "description": "The name of the referenced credential.",
+                                              "maxLength": 253,
+                                              "minLength": 1,
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "name"
+                                          ],
+                                          "type": "object",
+                                          "x-kubernetes-map-type": "atomic",
+                                          "x-kubernetes-validations": [
+                                            {
+                                              "message": "custom credential refs must set both group and kind",
+                                              "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                                            }
+                                          ],
+                                          "additionalProperties": false
+                                        },
+                                        "maxItems": 1,
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
+                                      },
+                                      "sni": {
+                                        "description": "Server Name Indicator (`SNI`) to use in the TLS\nhandshake. If unset, the `SNI` is automatically set based on the\ndestination hostname.",
+                                        "maxLength": 253,
+                                        "minLength": 1,
+                                        "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                                        "type": "string"
+                                      },
+                                      "verifySubjectAltNames": {
+                                        "description": "Subject Alternative Names (`SAN`)\nto verify in the server certificate.\nIf not present, the destination hostname is automatically used.",
+                                        "items": {
+                                          "maxLength": 256,
+                                          "minLength": 1,
+                                          "type": "string"
+                                        },
+                                        "maxItems": 16,
+                                        "minItems": 1,
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "x-kubernetes-validations": [
+                                      {
+                                        "message": "insecureSkipVerify All and caCertificateRefs may not be set together",
+                                        "rule": "has(self.insecureSkipVerify) && self.insecureSkipVerify == 'All' ? !has(self.caCertificateRefs) : true"
+                                      },
+                                      {
+                                        "message": "insecureSkipVerify and verifySubjectAltNames may not be set together",
+                                        "rule": "has(self.insecureSkipVerify) ? !has(self.verifySubjectAltNames) : true"
+                                      },
+                                      {
+                                        "message": "at most one of the fields in [verifySubjectAltNames insecureSkipVerify] may be set",
+                                        "rule": "[has(self.verifySubjectAltNames),has(self.insecureSkipVerify)].filter(x,x==true).size() <= 1"
+                                      }
+                                    ],
+                                    "additionalProperties": false
+                                  },
+                                  "tunnel": {
+                                    "description": "Settings for managing tunnel connections, with behavior like `HTTPS_PROXY`, to the backend.",
+                                    "properties": {
+                                      "backendRef": {
+                                        "description": "Proxy server to reach.\nSupported types: `Service` and `Backend`.",
+                                        "properties": {
+                                          "group": {
+                                            "default": "",
+                                            "description": "Group is the group of the referent. For example, \"gateway.networking.k8s.io\".\nWhen unspecified or empty string, core API group is inferred.",
+                                            "maxLength": 253,
+                                            "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                                            "type": "string"
+                                          },
+                                          "kind": {
+                                            "default": "Service",
+                                            "description": "Kind is the Kubernetes resource kind of the referent. For example\n\"Service\".\n\nDefaults to \"Service\" when not specified.\n\nExternalName services can refer to CNAME DNS records that may live\noutside of the cluster and as such are difficult to reason about in\nterms of conformance. They also may not be safe to forward to (see\nCVE-2021-25740 for more information). Implementations SHOULD NOT\nsupport ExternalName Services.\n\nSupport: Core (Services with a type other than ExternalName)\n\nSupport: Implementation-specific (Services with type ExternalName)",
+                                            "maxLength": 63,
+                                            "minLength": 1,
+                                            "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "description": "Name is the name of the referent.",
+                                            "maxLength": 253,
+                                            "minLength": 1,
+                                            "type": "string"
+                                          },
+                                          "namespace": {
+                                            "description": "Namespace is the namespace of the backend. When unspecified, the local\nnamespace is inferred.\n\nNote that when a namespace different than the local namespace is specified,\na ReferenceGrant object is required in the referent namespace to allow that\nnamespace's owner to accept the reference. See the ReferenceGrant\ndocumentation for details.\n\nSupport: Core",
+                                            "maxLength": 63,
+                                            "minLength": 1,
+                                            "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "description": "Port specifies the destination port number to use for this resource.\nPort is required when the referent is a Kubernetes Service. In this\ncase, the port number is the service port number, not the target port.\nFor other resources, destination port might be derived from the referent\nresource or this field.",
+                                            "format": "int32",
+                                            "maximum": 65535,
+                                            "minimum": 1,
+                                            "type": "integer"
+                                          }
+                                        },
+                                        "required": [
+                                          "name"
+                                        ],
+                                        "type": "object",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "Must have port for Service reference",
+                                            "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
+                                          }
+                                        ],
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "required": [
+                                      "backendRef"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "region": {
+                                "description": "AWS region where the guardrail is deployed, for example\n`us-west-2`).",
+                                "maxLength": 256,
+                                "minLength": 1,
+                                "type": "string"
+                              },
+                              "version": {
+                                "description": "Version of the Guardrail policy to use for the backend.",
+                                "maxLength": 256,
+                                "minLength": 1,
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "identifier",
+                              "region",
+                              "version"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "googleModelArmor": {
+                            "description": "Google Model Armor settings for prompt guarding.",
+                            "properties": {
+                              "location": {
+                                "default": "us-central1",
+                                "description": "Google Cloud location, for example `us-central1`.\nDefaults to `us-central1` if not specified.",
+                                "maxLength": 256,
+                                "minLength": 1,
+                                "type": "string"
+                              },
+                              "policies": {
+                                "description": "Policies for communicating with Google Model Armor.",
+                                "properties": {
+                                  "auth": {
+                                    "description": "Settings for managing authentication to the backend.",
+                                    "properties": {
+                                      "aws": {
+                                        "description": "Explicit AWS authentication method for the backend.\nWhen omitted, default AWS SDK credential discovery is used.",
+                                        "properties": {
+                                          "assumeRole": {
+                                            "description": "AWS STS AssumeRole settings to use before signing backend requests.\nAmbient AWS credentials are used as the source credentials for STS.",
+                                            "properties": {
+                                              "roleArn": {
+                                                "description": "AWS IAM role ARN to assume.",
+                                                "minLength": 1,
+                                                "pattern": "^arn:aws[a-z-]*:iam::[0-9]{12}:role/.+$",
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "roleArn"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "secretRef": {
+                                            "description": "Credential source, defaulting to a Kubernetes\n`Secret`, containing the AWS credentials. When using the default Secret\nresolver, the `Secret` must have keys `accessKey`, `secretKey`, and\noptionally `sessionToken`.",
+                                            "properties": {
+                                              "group": {
+                                                "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                                                "type": "string"
+                                              },
+                                              "kind": {
+                                                "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "description": "The name of the referenced credential.",
+                                                "maxLength": 253,
+                                                "minLength": 1,
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name"
+                                            ],
+                                            "type": "object",
+                                            "x-kubernetes-map-type": "atomic",
+                                            "x-kubernetes-validations": [
+                                              {
+                                                "message": "custom credential refs must set both group and kind",
+                                                "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                                              }
+                                            ],
+                                            "additionalProperties": false
+                                          },
+                                          "serviceName": {
+                                            "description": "AWS SigV4 signing service name, for example\n`bedrock`, `bedrock-agentcore`, or `execute-api`). If unset, typed AWS\nbackends may provide this automatically.",
+                                            "maxLength": 256,
+                                            "minLength": 1,
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "secretRef and assumeRole are mutually exclusive",
+                                            "rule": "!(has(self.secretRef) && has(self.assumeRole))"
+                                          }
+                                        ],
+                                        "additionalProperties": false
+                                      },
+                                      "azure": {
+                                        "description": "Azure authentication method for the backend.",
+                                        "properties": {
+                                          "managedIdentity": {
+                                            "description": "Managed identity authentication settings.",
+                                            "properties": {
+                                              "clientId": {
+                                                "type": "string"
+                                              },
+                                              "objectId": {
+                                                "type": "string"
+                                              },
+                                              "resourceId": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "clientId",
+                                              "objectId",
+                                              "resourceId"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "secretRef": {
+                                            "description": "Credential source, defaulting to a Kubernetes\n`Secret`, containing the Azure credentials. When using the default Secret\nresolver, the `Secret` must have keys `clientID`, `tenantID`, and\n`clientSecret`.",
+                                            "properties": {
+                                              "group": {
+                                                "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                                                "type": "string"
+                                              },
+                                              "kind": {
+                                                "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "description": "The name of the referenced credential.",
+                                                "maxLength": 253,
+                                                "minLength": 1,
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name"
+                                            ],
+                                            "type": "object",
+                                            "x-kubernetes-map-type": "atomic",
+                                            "x-kubernetes-validations": [
+                                              {
+                                                "message": "custom credential refs must set both group and kind",
+                                                "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                                              }
+                                            ],
+                                            "additionalProperties": false
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "gcp": {
+                                        "description": "Google authentication method for the backend.\nWhen omitted, default Google credential discovery is used.",
+                                        "properties": {
+                                          "audience": {
+                                            "description": "Explicit `aud` value for the ID token. Only\nvalid with `IdToken` type. If not set, the `aud` is automatically\nderived from the backend hostname.",
+                                            "maxLength": 256,
+                                            "minLength": 1,
+                                            "type": "string"
+                                          },
+                                          "secretRef": {
+                                            "description": "Credential source, defaulting to a Kubernetes\n`Secret`, containing ADC-compatible Google credential JSON. When using\nthe default Secret resolver, this must be stored in the `credentials.json`\nkey. When omitted, ambient credentials are used.",
+                                            "properties": {
+                                              "group": {
+                                                "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                                                "type": "string"
+                                              },
+                                              "kind": {
+                                                "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "description": "The name of the referenced credential.",
+                                                "maxLength": 253,
+                                                "minLength": 1,
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name"
+                                            ],
+                                            "type": "object",
+                                            "x-kubernetes-map-type": "atomic",
+                                            "x-kubernetes-validations": [
+                                              {
+                                                "message": "custom credential refs must set both group and kind",
+                                                "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                                              }
+                                            ],
+                                            "additionalProperties": false
+                                          },
+                                          "type": {
+                                            "description": "The type of token to generate. To authenticate to GCP services,\ngenerally an `AccessToken` is used. To authenticate to Cloud Run, an\n`IdToken` is used.",
+                                            "enum": [
+                                              "AccessToken",
+                                              "IdToken"
+                                            ],
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "audience is only valid with IdToken",
+                                            "rule": "has(self.audience) ? self.type == 'IdToken' : true"
+                                          }
+                                        ],
+                                        "additionalProperties": false
+                                      },
+                                      "key": {
+                                        "description": "Inline key to use as the value of the\n`Authorization` header. This option is the least secure; usage of a\n`Secret` is preferred.",
+                                        "maxLength": 2048,
+                                        "type": "string"
+                                      },
+                                      "location": {
+                                        "description": "Where backend credentials are inserted.\nIf omitted, credentials are written to the `Authorization` header with the `Bearer ` prefix.\nThis applies to `key`, `secretRef`, and `passthrough`.",
+                                        "properties": {
+                                          "cookie": {
+                                            "properties": {
+                                              "name": {
+                                                "maxLength": 256,
+                                                "minLength": 1,
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "header": {
+                                            "properties": {
+                                              "name": {
+                                                "description": "HTTPHeaderName is the name of an HTTP header.\n\nValid values include:\n\n* \"Authorization\"\n* \"Set-Cookie\"\n\nInvalid values include:\n\n  - \":method\" - \":\" is an invalid character. This means that HTTP/2 pseudo\n    headers are not currently supported by this type.\n  - \"/invalid\" - \"/ \" is an invalid character",
+                                                "maxLength": 256,
+                                                "minLength": 1,
+                                                "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                                                "type": "string"
+                                              },
+                                              "prefix": {
+                                                "maxLength": 256,
+                                                "minLength": 1,
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "queryParameter": {
+                                            "properties": {
+                                              "name": {
+                                                "maxLength": 256,
+                                                "minLength": 1,
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          }
+                                        },
+                                        "type": "object",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "exactly one of the fields in [header queryParameter cookie] must be set",
+                                            "rule": "[has(self.header),has(self.queryParameter),has(self.cookie)].filter(x,x==true).size() == 1"
+                                          }
+                                        ],
+                                        "additionalProperties": false
+                                      },
+                                      "passthrough": {
+                                        "description": "Passes through an existing token that has been sent by the\nclient and validated. Other policies, like JWT and API key\nauthentication, will strip the original client credentials. Passthrough backend authentication\ncauses the original token to be added back into the request. If there are no client authentication policies on the\nrequest, the original token would be unchanged, so this would have no effect.",
+                                        "type": "object"
+                                      },
+                                      "secretRef": {
+                                        "description": "Credential source, defaulting to a Kubernetes\n`Secret`, storing the key to use as the authorization value. When using\nthe default Secret resolver, this must be stored in the `Authorization`\nkey.",
+                                        "properties": {
+                                          "group": {
+                                            "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                                            "type": "string"
+                                          },
+                                          "kind": {
+                                            "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "description": "The name of the referenced credential.",
+                                            "maxLength": 253,
+                                            "minLength": 1,
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "name"
+                                        ],
+                                        "type": "object",
+                                        "x-kubernetes-map-type": "atomic",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "custom credential refs must set both group and kind",
+                                            "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                                          }
+                                        ],
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "x-kubernetes-validations": [
+                                      {
+                                        "message": "location may only be set for key or passthrough auth",
+                                        "rule": "has(self.location) ? has(self.key) || has(self.secretRef) || has(self.passthrough) : true"
+                                      },
+                                      {
+                                        "message": "exactly one of the fields in [key secretRef passthrough aws azure gcp] must be set",
+                                        "rule": "[has(self.key),has(self.secretRef),has(self.passthrough),has(self.aws),has(self.azure),has(self.gcp)].filter(x,x==true).size() == 1"
+                                      }
+                                    ],
+                                    "additionalProperties": false
+                                  },
+                                  "http": {
+                                    "description": "Settings for managing HTTP requests to the backend.",
+                                    "properties": {
+                                      "requestTimeout": {
+                                        "description": "Deadline for receiving a response from the backend.",
+                                        "type": "string",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "invalid duration value",
+                                            "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                          },
+                                          {
+                                            "message": "requestTimeout must be at least 1ms",
+                                            "rule": "duration(self) >= duration('1ms')"
+                                          }
+                                        ]
+                                      },
+                                      "version": {
+                                        "description": "HTTP protocol version to use when connecting to\nthe backend.\nIf not specified, the version is automatically determined:\n* `Service` types can specify it with `appProtocol` on the `Service`\n  port.\n* If traffic is identified as gRPC, `HTTP2` is used.\n* If the incoming traffic was plaintext HTTP, the original protocol will\n  be used.\n* If the incoming traffic was HTTPS, `HTTP1` will be used. This is\n  because most clients will transparently upgrade HTTPS traffic to\n  `HTTP2`, even if the backend doesn't support it.",
+                                        "enum": [
+                                          "HTTP1",
+                                          "HTTP2"
+                                        ],
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "tcp": {
+                                    "description": "Settings for managing TCP connections to the backend.",
+                                    "properties": {
+                                      "connectTimeout": {
+                                        "description": "Deadline for establishing a connection to\nthe destination.",
+                                        "type": "string",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "invalid duration value",
+                                            "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                          },
+                                          {
+                                            "message": "connectTimeout must be at least 100ms",
+                                            "rule": "duration(self) >= duration('100ms')"
+                                          }
+                                        ]
+                                      },
+                                      "keepalive": {
+                                        "description": "Settings for enabling TCP keepalives on the\nconnection.",
+                                        "properties": {
+                                          "interval": {
+                                            "description": "Time between keepalive probes.\nIf unset, this defaults to 180s.",
+                                            "type": "string",
+                                            "x-kubernetes-validations": [
+                                              {
+                                                "message": "invalid duration value",
+                                                "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                              },
+                                              {
+                                                "message": "interval must be at least 1 second",
+                                                "rule": "duration(self) >= duration('1s')"
+                                              }
+                                            ]
+                                          },
+                                          "retries": {
+                                            "description": "Maximum number of keepalive probes to send before dropping the connection.\nIf unset, this defaults to 9.",
+                                            "format": "int32",
+                                            "maximum": 64,
+                                            "minimum": 1,
+                                            "type": "integer"
+                                          },
+                                          "time": {
+                                            "description": "Time a connection needs to be idle before keepalive probes start being sent.\nIf unset, this defaults to 180s.",
+                                            "type": "string",
+                                            "x-kubernetes-validations": [
+                                              {
+                                                "message": "invalid duration value",
+                                                "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                              },
+                                              {
+                                                "message": "time must be at least 1 second",
+                                                "rule": "duration(self) >= duration('1s')"
+                                              }
+                                            ]
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "tls": {
+                                    "description": "Settings for managing TLS connections to the backend.\n\nIf this field is set, TLS will be initiated to the backend; the system trusted CA certificates will be used to\nvalidate the server, and the SNI will automatically be set based on the destination.",
+                                    "properties": {
+                                      "alpnProtocols": {
+                                        "description": "Application-Layer Protocol Negotiation (`ALPN`)\nvalue to use in the TLS handshake.\n\nIf not present, defaults to `[\"h2\", \"http/1.1\"]`.",
+                                        "items": {
+                                          "maxLength": 64,
+                                          "minLength": 1,
+                                          "type": "string"
+                                        },
+                                        "maxItems": 16,
+                                        "minItems": 1,
+                                        "type": "array"
+                                      },
+                                      "caCertificateRefs": {
+                                        "description": "CA certificate `ConfigMap` to use to\nverify the server certificate.\nIf unset, the system's trusted certificates are used.",
+                                        "items": {
+                                          "description": "LocalObjectReference contains enough information to let you locate the\nreferenced object inside the same namespace.",
+                                          "properties": {
+                                            "name": {
+                                              "default": "",
+                                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "x-kubernetes-map-type": "atomic",
+                                          "additionalProperties": false
+                                        },
+                                        "maxItems": 1,
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
+                                      },
+                                      "insecureSkipVerify": {
+                                        "description": "Originates TLS but skips verification of the backend's certificate.\nWARNING: This is an insecure option that should only be used if the risks are understood.\n\nThere are two modes:\n* `All` disables all TLS verification.\n* `Hostname` verifies the CA certificate is trusted, but ignores any\n  mismatch of hostname or SANs. Note that this method is still insecure;\n  prefer setting `verifySubjectAltNames` to customize the valid hostnames\n  if possible.",
+                                        "enum": [
+                                          "All",
+                                          "Hostname"
+                                        ],
+                                        "type": "string"
+                                      },
+                                      "keyExchangeGroups": {
+                                        "description": "Ordered list of key exchange groups for a TLS connection.\nFor example: `X25519_MLKEM768,X25519`.",
+                                        "items": {
+                                          "enum": [
+                                            "P-256",
+                                            "P-384",
+                                            "X25519",
+                                            "X25519_MLKEM768"
+                                          ],
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "mtlsCertificateRef": {
+                                        "description": "Enables mutual TLS to the backend, using the\nspecified key (`tls.key`) and cert (`tls.crt`) from the referenced\ncredential source, defaulting to a Kubernetes `Secret`.\n\nAn optional `ca.cert` field, if present, will be used to verify the\nserver certificate. If `caCertificateRefs` is also specified, the\n`caCertificateRefs` field takes priority.\n\nIf unspecified, no client certificate will be used.",
+                                        "items": {
+                                          "description": "References a same-namespace credential.\nSet only `name` to reference a Kubernetes Secret.",
+                                          "properties": {
+                                            "group": {
+                                              "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                                              "type": "string"
+                                            },
+                                            "kind": {
+                                              "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "description": "The name of the referenced credential.",
+                                              "maxLength": 253,
+                                              "minLength": 1,
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "name"
+                                          ],
+                                          "type": "object",
+                                          "x-kubernetes-map-type": "atomic",
+                                          "x-kubernetes-validations": [
+                                            {
+                                              "message": "custom credential refs must set both group and kind",
+                                              "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                                            }
+                                          ],
+                                          "additionalProperties": false
+                                        },
+                                        "maxItems": 1,
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
+                                      },
+                                      "sni": {
+                                        "description": "Server Name Indicator (`SNI`) to use in the TLS\nhandshake. If unset, the `SNI` is automatically set based on the\ndestination hostname.",
+                                        "maxLength": 253,
+                                        "minLength": 1,
+                                        "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                                        "type": "string"
+                                      },
+                                      "verifySubjectAltNames": {
+                                        "description": "Subject Alternative Names (`SAN`)\nto verify in the server certificate.\nIf not present, the destination hostname is automatically used.",
+                                        "items": {
+                                          "maxLength": 256,
+                                          "minLength": 1,
+                                          "type": "string"
+                                        },
+                                        "maxItems": 16,
+                                        "minItems": 1,
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "x-kubernetes-validations": [
+                                      {
+                                        "message": "insecureSkipVerify All and caCertificateRefs may not be set together",
+                                        "rule": "has(self.insecureSkipVerify) && self.insecureSkipVerify == 'All' ? !has(self.caCertificateRefs) : true"
+                                      },
+                                      {
+                                        "message": "insecureSkipVerify and verifySubjectAltNames may not be set together",
+                                        "rule": "has(self.insecureSkipVerify) ? !has(self.verifySubjectAltNames) : true"
+                                      },
+                                      {
+                                        "message": "at most one of the fields in [verifySubjectAltNames insecureSkipVerify] may be set",
+                                        "rule": "[has(self.verifySubjectAltNames),has(self.insecureSkipVerify)].filter(x,x==true).size() <= 1"
+                                      }
+                                    ],
+                                    "additionalProperties": false
+                                  },
+                                  "tunnel": {
+                                    "description": "Settings for managing tunnel connections, with behavior like `HTTPS_PROXY`, to the backend.",
+                                    "properties": {
+                                      "backendRef": {
+                                        "description": "Proxy server to reach.\nSupported types: `Service` and `Backend`.",
+                                        "properties": {
+                                          "group": {
+                                            "default": "",
+                                            "description": "Group is the group of the referent. For example, \"gateway.networking.k8s.io\".\nWhen unspecified or empty string, core API group is inferred.",
+                                            "maxLength": 253,
+                                            "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                                            "type": "string"
+                                          },
+                                          "kind": {
+                                            "default": "Service",
+                                            "description": "Kind is the Kubernetes resource kind of the referent. For example\n\"Service\".\n\nDefaults to \"Service\" when not specified.\n\nExternalName services can refer to CNAME DNS records that may live\noutside of the cluster and as such are difficult to reason about in\nterms of conformance. They also may not be safe to forward to (see\nCVE-2021-25740 for more information). Implementations SHOULD NOT\nsupport ExternalName Services.\n\nSupport: Core (Services with a type other than ExternalName)\n\nSupport: Implementation-specific (Services with type ExternalName)",
+                                            "maxLength": 63,
+                                            "minLength": 1,
+                                            "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "description": "Name is the name of the referent.",
+                                            "maxLength": 253,
+                                            "minLength": 1,
+                                            "type": "string"
+                                          },
+                                          "namespace": {
+                                            "description": "Namespace is the namespace of the backend. When unspecified, the local\nnamespace is inferred.\n\nNote that when a namespace different than the local namespace is specified,\na ReferenceGrant object is required in the referent namespace to allow that\nnamespace's owner to accept the reference. See the ReferenceGrant\ndocumentation for details.\n\nSupport: Core",
+                                            "maxLength": 63,
+                                            "minLength": 1,
+                                            "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "description": "Port specifies the destination port number to use for this resource.\nPort is required when the referent is a Kubernetes Service. In this\ncase, the port number is the service port number, not the target port.\nFor other resources, destination port might be derived from the referent\nresource or this field.",
+                                            "format": "int32",
+                                            "maximum": 65535,
+                                            "minimum": 1,
+                                            "type": "integer"
+                                          }
+                                        },
+                                        "required": [
+                                          "name"
+                                        ],
+                                        "type": "object",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "Must have port for Service reference",
+                                            "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
+                                          }
+                                        ],
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "required": [
+                                      "backendRef"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "projectId": {
+                                "description": "Google Cloud project ID.",
+                                "maxLength": 256,
+                                "minLength": 1,
+                                "type": "string"
+                              },
+                              "templateId": {
+                                "description": "Template ID for Google Model Armor.",
+                                "maxLength": 256,
+                                "minLength": 1,
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "projectId",
+                              "templateId"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "openAIModeration": {
+                            "description": "Passes prompt data through the OpenAI Moderations\nendpoint.\nSee https://developers.openai.com/api/reference/resources/moderations for more information.",
+                            "properties": {
+                              "model": {
+                                "description": "Moderation model to use. For example,\n`omni-moderation`.",
+                                "type": "string"
+                              },
+                              "policies": {
+                                "description": "Policies for communicating with OpenAI.",
+                                "properties": {
+                                  "auth": {
+                                    "description": "Settings for managing authentication to the backend.",
+                                    "properties": {
+                                      "aws": {
+                                        "description": "Explicit AWS authentication method for the backend.\nWhen omitted, default AWS SDK credential discovery is used.",
+                                        "properties": {
+                                          "assumeRole": {
+                                            "description": "AWS STS AssumeRole settings to use before signing backend requests.\nAmbient AWS credentials are used as the source credentials for STS.",
+                                            "properties": {
+                                              "roleArn": {
+                                                "description": "AWS IAM role ARN to assume.",
+                                                "minLength": 1,
+                                                "pattern": "^arn:aws[a-z-]*:iam::[0-9]{12}:role/.+$",
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "roleArn"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "secretRef": {
+                                            "description": "Credential source, defaulting to a Kubernetes\n`Secret`, containing the AWS credentials. When using the default Secret\nresolver, the `Secret` must have keys `accessKey`, `secretKey`, and\noptionally `sessionToken`.",
+                                            "properties": {
+                                              "group": {
+                                                "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                                                "type": "string"
+                                              },
+                                              "kind": {
+                                                "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "description": "The name of the referenced credential.",
+                                                "maxLength": 253,
+                                                "minLength": 1,
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name"
+                                            ],
+                                            "type": "object",
+                                            "x-kubernetes-map-type": "atomic",
+                                            "x-kubernetes-validations": [
+                                              {
+                                                "message": "custom credential refs must set both group and kind",
+                                                "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                                              }
+                                            ],
+                                            "additionalProperties": false
+                                          },
+                                          "serviceName": {
+                                            "description": "AWS SigV4 signing service name, for example\n`bedrock`, `bedrock-agentcore`, or `execute-api`). If unset, typed AWS\nbackends may provide this automatically.",
+                                            "maxLength": 256,
+                                            "minLength": 1,
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "secretRef and assumeRole are mutually exclusive",
+                                            "rule": "!(has(self.secretRef) && has(self.assumeRole))"
+                                          }
+                                        ],
+                                        "additionalProperties": false
+                                      },
+                                      "azure": {
+                                        "description": "Azure authentication method for the backend.",
+                                        "properties": {
+                                          "managedIdentity": {
+                                            "description": "Managed identity authentication settings.",
+                                            "properties": {
+                                              "clientId": {
+                                                "type": "string"
+                                              },
+                                              "objectId": {
+                                                "type": "string"
+                                              },
+                                              "resourceId": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "clientId",
+                                              "objectId",
+                                              "resourceId"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "secretRef": {
+                                            "description": "Credential source, defaulting to a Kubernetes\n`Secret`, containing the Azure credentials. When using the default Secret\nresolver, the `Secret` must have keys `clientID`, `tenantID`, and\n`clientSecret`.",
+                                            "properties": {
+                                              "group": {
+                                                "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                                                "type": "string"
+                                              },
+                                              "kind": {
+                                                "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "description": "The name of the referenced credential.",
+                                                "maxLength": 253,
+                                                "minLength": 1,
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name"
+                                            ],
+                                            "type": "object",
+                                            "x-kubernetes-map-type": "atomic",
+                                            "x-kubernetes-validations": [
+                                              {
+                                                "message": "custom credential refs must set both group and kind",
+                                                "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                                              }
+                                            ],
+                                            "additionalProperties": false
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "gcp": {
+                                        "description": "Google authentication method for the backend.\nWhen omitted, default Google credential discovery is used.",
+                                        "properties": {
+                                          "audience": {
+                                            "description": "Explicit `aud` value for the ID token. Only\nvalid with `IdToken` type. If not set, the `aud` is automatically\nderived from the backend hostname.",
+                                            "maxLength": 256,
+                                            "minLength": 1,
+                                            "type": "string"
+                                          },
+                                          "secretRef": {
+                                            "description": "Credential source, defaulting to a Kubernetes\n`Secret`, containing ADC-compatible Google credential JSON. When using\nthe default Secret resolver, this must be stored in the `credentials.json`\nkey. When omitted, ambient credentials are used.",
+                                            "properties": {
+                                              "group": {
+                                                "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                                                "type": "string"
+                                              },
+                                              "kind": {
+                                                "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "description": "The name of the referenced credential.",
+                                                "maxLength": 253,
+                                                "minLength": 1,
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name"
+                                            ],
+                                            "type": "object",
+                                            "x-kubernetes-map-type": "atomic",
+                                            "x-kubernetes-validations": [
+                                              {
+                                                "message": "custom credential refs must set both group and kind",
+                                                "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                                              }
+                                            ],
+                                            "additionalProperties": false
+                                          },
+                                          "type": {
+                                            "description": "The type of token to generate. To authenticate to GCP services,\ngenerally an `AccessToken` is used. To authenticate to Cloud Run, an\n`IdToken` is used.",
+                                            "enum": [
+                                              "AccessToken",
+                                              "IdToken"
+                                            ],
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "audience is only valid with IdToken",
+                                            "rule": "has(self.audience) ? self.type == 'IdToken' : true"
+                                          }
+                                        ],
+                                        "additionalProperties": false
+                                      },
+                                      "key": {
+                                        "description": "Inline key to use as the value of the\n`Authorization` header. This option is the least secure; usage of a\n`Secret` is preferred.",
+                                        "maxLength": 2048,
+                                        "type": "string"
+                                      },
+                                      "location": {
+                                        "description": "Where backend credentials are inserted.\nIf omitted, credentials are written to the `Authorization` header with the `Bearer ` prefix.\nThis applies to `key`, `secretRef`, and `passthrough`.",
+                                        "properties": {
+                                          "cookie": {
+                                            "properties": {
+                                              "name": {
+                                                "maxLength": 256,
+                                                "minLength": 1,
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "header": {
+                                            "properties": {
+                                              "name": {
+                                                "description": "HTTPHeaderName is the name of an HTTP header.\n\nValid values include:\n\n* \"Authorization\"\n* \"Set-Cookie\"\n\nInvalid values include:\n\n  - \":method\" - \":\" is an invalid character. This means that HTTP/2 pseudo\n    headers are not currently supported by this type.\n  - \"/invalid\" - \"/ \" is an invalid character",
+                                                "maxLength": 256,
+                                                "minLength": 1,
+                                                "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                                                "type": "string"
+                                              },
+                                              "prefix": {
+                                                "maxLength": 256,
+                                                "minLength": 1,
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "queryParameter": {
+                                            "properties": {
+                                              "name": {
+                                                "maxLength": 256,
+                                                "minLength": 1,
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          }
+                                        },
+                                        "type": "object",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "exactly one of the fields in [header queryParameter cookie] must be set",
+                                            "rule": "[has(self.header),has(self.queryParameter),has(self.cookie)].filter(x,x==true).size() == 1"
+                                          }
+                                        ],
+                                        "additionalProperties": false
+                                      },
+                                      "passthrough": {
+                                        "description": "Passes through an existing token that has been sent by the\nclient and validated. Other policies, like JWT and API key\nauthentication, will strip the original client credentials. Passthrough backend authentication\ncauses the original token to be added back into the request. If there are no client authentication policies on the\nrequest, the original token would be unchanged, so this would have no effect.",
+                                        "type": "object"
+                                      },
+                                      "secretRef": {
+                                        "description": "Credential source, defaulting to a Kubernetes\n`Secret`, storing the key to use as the authorization value. When using\nthe default Secret resolver, this must be stored in the `Authorization`\nkey.",
+                                        "properties": {
+                                          "group": {
+                                            "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                                            "type": "string"
+                                          },
+                                          "kind": {
+                                            "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "description": "The name of the referenced credential.",
+                                            "maxLength": 253,
+                                            "minLength": 1,
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "name"
+                                        ],
+                                        "type": "object",
+                                        "x-kubernetes-map-type": "atomic",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "custom credential refs must set both group and kind",
+                                            "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                                          }
+                                        ],
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "x-kubernetes-validations": [
+                                      {
+                                        "message": "location may only be set for key or passthrough auth",
+                                        "rule": "has(self.location) ? has(self.key) || has(self.secretRef) || has(self.passthrough) : true"
+                                      },
+                                      {
+                                        "message": "exactly one of the fields in [key secretRef passthrough aws azure gcp] must be set",
+                                        "rule": "[has(self.key),has(self.secretRef),has(self.passthrough),has(self.aws),has(self.azure),has(self.gcp)].filter(x,x==true).size() == 1"
+                                      }
+                                    ],
+                                    "additionalProperties": false
+                                  },
+                                  "http": {
+                                    "description": "Settings for managing HTTP requests to the backend.",
+                                    "properties": {
+                                      "requestTimeout": {
+                                        "description": "Deadline for receiving a response from the backend.",
+                                        "type": "string",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "invalid duration value",
+                                            "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                          },
+                                          {
+                                            "message": "requestTimeout must be at least 1ms",
+                                            "rule": "duration(self) >= duration('1ms')"
+                                          }
+                                        ]
+                                      },
+                                      "version": {
+                                        "description": "HTTP protocol version to use when connecting to\nthe backend.\nIf not specified, the version is automatically determined:\n* `Service` types can specify it with `appProtocol` on the `Service`\n  port.\n* If traffic is identified as gRPC, `HTTP2` is used.\n* If the incoming traffic was plaintext HTTP, the original protocol will\n  be used.\n* If the incoming traffic was HTTPS, `HTTP1` will be used. This is\n  because most clients will transparently upgrade HTTPS traffic to\n  `HTTP2`, even if the backend doesn't support it.",
+                                        "enum": [
+                                          "HTTP1",
+                                          "HTTP2"
+                                        ],
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "tcp": {
+                                    "description": "Settings for managing TCP connections to the backend.",
+                                    "properties": {
+                                      "connectTimeout": {
+                                        "description": "Deadline for establishing a connection to\nthe destination.",
+                                        "type": "string",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "invalid duration value",
+                                            "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                          },
+                                          {
+                                            "message": "connectTimeout must be at least 100ms",
+                                            "rule": "duration(self) >= duration('100ms')"
+                                          }
+                                        ]
+                                      },
+                                      "keepalive": {
+                                        "description": "Settings for enabling TCP keepalives on the\nconnection.",
+                                        "properties": {
+                                          "interval": {
+                                            "description": "Time between keepalive probes.\nIf unset, this defaults to 180s.",
+                                            "type": "string",
+                                            "x-kubernetes-validations": [
+                                              {
+                                                "message": "invalid duration value",
+                                                "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                              },
+                                              {
+                                                "message": "interval must be at least 1 second",
+                                                "rule": "duration(self) >= duration('1s')"
+                                              }
+                                            ]
+                                          },
+                                          "retries": {
+                                            "description": "Maximum number of keepalive probes to send before dropping the connection.\nIf unset, this defaults to 9.",
+                                            "format": "int32",
+                                            "maximum": 64,
+                                            "minimum": 1,
+                                            "type": "integer"
+                                          },
+                                          "time": {
+                                            "description": "Time a connection needs to be idle before keepalive probes start being sent.\nIf unset, this defaults to 180s.",
+                                            "type": "string",
+                                            "x-kubernetes-validations": [
+                                              {
+                                                "message": "invalid duration value",
+                                                "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                              },
+                                              {
+                                                "message": "time must be at least 1 second",
+                                                "rule": "duration(self) >= duration('1s')"
+                                              }
+                                            ]
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "tls": {
+                                    "description": "Settings for managing TLS connections to the backend.\n\nIf this field is set, TLS will be initiated to the backend; the system trusted CA certificates will be used to\nvalidate the server, and the SNI will automatically be set based on the destination.",
+                                    "properties": {
+                                      "alpnProtocols": {
+                                        "description": "Application-Layer Protocol Negotiation (`ALPN`)\nvalue to use in the TLS handshake.\n\nIf not present, defaults to `[\"h2\", \"http/1.1\"]`.",
+                                        "items": {
+                                          "maxLength": 64,
+                                          "minLength": 1,
+                                          "type": "string"
+                                        },
+                                        "maxItems": 16,
+                                        "minItems": 1,
+                                        "type": "array"
+                                      },
+                                      "caCertificateRefs": {
+                                        "description": "CA certificate `ConfigMap` to use to\nverify the server certificate.\nIf unset, the system's trusted certificates are used.",
+                                        "items": {
+                                          "description": "LocalObjectReference contains enough information to let you locate the\nreferenced object inside the same namespace.",
+                                          "properties": {
+                                            "name": {
+                                              "default": "",
+                                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "x-kubernetes-map-type": "atomic",
+                                          "additionalProperties": false
+                                        },
+                                        "maxItems": 1,
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
+                                      },
+                                      "insecureSkipVerify": {
+                                        "description": "Originates TLS but skips verification of the backend's certificate.\nWARNING: This is an insecure option that should only be used if the risks are understood.\n\nThere are two modes:\n* `All` disables all TLS verification.\n* `Hostname` verifies the CA certificate is trusted, but ignores any\n  mismatch of hostname or SANs. Note that this method is still insecure;\n  prefer setting `verifySubjectAltNames` to customize the valid hostnames\n  if possible.",
+                                        "enum": [
+                                          "All",
+                                          "Hostname"
+                                        ],
+                                        "type": "string"
+                                      },
+                                      "keyExchangeGroups": {
+                                        "description": "Ordered list of key exchange groups for a TLS connection.\nFor example: `X25519_MLKEM768,X25519`.",
+                                        "items": {
+                                          "enum": [
+                                            "P-256",
+                                            "P-384",
+                                            "X25519",
+                                            "X25519_MLKEM768"
+                                          ],
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "mtlsCertificateRef": {
+                                        "description": "Enables mutual TLS to the backend, using the\nspecified key (`tls.key`) and cert (`tls.crt`) from the referenced\ncredential source, defaulting to a Kubernetes `Secret`.\n\nAn optional `ca.cert` field, if present, will be used to verify the\nserver certificate. If `caCertificateRefs` is also specified, the\n`caCertificateRefs` field takes priority.\n\nIf unspecified, no client certificate will be used.",
+                                        "items": {
+                                          "description": "References a same-namespace credential.\nSet only `name` to reference a Kubernetes Secret.",
+                                          "properties": {
+                                            "group": {
+                                              "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                                              "type": "string"
+                                            },
+                                            "kind": {
+                                              "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "description": "The name of the referenced credential.",
+                                              "maxLength": 253,
+                                              "minLength": 1,
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "name"
+                                          ],
+                                          "type": "object",
+                                          "x-kubernetes-map-type": "atomic",
+                                          "x-kubernetes-validations": [
+                                            {
+                                              "message": "custom credential refs must set both group and kind",
+                                              "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                                            }
+                                          ],
+                                          "additionalProperties": false
+                                        },
+                                        "maxItems": 1,
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
+                                      },
+                                      "sni": {
+                                        "description": "Server Name Indicator (`SNI`) to use in the TLS\nhandshake. If unset, the `SNI` is automatically set based on the\ndestination hostname.",
+                                        "maxLength": 253,
+                                        "minLength": 1,
+                                        "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                                        "type": "string"
+                                      },
+                                      "verifySubjectAltNames": {
+                                        "description": "Subject Alternative Names (`SAN`)\nto verify in the server certificate.\nIf not present, the destination hostname is automatically used.",
+                                        "items": {
+                                          "maxLength": 256,
+                                          "minLength": 1,
+                                          "type": "string"
+                                        },
+                                        "maxItems": 16,
+                                        "minItems": 1,
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "x-kubernetes-validations": [
+                                      {
+                                        "message": "insecureSkipVerify All and caCertificateRefs may not be set together",
+                                        "rule": "has(self.insecureSkipVerify) && self.insecureSkipVerify == 'All' ? !has(self.caCertificateRefs) : true"
+                                      },
+                                      {
+                                        "message": "insecureSkipVerify and verifySubjectAltNames may not be set together",
+                                        "rule": "has(self.insecureSkipVerify) ? !has(self.verifySubjectAltNames) : true"
+                                      },
+                                      {
+                                        "message": "at most one of the fields in [verifySubjectAltNames insecureSkipVerify] may be set",
+                                        "rule": "[has(self.verifySubjectAltNames),has(self.insecureSkipVerify)].filter(x,x==true).size() <= 1"
+                                      }
+                                    ],
+                                    "additionalProperties": false
+                                  },
+                                  "tunnel": {
+                                    "description": "Settings for managing tunnel connections, with behavior like `HTTPS_PROXY`, to the backend.",
+                                    "properties": {
+                                      "backendRef": {
+                                        "description": "Proxy server to reach.\nSupported types: `Service` and `Backend`.",
+                                        "properties": {
+                                          "group": {
+                                            "default": "",
+                                            "description": "Group is the group of the referent. For example, \"gateway.networking.k8s.io\".\nWhen unspecified or empty string, core API group is inferred.",
+                                            "maxLength": 253,
+                                            "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                                            "type": "string"
+                                          },
+                                          "kind": {
+                                            "default": "Service",
+                                            "description": "Kind is the Kubernetes resource kind of the referent. For example\n\"Service\".\n\nDefaults to \"Service\" when not specified.\n\nExternalName services can refer to CNAME DNS records that may live\noutside of the cluster and as such are difficult to reason about in\nterms of conformance. They also may not be safe to forward to (see\nCVE-2021-25740 for more information). Implementations SHOULD NOT\nsupport ExternalName Services.\n\nSupport: Core (Services with a type other than ExternalName)\n\nSupport: Implementation-specific (Services with type ExternalName)",
+                                            "maxLength": 63,
+                                            "minLength": 1,
+                                            "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "description": "Name is the name of the referent.",
+                                            "maxLength": 253,
+                                            "minLength": 1,
+                                            "type": "string"
+                                          },
+                                          "namespace": {
+                                            "description": "Namespace is the namespace of the backend. When unspecified, the local\nnamespace is inferred.\n\nNote that when a namespace different than the local namespace is specified,\na ReferenceGrant object is required in the referent namespace to allow that\nnamespace's owner to accept the reference. See the ReferenceGrant\ndocumentation for details.\n\nSupport: Core",
+                                            "maxLength": 63,
+                                            "minLength": 1,
+                                            "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "description": "Port specifies the destination port number to use for this resource.\nPort is required when the referent is a Kubernetes Service. In this\ncase, the port number is the service port number, not the target port.\nFor other resources, destination port might be derived from the referent\nresource or this field.",
+                                            "format": "int32",
+                                            "maximum": 65535,
+                                            "minimum": 1,
+                                            "type": "integer"
+                                          }
+                                        },
+                                        "required": [
+                                          "name"
+                                        ],
+                                        "type": "object",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "Must have port for Service reference",
+                                            "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
+                                          }
+                                        ],
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "required": [
+                                      "backendRef"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "regex": {
+                            "description": "Regular expression (regex) matching for prompt guards and data masking.",
+                            "properties": {
+                              "action": {
+                                "default": "Mask",
+                                "description": "The action to take if a regex pattern is matched in a request or response.\nThis setting applies only to request matches. `PromptguardResponse`\nmatches are always masked by default.\nDefaults to `Mask`.",
+                                "enum": [
+                                  "Mask",
+                                  "Reject"
+                                ],
+                                "type": "string"
+                              },
+                              "builtins": {
+                                "description": "Built-in regex patterns to match against the request or response.\nMatches and built-ins are additive.",
+                                "items": {
+                                  "description": "Built-in regex patterns for specific types of strings in prompts.\nFor example, if you specify `CreditCard`, any credit card numbers\nin the request or response are matched.",
+                                  "enum": [
+                                    "CaSin",
+                                    "CreditCard",
+                                    "Email",
+                                    "PhoneNumber",
+                                    "Ssn"
+                                  ],
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "matches": {
+                                "description": "Regex patterns to match against the request or response.\nMatches and built-ins are additive.",
+                                "items": {
+                                  "maxLength": 1024,
+                                  "minLength": 1,
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "response": {
+                            "description": "Custom response message to return to the client. If not specified, defaults to\n`The request was rejected due to inappropriate content`.",
+                            "properties": {
+                              "message": {
+                                "default": "The request was rejected due to inappropriate content",
+                                "description": "Custom response message to return to the client. If not specified, defaults to\n`The request was rejected due to inappropriate content`.",
+                                "type": "string"
+                              },
+                              "statusCode": {
+                                "default": 403,
+                                "description": "Status code to return to the client. Defaults to 403.",
+                                "format": "int32",
+                                "maximum": 599,
+                                "minimum": 200,
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-validations": [
+                              {
+                                "message": "at least one of the fields in [message statusCode] must be set",
+                                "rule": "[has(self.message),has(self.statusCode)].filter(x,x==true).size() >= 1"
+                              }
+                            ],
+                            "additionalProperties": false
+                          },
+                          "webhook": {
+                            "description": "Webhook that receives requests for prompt guarding.",
+                            "properties": {
+                              "backendRef": {
+                                "description": "Webhook server to reach.\n\nSupported types: Service and Backend.",
+                                "properties": {
+                                  "group": {
+                                    "default": "",
+                                    "description": "Group is the group of the referent. For example, \"gateway.networking.k8s.io\".\nWhen unspecified or empty string, core API group is inferred.",
+                                    "maxLength": 253,
+                                    "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                                    "type": "string"
+                                  },
+                                  "kind": {
+                                    "default": "Service",
+                                    "description": "Kind is the Kubernetes resource kind of the referent. For example\n\"Service\".\n\nDefaults to \"Service\" when not specified.\n\nExternalName services can refer to CNAME DNS records that may live\noutside of the cluster and as such are difficult to reason about in\nterms of conformance. They also may not be safe to forward to (see\nCVE-2021-25740 for more information). Implementations SHOULD NOT\nsupport ExternalName Services.\n\nSupport: Core (Services with a type other than ExternalName)\n\nSupport: Implementation-specific (Services with type ExternalName)",
+                                    "maxLength": 63,
+                                    "minLength": 1,
+                                    "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "description": "Name is the name of the referent.",
+                                    "maxLength": 253,
+                                    "minLength": 1,
+                                    "type": "string"
+                                  },
+                                  "namespace": {
+                                    "description": "Namespace is the namespace of the backend. When unspecified, the local\nnamespace is inferred.\n\nNote that when a namespace different than the local namespace is specified,\na ReferenceGrant object is required in the referent namespace to allow that\nnamespace's owner to accept the reference. See the ReferenceGrant\ndocumentation for details.\n\nSupport: Core",
+                                    "maxLength": 63,
+                                    "minLength": 1,
+                                    "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "description": "Port specifies the destination port number to use for this resource.\nPort is required when the referent is a Kubernetes Service. In this\ncase, the port number is the service port number, not the target port.\nFor other resources, destination port might be derived from the referent\nresource or this field.",
+                                    "format": "int32",
+                                    "maximum": 65535,
+                                    "minimum": 1,
+                                    "type": "integer"
+                                  }
+                                },
+                                "required": [
+                                  "name"
+                                ],
+                                "type": "object",
+                                "x-kubernetes-validations": [
+                                  {
+                                    "message": "Must have port for Service reference",
+                                    "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
+                                  }
+                                ],
+                                "additionalProperties": false
+                              },
+                              "failureMode": {
+                                "description": "Behavior when the webhook guardrail is unavailable\nor returns an error. `FailOpen` allows the request to continue.\n`FailClosed` (default) rejects the request.",
+                                "enum": [
+                                  "FailClosed",
+                                  "FailOpen"
+                                ],
+                                "type": "string"
+                              },
+                              "forwardHeaderMatches": {
+                                "description": "HTTP header matches used to select the headers to forward to the webhook.\nRequest headers are used when forwarding requests and response headers\nare used when forwarding responses.\nBy default, no headers are forwarded.",
+                                "items": {
+                                  "description": "HTTPHeaderMatch describes how to select a HTTP route by matching HTTP request\nheaders.",
+                                  "properties": {
+                                    "name": {
+                                      "description": "Name is the name of the HTTP Header to be matched. Name matching MUST be\ncase-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).\n\nIf multiple entries specify equivalent header names, only the first\nentry with an equivalent name MUST be considered for a match. Subsequent\nentries with an equivalent header name MUST be ignored. Due to the\ncase-insensitivity of header names, \"foo\" and \"Foo\" are considered\nequivalent.\n\nWhen a header is repeated in an HTTP request, it is\nimplementation-specific behavior as to how this is represented.\nGenerally, proxies should follow the guidance from the RFC:\nhttps://www.rfc-editor.org/rfc/rfc7230.html#section-3.2.2 regarding\nprocessing a repeated header, with special handling for \"Set-Cookie\".",
+                                      "maxLength": 256,
+                                      "minLength": 1,
+                                      "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                                      "type": "string"
+                                    },
+                                    "type": {
+                                      "default": "Exact",
+                                      "description": "Type specifies how to match against the value of the header.\n\nSupport: Core (Exact)\n\nSupport: Implementation-specific (RegularExpression)\n\nSince RegularExpression HeaderMatchType has implementation-specific\nconformance, implementations can support POSIX, PCRE or any other dialects\nof regular expressions. Please read the implementation's documentation to\ndetermine the supported dialect.",
+                                      "enum": [
+                                        "Exact",
+                                        "RegularExpression"
+                                      ],
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "description": "Value is the value of HTTP Header to be matched.\n<gateway:experimental:description>\nMust consist of printable US-ASCII characters, optionally separated\nby single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2\n</gateway:experimental:description>\n\n<gateway:experimental:validation:Pattern=`^[!-~]+([\\t ]?[!-~]+)*$`>",
+                                      "maxLength": 4096,
+                                      "minLength": 1,
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "name",
+                                    "value"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "required": [
+                              "backendRef"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-validations": [
+                          {
+                            "message": "exactly one of the fields in [regex webhook openAIModeration bedrockGuardrails googleModelArmor] must be set",
+                            "rule": "[has(self.regex),has(self.webhook),has(self.openAIModeration),has(self.bedrockGuardrails),has(self.googleModelArmor)].filter(x,x==true).size() == 1"
+                          }
+                        ],
+                        "additionalProperties": false
+                      },
+                      "maxItems": 8,
+                      "minItems": 1,
+                      "type": "array"
+                    },
+                    "response": {
+                      "description": "Prompt guards to apply to responses returned by the LLM provider.",
+                      "items": {
+                        "description": "Prompt guards to apply to responses returned by the LLM provider.",
+                        "properties": {
+                          "bedrockGuardrails": {
+                            "description": "AWS Bedrock Guardrails settings for prompt\nguarding.",
+                            "properties": {
+                              "identifier": {
+                                "description": "Identifier of the Guardrail policy to use for the backend.",
+                                "maxLength": 256,
+                                "minLength": 1,
+                                "type": "string"
+                              },
+                              "policies": {
+                                "description": "Policies for communicating with AWS Bedrock Guardrails.",
+                                "properties": {
+                                  "auth": {
+                                    "description": "Settings for managing authentication to the backend.",
+                                    "properties": {
+                                      "aws": {
+                                        "description": "Explicit AWS authentication method for the backend.\nWhen omitted, default AWS SDK credential discovery is used.",
+                                        "properties": {
+                                          "assumeRole": {
+                                            "description": "AWS STS AssumeRole settings to use before signing backend requests.\nAmbient AWS credentials are used as the source credentials for STS.",
+                                            "properties": {
+                                              "roleArn": {
+                                                "description": "AWS IAM role ARN to assume.",
+                                                "minLength": 1,
+                                                "pattern": "^arn:aws[a-z-]*:iam::[0-9]{12}:role/.+$",
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "roleArn"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "secretRef": {
+                                            "description": "Credential source, defaulting to a Kubernetes\n`Secret`, containing the AWS credentials. When using the default Secret\nresolver, the `Secret` must have keys `accessKey`, `secretKey`, and\noptionally `sessionToken`.",
+                                            "properties": {
+                                              "group": {
+                                                "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                                                "type": "string"
+                                              },
+                                              "kind": {
+                                                "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "description": "The name of the referenced credential.",
+                                                "maxLength": 253,
+                                                "minLength": 1,
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name"
+                                            ],
+                                            "type": "object",
+                                            "x-kubernetes-map-type": "atomic",
+                                            "x-kubernetes-validations": [
+                                              {
+                                                "message": "custom credential refs must set both group and kind",
+                                                "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                                              }
+                                            ],
+                                            "additionalProperties": false
+                                          },
+                                          "serviceName": {
+                                            "description": "AWS SigV4 signing service name, for example\n`bedrock`, `bedrock-agentcore`, or `execute-api`). If unset, typed AWS\nbackends may provide this automatically.",
+                                            "maxLength": 256,
+                                            "minLength": 1,
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "secretRef and assumeRole are mutually exclusive",
+                                            "rule": "!(has(self.secretRef) && has(self.assumeRole))"
+                                          }
+                                        ],
+                                        "additionalProperties": false
+                                      },
+                                      "azure": {
+                                        "description": "Azure authentication method for the backend.",
+                                        "properties": {
+                                          "managedIdentity": {
+                                            "description": "Managed identity authentication settings.",
+                                            "properties": {
+                                              "clientId": {
+                                                "type": "string"
+                                              },
+                                              "objectId": {
+                                                "type": "string"
+                                              },
+                                              "resourceId": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "clientId",
+                                              "objectId",
+                                              "resourceId"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "secretRef": {
+                                            "description": "Credential source, defaulting to a Kubernetes\n`Secret`, containing the Azure credentials. When using the default Secret\nresolver, the `Secret` must have keys `clientID`, `tenantID`, and\n`clientSecret`.",
+                                            "properties": {
+                                              "group": {
+                                                "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                                                "type": "string"
+                                              },
+                                              "kind": {
+                                                "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "description": "The name of the referenced credential.",
+                                                "maxLength": 253,
+                                                "minLength": 1,
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name"
+                                            ],
+                                            "type": "object",
+                                            "x-kubernetes-map-type": "atomic",
+                                            "x-kubernetes-validations": [
+                                              {
+                                                "message": "custom credential refs must set both group and kind",
+                                                "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                                              }
+                                            ],
+                                            "additionalProperties": false
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "gcp": {
+                                        "description": "Google authentication method for the backend.\nWhen omitted, default Google credential discovery is used.",
+                                        "properties": {
+                                          "audience": {
+                                            "description": "Explicit `aud` value for the ID token. Only\nvalid with `IdToken` type. If not set, the `aud` is automatically\nderived from the backend hostname.",
+                                            "maxLength": 256,
+                                            "minLength": 1,
+                                            "type": "string"
+                                          },
+                                          "secretRef": {
+                                            "description": "Credential source, defaulting to a Kubernetes\n`Secret`, containing ADC-compatible Google credential JSON. When using\nthe default Secret resolver, this must be stored in the `credentials.json`\nkey. When omitted, ambient credentials are used.",
+                                            "properties": {
+                                              "group": {
+                                                "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                                                "type": "string"
+                                              },
+                                              "kind": {
+                                                "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "description": "The name of the referenced credential.",
+                                                "maxLength": 253,
+                                                "minLength": 1,
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name"
+                                            ],
+                                            "type": "object",
+                                            "x-kubernetes-map-type": "atomic",
+                                            "x-kubernetes-validations": [
+                                              {
+                                                "message": "custom credential refs must set both group and kind",
+                                                "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                                              }
+                                            ],
+                                            "additionalProperties": false
+                                          },
+                                          "type": {
+                                            "description": "The type of token to generate. To authenticate to GCP services,\ngenerally an `AccessToken` is used. To authenticate to Cloud Run, an\n`IdToken` is used.",
+                                            "enum": [
+                                              "AccessToken",
+                                              "IdToken"
+                                            ],
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "audience is only valid with IdToken",
+                                            "rule": "has(self.audience) ? self.type == 'IdToken' : true"
+                                          }
+                                        ],
+                                        "additionalProperties": false
+                                      },
+                                      "key": {
+                                        "description": "Inline key to use as the value of the\n`Authorization` header. This option is the least secure; usage of a\n`Secret` is preferred.",
+                                        "maxLength": 2048,
+                                        "type": "string"
+                                      },
+                                      "location": {
+                                        "description": "Where backend credentials are inserted.\nIf omitted, credentials are written to the `Authorization` header with the `Bearer ` prefix.\nThis applies to `key`, `secretRef`, and `passthrough`.",
+                                        "properties": {
+                                          "cookie": {
+                                            "properties": {
+                                              "name": {
+                                                "maxLength": 256,
+                                                "minLength": 1,
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "header": {
+                                            "properties": {
+                                              "name": {
+                                                "description": "HTTPHeaderName is the name of an HTTP header.\n\nValid values include:\n\n* \"Authorization\"\n* \"Set-Cookie\"\n\nInvalid values include:\n\n  - \":method\" - \":\" is an invalid character. This means that HTTP/2 pseudo\n    headers are not currently supported by this type.\n  - \"/invalid\" - \"/ \" is an invalid character",
+                                                "maxLength": 256,
+                                                "minLength": 1,
+                                                "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                                                "type": "string"
+                                              },
+                                              "prefix": {
+                                                "maxLength": 256,
+                                                "minLength": 1,
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "queryParameter": {
+                                            "properties": {
+                                              "name": {
+                                                "maxLength": 256,
+                                                "minLength": 1,
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          }
+                                        },
+                                        "type": "object",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "exactly one of the fields in [header queryParameter cookie] must be set",
+                                            "rule": "[has(self.header),has(self.queryParameter),has(self.cookie)].filter(x,x==true).size() == 1"
+                                          }
+                                        ],
+                                        "additionalProperties": false
+                                      },
+                                      "passthrough": {
+                                        "description": "Passes through an existing token that has been sent by the\nclient and validated. Other policies, like JWT and API key\nauthentication, will strip the original client credentials. Passthrough backend authentication\ncauses the original token to be added back into the request. If there are no client authentication policies on the\nrequest, the original token would be unchanged, so this would have no effect.",
+                                        "type": "object"
+                                      },
+                                      "secretRef": {
+                                        "description": "Credential source, defaulting to a Kubernetes\n`Secret`, storing the key to use as the authorization value. When using\nthe default Secret resolver, this must be stored in the `Authorization`\nkey.",
+                                        "properties": {
+                                          "group": {
+                                            "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                                            "type": "string"
+                                          },
+                                          "kind": {
+                                            "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "description": "The name of the referenced credential.",
+                                            "maxLength": 253,
+                                            "minLength": 1,
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "name"
+                                        ],
+                                        "type": "object",
+                                        "x-kubernetes-map-type": "atomic",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "custom credential refs must set both group and kind",
+                                            "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                                          }
+                                        ],
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "x-kubernetes-validations": [
+                                      {
+                                        "message": "location may only be set for key or passthrough auth",
+                                        "rule": "has(self.location) ? has(self.key) || has(self.secretRef) || has(self.passthrough) : true"
+                                      },
+                                      {
+                                        "message": "exactly one of the fields in [key secretRef passthrough aws azure gcp] must be set",
+                                        "rule": "[has(self.key),has(self.secretRef),has(self.passthrough),has(self.aws),has(self.azure),has(self.gcp)].filter(x,x==true).size() == 1"
+                                      }
+                                    ],
+                                    "additionalProperties": false
+                                  },
+                                  "http": {
+                                    "description": "Settings for managing HTTP requests to the backend.",
+                                    "properties": {
+                                      "requestTimeout": {
+                                        "description": "Deadline for receiving a response from the backend.",
+                                        "type": "string",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "invalid duration value",
+                                            "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                          },
+                                          {
+                                            "message": "requestTimeout must be at least 1ms",
+                                            "rule": "duration(self) >= duration('1ms')"
+                                          }
+                                        ]
+                                      },
+                                      "version": {
+                                        "description": "HTTP protocol version to use when connecting to\nthe backend.\nIf not specified, the version is automatically determined:\n* `Service` types can specify it with `appProtocol` on the `Service`\n  port.\n* If traffic is identified as gRPC, `HTTP2` is used.\n* If the incoming traffic was plaintext HTTP, the original protocol will\n  be used.\n* If the incoming traffic was HTTPS, `HTTP1` will be used. This is\n  because most clients will transparently upgrade HTTPS traffic to\n  `HTTP2`, even if the backend doesn't support it.",
+                                        "enum": [
+                                          "HTTP1",
+                                          "HTTP2"
+                                        ],
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "tcp": {
+                                    "description": "Settings for managing TCP connections to the backend.",
+                                    "properties": {
+                                      "connectTimeout": {
+                                        "description": "Deadline for establishing a connection to\nthe destination.",
+                                        "type": "string",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "invalid duration value",
+                                            "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                          },
+                                          {
+                                            "message": "connectTimeout must be at least 100ms",
+                                            "rule": "duration(self) >= duration('100ms')"
+                                          }
+                                        ]
+                                      },
+                                      "keepalive": {
+                                        "description": "Settings for enabling TCP keepalives on the\nconnection.",
+                                        "properties": {
+                                          "interval": {
+                                            "description": "Time between keepalive probes.\nIf unset, this defaults to 180s.",
+                                            "type": "string",
+                                            "x-kubernetes-validations": [
+                                              {
+                                                "message": "invalid duration value",
+                                                "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                              },
+                                              {
+                                                "message": "interval must be at least 1 second",
+                                                "rule": "duration(self) >= duration('1s')"
+                                              }
+                                            ]
+                                          },
+                                          "retries": {
+                                            "description": "Maximum number of keepalive probes to send before dropping the connection.\nIf unset, this defaults to 9.",
+                                            "format": "int32",
+                                            "maximum": 64,
+                                            "minimum": 1,
+                                            "type": "integer"
+                                          },
+                                          "time": {
+                                            "description": "Time a connection needs to be idle before keepalive probes start being sent.\nIf unset, this defaults to 180s.",
+                                            "type": "string",
+                                            "x-kubernetes-validations": [
+                                              {
+                                                "message": "invalid duration value",
+                                                "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                              },
+                                              {
+                                                "message": "time must be at least 1 second",
+                                                "rule": "duration(self) >= duration('1s')"
+                                              }
+                                            ]
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "tls": {
+                                    "description": "Settings for managing TLS connections to the backend.\n\nIf this field is set, TLS will be initiated to the backend; the system trusted CA certificates will be used to\nvalidate the server, and the SNI will automatically be set based on the destination.",
+                                    "properties": {
+                                      "alpnProtocols": {
+                                        "description": "Application-Layer Protocol Negotiation (`ALPN`)\nvalue to use in the TLS handshake.\n\nIf not present, defaults to `[\"h2\", \"http/1.1\"]`.",
+                                        "items": {
+                                          "maxLength": 64,
+                                          "minLength": 1,
+                                          "type": "string"
+                                        },
+                                        "maxItems": 16,
+                                        "minItems": 1,
+                                        "type": "array"
+                                      },
+                                      "caCertificateRefs": {
+                                        "description": "CA certificate `ConfigMap` to use to\nverify the server certificate.\nIf unset, the system's trusted certificates are used.",
+                                        "items": {
+                                          "description": "LocalObjectReference contains enough information to let you locate the\nreferenced object inside the same namespace.",
+                                          "properties": {
+                                            "name": {
+                                              "default": "",
+                                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "x-kubernetes-map-type": "atomic",
+                                          "additionalProperties": false
+                                        },
+                                        "maxItems": 1,
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
+                                      },
+                                      "insecureSkipVerify": {
+                                        "description": "Originates TLS but skips verification of the backend's certificate.\nWARNING: This is an insecure option that should only be used if the risks are understood.\n\nThere are two modes:\n* `All` disables all TLS verification.\n* `Hostname` verifies the CA certificate is trusted, but ignores any\n  mismatch of hostname or SANs. Note that this method is still insecure;\n  prefer setting `verifySubjectAltNames` to customize the valid hostnames\n  if possible.",
+                                        "enum": [
+                                          "All",
+                                          "Hostname"
+                                        ],
+                                        "type": "string"
+                                      },
+                                      "keyExchangeGroups": {
+                                        "description": "Ordered list of key exchange groups for a TLS connection.\nFor example: `X25519_MLKEM768,X25519`.",
+                                        "items": {
+                                          "enum": [
+                                            "P-256",
+                                            "P-384",
+                                            "X25519",
+                                            "X25519_MLKEM768"
+                                          ],
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "mtlsCertificateRef": {
+                                        "description": "Enables mutual TLS to the backend, using the\nspecified key (`tls.key`) and cert (`tls.crt`) from the referenced\ncredential source, defaulting to a Kubernetes `Secret`.\n\nAn optional `ca.cert` field, if present, will be used to verify the\nserver certificate. If `caCertificateRefs` is also specified, the\n`caCertificateRefs` field takes priority.\n\nIf unspecified, no client certificate will be used.",
+                                        "items": {
+                                          "description": "References a same-namespace credential.\nSet only `name` to reference a Kubernetes Secret.",
+                                          "properties": {
+                                            "group": {
+                                              "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                                              "type": "string"
+                                            },
+                                            "kind": {
+                                              "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "description": "The name of the referenced credential.",
+                                              "maxLength": 253,
+                                              "minLength": 1,
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "name"
+                                          ],
+                                          "type": "object",
+                                          "x-kubernetes-map-type": "atomic",
+                                          "x-kubernetes-validations": [
+                                            {
+                                              "message": "custom credential refs must set both group and kind",
+                                              "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                                            }
+                                          ],
+                                          "additionalProperties": false
+                                        },
+                                        "maxItems": 1,
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
+                                      },
+                                      "sni": {
+                                        "description": "Server Name Indicator (`SNI`) to use in the TLS\nhandshake. If unset, the `SNI` is automatically set based on the\ndestination hostname.",
+                                        "maxLength": 253,
+                                        "minLength": 1,
+                                        "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                                        "type": "string"
+                                      },
+                                      "verifySubjectAltNames": {
+                                        "description": "Subject Alternative Names (`SAN`)\nto verify in the server certificate.\nIf not present, the destination hostname is automatically used.",
+                                        "items": {
+                                          "maxLength": 256,
+                                          "minLength": 1,
+                                          "type": "string"
+                                        },
+                                        "maxItems": 16,
+                                        "minItems": 1,
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "x-kubernetes-validations": [
+                                      {
+                                        "message": "insecureSkipVerify All and caCertificateRefs may not be set together",
+                                        "rule": "has(self.insecureSkipVerify) && self.insecureSkipVerify == 'All' ? !has(self.caCertificateRefs) : true"
+                                      },
+                                      {
+                                        "message": "insecureSkipVerify and verifySubjectAltNames may not be set together",
+                                        "rule": "has(self.insecureSkipVerify) ? !has(self.verifySubjectAltNames) : true"
+                                      },
+                                      {
+                                        "message": "at most one of the fields in [verifySubjectAltNames insecureSkipVerify] may be set",
+                                        "rule": "[has(self.verifySubjectAltNames),has(self.insecureSkipVerify)].filter(x,x==true).size() <= 1"
+                                      }
+                                    ],
+                                    "additionalProperties": false
+                                  },
+                                  "tunnel": {
+                                    "description": "Settings for managing tunnel connections, with behavior like `HTTPS_PROXY`, to the backend.",
+                                    "properties": {
+                                      "backendRef": {
+                                        "description": "Proxy server to reach.\nSupported types: `Service` and `Backend`.",
+                                        "properties": {
+                                          "group": {
+                                            "default": "",
+                                            "description": "Group is the group of the referent. For example, \"gateway.networking.k8s.io\".\nWhen unspecified or empty string, core API group is inferred.",
+                                            "maxLength": 253,
+                                            "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                                            "type": "string"
+                                          },
+                                          "kind": {
+                                            "default": "Service",
+                                            "description": "Kind is the Kubernetes resource kind of the referent. For example\n\"Service\".\n\nDefaults to \"Service\" when not specified.\n\nExternalName services can refer to CNAME DNS records that may live\noutside of the cluster and as such are difficult to reason about in\nterms of conformance. They also may not be safe to forward to (see\nCVE-2021-25740 for more information). Implementations SHOULD NOT\nsupport ExternalName Services.\n\nSupport: Core (Services with a type other than ExternalName)\n\nSupport: Implementation-specific (Services with type ExternalName)",
+                                            "maxLength": 63,
+                                            "minLength": 1,
+                                            "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "description": "Name is the name of the referent.",
+                                            "maxLength": 253,
+                                            "minLength": 1,
+                                            "type": "string"
+                                          },
+                                          "namespace": {
+                                            "description": "Namespace is the namespace of the backend. When unspecified, the local\nnamespace is inferred.\n\nNote that when a namespace different than the local namespace is specified,\na ReferenceGrant object is required in the referent namespace to allow that\nnamespace's owner to accept the reference. See the ReferenceGrant\ndocumentation for details.\n\nSupport: Core",
+                                            "maxLength": 63,
+                                            "minLength": 1,
+                                            "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "description": "Port specifies the destination port number to use for this resource.\nPort is required when the referent is a Kubernetes Service. In this\ncase, the port number is the service port number, not the target port.\nFor other resources, destination port might be derived from the referent\nresource or this field.",
+                                            "format": "int32",
+                                            "maximum": 65535,
+                                            "minimum": 1,
+                                            "type": "integer"
+                                          }
+                                        },
+                                        "required": [
+                                          "name"
+                                        ],
+                                        "type": "object",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "Must have port for Service reference",
+                                            "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
+                                          }
+                                        ],
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "required": [
+                                      "backendRef"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "region": {
+                                "description": "AWS region where the guardrail is deployed, for example\n`us-west-2`).",
+                                "maxLength": 256,
+                                "minLength": 1,
+                                "type": "string"
+                              },
+                              "version": {
+                                "description": "Version of the Guardrail policy to use for the backend.",
+                                "maxLength": 256,
+                                "minLength": 1,
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "identifier",
+                              "region",
+                              "version"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "googleModelArmor": {
+                            "description": "Google Model Armor settings for prompt guarding.",
+                            "properties": {
+                              "location": {
+                                "default": "us-central1",
+                                "description": "Google Cloud location, for example `us-central1`.\nDefaults to `us-central1` if not specified.",
+                                "maxLength": 256,
+                                "minLength": 1,
+                                "type": "string"
+                              },
+                              "policies": {
+                                "description": "Policies for communicating with Google Model Armor.",
+                                "properties": {
+                                  "auth": {
+                                    "description": "Settings for managing authentication to the backend.",
+                                    "properties": {
+                                      "aws": {
+                                        "description": "Explicit AWS authentication method for the backend.\nWhen omitted, default AWS SDK credential discovery is used.",
+                                        "properties": {
+                                          "assumeRole": {
+                                            "description": "AWS STS AssumeRole settings to use before signing backend requests.\nAmbient AWS credentials are used as the source credentials for STS.",
+                                            "properties": {
+                                              "roleArn": {
+                                                "description": "AWS IAM role ARN to assume.",
+                                                "minLength": 1,
+                                                "pattern": "^arn:aws[a-z-]*:iam::[0-9]{12}:role/.+$",
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "roleArn"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "secretRef": {
+                                            "description": "Credential source, defaulting to a Kubernetes\n`Secret`, containing the AWS credentials. When using the default Secret\nresolver, the `Secret` must have keys `accessKey`, `secretKey`, and\noptionally `sessionToken`.",
+                                            "properties": {
+                                              "group": {
+                                                "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                                                "type": "string"
+                                              },
+                                              "kind": {
+                                                "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "description": "The name of the referenced credential.",
+                                                "maxLength": 253,
+                                                "minLength": 1,
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name"
+                                            ],
+                                            "type": "object",
+                                            "x-kubernetes-map-type": "atomic",
+                                            "x-kubernetes-validations": [
+                                              {
+                                                "message": "custom credential refs must set both group and kind",
+                                                "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                                              }
+                                            ],
+                                            "additionalProperties": false
+                                          },
+                                          "serviceName": {
+                                            "description": "AWS SigV4 signing service name, for example\n`bedrock`, `bedrock-agentcore`, or `execute-api`). If unset, typed AWS\nbackends may provide this automatically.",
+                                            "maxLength": 256,
+                                            "minLength": 1,
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "secretRef and assumeRole are mutually exclusive",
+                                            "rule": "!(has(self.secretRef) && has(self.assumeRole))"
+                                          }
+                                        ],
+                                        "additionalProperties": false
+                                      },
+                                      "azure": {
+                                        "description": "Azure authentication method for the backend.",
+                                        "properties": {
+                                          "managedIdentity": {
+                                            "description": "Managed identity authentication settings.",
+                                            "properties": {
+                                              "clientId": {
+                                                "type": "string"
+                                              },
+                                              "objectId": {
+                                                "type": "string"
+                                              },
+                                              "resourceId": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "clientId",
+                                              "objectId",
+                                              "resourceId"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "secretRef": {
+                                            "description": "Credential source, defaulting to a Kubernetes\n`Secret`, containing the Azure credentials. When using the default Secret\nresolver, the `Secret` must have keys `clientID`, `tenantID`, and\n`clientSecret`.",
+                                            "properties": {
+                                              "group": {
+                                                "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                                                "type": "string"
+                                              },
+                                              "kind": {
+                                                "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "description": "The name of the referenced credential.",
+                                                "maxLength": 253,
+                                                "minLength": 1,
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name"
+                                            ],
+                                            "type": "object",
+                                            "x-kubernetes-map-type": "atomic",
+                                            "x-kubernetes-validations": [
+                                              {
+                                                "message": "custom credential refs must set both group and kind",
+                                                "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                                              }
+                                            ],
+                                            "additionalProperties": false
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "gcp": {
+                                        "description": "Google authentication method for the backend.\nWhen omitted, default Google credential discovery is used.",
+                                        "properties": {
+                                          "audience": {
+                                            "description": "Explicit `aud` value for the ID token. Only\nvalid with `IdToken` type. If not set, the `aud` is automatically\nderived from the backend hostname.",
+                                            "maxLength": 256,
+                                            "minLength": 1,
+                                            "type": "string"
+                                          },
+                                          "secretRef": {
+                                            "description": "Credential source, defaulting to a Kubernetes\n`Secret`, containing ADC-compatible Google credential JSON. When using\nthe default Secret resolver, this must be stored in the `credentials.json`\nkey. When omitted, ambient credentials are used.",
+                                            "properties": {
+                                              "group": {
+                                                "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                                                "type": "string"
+                                              },
+                                              "kind": {
+                                                "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "description": "The name of the referenced credential.",
+                                                "maxLength": 253,
+                                                "minLength": 1,
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name"
+                                            ],
+                                            "type": "object",
+                                            "x-kubernetes-map-type": "atomic",
+                                            "x-kubernetes-validations": [
+                                              {
+                                                "message": "custom credential refs must set both group and kind",
+                                                "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                                              }
+                                            ],
+                                            "additionalProperties": false
+                                          },
+                                          "type": {
+                                            "description": "The type of token to generate. To authenticate to GCP services,\ngenerally an `AccessToken` is used. To authenticate to Cloud Run, an\n`IdToken` is used.",
+                                            "enum": [
+                                              "AccessToken",
+                                              "IdToken"
+                                            ],
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "audience is only valid with IdToken",
+                                            "rule": "has(self.audience) ? self.type == 'IdToken' : true"
+                                          }
+                                        ],
+                                        "additionalProperties": false
+                                      },
+                                      "key": {
+                                        "description": "Inline key to use as the value of the\n`Authorization` header. This option is the least secure; usage of a\n`Secret` is preferred.",
+                                        "maxLength": 2048,
+                                        "type": "string"
+                                      },
+                                      "location": {
+                                        "description": "Where backend credentials are inserted.\nIf omitted, credentials are written to the `Authorization` header with the `Bearer ` prefix.\nThis applies to `key`, `secretRef`, and `passthrough`.",
+                                        "properties": {
+                                          "cookie": {
+                                            "properties": {
+                                              "name": {
+                                                "maxLength": 256,
+                                                "minLength": 1,
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "header": {
+                                            "properties": {
+                                              "name": {
+                                                "description": "HTTPHeaderName is the name of an HTTP header.\n\nValid values include:\n\n* \"Authorization\"\n* \"Set-Cookie\"\n\nInvalid values include:\n\n  - \":method\" - \":\" is an invalid character. This means that HTTP/2 pseudo\n    headers are not currently supported by this type.\n  - \"/invalid\" - \"/ \" is an invalid character",
+                                                "maxLength": 256,
+                                                "minLength": 1,
+                                                "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                                                "type": "string"
+                                              },
+                                              "prefix": {
+                                                "maxLength": 256,
+                                                "minLength": 1,
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "queryParameter": {
+                                            "properties": {
+                                              "name": {
+                                                "maxLength": 256,
+                                                "minLength": 1,
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          }
+                                        },
+                                        "type": "object",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "exactly one of the fields in [header queryParameter cookie] must be set",
+                                            "rule": "[has(self.header),has(self.queryParameter),has(self.cookie)].filter(x,x==true).size() == 1"
+                                          }
+                                        ],
+                                        "additionalProperties": false
+                                      },
+                                      "passthrough": {
+                                        "description": "Passes through an existing token that has been sent by the\nclient and validated. Other policies, like JWT and API key\nauthentication, will strip the original client credentials. Passthrough backend authentication\ncauses the original token to be added back into the request. If there are no client authentication policies on the\nrequest, the original token would be unchanged, so this would have no effect.",
+                                        "type": "object"
+                                      },
+                                      "secretRef": {
+                                        "description": "Credential source, defaulting to a Kubernetes\n`Secret`, storing the key to use as the authorization value. When using\nthe default Secret resolver, this must be stored in the `Authorization`\nkey.",
+                                        "properties": {
+                                          "group": {
+                                            "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                                            "type": "string"
+                                          },
+                                          "kind": {
+                                            "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "description": "The name of the referenced credential.",
+                                            "maxLength": 253,
+                                            "minLength": 1,
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "name"
+                                        ],
+                                        "type": "object",
+                                        "x-kubernetes-map-type": "atomic",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "custom credential refs must set both group and kind",
+                                            "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                                          }
+                                        ],
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "x-kubernetes-validations": [
+                                      {
+                                        "message": "location may only be set for key or passthrough auth",
+                                        "rule": "has(self.location) ? has(self.key) || has(self.secretRef) || has(self.passthrough) : true"
+                                      },
+                                      {
+                                        "message": "exactly one of the fields in [key secretRef passthrough aws azure gcp] must be set",
+                                        "rule": "[has(self.key),has(self.secretRef),has(self.passthrough),has(self.aws),has(self.azure),has(self.gcp)].filter(x,x==true).size() == 1"
+                                      }
+                                    ],
+                                    "additionalProperties": false
+                                  },
+                                  "http": {
+                                    "description": "Settings for managing HTTP requests to the backend.",
+                                    "properties": {
+                                      "requestTimeout": {
+                                        "description": "Deadline for receiving a response from the backend.",
+                                        "type": "string",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "invalid duration value",
+                                            "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                          },
+                                          {
+                                            "message": "requestTimeout must be at least 1ms",
+                                            "rule": "duration(self) >= duration('1ms')"
+                                          }
+                                        ]
+                                      },
+                                      "version": {
+                                        "description": "HTTP protocol version to use when connecting to\nthe backend.\nIf not specified, the version is automatically determined:\n* `Service` types can specify it with `appProtocol` on the `Service`\n  port.\n* If traffic is identified as gRPC, `HTTP2` is used.\n* If the incoming traffic was plaintext HTTP, the original protocol will\n  be used.\n* If the incoming traffic was HTTPS, `HTTP1` will be used. This is\n  because most clients will transparently upgrade HTTPS traffic to\n  `HTTP2`, even if the backend doesn't support it.",
+                                        "enum": [
+                                          "HTTP1",
+                                          "HTTP2"
+                                        ],
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "tcp": {
+                                    "description": "Settings for managing TCP connections to the backend.",
+                                    "properties": {
+                                      "connectTimeout": {
+                                        "description": "Deadline for establishing a connection to\nthe destination.",
+                                        "type": "string",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "invalid duration value",
+                                            "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                          },
+                                          {
+                                            "message": "connectTimeout must be at least 100ms",
+                                            "rule": "duration(self) >= duration('100ms')"
+                                          }
+                                        ]
+                                      },
+                                      "keepalive": {
+                                        "description": "Settings for enabling TCP keepalives on the\nconnection.",
+                                        "properties": {
+                                          "interval": {
+                                            "description": "Time between keepalive probes.\nIf unset, this defaults to 180s.",
+                                            "type": "string",
+                                            "x-kubernetes-validations": [
+                                              {
+                                                "message": "invalid duration value",
+                                                "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                              },
+                                              {
+                                                "message": "interval must be at least 1 second",
+                                                "rule": "duration(self) >= duration('1s')"
+                                              }
+                                            ]
+                                          },
+                                          "retries": {
+                                            "description": "Maximum number of keepalive probes to send before dropping the connection.\nIf unset, this defaults to 9.",
+                                            "format": "int32",
+                                            "maximum": 64,
+                                            "minimum": 1,
+                                            "type": "integer"
+                                          },
+                                          "time": {
+                                            "description": "Time a connection needs to be idle before keepalive probes start being sent.\nIf unset, this defaults to 180s.",
+                                            "type": "string",
+                                            "x-kubernetes-validations": [
+                                              {
+                                                "message": "invalid duration value",
+                                                "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                              },
+                                              {
+                                                "message": "time must be at least 1 second",
+                                                "rule": "duration(self) >= duration('1s')"
+                                              }
+                                            ]
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "tls": {
+                                    "description": "Settings for managing TLS connections to the backend.\n\nIf this field is set, TLS will be initiated to the backend; the system trusted CA certificates will be used to\nvalidate the server, and the SNI will automatically be set based on the destination.",
+                                    "properties": {
+                                      "alpnProtocols": {
+                                        "description": "Application-Layer Protocol Negotiation (`ALPN`)\nvalue to use in the TLS handshake.\n\nIf not present, defaults to `[\"h2\", \"http/1.1\"]`.",
+                                        "items": {
+                                          "maxLength": 64,
+                                          "minLength": 1,
+                                          "type": "string"
+                                        },
+                                        "maxItems": 16,
+                                        "minItems": 1,
+                                        "type": "array"
+                                      },
+                                      "caCertificateRefs": {
+                                        "description": "CA certificate `ConfigMap` to use to\nverify the server certificate.\nIf unset, the system's trusted certificates are used.",
+                                        "items": {
+                                          "description": "LocalObjectReference contains enough information to let you locate the\nreferenced object inside the same namespace.",
+                                          "properties": {
+                                            "name": {
+                                              "default": "",
+                                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "x-kubernetes-map-type": "atomic",
+                                          "additionalProperties": false
+                                        },
+                                        "maxItems": 1,
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
+                                      },
+                                      "insecureSkipVerify": {
+                                        "description": "Originates TLS but skips verification of the backend's certificate.\nWARNING: This is an insecure option that should only be used if the risks are understood.\n\nThere are two modes:\n* `All` disables all TLS verification.\n* `Hostname` verifies the CA certificate is trusted, but ignores any\n  mismatch of hostname or SANs. Note that this method is still insecure;\n  prefer setting `verifySubjectAltNames` to customize the valid hostnames\n  if possible.",
+                                        "enum": [
+                                          "All",
+                                          "Hostname"
+                                        ],
+                                        "type": "string"
+                                      },
+                                      "keyExchangeGroups": {
+                                        "description": "Ordered list of key exchange groups for a TLS connection.\nFor example: `X25519_MLKEM768,X25519`.",
+                                        "items": {
+                                          "enum": [
+                                            "P-256",
+                                            "P-384",
+                                            "X25519",
+                                            "X25519_MLKEM768"
+                                          ],
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "mtlsCertificateRef": {
+                                        "description": "Enables mutual TLS to the backend, using the\nspecified key (`tls.key`) and cert (`tls.crt`) from the referenced\ncredential source, defaulting to a Kubernetes `Secret`.\n\nAn optional `ca.cert` field, if present, will be used to verify the\nserver certificate. If `caCertificateRefs` is also specified, the\n`caCertificateRefs` field takes priority.\n\nIf unspecified, no client certificate will be used.",
+                                        "items": {
+                                          "description": "References a same-namespace credential.\nSet only `name` to reference a Kubernetes Secret.",
+                                          "properties": {
+                                            "group": {
+                                              "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                                              "type": "string"
+                                            },
+                                            "kind": {
+                                              "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "description": "The name of the referenced credential.",
+                                              "maxLength": 253,
+                                              "minLength": 1,
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "name"
+                                          ],
+                                          "type": "object",
+                                          "x-kubernetes-map-type": "atomic",
+                                          "x-kubernetes-validations": [
+                                            {
+                                              "message": "custom credential refs must set both group and kind",
+                                              "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                                            }
+                                          ],
+                                          "additionalProperties": false
+                                        },
+                                        "maxItems": 1,
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
+                                      },
+                                      "sni": {
+                                        "description": "Server Name Indicator (`SNI`) to use in the TLS\nhandshake. If unset, the `SNI` is automatically set based on the\ndestination hostname.",
+                                        "maxLength": 253,
+                                        "minLength": 1,
+                                        "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                                        "type": "string"
+                                      },
+                                      "verifySubjectAltNames": {
+                                        "description": "Subject Alternative Names (`SAN`)\nto verify in the server certificate.\nIf not present, the destination hostname is automatically used.",
+                                        "items": {
+                                          "maxLength": 256,
+                                          "minLength": 1,
+                                          "type": "string"
+                                        },
+                                        "maxItems": 16,
+                                        "minItems": 1,
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "x-kubernetes-validations": [
+                                      {
+                                        "message": "insecureSkipVerify All and caCertificateRefs may not be set together",
+                                        "rule": "has(self.insecureSkipVerify) && self.insecureSkipVerify == 'All' ? !has(self.caCertificateRefs) : true"
+                                      },
+                                      {
+                                        "message": "insecureSkipVerify and verifySubjectAltNames may not be set together",
+                                        "rule": "has(self.insecureSkipVerify) ? !has(self.verifySubjectAltNames) : true"
+                                      },
+                                      {
+                                        "message": "at most one of the fields in [verifySubjectAltNames insecureSkipVerify] may be set",
+                                        "rule": "[has(self.verifySubjectAltNames),has(self.insecureSkipVerify)].filter(x,x==true).size() <= 1"
+                                      }
+                                    ],
+                                    "additionalProperties": false
+                                  },
+                                  "tunnel": {
+                                    "description": "Settings for managing tunnel connections, with behavior like `HTTPS_PROXY`, to the backend.",
+                                    "properties": {
+                                      "backendRef": {
+                                        "description": "Proxy server to reach.\nSupported types: `Service` and `Backend`.",
+                                        "properties": {
+                                          "group": {
+                                            "default": "",
+                                            "description": "Group is the group of the referent. For example, \"gateway.networking.k8s.io\".\nWhen unspecified or empty string, core API group is inferred.",
+                                            "maxLength": 253,
+                                            "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                                            "type": "string"
+                                          },
+                                          "kind": {
+                                            "default": "Service",
+                                            "description": "Kind is the Kubernetes resource kind of the referent. For example\n\"Service\".\n\nDefaults to \"Service\" when not specified.\n\nExternalName services can refer to CNAME DNS records that may live\noutside of the cluster and as such are difficult to reason about in\nterms of conformance. They also may not be safe to forward to (see\nCVE-2021-25740 for more information). Implementations SHOULD NOT\nsupport ExternalName Services.\n\nSupport: Core (Services with a type other than ExternalName)\n\nSupport: Implementation-specific (Services with type ExternalName)",
+                                            "maxLength": 63,
+                                            "minLength": 1,
+                                            "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "description": "Name is the name of the referent.",
+                                            "maxLength": 253,
+                                            "minLength": 1,
+                                            "type": "string"
+                                          },
+                                          "namespace": {
+                                            "description": "Namespace is the namespace of the backend. When unspecified, the local\nnamespace is inferred.\n\nNote that when a namespace different than the local namespace is specified,\na ReferenceGrant object is required in the referent namespace to allow that\nnamespace's owner to accept the reference. See the ReferenceGrant\ndocumentation for details.\n\nSupport: Core",
+                                            "maxLength": 63,
+                                            "minLength": 1,
+                                            "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "description": "Port specifies the destination port number to use for this resource.\nPort is required when the referent is a Kubernetes Service. In this\ncase, the port number is the service port number, not the target port.\nFor other resources, destination port might be derived from the referent\nresource or this field.",
+                                            "format": "int32",
+                                            "maximum": 65535,
+                                            "minimum": 1,
+                                            "type": "integer"
+                                          }
+                                        },
+                                        "required": [
+                                          "name"
+                                        ],
+                                        "type": "object",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "Must have port for Service reference",
+                                            "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
+                                          }
+                                        ],
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "required": [
+                                      "backendRef"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "projectId": {
+                                "description": "Google Cloud project ID.",
+                                "maxLength": 256,
+                                "minLength": 1,
+                                "type": "string"
+                              },
+                              "templateId": {
+                                "description": "Template ID for Google Model Armor.",
+                                "maxLength": 256,
+                                "minLength": 1,
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "projectId",
+                              "templateId"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "regex": {
+                            "description": "Regular expression (regex) matching for prompt guards and data masking.",
+                            "properties": {
+                              "action": {
+                                "default": "Mask",
+                                "description": "The action to take if a regex pattern is matched in a request or response.\nThis setting applies only to request matches. `PromptguardResponse`\nmatches are always masked by default.\nDefaults to `Mask`.",
+                                "enum": [
+                                  "Mask",
+                                  "Reject"
+                                ],
+                                "type": "string"
+                              },
+                              "builtins": {
+                                "description": "Built-in regex patterns to match against the request or response.\nMatches and built-ins are additive.",
+                                "items": {
+                                  "description": "Built-in regex patterns for specific types of strings in prompts.\nFor example, if you specify `CreditCard`, any credit card numbers\nin the request or response are matched.",
+                                  "enum": [
+                                    "CaSin",
+                                    "CreditCard",
+                                    "Email",
+                                    "PhoneNumber",
+                                    "Ssn"
+                                  ],
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "matches": {
+                                "description": "Regex patterns to match against the request or response.\nMatches and built-ins are additive.",
+                                "items": {
+                                  "maxLength": 1024,
+                                  "minLength": 1,
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "response": {
+                            "description": "Custom response message to return to the client. If not specified, defaults to\n`The response was rejected due to inappropriate content`.",
+                            "properties": {
+                              "message": {
+                                "default": "The request was rejected due to inappropriate content",
+                                "description": "Custom response message to return to the client. If not specified, defaults to\n`The request was rejected due to inappropriate content`.",
+                                "type": "string"
+                              },
+                              "statusCode": {
+                                "default": 403,
+                                "description": "Status code to return to the client. Defaults to 403.",
+                                "format": "int32",
+                                "maximum": 599,
+                                "minimum": 200,
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-validations": [
+                              {
+                                "message": "at least one of the fields in [message statusCode] must be set",
+                                "rule": "[has(self.message),has(self.statusCode)].filter(x,x==true).size() >= 1"
+                              }
+                            ],
+                            "additionalProperties": false
+                          },
+                          "webhook": {
+                            "description": "Webhook that receives responses for prompt guarding.",
+                            "properties": {
+                              "backendRef": {
+                                "description": "Webhook server to reach.\n\nSupported types: Service and Backend.",
+                                "properties": {
+                                  "group": {
+                                    "default": "",
+                                    "description": "Group is the group of the referent. For example, \"gateway.networking.k8s.io\".\nWhen unspecified or empty string, core API group is inferred.",
+                                    "maxLength": 253,
+                                    "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                                    "type": "string"
+                                  },
+                                  "kind": {
+                                    "default": "Service",
+                                    "description": "Kind is the Kubernetes resource kind of the referent. For example\n\"Service\".\n\nDefaults to \"Service\" when not specified.\n\nExternalName services can refer to CNAME DNS records that may live\noutside of the cluster and as such are difficult to reason about in\nterms of conformance. They also may not be safe to forward to (see\nCVE-2021-25740 for more information). Implementations SHOULD NOT\nsupport ExternalName Services.\n\nSupport: Core (Services with a type other than ExternalName)\n\nSupport: Implementation-specific (Services with type ExternalName)",
+                                    "maxLength": 63,
+                                    "minLength": 1,
+                                    "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "description": "Name is the name of the referent.",
+                                    "maxLength": 253,
+                                    "minLength": 1,
+                                    "type": "string"
+                                  },
+                                  "namespace": {
+                                    "description": "Namespace is the namespace of the backend. When unspecified, the local\nnamespace is inferred.\n\nNote that when a namespace different than the local namespace is specified,\na ReferenceGrant object is required in the referent namespace to allow that\nnamespace's owner to accept the reference. See the ReferenceGrant\ndocumentation for details.\n\nSupport: Core",
+                                    "maxLength": 63,
+                                    "minLength": 1,
+                                    "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "description": "Port specifies the destination port number to use for this resource.\nPort is required when the referent is a Kubernetes Service. In this\ncase, the port number is the service port number, not the target port.\nFor other resources, destination port might be derived from the referent\nresource or this field.",
+                                    "format": "int32",
+                                    "maximum": 65535,
+                                    "minimum": 1,
+                                    "type": "integer"
+                                  }
+                                },
+                                "required": [
+                                  "name"
+                                ],
+                                "type": "object",
+                                "x-kubernetes-validations": [
+                                  {
+                                    "message": "Must have port for Service reference",
+                                    "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
+                                  }
+                                ],
+                                "additionalProperties": false
+                              },
+                              "failureMode": {
+                                "description": "Behavior when the webhook guardrail is unavailable\nor returns an error. `FailOpen` allows the request to continue.\n`FailClosed` (default) rejects the request.",
+                                "enum": [
+                                  "FailClosed",
+                                  "FailOpen"
+                                ],
+                                "type": "string"
+                              },
+                              "forwardHeaderMatches": {
+                                "description": "HTTP header matches used to select the headers to forward to the webhook.\nRequest headers are used when forwarding requests and response headers\nare used when forwarding responses.\nBy default, no headers are forwarded.",
+                                "items": {
+                                  "description": "HTTPHeaderMatch describes how to select a HTTP route by matching HTTP request\nheaders.",
+                                  "properties": {
+                                    "name": {
+                                      "description": "Name is the name of the HTTP Header to be matched. Name matching MUST be\ncase-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).\n\nIf multiple entries specify equivalent header names, only the first\nentry with an equivalent name MUST be considered for a match. Subsequent\nentries with an equivalent header name MUST be ignored. Due to the\ncase-insensitivity of header names, \"foo\" and \"Foo\" are considered\nequivalent.\n\nWhen a header is repeated in an HTTP request, it is\nimplementation-specific behavior as to how this is represented.\nGenerally, proxies should follow the guidance from the RFC:\nhttps://www.rfc-editor.org/rfc/rfc7230.html#section-3.2.2 regarding\nprocessing a repeated header, with special handling for \"Set-Cookie\".",
+                                      "maxLength": 256,
+                                      "minLength": 1,
+                                      "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                                      "type": "string"
+                                    },
+                                    "type": {
+                                      "default": "Exact",
+                                      "description": "Type specifies how to match against the value of the header.\n\nSupport: Core (Exact)\n\nSupport: Implementation-specific (RegularExpression)\n\nSince RegularExpression HeaderMatchType has implementation-specific\nconformance, implementations can support POSIX, PCRE or any other dialects\nof regular expressions. Please read the implementation's documentation to\ndetermine the supported dialect.",
+                                      "enum": [
+                                        "Exact",
+                                        "RegularExpression"
+                                      ],
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "description": "Value is the value of HTTP Header to be matched.\n<gateway:experimental:description>\nMust consist of printable US-ASCII characters, optionally separated\nby single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2\n</gateway:experimental:description>\n\n<gateway:experimental:validation:Pattern=`^[!-~]+([\\t ]?[!-~]+)*$`>",
+                                      "maxLength": 4096,
+                                      "minLength": 1,
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "name",
+                                    "value"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "required": [
+                              "backendRef"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-validations": [
+                          {
+                            "message": "exactly one of the fields in [regex webhook bedrockGuardrails googleModelArmor] must be set",
+                            "rule": "[has(self.regex),has(self.webhook),has(self.bedrockGuardrails),has(self.googleModelArmor)].filter(x,x==true).size() == 1"
+                          }
+                        ],
+                        "additionalProperties": false
+                      },
+                      "maxItems": 8,
+                      "minItems": 1,
+                      "type": "array"
+                    },
+                    "streaming": {
+                      "description": "Apply prompt guards to streaming responses and realtime websocket messages.\nDefaults to disabled to preserve streaming throughput unless explicitly enabled.",
+                      "enum": [
+                        "Enabled"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "at least one of the fields in [request response] must be set",
+                      "rule": "[has(self.request),has(self.response)].filter(x,x==true).size() >= 1"
+                    }
+                  ],
+                  "additionalProperties": false
+                },
+                "routes": {
+                  "additionalProperties": {
+                    "description": "How the AI gateway should process incoming requests\nbased on the URL path and the API format expected.",
+                    "enum": [
+                      "AnthropicTokenCount",
+                      "Completions",
+                      "Detect",
+                      "Embeddings",
+                      "Messages",
+                      "Models",
+                      "Passthrough",
+                      "Realtime",
+                      "Rerank",
+                      "Responses"
+                    ],
+                    "type": "string"
+                  },
+                  "description": "Rules for identifying the type of traffic to handle.\nThe keys are URL path suffixes matched using ends-with comparison, for\nexample `\"/v1/chat/completions\"`.\nThe special `*` wildcard matches any path.\nIf not specified, all traffic defaults to `completions` type.",
+                  "type": "object"
+                },
+                "transformations": {
+                  "description": "CEL transformations to compute and set fields in the request body.\nThe expression result overwrites any existing value for that field.\nThis has a higher priority than `overrides` if both are set for the same\nkey.",
+                  "items": {
+                    "description": "Maps a request JSON field to a CEL expression.\nThe expression is evaluated against the current request body and its result\nis assigned to the configured field.",
+                    "properties": {
+                      "expression": {
+                        "description": "CEL expression used to compute the field value.",
+                        "maxLength": 16384,
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "field": {
+                        "allOf": [
+                          {
+                            "minLength": 1
+                          },
+                          {
+                            "minLength": 1
+                          }
+                        ],
+                        "description": "Name of the field to set.",
+                        "maxLength": 256,
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "expression",
+                      "field"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "maxItems": 64,
+                  "minItems": 1,
+                  "type": "array"
+                }
+              },
+              "type": "object",
+              "x-kubernetes-validations": [
+                {
+                  "message": "at least one of the fields in [defaults modelAliases overrides prompt promptCaching promptGuard routes transformations] must be set",
+                  "rule": "[has(self.defaults),has(self.modelAliases),has(self.overrides),has(self.prompt),has(self.promptCaching),has(self.promptGuard),has(self.routes),has(self.transformations)].filter(x,x==true).size() >= 1"
+                }
+              ],
+              "additionalProperties": false
+            },
+            "auth": {
+              "description": "Settings for managing authentication to the backend.",
+              "properties": {
+                "aws": {
+                  "description": "Explicit AWS authentication method for the backend.\nWhen omitted, default AWS SDK credential discovery is used.",
+                  "properties": {
+                    "assumeRole": {
+                      "description": "AWS STS AssumeRole settings to use before signing backend requests.\nAmbient AWS credentials are used as the source credentials for STS.",
+                      "properties": {
+                        "roleArn": {
+                          "description": "AWS IAM role ARN to assume.",
+                          "minLength": 1,
+                          "pattern": "^arn:aws[a-z-]*:iam::[0-9]{12}:role/.+$",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "roleArn"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "secretRef": {
+                      "description": "Credential source, defaulting to a Kubernetes\n`Secret`, containing the AWS credentials. When using the default Secret\nresolver, the `Secret` must have keys `accessKey`, `secretKey`, and\noptionally `sessionToken`.",
+                      "properties": {
+                        "group": {
+                          "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                          "type": "string"
+                        },
+                        "kind": {
+                          "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "description": "The name of the referenced credential.",
+                          "maxLength": 253,
+                          "minLength": 1,
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "x-kubernetes-validations": [
+                        {
+                          "message": "custom credential refs must set both group and kind",
+                          "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                        }
+                      ],
+                      "additionalProperties": false
+                    },
+                    "serviceName": {
+                      "description": "AWS SigV4 signing service name, for example\n`bedrock`, `bedrock-agentcore`, or `execute-api`). If unset, typed AWS\nbackends may provide this automatically.",
+                      "maxLength": 256,
+                      "minLength": 1,
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "secretRef and assumeRole are mutually exclusive",
+                      "rule": "!(has(self.secretRef) && has(self.assumeRole))"
+                    }
+                  ],
+                  "additionalProperties": false
+                },
+                "azure": {
+                  "description": "Azure authentication method for the backend.",
+                  "properties": {
+                    "managedIdentity": {
+                      "description": "Managed identity authentication settings.",
+                      "properties": {
+                        "clientId": {
+                          "type": "string"
+                        },
+                        "objectId": {
+                          "type": "string"
+                        },
+                        "resourceId": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "clientId",
+                        "objectId",
+                        "resourceId"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "secretRef": {
+                      "description": "Credential source, defaulting to a Kubernetes\n`Secret`, containing the Azure credentials. When using the default Secret\nresolver, the `Secret` must have keys `clientID`, `tenantID`, and\n`clientSecret`.",
+                      "properties": {
+                        "group": {
+                          "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                          "type": "string"
+                        },
+                        "kind": {
+                          "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "description": "The name of the referenced credential.",
+                          "maxLength": 253,
+                          "minLength": 1,
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "x-kubernetes-validations": [
+                        {
+                          "message": "custom credential refs must set both group and kind",
+                          "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                        }
+                      ],
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "gcp": {
+                  "description": "Google authentication method for the backend.\nWhen omitted, default Google credential discovery is used.",
+                  "properties": {
+                    "audience": {
+                      "description": "Explicit `aud` value for the ID token. Only\nvalid with `IdToken` type. If not set, the `aud` is automatically\nderived from the backend hostname.",
+                      "maxLength": 256,
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "secretRef": {
+                      "description": "Credential source, defaulting to a Kubernetes\n`Secret`, containing ADC-compatible Google credential JSON. When using\nthe default Secret resolver, this must be stored in the `credentials.json`\nkey. When omitted, ambient credentials are used.",
+                      "properties": {
+                        "group": {
+                          "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                          "type": "string"
+                        },
+                        "kind": {
+                          "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "description": "The name of the referenced credential.",
+                          "maxLength": 253,
+                          "minLength": 1,
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "x-kubernetes-validations": [
+                        {
+                          "message": "custom credential refs must set both group and kind",
+                          "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                        }
+                      ],
+                      "additionalProperties": false
+                    },
+                    "type": {
+                      "description": "The type of token to generate. To authenticate to GCP services,\ngenerally an `AccessToken` is used. To authenticate to Cloud Run, an\n`IdToken` is used.",
+                      "enum": [
+                        "AccessToken",
+                        "IdToken"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "audience is only valid with IdToken",
+                      "rule": "has(self.audience) ? self.type == 'IdToken' : true"
+                    }
+                  ],
+                  "additionalProperties": false
+                },
+                "key": {
+                  "description": "Inline key to use as the value of the\n`Authorization` header. This option is the least secure; usage of a\n`Secret` is preferred.",
+                  "maxLength": 2048,
+                  "type": "string"
+                },
+                "location": {
+                  "description": "Where backend credentials are inserted.\nIf omitted, credentials are written to the `Authorization` header with the `Bearer ` prefix.\nThis applies to `key`, `secretRef`, and `passthrough`.",
+                  "properties": {
+                    "cookie": {
+                      "properties": {
+                        "name": {
+                          "maxLength": 256,
+                          "minLength": 1,
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "header": {
+                      "properties": {
+                        "name": {
+                          "description": "HTTPHeaderName is the name of an HTTP header.\n\nValid values include:\n\n* \"Authorization\"\n* \"Set-Cookie\"\n\nInvalid values include:\n\n  - \":method\" - \":\" is an invalid character. This means that HTTP/2 pseudo\n    headers are not currently supported by this type.\n  - \"/invalid\" - \"/ \" is an invalid character",
+                          "maxLength": 256,
+                          "minLength": 1,
+                          "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                          "type": "string"
+                        },
+                        "prefix": {
+                          "maxLength": 256,
+                          "minLength": 1,
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "queryParameter": {
+                      "properties": {
+                        "name": {
+                          "maxLength": 256,
+                          "minLength": 1,
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "exactly one of the fields in [header queryParameter cookie] must be set",
+                      "rule": "[has(self.header),has(self.queryParameter),has(self.cookie)].filter(x,x==true).size() == 1"
+                    }
+                  ],
+                  "additionalProperties": false
+                },
+                "passthrough": {
+                  "description": "Passes through an existing token that has been sent by the\nclient and validated. Other policies, like JWT and API key\nauthentication, will strip the original client credentials. Passthrough backend authentication\ncauses the original token to be added back into the request. If there are no client authentication policies on the\nrequest, the original token would be unchanged, so this would have no effect.",
+                  "type": "object"
+                },
+                "secretRef": {
+                  "description": "Credential source, defaulting to a Kubernetes\n`Secret`, storing the key to use as the authorization value. When using\nthe default Secret resolver, this must be stored in the `Authorization`\nkey.",
+                  "properties": {
+                    "group": {
+                      "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                      "type": "string"
+                    },
+                    "kind": {
+                      "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                      "type": "string"
+                    },
+                    "name": {
+                      "description": "The name of the referenced credential.",
+                      "maxLength": 253,
+                      "minLength": 1,
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "name"
+                  ],
+                  "type": "object",
+                  "x-kubernetes-map-type": "atomic",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "custom credential refs must set both group and kind",
+                      "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                    }
+                  ],
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "x-kubernetes-validations": [
+                {
+                  "message": "location may only be set for key or passthrough auth",
+                  "rule": "has(self.location) ? has(self.key) || has(self.secretRef) || has(self.passthrough) : true"
+                },
+                {
+                  "message": "exactly one of the fields in [key secretRef passthrough aws azure gcp] must be set",
+                  "rule": "[has(self.key),has(self.secretRef),has(self.passthrough),has(self.aws),has(self.azure),has(self.gcp)].filter(x,x==true).size() == 1"
+                }
+              ],
+              "additionalProperties": false
+            },
+            "extAuth": {
+              "description": "External authentication configuration for requests\nsent to this backend.",
+              "properties": {
+                "backendRef": {
+                  "description": "External Authorization server to reach.\n\nSupported types: `Service` and `Backend`.",
+                  "properties": {
+                    "group": {
+                      "default": "",
+                      "description": "Group is the group of the referent. For example, \"gateway.networking.k8s.io\".\nWhen unspecified or empty string, core API group is inferred.",
+                      "maxLength": 253,
+                      "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                      "type": "string"
+                    },
+                    "kind": {
+                      "default": "Service",
+                      "description": "Kind is the Kubernetes resource kind of the referent. For example\n\"Service\".\n\nDefaults to \"Service\" when not specified.\n\nExternalName services can refer to CNAME DNS records that may live\noutside of the cluster and as such are difficult to reason about in\nterms of conformance. They also may not be safe to forward to (see\nCVE-2021-25740 for more information). Implementations SHOULD NOT\nsupport ExternalName Services.\n\nSupport: Core (Services with a type other than ExternalName)\n\nSupport: Implementation-specific (Services with type ExternalName)",
+                      "maxLength": 63,
+                      "minLength": 1,
+                      "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
+                      "type": "string"
+                    },
+                    "name": {
+                      "description": "Name is the name of the referent.",
+                      "maxLength": 253,
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "namespace": {
+                      "description": "Namespace is the namespace of the backend. When unspecified, the local\nnamespace is inferred.\n\nNote that when a namespace different than the local namespace is specified,\na ReferenceGrant object is required in the referent namespace to allow that\nnamespace's owner to accept the reference. See the ReferenceGrant\ndocumentation for details.\n\nSupport: Core",
+                      "maxLength": 63,
+                      "minLength": 1,
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                      "type": "string"
+                    },
+                    "port": {
+                      "description": "Port specifies the destination port number to use for this resource.\nPort is required when the referent is a Kubernetes Service. In this\ncase, the port number is the service port number, not the target port.\nFor other resources, destination port might be derived from the referent\nresource or this field.",
+                      "format": "int32",
+                      "maximum": 65535,
+                      "minimum": 1,
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "name"
+                  ],
+                  "type": "object",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "Must have port for Service reference",
+                      "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
+                    }
+                  ],
+                  "additionalProperties": false
+                },
+                "cache": {
+                  "description": "Caches gRPC authorization results.\n\nWARNING: the safety of this feature depends on the cache key accurately\ncapturing every request property that the authorization service uses to\nmake a decision. For example, if the service returns different results\nbased on both path and authorization header, both must be included in\n`key`; otherwise, one request may incorrectly reuse another request's\nauthorization result.\n\nIf any key expression fails to evaluate or produces an unsupported value,\nthe request is still sent to the authorization service, but its result is\nnot read from or written to the cache.",
+                  "properties": {
+                    "key": {
+                      "description": "Ordered list of CEL expressions evaluated against the request\nto construct the cache key.",
+                      "items": {
+                        "description": "A Common Expression Language (CEL) expression.",
+                        "maxLength": 16384,
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "maxItems": 16,
+                      "minItems": 1,
+                      "type": "array"
+                    },
+                    "maxEntries": {
+                      "description": "Maximum number of authorization results to keep in\nthe cache. If unset, this defaults to 10000.",
+                      "format": "int32",
+                      "minimum": 1,
+                      "type": "integer"
+                    },
+                    "ttl": {
+                      "description": "Duration string, such as `5m`, or a CEL expression that\nreturns the duration that cached authorization results may be reused, or a\ntimestamp when the cached authorization result expires. The expression is\nevaluated after the authorization response has been applied to the request.",
+                      "maxLength": 16384,
+                      "minLength": 1,
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "key",
+                    "ttl"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "failureMode": {
+                  "description": "Behavior when the external authorization service is\nunavailable or returns an error. \"FailOpen\" allows the request to continue.\n\"FailClosed\" (default) denies the request.",
+                  "enum": [
+                    "FailClosed",
+                    "FailOpen"
+                  ],
+                  "type": "string"
+                },
+                "forwardBody": {
+                  "description": "Whether to include the HTTP body in the authorization request.\nIf enabled, the request body will be buffered.",
+                  "properties": {
+                    "maxSize": {
+                      "anyOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ],
+                      "description": "Largest body, in bytes, that will be buffered\nand sent to the authorization server. If the body size is larger than\n`maxSize`, then the request will be rejected with a response.",
+                      "maxLength": 32,
+                      "minLength": 1,
+                      "pattern": "^[+-]?([0-9]+(\\.[0-9]*)?|\\.[0-9]+)(([KMGTPE]i)|[numkMGTPE]|[eE](\\+?0*([0-9]|1[0-8])|-0*[0-9]))?$",
+                      "x-kubernetes-int-or-string": true,
+                      "x-kubernetes-validations": [
+                        {
+                          "message": "value must be at least 1 byte and fit within uint32",
+                          "rule": "(self >= 1 && self <= 4294967295) || self.size() > 0"
+                        }
+                      ]
+                    }
+                  },
+                  "required": [
+                    "maxSize"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "grpc": {
+                  "description": "Uses the gRPC External Authorization\n[protocol](https://www.envoyproxy.io/docs/envoy/latest/api-v3/service/auth/v3/external_auth.proto) should be used.",
+                  "properties": {
+                    "contextExtensions": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "Additional arbitrary key-value pairs to\nsend to the authorization server in the `context_extensions` field.",
+                      "maxProperties": 64,
+                      "type": "object"
+                    },
+                    "requestMetadata": {
+                      "additionalProperties": {
+                        "description": "A Common Expression Language (CEL) expression.",
+                        "maxLength": 16384,
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "description": "Metadata to send to the authorization\nserver. This maps to the `metadata_context.filter_metadata` field of the\nrequest, and allows dynamic CEL expressions. If unset, by default the\n`envoy.filters.http.jwt_authn` key is set if the JWT policy is used as\nwell, for compatibility.",
+                      "maxProperties": 64,
+                      "type": "object"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "http": {
+                  "description": "Uses HTTP to connect to\nthe authorization server. The authorization server must return a `200`\nstatus code, otherwise the request is considered an authorization\nfailure.",
+                  "properties": {
+                    "addRequestHeaders": {
+                      "additionalProperties": {
+                        "description": "A Common Expression Language (CEL) expression.",
+                        "maxLength": 16384,
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "description": "Additional headers to add to the\nrequest to the authorization server. While `allowedRequestHeaders` just\npasses the original headers through, `addRequestHeaders` allows defining\ncustom headers based on CEL expressions.",
+                      "maxProperties": 64,
+                      "type": "object"
+                    },
+                    "allowedRequestHeaders": {
+                      "description": "Additional headers from the client request that\nwill be sent to the authorization server.\n\nIf unset, the following headers are sent by default: `Authorization`.",
+                      "items": {
+                        "maxLength": 256,
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "maxItems": 64,
+                      "type": "array"
+                    },
+                    "allowedResponseHeaders": {
+                      "description": "Headers from the authorization response that\nwill be copied into the request to the backend.",
+                      "items": {
+                        "maxLength": 256,
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "maxItems": 64,
+                      "type": "array"
+                    },
+                    "path": {
+                      "description": "Path to send to the authorization server. If\nunset, this defaults to the original request path.\nThis is a CEL expression, which allows customizing the path based on the\nincoming request. For example, to add a prefix, use\n`\"/prefix/\" + request.path`.",
+                      "maxLength": 16384,
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "redirect": {
+                      "description": "Optional expression that determines a path to\nredirect to on authorization failure. This is useful to redirect to a\nsign-in page.",
+                      "maxLength": 16384,
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "responseMetadata": {
+                      "additionalProperties": {
+                        "description": "A Common Expression Language (CEL) expression.",
+                        "maxLength": 16384,
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "description": "Metadata fields to construct\nfrom the authorization response. These will be included under the\n`extauthz` variable in future CEL expressions. Setting this is useful\nfor things like logging usernames, without needing to include them as\nheaders to the backend, as `allowedResponseHeaders` would.",
+                      "maxProperties": 64,
+                      "type": "object"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "x-kubernetes-validations": [
+                {
+                  "message": "cache requires grpc",
+                  "rule": "!has(self.cache) || has(self.grpc)"
+                }
+              ],
+              "additionalProperties": false
+            },
+            "health": {
+              "description": "Settings for passive and active health checking.",
+              "properties": {
+                "eviction": {
+                  "description": "Settings for evicting unhealthy backends.",
+                  "properties": {
+                    "consecutiveFailures": {
+                      "description": "Number of consecutive unhealthy responses required before the backend is evicted.\nFor example, a value of 5 means the backend must receive 5 unhealthy responses in a row before being evicted.\nWhen both consecutiveFailures and healthThreshold are set, the backend is evicted when either condition is met.\nWhen neither is set, a single unhealthy response can trigger eviction.",
+                      "format": "int32",
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "duration": {
+                      "default": "3s",
+                      "description": "Base time a backend should be evicted after being marked unhealthy.\nSubsequent evictions use multiplicative backoff (duration * times_evicted).\nIf all endpoints are evicted, the load balancer falls back to returning evicted endpoints\nrather than failing entirely.\nIf unset, defaults to `3s`.",
+                      "type": "string",
+                      "x-kubernetes-validations": [
+                        {
+                          "message": "invalid duration value",
+                          "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                        },
+                        {
+                          "message": "evictionDuration must be at least 1 second",
+                          "rule": "duration(self) >= duration('1s')"
+                        }
+                      ]
+                    },
+                    "healthThreshold": {
+                      "description": "EWMA health score threshold, expressed as 0 to 100.\nWhen set, a backend is only evicted if its computed health drops below this value after an unhealthy response.\nFor example, 50 means the backend is evicted when its EWMA health falls below 50% following failures.\nUnlike consecutiveFailures (which counts consecutive failures), this uses a sliding-window average\nso a single success in a stream of failures can delay eviction.\nWhen both consecutiveFailures and healthThreshold are set, the backend is evicted when either condition is met.\nWhen neither is set, a single unhealthy response triggers eviction.",
+                      "format": "int32",
+                      "maximum": 100,
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "restoreHealth": {
+                      "description": "Health score from 0 to 100 assigned to a backend when it returns from eviction.\nFor gradual recovery, set below 100; for full recovery immediately, set 100.\nIf unset, the backend resumes with the health it had when evicted.",
+                      "format": "int32",
+                      "maximum": 100,
+                      "minimum": 0,
+                      "type": "integer"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "unhealthyCondition": {
+                  "description": "CEL expression that determines whether a response indicates an unhealthy backend.\nWhen the expression evaluates to true, the backend is considered unhealthy and may be evicted.\n\nFor example, to evict on 5xx responses: `response.code >= 500`.\n\nWhen unset, any 5xx response, or a connection failure, is treated as unhealthy.\nThis default lowers the backend's health score but does not trigger eviction on its own.",
+                  "maxLength": 16384,
+                  "minLength": 1,
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "http": {
+              "description": "Settings for managing HTTP requests to the backend.",
+              "properties": {
+                "requestTimeout": {
+                  "description": "Deadline for receiving a response from the backend.",
+                  "type": "string",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "invalid duration value",
+                      "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                    },
+                    {
+                      "message": "requestTimeout must be at least 1ms",
+                      "rule": "duration(self) >= duration('1ms')"
+                    }
+                  ]
+                },
+                "version": {
+                  "description": "HTTP protocol version to use when connecting to\nthe backend.\nIf not specified, the version is automatically determined:\n* `Service` types can specify it with `appProtocol` on the `Service`\n  port.\n* If traffic is identified as gRPC, `HTTP2` is used.\n* If the incoming traffic was plaintext HTTP, the original protocol will\n  be used.\n* If the incoming traffic was HTTPS, `HTTP1` will be used. This is\n  because most clients will transparently upgrade HTTPS traffic to\n  `HTTP2`, even if the backend doesn't support it.",
+                  "enum": [
+                    "HTTP1",
+                    "HTTP2"
+                  ],
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "mcp": {
+              "description": "Settings for MCP workloads. This is only applicable when\nconnecting to a `Backend` of type `mcp`.",
+              "properties": {
+                "authentication": {
+                  "description": "MCP backend-specific authentication rules.\n\nThis field is deprecated; prefer to use traffic policy `jwtAuthentication.mcp`, which ensures authentication runs before\nother policies such as transformation and rate limiting.",
+                  "properties": {
+                    "audiences": {
+                      "description": "Allowed audiences that are allowed\naccess. This corresponds to the `aud` claim\n([RFC 7519 \u00a74.1.3](https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.3)).\nIf unset, any audience is allowed.",
+                      "items": {
+                        "type": "string"
+                      },
+                      "maxItems": 64,
+                      "minItems": 1,
+                      "type": "array"
+                    },
+                    "clientId": {
+                      "description": "Client ID to use for short-circuiting Dynamic Client Registration.\nIf set, the gateway will not proxy registration requests to the IDP and instead return this client ID.",
+                      "type": "string"
+                    },
+                    "issuer": {
+                      "description": "IdP that issued the JWT. This corresponds to the\n`iss` claim ([RFC 7519 \u00a74.1.1](https://tools.ietf.org/html/rfc7519#section-4.1.1)).",
+                      "maxLength": 256,
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "jwks": {
+                      "description": "Remote JSON Web Key used to validate the signature of\nthe JWT.",
+                      "properties": {
+                        "backendRef": {
+                          "description": "Remote JWKS server to reach.\nSupported types are `Service` and static `Backend`. An\n`AgentgatewayPolicy` containing backend TLS config can then be attached\nto the `Service` or `Backend` in order to set TLS options for a\nconnection to the remote `jwks` source.",
+                          "properties": {
+                            "group": {
+                              "default": "",
+                              "description": "Group is the group of the referent. For example, \"gateway.networking.k8s.io\".\nWhen unspecified or empty string, core API group is inferred.",
+                              "maxLength": 253,
+                              "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                              "type": "string"
+                            },
+                            "kind": {
+                              "default": "Service",
+                              "description": "Kind is the Kubernetes resource kind of the referent. For example\n\"Service\".\n\nDefaults to \"Service\" when not specified.\n\nExternalName services can refer to CNAME DNS records that may live\noutside of the cluster and as such are difficult to reason about in\nterms of conformance. They also may not be safe to forward to (see\nCVE-2021-25740 for more information). Implementations SHOULD NOT\nsupport ExternalName Services.\n\nSupport: Core (Services with a type other than ExternalName)\n\nSupport: Implementation-specific (Services with type ExternalName)",
+                              "maxLength": 63,
+                              "minLength": 1,
+                              "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
+                              "type": "string"
+                            },
+                            "name": {
+                              "description": "Name is the name of the referent.",
+                              "maxLength": 253,
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "namespace": {
+                              "description": "Namespace is the namespace of the backend. When unspecified, the local\nnamespace is inferred.\n\nNote that when a namespace different than the local namespace is specified,\na ReferenceGrant object is required in the referent namespace to allow that\nnamespace's owner to accept the reference. See the ReferenceGrant\ndocumentation for details.\n\nSupport: Core",
+                              "maxLength": 63,
+                              "minLength": 1,
+                              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                              "type": "string"
+                            },
+                            "port": {
+                              "description": "Port specifies the destination port number to use for this resource.\nPort is required when the referent is a Kubernetes Service. In this\ncase, the port number is the service port number, not the target port.\nFor other resources, destination port might be derived from the referent\nresource or this field.",
+                              "format": "int32",
+                              "maximum": 65535,
+                              "minimum": 1,
+                              "type": "integer"
+                            }
+                          },
+                          "required": [
+                            "name"
+                          ],
+                          "type": "object",
+                          "x-kubernetes-validations": [
+                            {
+                              "message": "Must have port for Service reference",
+                              "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
+                            }
+                          ],
+                          "additionalProperties": false
+                        },
+                        "cacheDuration": {
+                          "default": "5m",
+                          "type": "string",
+                          "x-kubernetes-validations": [
+                            {
+                              "message": "invalid duration value",
+                              "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                            },
+                            {
+                              "message": "cacheDuration must be at least 5m.",
+                              "rule": "duration(self) >= duration('5m')"
+                            }
+                          ]
+                        },
+                        "jwksPath": {
+                          "description": "Path to the IdP `jwks` endpoint, relative to the root, commonly\n`\".well-known/jwks.json\"`.",
+                          "maxLength": 2000,
+                          "minLength": 1,
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "backendRef",
+                        "jwksPath"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "mode": {
+                      "default": "Strict",
+                      "description": "Validation mode for JWT authentication.",
+                      "enum": [
+                        "Optional",
+                        "Permissive",
+                        "Strict"
+                      ],
+                      "type": "string"
+                    },
+                    "provider": {
+                      "description": "Identity provider to use for authentication.",
+                      "enum": [
+                        "Auth0",
+                        "Keycloak",
+                        "Okta"
+                      ],
+                      "type": "string"
+                    },
+                    "resourceMetadata": {
+                      "additionalProperties": {
+                        "x-kubernetes-preserve-unknown-fields": true
+                      },
+                      "description": "Metadata to use for MCP resources.",
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "jwks"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "authorization": {
+                  "description": "MCP backend authorization. Unlike authorization at the HTTP level, which rejects\nunauthorized requests with a `403` error, this policy works at the\n`MCPBackend` level.\n\nList operations, such as `list_tools`, will have each item evaluated.\nItems that do not meet the rule will be filtered.\n\nGet or call operations, such as `call_tool`, will evaluate the specific\nitem and reject requests that do not meet the rule.",
+                  "properties": {
+                    "action": {
+                      "default": "Allow",
+                      "description": "The effect of this rule when it matches.\nIf unspecified, defaults to `Allow`.\n`Require` rules are cumulative: all require rules must match.",
+                      "enum": [
+                        "Allow",
+                        "Deny",
+                        "Require"
+                      ],
+                      "type": "string"
+                    },
+                    "policy": {
+                      "description": "The authorization rule to evaluate.\n\n* `Allow`: any matching allow rule allows the request.\n* `Require`: every require rule must match for the request to be allowed.\n* `Deny`: any matching deny rule denies the request.\n\nA CEL expression that fails to evaluate does not match. Prefer `Require`\nfor deny-by-default behavior.\n\nIf at least one `Allow` rule is configured, requests are denied unless at\nleast one allow rule matches.",
+                      "properties": {
+                        "matchExpressions": {
+                          "description": "CEL expressions that must all evaluate to true for the rule to match.",
+                          "items": {
+                            "description": "A Common Expression Language (CEL) expression.",
+                            "maxLength": 16384,
+                            "minLength": 1,
+                            "type": "string"
+                          },
+                          "maxItems": 256,
+                          "minItems": 1,
+                          "type": "array"
+                        }
+                      },
+                      "required": [
+                        "matchExpressions"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": [
+                    "policy"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "guardrails": {
+                  "description": "`guardrails` routes selected JSON-RPC methods through a remote policy server.",
+                  "properties": {
+                    "processors": {
+                      "description": "`processors` is the ordered list of policy processors applied to matched\nmethods. Processors run in the order listed; the first to reject a request\nshort-circuits the chain.",
+                      "items": {
+                        "description": "MCPGuardrailsProcessor selects a single policy processor. Exactly one variant must be set.",
+                        "properties": {
+                          "methods": {
+                            "additionalProperties": {
+                              "description": "MCPMethodPhase controls when an MCP method is run through the guardrails pipeline.",
+                              "enum": [
+                                "Full",
+                                "Off",
+                                "Request",
+                                "Response"
+                              ],
+                              "type": "string"
+                            },
+                            "description": "`methods` is the allowlist of JSON-RPC methods (e.g. `tools/call`,\n`tools/list`) routed through this processor, keyed by method name with the\nphase it runs in. Keys may be exact, a prefix wildcard (`tools/*`), a suffix\nwildcard (`*/list`), or `*` for all methods; the most specific match wins.\nMethods matching no key, including unknown ones, bypass this processor.",
+                            "maxProperties": 64,
+                            "minProperties": 1,
+                            "type": "object",
+                            "x-kubernetes-validations": [
+                              {
+                                "message": "method wildcards must be '*', a prefix like 'tools/*', or a suffix like '*/list'",
+                                "rule": "self.all(k, !k.contains('*') || (k.indexOf('*') == k.lastIndexOf('*') && (k.indexOf('*') == 0 || k.indexOf('*') == size(k) - 1)))"
+                              }
+                            ]
+                          },
+                          "remote": {
+                            "description": "`remote` configures a gRPC policy server.",
+                            "properties": {
+                              "allowedRequestHeaders": {
+                                "description": "`allowedRequestHeaders` lists the incoming request headers forwarded to\nthe policy server in `McpRequest.headers`. If empty, all headers and\npseudo-headers (`:authority`, `:method`, ...) are forwarded. Matching is\ncase-insensitive.",
+                                "items": {
+                                  "description": "HTTP header name.",
+                                  "maxLength": 256,
+                                  "minLength": 1,
+                                  "pattern": "^:?[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                                  "type": "string",
+                                  "x-kubernetes-validations": [
+                                    {
+                                      "message": "pseudo-headers must be one of :authority, :method, :path, :scheme, or :status",
+                                      "rule": "!self.startsWith(':') || self in [':authority', ':method', ':path', ':scheme', ':status']"
+                                    }
+                                  ]
+                                },
+                                "maxItems": 64,
+                                "type": "array",
+                                "x-kubernetes-list-type": "set"
+                              },
+                              "backendRef": {
+                                "description": "`backendRef` references the remote guardrails policy server.\nSupported types: `Service` and `Backend`.",
+                                "properties": {
+                                  "group": {
+                                    "default": "",
+                                    "description": "Group is the group of the referent. For example, \"gateway.networking.k8s.io\".\nWhen unspecified or empty string, core API group is inferred.",
+                                    "maxLength": 253,
+                                    "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                                    "type": "string"
+                                  },
+                                  "kind": {
+                                    "default": "Service",
+                                    "description": "Kind is the Kubernetes resource kind of the referent. For example\n\"Service\".\n\nDefaults to \"Service\" when not specified.\n\nExternalName services can refer to CNAME DNS records that may live\noutside of the cluster and as such are difficult to reason about in\nterms of conformance. They also may not be safe to forward to (see\nCVE-2021-25740 for more information). Implementations SHOULD NOT\nsupport ExternalName Services.\n\nSupport: Core (Services with a type other than ExternalName)\n\nSupport: Implementation-specific (Services with type ExternalName)",
+                                    "maxLength": 63,
+                                    "minLength": 1,
+                                    "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "description": "Name is the name of the referent.",
+                                    "maxLength": 253,
+                                    "minLength": 1,
+                                    "type": "string"
+                                  },
+                                  "namespace": {
+                                    "description": "Namespace is the namespace of the backend. When unspecified, the local\nnamespace is inferred.\n\nNote that when a namespace different than the local namespace is specified,\na ReferenceGrant object is required in the referent namespace to allow that\nnamespace's owner to accept the reference. See the ReferenceGrant\ndocumentation for details.\n\nSupport: Core",
+                                    "maxLength": 63,
+                                    "minLength": 1,
+                                    "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "description": "Port specifies the destination port number to use for this resource.\nPort is required when the referent is a Kubernetes Service. In this\ncase, the port number is the service port number, not the target port.\nFor other resources, destination port might be derived from the referent\nresource or this field.",
+                                    "format": "int32",
+                                    "maximum": 65535,
+                                    "minimum": 1,
+                                    "type": "integer"
+                                  }
+                                },
+                                "required": [
+                                  "name"
+                                ],
+                                "type": "object",
+                                "x-kubernetes-validations": [
+                                  {
+                                    "message": "Must have port for Service reference",
+                                    "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
+                                  }
+                                ],
+                                "additionalProperties": false
+                              },
+                              "disallowedRequestHeaders": {
+                                "description": "`disallowedRequestHeaders` lists header names never forwarded to the\npolicy server, even if listed in `allowedRequestHeaders`. Matching is\ncase-insensitive.",
+                                "items": {
+                                  "description": "HTTP header name.",
+                                  "maxLength": 256,
+                                  "minLength": 1,
+                                  "pattern": "^:?[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                                  "type": "string",
+                                  "x-kubernetes-validations": [
+                                    {
+                                      "message": "pseudo-headers must be one of :authority, :method, :path, :scheme, or :status",
+                                      "rule": "!self.startsWith(':') || self in [':authority', ':method', ':path', ':scheme', ':status']"
+                                    }
+                                  ]
+                                },
+                                "maxItems": 64,
+                                "type": "array",
+                                "x-kubernetes-list-type": "set"
+                              },
+                              "failureMode": {
+                                "description": "`failureMode` controls behavior when the policy server is unreachable\nor returns an error. `FailOpen` allows the request; `FailClosed`\n(default) denies it.",
+                                "enum": [
+                                  "FailClosed",
+                                  "FailOpen"
+                                ],
+                                "type": "string"
+                              },
+                              "metadata": {
+                                "additionalProperties": {
+                                  "description": "A Common Expression Language (CEL) expression.",
+                                  "maxLength": 16384,
+                                  "minLength": 1,
+                                  "type": "string"
+                                },
+                                "description": "`metadata` is static or CEL-evaluated context surfaced to the policy\nserver as fields of the `metadata_context` google.protobuf.Struct,\nkeyed by config key. Values are CEL expressions.",
+                                "maxProperties": 64,
+                                "type": "object"
+                              }
+                            },
+                            "required": [
+                              "backendRef"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "required": [
+                          "methods"
+                        ],
+                        "type": "object",
+                        "x-kubernetes-validations": [
+                          {
+                            "message": "exactly one of the fields in [remote] must be set",
+                            "rule": "[has(self.remote)].filter(x,x==true).size() == 1"
+                          }
+                        ],
+                        "additionalProperties": false
+                      },
+                      "maxItems": 16,
+                      "minItems": 1,
+                      "type": "array"
+                    }
+                  },
+                  "required": [
+                    "processors"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "x-kubernetes-validations": [
+                {
+                  "message": "at least one of the fields in [authentication authorization guardrails] must be set",
+                  "rule": "[has(self.authentication),has(self.authorization),has(self.guardrails)].filter(x,x==true).size() >= 1"
+                }
+              ],
+              "additionalProperties": false
+            },
+            "tcp": {
+              "description": "Settings for managing TCP connections to the backend.",
+              "properties": {
+                "connectTimeout": {
+                  "description": "Deadline for establishing a connection to\nthe destination.",
+                  "type": "string",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "invalid duration value",
+                      "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                    },
+                    {
+                      "message": "connectTimeout must be at least 100ms",
+                      "rule": "duration(self) >= duration('100ms')"
+                    }
+                  ]
+                },
+                "keepalive": {
+                  "description": "Settings for enabling TCP keepalives on the\nconnection.",
+                  "properties": {
+                    "interval": {
+                      "description": "Time between keepalive probes.\nIf unset, this defaults to 180s.",
+                      "type": "string",
+                      "x-kubernetes-validations": [
+                        {
+                          "message": "invalid duration value",
+                          "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                        },
+                        {
+                          "message": "interval must be at least 1 second",
+                          "rule": "duration(self) >= duration('1s')"
+                        }
+                      ]
+                    },
+                    "retries": {
+                      "description": "Maximum number of keepalive probes to send before dropping the connection.\nIf unset, this defaults to 9.",
+                      "format": "int32",
+                      "maximum": 64,
+                      "minimum": 1,
+                      "type": "integer"
+                    },
+                    "time": {
+                      "description": "Time a connection needs to be idle before keepalive probes start being sent.\nIf unset, this defaults to 180s.",
+                      "type": "string",
+                      "x-kubernetes-validations": [
+                        {
+                          "message": "invalid duration value",
+                          "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                        },
+                        {
+                          "message": "time must be at least 1 second",
+                          "rule": "duration(self) >= duration('1s')"
+                        }
+                      ]
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "tls": {
+              "description": "Settings for managing TLS connections to the backend.\n\nIf this field is set, TLS will be initiated to the backend; the system trusted CA certificates will be used to\nvalidate the server, and the SNI will automatically be set based on the destination.",
+              "properties": {
+                "alpnProtocols": {
+                  "description": "Application-Layer Protocol Negotiation (`ALPN`)\nvalue to use in the TLS handshake.\n\nIf not present, defaults to `[\"h2\", \"http/1.1\"]`.",
+                  "items": {
+                    "maxLength": 64,
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "maxItems": 16,
+                  "minItems": 1,
+                  "type": "array"
+                },
+                "caCertificateRefs": {
+                  "description": "CA certificate `ConfigMap` to use to\nverify the server certificate.\nIf unset, the system's trusted certificates are used.",
+                  "items": {
+                    "description": "LocalObjectReference contains enough information to let you locate the\nreferenced object inside the same namespace.",
+                    "properties": {
+                      "name": {
+                        "default": "",
+                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "x-kubernetes-map-type": "atomic",
+                    "additionalProperties": false
+                  },
+                  "maxItems": 1,
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
+                },
+                "insecureSkipVerify": {
+                  "description": "Originates TLS but skips verification of the backend's certificate.\nWARNING: This is an insecure option that should only be used if the risks are understood.\n\nThere are two modes:\n* `All` disables all TLS verification.\n* `Hostname` verifies the CA certificate is trusted, but ignores any\n  mismatch of hostname or SANs. Note that this method is still insecure;\n  prefer setting `verifySubjectAltNames` to customize the valid hostnames\n  if possible.",
+                  "enum": [
+                    "All",
+                    "Hostname"
+                  ],
+                  "type": "string"
+                },
+                "keyExchangeGroups": {
+                  "description": "Ordered list of key exchange groups for a TLS connection.\nFor example: `X25519_MLKEM768,X25519`.",
+                  "items": {
+                    "enum": [
+                      "P-256",
+                      "P-384",
+                      "X25519",
+                      "X25519_MLKEM768"
+                    ],
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "mtlsCertificateRef": {
+                  "description": "Enables mutual TLS to the backend, using the\nspecified key (`tls.key`) and cert (`tls.crt`) from the referenced\ncredential source, defaulting to a Kubernetes `Secret`.\n\nAn optional `ca.cert` field, if present, will be used to verify the\nserver certificate. If `caCertificateRefs` is also specified, the\n`caCertificateRefs` field takes priority.\n\nIf unspecified, no client certificate will be used.",
+                  "items": {
+                    "description": "References a same-namespace credential.\nSet only `name` to reference a Kubernetes Secret.",
+                    "properties": {
+                      "group": {
+                        "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                        "type": "string"
+                      },
+                      "kind": {
+                        "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "The name of the referenced credential.",
+                        "maxLength": 253,
+                        "minLength": 1,
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "name"
+                    ],
+                    "type": "object",
+                    "x-kubernetes-map-type": "atomic",
+                    "x-kubernetes-validations": [
+                      {
+                        "message": "custom credential refs must set both group and kind",
+                        "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                      }
+                    ],
+                    "additionalProperties": false
+                  },
+                  "maxItems": 1,
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
+                },
+                "sni": {
+                  "description": "Server Name Indicator (`SNI`) to use in the TLS\nhandshake. If unset, the `SNI` is automatically set based on the\ndestination hostname.",
+                  "maxLength": 253,
+                  "minLength": 1,
+                  "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                  "type": "string"
+                },
+                "verifySubjectAltNames": {
+                  "description": "Subject Alternative Names (`SAN`)\nto verify in the server certificate.\nIf not present, the destination hostname is automatically used.",
+                  "items": {
+                    "maxLength": 256,
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "maxItems": 16,
+                  "minItems": 1,
+                  "type": "array"
+                }
+              },
+              "type": "object",
+              "x-kubernetes-validations": [
+                {
+                  "message": "insecureSkipVerify All and caCertificateRefs may not be set together",
+                  "rule": "has(self.insecureSkipVerify) && self.insecureSkipVerify == 'All' ? !has(self.caCertificateRefs) : true"
+                },
+                {
+                  "message": "insecureSkipVerify and verifySubjectAltNames may not be set together",
+                  "rule": "has(self.insecureSkipVerify) ? !has(self.verifySubjectAltNames) : true"
+                },
+                {
+                  "message": "at most one of the fields in [verifySubjectAltNames insecureSkipVerify] may be set",
+                  "rule": "[has(self.verifySubjectAltNames),has(self.insecureSkipVerify)].filter(x,x==true).size() <= 1"
+                }
+              ],
+              "additionalProperties": false
+            },
+            "transformation": {
+              "description": "Mutates and transforms requests and responses sent to and from the backend.",
+              "properties": {
+                "request": {
+                  "description": "Request transformation settings.",
+                  "properties": {
+                    "add": {
+                      "description": "Headers to add to the request and what each value\nshould be set to. If there is already a header with these values then\nappend the value as an extra entry.",
+                      "items": {
+                        "properties": {
+                          "name": {
+                            "description": "The name of the header to add.",
+                            "maxLength": 256,
+                            "minLength": 1,
+                            "pattern": "^:?[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                            "type": "string",
+                            "x-kubernetes-validations": [
+                              {
+                                "message": "pseudo-headers must be one of :authority, :method, :path, :scheme, or :status",
+                                "rule": "!self.startsWith(':') || self in [':authority', ':method', ':path', ':scheme', ':status']"
+                              }
+                            ]
+                          },
+                          "value": {
+                            "description": "CEL expression that generates the output value for\nthe header.",
+                            "maxLength": 16384,
+                            "minLength": 1,
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "name",
+                          "value"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "maxItems": 16,
+                      "minItems": 1,
+                      "type": "array",
+                      "x-kubernetes-list-map-keys": [
+                        "name"
+                      ],
+                      "x-kubernetes-list-type": "map"
+                    },
+                    "body": {
+                      "description": "HTTP body transformation.",
+                      "maxLength": 16384,
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "metadata": {
+                      "additionalProperties": {
+                        "description": "A Common Expression Language (CEL) expression.",
+                        "maxLength": 16384,
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "description": "Stores CEL-evaluated values under the `metadata` CEL variable\nfor subsequent policy evaluations. `metadata` is evaluated before header\nor body transformations.",
+                      "maxProperties": 16,
+                      "minProperties": 1,
+                      "type": "object"
+                    },
+                    "remove": {
+                      "description": "Header names to remove from the request or\nresponse.",
+                      "items": {
+                        "description": "HTTP header name.",
+                        "maxLength": 256,
+                        "minLength": 1,
+                        "pattern": "^:?[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                        "type": "string",
+                        "x-kubernetes-validations": [
+                          {
+                            "message": "pseudo-headers must be one of :authority, :method, :path, :scheme, or :status",
+                            "rule": "!self.startsWith(':') || self in [':authority', ':method', ':path', ':scheme', ':status']"
+                          }
+                        ]
+                      },
+                      "maxItems": 16,
+                      "minItems": 1,
+                      "type": "array",
+                      "x-kubernetes-list-type": "set"
+                    },
+                    "set": {
+                      "description": "Headers to set and the values to use.",
+                      "items": {
+                        "properties": {
+                          "name": {
+                            "description": "The name of the header to add.",
+                            "maxLength": 256,
+                            "minLength": 1,
+                            "pattern": "^:?[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                            "type": "string",
+                            "x-kubernetes-validations": [
+                              {
+                                "message": "pseudo-headers must be one of :authority, :method, :path, :scheme, or :status",
+                                "rule": "!self.startsWith(':') || self in [':authority', ':method', ':path', ':scheme', ':status']"
+                              }
+                            ]
+                          },
+                          "value": {
+                            "description": "CEL expression that generates the output value for\nthe header.",
+                            "maxLength": 16384,
+                            "minLength": 1,
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "name",
+                          "value"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "maxItems": 16,
+                      "minItems": 1,
+                      "type": "array",
+                      "x-kubernetes-list-map-keys": [
+                        "name"
+                      ],
+                      "x-kubernetes-list-type": "map"
+                    }
+                  },
+                  "type": "object",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "at least one of the fields in [add body metadata remove set] must be set",
+                      "rule": "[has(self.add),has(self.body),has(self.metadata),has(self.remove),has(self.set)].filter(x,x==true).size() >= 1"
+                    }
+                  ],
+                  "additionalProperties": false
+                },
+                "response": {
+                  "description": "Response transformation settings.",
+                  "properties": {
+                    "add": {
+                      "description": "Headers to add to the request and what each value\nshould be set to. If there is already a header with these values then\nappend the value as an extra entry.",
+                      "items": {
+                        "properties": {
+                          "name": {
+                            "description": "The name of the header to add.",
+                            "maxLength": 256,
+                            "minLength": 1,
+                            "pattern": "^:?[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                            "type": "string",
+                            "x-kubernetes-validations": [
+                              {
+                                "message": "pseudo-headers must be one of :authority, :method, :path, :scheme, or :status",
+                                "rule": "!self.startsWith(':') || self in [':authority', ':method', ':path', ':scheme', ':status']"
+                              }
+                            ]
+                          },
+                          "value": {
+                            "description": "CEL expression that generates the output value for\nthe header.",
+                            "maxLength": 16384,
+                            "minLength": 1,
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "name",
+                          "value"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "maxItems": 16,
+                      "minItems": 1,
+                      "type": "array",
+                      "x-kubernetes-list-map-keys": [
+                        "name"
+                      ],
+                      "x-kubernetes-list-type": "map"
+                    },
+                    "body": {
+                      "description": "HTTP body transformation.",
+                      "maxLength": 16384,
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "metadata": {
+                      "additionalProperties": {
+                        "description": "A Common Expression Language (CEL) expression.",
+                        "maxLength": 16384,
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "description": "Stores CEL-evaluated values under the `metadata` CEL variable\nfor subsequent policy evaluations. `metadata` is evaluated before header\nor body transformations.",
+                      "maxProperties": 16,
+                      "minProperties": 1,
+                      "type": "object"
+                    },
+                    "remove": {
+                      "description": "Header names to remove from the request or\nresponse.",
+                      "items": {
+                        "description": "HTTP header name.",
+                        "maxLength": 256,
+                        "minLength": 1,
+                        "pattern": "^:?[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                        "type": "string",
+                        "x-kubernetes-validations": [
+                          {
+                            "message": "pseudo-headers must be one of :authority, :method, :path, :scheme, or :status",
+                            "rule": "!self.startsWith(':') || self in [':authority', ':method', ':path', ':scheme', ':status']"
+                          }
+                        ]
+                      },
+                      "maxItems": 16,
+                      "minItems": 1,
+                      "type": "array",
+                      "x-kubernetes-list-type": "set"
+                    },
+                    "set": {
+                      "description": "Headers to set and the values to use.",
+                      "items": {
+                        "properties": {
+                          "name": {
+                            "description": "The name of the header to add.",
+                            "maxLength": 256,
+                            "minLength": 1,
+                            "pattern": "^:?[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                            "type": "string",
+                            "x-kubernetes-validations": [
+                              {
+                                "message": "pseudo-headers must be one of :authority, :method, :path, :scheme, or :status",
+                                "rule": "!self.startsWith(':') || self in [':authority', ':method', ':path', ':scheme', ':status']"
+                              }
+                            ]
+                          },
+                          "value": {
+                            "description": "CEL expression that generates the output value for\nthe header.",
+                            "maxLength": 16384,
+                            "minLength": 1,
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "name",
+                          "value"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "maxItems": 16,
+                      "minItems": 1,
+                      "type": "array",
+                      "x-kubernetes-list-map-keys": [
+                        "name"
+                      ],
+                      "x-kubernetes-list-type": "map"
+                    }
+                  },
+                  "type": "object",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "at least one of the fields in [add body metadata remove set] must be set",
+                      "rule": "[has(self.add),has(self.body),has(self.metadata),has(self.remove),has(self.set)].filter(x,x==true).size() >= 1"
+                    }
+                  ],
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "x-kubernetes-validations": [
+                {
+                  "message": "at least one of the fields in [request response] must be set",
+                  "rule": "[has(self.request),has(self.response)].filter(x,x==true).size() >= 1"
+                }
+              ],
+              "additionalProperties": false
+            },
+            "tunnel": {
+              "description": "Settings for managing tunnel connections, with behavior like `HTTPS_PROXY`, to the backend.",
+              "properties": {
+                "backendRef": {
+                  "description": "Proxy server to reach.\nSupported types: `Service` and `Backend`.",
+                  "properties": {
+                    "group": {
+                      "default": "",
+                      "description": "Group is the group of the referent. For example, \"gateway.networking.k8s.io\".\nWhen unspecified or empty string, core API group is inferred.",
+                      "maxLength": 253,
+                      "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                      "type": "string"
+                    },
+                    "kind": {
+                      "default": "Service",
+                      "description": "Kind is the Kubernetes resource kind of the referent. For example\n\"Service\".\n\nDefaults to \"Service\" when not specified.\n\nExternalName services can refer to CNAME DNS records that may live\noutside of the cluster and as such are difficult to reason about in\nterms of conformance. They also may not be safe to forward to (see\nCVE-2021-25740 for more information). Implementations SHOULD NOT\nsupport ExternalName Services.\n\nSupport: Core (Services with a type other than ExternalName)\n\nSupport: Implementation-specific (Services with type ExternalName)",
+                      "maxLength": 63,
+                      "minLength": 1,
+                      "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
+                      "type": "string"
+                    },
+                    "name": {
+                      "description": "Name is the name of the referent.",
+                      "maxLength": 253,
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "namespace": {
+                      "description": "Namespace is the namespace of the backend. When unspecified, the local\nnamespace is inferred.\n\nNote that when a namespace different than the local namespace is specified,\na ReferenceGrant object is required in the referent namespace to allow that\nnamespace's owner to accept the reference. See the ReferenceGrant\ndocumentation for details.\n\nSupport: Core",
+                      "maxLength": 63,
+                      "minLength": 1,
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                      "type": "string"
+                    },
+                    "port": {
+                      "description": "Port specifies the destination port number to use for this resource.\nPort is required when the referent is a Kubernetes Service. In this\ncase, the port number is the service port number, not the target port.\nFor other resources, destination port might be derived from the referent\nresource or this field.",
+                      "format": "int32",
+                      "maximum": 65535,
+                      "minimum": 1,
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "name"
+                  ],
+                  "type": "object",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "Must have port for Service reference",
+                      "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
+                    }
+                  ],
+                  "additionalProperties": false
+                }
+              },
+              "required": [
+                "backendRef"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "x-kubernetes-validations": [
+            {
+              "message": "at least one of the fields in [ai auth extAuth health http mcp tcp tls transformation tunnel] must be set",
+              "rule": "[has(self.ai),has(self.auth),has(self.extAuth),has(self.health),has(self.http),has(self.mcp),has(self.tcp),has(self.tls),has(self.transformation),has(self.tunnel)].filter(x,x==true).size() >= 1"
+            }
+          ],
+          "additionalProperties": false
+        },
+        "frontend": {
+          "description": "Settings for how to handle incoming traffic.\n\nA frontend policy can only target a `Gateway`. `Listener` and\n`ListenerSet` are not valid targets.\n\nWhen multiple policies are selected for a given request, they are merged on a field-level basis, but not a deep\nmerge. For example, policy A sets `tcp` and `tls`, and policy B sets\n`tls`; the effective policy would be `tcp` from policy A, and `tls` from\npolicy B.",
+          "properties": {
+            "accessLog": {
+              "description": "Access logging configuration.",
+              "properties": {
+                "attributes": {
+                  "description": "Customizations to the key-value pairs that are\nlogged.",
+                  "properties": {
+                    "add": {
+                      "description": "Additional key-value pairs to add to each entry.\nThe value is a CEL expression. If the CEL expression fails to evaluate,\nthe pair will be excluded.",
+                      "items": {
+                        "properties": {
+                          "expression": {
+                            "description": "A Common Expression Language (CEL) expression.",
+                            "maxLength": 16384,
+                            "minLength": 1,
+                            "type": "string"
+                          },
+                          "name": {
+                            "maxLength": 256,
+                            "minLength": 1,
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "expression",
+                          "name"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "minItems": 1,
+                      "type": "array"
+                    },
+                    "remove": {
+                      "description": "Default fields to remove. For example,\n`http.method`.",
+                      "items": {
+                        "maxLength": 64,
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "maxItems": 32,
+                      "minItems": 1,
+                      "type": "array"
+                    }
+                  },
+                  "type": "object",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "at least one of the fields in [add remove] must be set",
+                      "rule": "[has(self.add),has(self.remove)].filter(x,x==true).size() >= 1"
+                    }
+                  ],
+                  "additionalProperties": false
+                },
+                "filter": {
+                  "description": "CEL expression used to filter logs. A log\nwill only be emitted if the expression evaluates to `true`.",
+                  "maxLength": 16384,
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "otlp": {
+                  "description": "OTLP access log export to an\nOpenTelemetry-compatible backend.",
+                  "properties": {
+                    "backendRef": {
+                      "description": "OTLP server to send access logs to.\nSupported types: `Service` and `AgentgatewayBackend`.",
+                      "properties": {
+                        "group": {
+                          "default": "",
+                          "description": "Group is the group of the referent. For example, \"gateway.networking.k8s.io\".\nWhen unspecified or empty string, core API group is inferred.",
+                          "maxLength": 253,
+                          "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                          "type": "string"
+                        },
+                        "kind": {
+                          "default": "Service",
+                          "description": "Kind is the Kubernetes resource kind of the referent. For example\n\"Service\".\n\nDefaults to \"Service\" when not specified.\n\nExternalName services can refer to CNAME DNS records that may live\noutside of the cluster and as such are difficult to reason about in\nterms of conformance. They also may not be safe to forward to (see\nCVE-2021-25740 for more information). Implementations SHOULD NOT\nsupport ExternalName Services.\n\nSupport: Core (Services with a type other than ExternalName)\n\nSupport: Implementation-specific (Services with type ExternalName)",
+                          "maxLength": 63,
+                          "minLength": 1,
+                          "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
+                          "type": "string"
+                        },
+                        "name": {
+                          "description": "Name is the name of the referent.",
+                          "maxLength": 253,
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "namespace": {
+                          "description": "Namespace is the namespace of the backend. When unspecified, the local\nnamespace is inferred.\n\nNote that when a namespace different than the local namespace is specified,\na ReferenceGrant object is required in the referent namespace to allow that\nnamespace's owner to accept the reference. See the ReferenceGrant\ndocumentation for details.\n\nSupport: Core",
+                          "maxLength": 63,
+                          "minLength": 1,
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                          "type": "string"
+                        },
+                        "port": {
+                          "description": "Port specifies the destination port number to use for this resource.\nPort is required when the referent is a Kubernetes Service. In this\ncase, the port number is the service port number, not the target port.\nFor other resources, destination port might be derived from the referent\nresource or this field.",
+                          "format": "int32",
+                          "maximum": 65535,
+                          "minimum": 1,
+                          "type": "integer"
+                        }
+                      },
+                      "required": [
+                        "name"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-validations": [
+                        {
+                          "message": "Must have port for Service reference",
+                          "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
+                        }
+                      ],
+                      "additionalProperties": false
+                    },
+                    "path": {
+                      "description": "OTLP/HTTP path to use. This is only applicable\nwhen `protocol` is `HTTP`. If unset, this defaults to `/v1/logs`.",
+                      "maxLength": 1024,
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "protocol": {
+                      "default": "GRPC",
+                      "description": "OTLP protocol variant to use.",
+                      "enum": [
+                        "GRPC",
+                        "HTTP"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "backendRef"
+                  ],
+                  "type": "object",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "path is only valid with protocol HTTP",
+                      "rule": "!has(self.path) || !has(self.protocol) || self.protocol == 'HTTP'"
+                    },
+                    {
+                      "message": "path must start with /",
+                      "rule": "!has(self.path) || self.path.startsWith('/')"
+                    }
+                  ],
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "connect": {
+              "description": "Settings for downstream HTTP CONNECT handling.\n\nIf unset, CONNECT requests are rejected with Method Not Allowed.",
+              "properties": {
+                "mode": {
+                  "description": "Whether downstream CONNECT requests are accepted.",
+                  "enum": [
+                    "Deny",
+                    "Route",
+                    "Tunnel"
+                  ],
+                  "type": "string"
+                }
+              },
+              "required": [
+                "mode"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "http": {
+              "description": "Settings for managing incoming HTTP requests.",
+              "properties": {
+                "http1HeaderCase": {
+                  "description": "Controls HTTP/1 request header name casing when encoding responses on the same connection.\nThis only applies to `HTTP/1`. If a request is HTTP/2 in either the incoming or outgoing request, this will be ignored.\nHTTP/2 requests are always lower case.\n\nModifying the headers from other policies may result in the original case being lost.",
+                  "enum": [
+                    "Lowercase",
+                    "Preserve"
+                  ],
+                  "type": "string"
+                },
+                "http1IdleTimeout": {
+                  "description": "Timeout before an unused connection is\nclosed.\nIf unset, this defaults to 10 minutes.",
+                  "type": "string",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "invalid duration value",
+                      "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                    },
+                    {
+                      "message": "http1IdleTimeout must be at least 1 second",
+                      "rule": "duration(self) >= duration('1s')"
+                    }
+                  ]
+                },
+                "http1MaxHeaders": {
+                  "description": "Maximum number of headers allowed\nin `HTTP/1.1` requests.\nIf unset, this defaults to 100.",
+                  "format": "int32",
+                  "maximum": 4096,
+                  "minimum": 1,
+                  "type": "integer"
+                },
+                "http2ConnectionWindowSize": {
+                  "anyOf": [
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ],
+                  "description": "Initial window size for\nconnection-level flow control for received data.",
+                  "maxLength": 32,
+                  "minLength": 1,
+                  "pattern": "^[+-]?([0-9]+(\\.[0-9]*)?|\\.[0-9]+)(([KMGTPE]i)|[numkMGTPE]|[eE](\\+?0*([0-9]|1[0-8])|-0*[0-9]))?$",
+                  "x-kubernetes-int-or-string": true,
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "value must be at least 1 byte and fit within uint32",
+                      "rule": "(self >= 1 && self <= 4294967295) || self.size() > 0"
+                    }
+                  ]
+                },
+                "http2FrameSize": {
+                  "anyOf": [
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ],
+                  "description": "Maximum frame size to use.\nIf unset, this defaults to `16kb`.",
+                  "maxLength": 32,
+                  "minLength": 1,
+                  "pattern": "^[+-]?([0-9]+(\\.[0-9]*)?|\\.[0-9]+)(([KMGTPE]i)|[numkMGTPE]|[eE](\\+?0*([0-9]|1[0-8])|-0*[0-9]))?$",
+                  "x-kubernetes-int-or-string": true,
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "http2FrameSize must be at least 16384 bytes",
+                      "rule": "!quantity(string(self)).isLessThan(quantity('16384'))"
+                    },
+                    {
+                      "message": "http2FrameSize must be at most 1677215 bytes",
+                      "rule": "!quantity(string(self)).isGreaterThan(quantity('1677215'))"
+                    },
+                    {
+                      "message": "value must be at least 1 byte and fit within uint32",
+                      "rule": "(self >= 1 && self <= 4294967295) || self.size() > 0"
+                    }
+                  ]
+                },
+                "http2KeepaliveInterval": {
+                  "type": "string",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "invalid duration value",
+                      "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                    },
+                    {
+                      "message": "http2KeepaliveInterval must be at least 1 second",
+                      "rule": "duration(self) >= duration('1s')"
+                    }
+                  ]
+                },
+                "http2KeepaliveTimeout": {
+                  "type": "string",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "invalid duration value",
+                      "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                    },
+                    {
+                      "message": "http2KeepaliveTimeout must be at least 1 second",
+                      "rule": "duration(self) >= duration('1s')"
+                    }
+                  ]
+                },
+                "http2MaxHeaderSize": {
+                  "anyOf": [
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ],
+                  "description": "Maximum aggregate size of decoded HTTP/2\nrequest headers.\nIf unset, this defaults to `16Ki`.",
+                  "maxLength": 32,
+                  "minLength": 1,
+                  "pattern": "^[+-]?([0-9]+(\\.[0-9]*)?|\\.[0-9]+)(([KMGTPE]i)|[numkMGTPE]|[eE](\\+?0*([0-9]|1[0-8])|-0*[0-9]))?$",
+                  "x-kubernetes-int-or-string": true,
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "value must be at least 1 byte and fit within uint32",
+                      "rule": "(self >= 1 && self <= 4294967295) || self.size() > 0"
+                    }
+                  ]
+                },
+                "http2WindowSize": {
+                  "anyOf": [
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ],
+                  "description": "Initial window size for stream-level flow\ncontrol for received data.",
+                  "maxLength": 32,
+                  "minLength": 1,
+                  "pattern": "^[+-]?([0-9]+(\\.[0-9]*)?|\\.[0-9]+)(([KMGTPE]i)|[numkMGTPE]|[eE](\\+?0*([0-9]|1[0-8])|-0*[0-9]))?$",
+                  "x-kubernetes-int-or-string": true,
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "value must be at least 1 byte and fit within uint32",
+                      "rule": "(self >= 1 && self <= 4294967295) || self.size() > 0"
+                    }
+                  ]
+                },
+                "maxBufferSize": {
+                  "anyOf": [
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ],
+                  "description": "Maximum HTTP body size that will be buffered\ninto memory.\nBodies will only be buffered for policies which require buffering.\nIf unset, this defaults to `2mb`.",
+                  "maxLength": 32,
+                  "minLength": 1,
+                  "pattern": "^[+-]?([0-9]+(\\.[0-9]*)?|\\.[0-9]+)(([KMGTPE]i)|[numkMGTPE]|[eE](\\+?0*([0-9]|1[0-8])|-0*[0-9]))?$",
+                  "x-kubernetes-int-or-string": true,
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "value must be at least 1 byte and fit within uint32",
+                      "rule": "(self >= 1 && self <= 4294967295) || self.size() > 0"
+                    }
+                  ]
+                },
+                "maxConnectionDuration": {
+                  "description": "Maximum time a connection is allowed to remain open.\nAfter this duration, the connection is gracefully closed after the current in-flight request completes.\nUseful for ensuring even traffic distribution behind load balancers during scaling events.",
+                  "type": "string",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "invalid duration value",
+                      "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                    },
+                    {
+                      "message": "maxConnectionDuration must be at least 1 second",
+                      "rule": "duration(self) >= duration('1s')"
+                    }
+                  ]
+                }
+              },
+              "type": "object",
+              "x-kubernetes-validations": [
+                {
+                  "message": "at least one of the fields in [http1HeaderCase http1IdleTimeout http1MaxHeaders http2ConnectionWindowSize http2FrameSize http2KeepaliveInterval http2KeepaliveTimeout http2MaxHeaderSize http2WindowSize maxBufferSize maxConnectionDuration] must be set",
+                  "rule": "[has(self.http1HeaderCase),has(self.http1IdleTimeout),has(self.http1MaxHeaders),has(self.http2ConnectionWindowSize),has(self.http2FrameSize),has(self.http2KeepaliveInterval),has(self.http2KeepaliveTimeout),has(self.http2MaxHeaderSize),has(self.http2WindowSize),has(self.maxBufferSize),has(self.maxConnectionDuration)].filter(x,x==true).size() >= 1"
+                }
+              ],
+              "additionalProperties": false
+            },
+            "metrics": {
+              "description": "Custom Prometheus metric label configuration.\nCEL expressions are evaluated per-request and added as labels to all\nPrometheus metrics exposed by agentgateway.",
+              "properties": {
+                "attributes": {
+                  "description": "Customizations to the labels that are\nadded to Prometheus metrics.",
+                  "properties": {
+                    "add": {
+                      "description": "Additional key-value pairs to add as custom labels\nto all Prometheus metrics. The value is a CEL expression evaluated\nper-request. If the CEL expression fails to evaluate, the label value\nis set to \"unknown\".\n\nWARNING: High-cardinality labels (e.g., per-user IDs) can significantly\nincrease Prometheus storage and memory usage. Prefer low-cardinality\ndimensions like team or environment.",
+                      "items": {
+                        "properties": {
+                          "expression": {
+                            "description": "A Common Expression Language (CEL) expression.",
+                            "maxLength": 16384,
+                            "minLength": 1,
+                            "type": "string"
+                          },
+                          "name": {
+                            "maxLength": 256,
+                            "minLength": 1,
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "expression",
+                          "name"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "maxItems": 16,
+                      "minItems": 1,
+                      "type": "array",
+                      "x-kubernetes-list-map-keys": [
+                        "name"
+                      ],
+                      "x-kubernetes-list-type": "map"
+                    }
+                  },
+                  "type": "object",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "at least one of the fields in [add] must be set",
+                      "rule": "[has(self.add)].filter(x,x==true).size() >= 1"
+                    }
+                  ],
+                  "additionalProperties": false
+                }
+              },
+              "required": [
+                "attributes"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "networkAuthorization": {
+              "description": "CEL authorization on downstream network connections.\n\nThis runs before protocol handling and is intended for L4 access control,\nfor example using `source.address` with `cidr(...).containsIP(...)`.",
+              "properties": {
+                "action": {
+                  "default": "Allow",
+                  "description": "The effect of this rule when it matches.\nIf unspecified, defaults to `Allow`.\n`Require` rules are cumulative: all require rules must match.",
+                  "enum": [
+                    "Allow",
+                    "Deny",
+                    "Require"
+                  ],
+                  "type": "string"
+                },
+                "policy": {
+                  "description": "The authorization rule to evaluate.\n\n* `Allow`: any matching allow rule allows the request.\n* `Require`: every require rule must match for the request to be allowed.\n* `Deny`: any matching deny rule denies the request.\n\nA CEL expression that fails to evaluate does not match. Prefer `Require`\nfor deny-by-default behavior.\n\nIf at least one `Allow` rule is configured, requests are denied unless at\nleast one allow rule matches.",
+                  "properties": {
+                    "matchExpressions": {
+                      "description": "CEL expressions that must all evaluate to true for the rule to match.",
+                      "items": {
+                        "description": "A Common Expression Language (CEL) expression.",
+                        "maxLength": 16384,
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "maxItems": 256,
+                      "minItems": 1,
+                      "type": "array"
+                    }
+                  },
+                  "required": [
+                    "matchExpressions"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "required": [
+                "policy"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "proxyProtocol": {
+              "description": "Settings for downstream PROXY protocol handling.\n\nIf configured, incoming connections may require a PROXY header before\nnormal protocol handling. This can also be configured to allow both\nPROXY and non-PROXY traffic on the same listener.",
+              "properties": {
+                "mode": {
+                  "default": "Strict",
+                  "description": "Whether PROXY headers are required or optional.\n\nIf unset, this defaults to `Strict`.",
+                  "enum": [
+                    "Optional",
+                    "Strict"
+                  ],
+                  "type": "string"
+                },
+                "version": {
+                  "default": "V2",
+                  "description": "PROXY protocol version to accept.\n\nIf unset, this defaults to `V2`.",
+                  "enum": [
+                    "All",
+                    "V1",
+                    "V2"
+                  ],
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "tcp": {
+              "description": "Settings for managing incoming TCP connections.",
+              "properties": {
+                "keepalive": {
+                  "description": "Settings for enabling TCP keepalives on the connection.",
+                  "properties": {
+                    "interval": {
+                      "description": "Time between keepalive probes.\nIf unset, this defaults to 180s.",
+                      "type": "string",
+                      "x-kubernetes-validations": [
+                        {
+                          "message": "invalid duration value",
+                          "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                        },
+                        {
+                          "message": "interval must be at least 1 second",
+                          "rule": "duration(self) >= duration('1s')"
+                        }
+                      ]
+                    },
+                    "retries": {
+                      "description": "Maximum number of keepalive probes to send before dropping the connection.\nIf unset, this defaults to 9.",
+                      "format": "int32",
+                      "maximum": 64,
+                      "minimum": 1,
+                      "type": "integer"
+                    },
+                    "time": {
+                      "description": "Time a connection needs to be idle before keepalive probes start being sent.\nIf unset, this defaults to 180s.",
+                      "type": "string",
+                      "x-kubernetes-validations": [
+                        {
+                          "message": "invalid duration value",
+                          "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                        },
+                        {
+                          "message": "time must be at least 1 second",
+                          "rule": "duration(self) >= duration('1s')"
+                        }
+                      ]
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "x-kubernetes-validations": [
+                {
+                  "message": "at least one of the fields in [keepalive] must be set",
+                  "rule": "[has(self.keepalive)].filter(x,x==true).size() >= 1"
+                }
+              ],
+              "additionalProperties": false
+            },
+            "tls": {
+              "description": "Settings for managing incoming TLS connections.",
+              "properties": {
+                "alpnProtocols": {
+                  "description": "Application-Layer Protocol Negotiation (`ALPN`)\nvalue to use in the TLS handshake.\n\nIf not present, defaults to `[\"h2\", \"http/1.1\"]`.",
+                  "items": {
+                    "maxLength": 64,
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "maxItems": 16,
+                  "minItems": 1,
+                  "type": "array"
+                },
+                "cipherSuites": {
+                  "description": "Cipher suites for a TLS listener.\nThe value is a comma-separated list of cipher suites, for example\n`TLS13_AES_256_GCM_SHA384,TLS13_AES_128_GCM_SHA256`.\nUse this in the TLS options field of a TLS listener.",
+                  "items": {
+                    "enum": [
+                      "TLS13_AES_128_GCM_SHA256",
+                      "TLS13_AES_256_GCM_SHA384",
+                      "TLS13_CHACHA20_POLY1305_SHA256",
+                      "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+                      "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
+                      "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256",
+                      "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+                      "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
+                      "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256"
+                    ],
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "handshakeTimeout": {
+                  "description": "Deadline for a TLS handshake to\ncomplete. If unset, this defaults to `15s`.",
+                  "type": "string",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "invalid duration value",
+                      "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                    },
+                    {
+                      "message": "handshakeTimeout must be at least 100ms",
+                      "rule": "duration(self) >= duration('100ms')"
+                    }
+                  ]
+                },
+                "keyExchangeGroups": {
+                  "description": "Ordered list of key exchange groups for a TLS listener.\nFor example: `X25519_MLKEM768,X25519`.",
+                  "items": {
+                    "enum": [
+                      "P-256",
+                      "P-384",
+                      "X25519",
+                      "X25519_MLKEM768"
+                    ],
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "maxProtocolVersion": {
+                  "description": "Maximum TLS version to support.",
+                  "enum": [
+                    "1.2",
+                    "1.3"
+                  ],
+                  "type": "string"
+                },
+                "minProtocolVersion": {
+                  "description": "Minimum TLS version to support.",
+                  "enum": [
+                    "1.2",
+                    "1.3"
+                  ],
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "x-kubernetes-validations": [
+                {
+                  "message": "at least one of the fields in [alpnProtocols cipherSuites handshakeTimeout keyExchangeGroups maxProtocolVersion minProtocolVersion] must be set",
+                  "rule": "[has(self.alpnProtocols),has(self.cipherSuites),has(self.handshakeTimeout),has(self.keyExchangeGroups),has(self.maxProtocolVersion),has(self.minProtocolVersion)].filter(x,x==true).size() >= 1"
+                }
+              ],
+              "additionalProperties": false
+            },
+            "tracing": {
+              "description": "OpenTelemetry tracing settings.",
+              "properties": {
+                "attributes": {
+                  "description": "Customizations to the key-value pairs that are\nincluded in the trace.",
+                  "properties": {
+                    "add": {
+                      "description": "Additional key-value pairs to add to each entry.\nThe value is a CEL expression. If the CEL expression fails to evaluate,\nthe pair will be excluded.",
+                      "items": {
+                        "properties": {
+                          "expression": {
+                            "description": "A Common Expression Language (CEL) expression.",
+                            "maxLength": 16384,
+                            "minLength": 1,
+                            "type": "string"
+                          },
+                          "name": {
+                            "maxLength": 256,
+                            "minLength": 1,
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "expression",
+                          "name"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "minItems": 1,
+                      "type": "array"
+                    },
+                    "remove": {
+                      "description": "Default fields to remove. For example,\n`http.method`.",
+                      "items": {
+                        "maxLength": 64,
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "maxItems": 32,
+                      "minItems": 1,
+                      "type": "array"
+                    }
+                  },
+                  "type": "object",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "at least one of the fields in [add remove] must be set",
+                      "rule": "[has(self.add),has(self.remove)].filter(x,x==true).size() >= 1"
+                    }
+                  ],
+                  "additionalProperties": false
+                },
+                "backendRef": {
+                  "description": "OTLP server to reach.\nSupported types: `Service` and `AgentgatewayBackend`.",
+                  "properties": {
+                    "group": {
+                      "default": "",
+                      "description": "Group is the group of the referent. For example, \"gateway.networking.k8s.io\".\nWhen unspecified or empty string, core API group is inferred.",
+                      "maxLength": 253,
+                      "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                      "type": "string"
+                    },
+                    "kind": {
+                      "default": "Service",
+                      "description": "Kind is the Kubernetes resource kind of the referent. For example\n\"Service\".\n\nDefaults to \"Service\" when not specified.\n\nExternalName services can refer to CNAME DNS records that may live\noutside of the cluster and as such are difficult to reason about in\nterms of conformance. They also may not be safe to forward to (see\nCVE-2021-25740 for more information). Implementations SHOULD NOT\nsupport ExternalName Services.\n\nSupport: Core (Services with a type other than ExternalName)\n\nSupport: Implementation-specific (Services with type ExternalName)",
+                      "maxLength": 63,
+                      "minLength": 1,
+                      "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
+                      "type": "string"
+                    },
+                    "name": {
+                      "description": "Name is the name of the referent.",
+                      "maxLength": 253,
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "namespace": {
+                      "description": "Namespace is the namespace of the backend. When unspecified, the local\nnamespace is inferred.\n\nNote that when a namespace different than the local namespace is specified,\na ReferenceGrant object is required in the referent namespace to allow that\nnamespace's owner to accept the reference. See the ReferenceGrant\ndocumentation for details.\n\nSupport: Core",
+                      "maxLength": 63,
+                      "minLength": 1,
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                      "type": "string"
+                    },
+                    "port": {
+                      "description": "Port specifies the destination port number to use for this resource.\nPort is required when the referent is a Kubernetes Service. In this\ncase, the port number is the service port number, not the target port.\nFor other resources, destination port might be derived from the referent\nresource or this field.",
+                      "format": "int32",
+                      "maximum": 65535,
+                      "minimum": 1,
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "name"
+                  ],
+                  "type": "object",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "Must have port for Service reference",
+                      "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
+                    }
+                  ],
+                  "additionalProperties": false
+                },
+                "clientSampling": {
+                  "description": "Expression that determines the amount of client\nsampling. Client sampling determines whether to initiate a new trace\nspan if the incoming request does have a trace already. This should\nevaluate to a float between `0.0` and `1.0`, or a boolean (`true` or\n`false`). If unspecified, client sampling is `100%` enabled.",
+                  "maxLength": 16384,
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "path": {
+                  "description": "OTLP path to use. This is only applicable when\n`protocol` is `HTTP`. If unset, this defaults to `/v1/traces`.",
+                  "maxLength": 1024,
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "protocol": {
+                  "default": "GRPC",
+                  "description": "OTLP protocol variant to use.",
+                  "enum": [
+                    "GRPC",
+                    "HTTP"
+                  ],
+                  "type": "string"
+                },
+                "randomSampling": {
+                  "description": "Expression that determines the amount of random\nsampling. Random sampling will initiate a new trace span if the incoming\nrequest does not have a trace initiated already. This should evaluate to\na float between `0.0` and `1.0`, or a boolean (`true` or `false`). If\nunspecified, random sampling is disabled.",
+                  "maxLength": 16384,
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "resources": {
+                  "description": "Entity producing telemetry and resources\nresources to be included in the trace.",
+                  "items": {
+                    "properties": {
+                      "expression": {
+                        "description": "A Common Expression Language (CEL) expression.",
+                        "maxLength": 16384,
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "name": {
+                        "maxLength": 256,
+                        "minLength": 1,
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "expression",
+                      "name"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                }
+              },
+              "required": [
+                "backendRef"
+              ],
+              "type": "object",
+              "x-kubernetes-validations": [
+                {
+                  "message": "path is only valid with protocol HTTP",
+                  "rule": "!has(self.path) || !has(self.protocol) || self.protocol == 'HTTP'"
+                },
+                {
+                  "message": "path must start with /",
+                  "rule": "!has(self.path) || self.path.startsWith('/')"
+                }
+              ],
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "x-kubernetes-validations": [
+            {
+              "message": "at least one of the fields in [accessLog connect http metrics networkAuthorization proxyProtocol tcp tls tracing] must be set",
+              "rule": "[has(self.accessLog),has(self.connect),has(self.http),has(self.metrics),has(self.networkAuthorization),has(self.proxyProtocol),has(self.tcp),has(self.tls),has(self.tracing)].filter(x,x==true).size() >= 1"
+            }
+          ],
+          "additionalProperties": false
+        },
+        "strategy": {
+          "description": "Policy merge and conflict resolution strategy.\n\nStrategy settings apply to the policy object as a whole. Individual strategy fields may\nonly be valid for specific policy kinds; for example, inheritance is only valid when this\npolicy contains traffic settings.",
+          "properties": {
+            "inheritance": {
+              "description": "Controls whether less-specific traffic policies prevent more-specific traffic policies\nfrom contributing to the effective policy.\n\nThis field is only valid on traffic policies. Frontend and backend policy merging does not use\ninheritance.\n\nWhen unset or set to `Default`, traffic policy fields are merged by specificity, with more-specific\nattachment points such as routes and route rules able to override fields from less-specific\nattachment points such as gateways and listeners.\nIn other words, this policy provides `Default`s that can be overridden. For example, you may provide a `Default`\ntimeout policy for the entire Gateway that is overridden by specific routes.\n\nWhen set to `Override`, this policy blocks traffic policies at more-specific attachment points from\nbeing included in the effective policy. This is useful when a gateway-level policy must remain\nauthoritative for all routes below it.",
+              "enum": [
+                "Default",
+                "Override"
+              ],
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "targetRefs": {
+          "description": "Target resources to attach the\npolicy to.",
+          "items": {
+            "description": "Selects one same-namespace object by `group`, `kind`, `name`, and,\noptionally, `sectionName`.\nThe object must be in the same namespace as the policy.",
+            "properties": {
+              "group": {
+                "description": "The API group of the target resource.\nFor Kubernetes Gateway API resources, the group is `gateway.networking.k8s.io`.",
+                "maxLength": 253,
+                "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                "type": "string"
+              },
+              "kind": {
+                "description": "The API kind of the target resource, such as `Gateway` or `HTTPRoute`.",
+                "maxLength": 63,
+                "minLength": 1,
+                "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
+                "type": "string"
+              },
+              "name": {
+                "description": "The name of the target resource.",
+                "maxLength": 253,
+                "minLength": 1,
+                "type": "string"
+              },
+              "sectionName": {
+                "description": "The named section of the target resource.",
+                "maxLength": 253,
+                "minLength": 1,
+                "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                "type": "string"
+              }
+            },
+            "required": [
+              "group",
+              "kind",
+              "name"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "maxItems": 16,
+          "minItems": 1,
+          "type": "array",
+          "x-kubernetes-list-type": "atomic",
+          "x-kubernetes-validations": [
+            {
+              "message": "targetRefs may only reference Gateway, HTTPRoute, GRPCRoute, ListenerSet, Service, AgentgatewayBackend, or InferencePool resources",
+              "rule": "self.all(r, (r.kind == 'Service' && r.group == '') || (r.kind == 'AgentgatewayBackend' && r.group == 'agentgateway.dev') || (r.kind in ['Gateway', 'HTTPRoute', 'GRPCRoute'] && r.group == 'gateway.networking.k8s.io') || (r.kind == 'ListenerSet' && r.group == 'gateway.networking.k8s.io') || (r.kind == 'InferencePool' && r.group == 'inference.networking.k8s.io'))"
+            },
+            {
+              "message": "Only one Kind of targetRef can be set on one policy",
+              "rule": "self.all(l1, !self.exists(l2, l1.kind != l2.kind))"
+            }
+          ]
+        },
+        "targetSelectors": {
+          "description": "Target selectors used to select resources to attach the policy to.",
+          "items": {
+            "description": "Selects same-namespace objects by `group`, `kind`, `matchLabels`, and,\noptionally, `sectionName`.\nEach selected object must be in the same namespace as the policy and match\nthe specified labels.\nPrefer `targetRefs` when reconciliation latency is important, especially\nwhen many policies target the same resource.",
+            "properties": {
+              "group": {
+                "description": "The API group of the target resource.\nFor Kubernetes Gateway API resources, the group is `gateway.networking.k8s.io`.",
+                "maxLength": 253,
+                "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                "type": "string"
+              },
+              "kind": {
+                "description": "The API kind of the target resource, such as `Gateway` or `HTTPRoute`.",
+                "maxLength": 63,
+                "minLength": 1,
+                "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
+                "type": "string"
+              },
+              "matchLabels": {
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "description": "Labels that must be present on each selected target resource.",
+                "type": "object"
+              },
+              "sectionName": {
+                "description": "The named section of each selected target resource.",
+                "maxLength": 253,
+                "minLength": 1,
+                "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                "type": "string"
+              }
+            },
+            "required": [
+              "group",
+              "kind",
+              "matchLabels"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "maxItems": 16,
+          "minItems": 1,
+          "type": "array",
+          "x-kubernetes-validations": [
+            {
+              "message": "targetRefs may only reference Gateway, HTTPRoute, GRPCRoute, ListenerSet, Service, AgentgatewayBackend, or InferencePool resources",
+              "rule": "self.all(r, (r.kind == 'Service' && r.group == '') || (r.kind == 'AgentgatewayBackend' && r.group == 'agentgateway.dev') || (r.kind in ['Gateway', 'HTTPRoute', 'GRPCRoute'] && r.group == 'gateway.networking.k8s.io') || (r.kind == 'ListenerSet' && r.group == 'gateway.networking.k8s.io') || (r.kind == 'InferencePool' && r.group == 'inference.networking.k8s.io'))"
+            },
+            {
+              "message": "Only one Kind of targetRef can be set on one policy",
+              "rule": "self.all(l1, !self.exists(l2, l1.kind != l2.kind))"
+            }
+          ]
+        },
+        "traffic": {
+          "description": "Settings for how to process traffic.\n\nA traffic policy can target a `Gateway` (optionally, with a\n`sectionName` indicating the listener), `ListenerSet`, or `Route`\n(optionally, with a `sectionName` indicating the route rule).\n\nWhen multiple policies are selected for a given request, they are merged on a field-level basis, but not a deep\nmerge. Precedence is given to more precise policies: `Gateway` <\n`Listener` < `Route` < `Route Rule`. For example, policy A sets\n`timeouts` and `retries`, and policy B sets `retries`; the effective\npolicy would be `timeouts` from policy A, and `retries` from policy B.",
+          "properties": {
+            "apiKeyAuthentication": {
+              "description": "Authenticates users based on a configured API\nkey.",
+              "properties": {
+                "location": {
+                  "description": "Where API keys are read from.\nIf omitted, credentials are read from the `Authorization` header with the `Bearer ` prefix.",
+                  "properties": {
+                    "cookie": {
+                      "properties": {
+                        "name": {
+                          "maxLength": 256,
+                          "minLength": 1,
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "expression": {
+                      "description": "CEL expression that extracts the credential from the request.",
+                      "maxLength": 16384,
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "header": {
+                      "properties": {
+                        "name": {
+                          "description": "HTTPHeaderName is the name of an HTTP header.\n\nValid values include:\n\n* \"Authorization\"\n* \"Set-Cookie\"\n\nInvalid values include:\n\n  - \":method\" - \":\" is an invalid character. This means that HTTP/2 pseudo\n    headers are not currently supported by this type.\n  - \"/invalid\" - \"/ \" is an invalid character",
+                          "maxLength": 256,
+                          "minLength": 1,
+                          "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                          "type": "string"
+                        },
+                        "prefix": {
+                          "maxLength": 256,
+                          "minLength": 1,
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "queryParameter": {
+                      "properties": {
+                        "name": {
+                          "maxLength": 256,
+                          "minLength": 1,
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "exactly one of the fields in [header queryParameter cookie expression] must be set",
+                      "rule": "[has(self.header),has(self.queryParameter),has(self.cookie),has(self.expression)].filter(x,x==true).size() == 1"
+                    }
+                  ],
+                  "additionalProperties": false
+                },
+                "mode": {
+                  "default": "Strict",
+                  "description": "Validation mode for API key authentication.",
+                  "enum": [
+                    "Optional",
+                    "Permissive",
+                    "Strict"
+                  ],
+                  "type": "string"
+                },
+                "secretRef": {
+                  "description": "Credential source, defaulting to a Kubernetes\n`Secret`, storing a set of API keys. If there are many Secret-backed\nkeys, `secretSelector` can be used instead.\n\nEach entry in the credential data represents one API key. The key is an\narbitrary identifier. The value can either be:\n* A string representing the API key.\n* A JSON object with two fields, `key` and `metadata`. `key` contains\n  the API key. `metadata` contains arbitrary JSON metadata associated\n  with the key, which may be used by other policies. For example, you\n  may write an authorization policy allowing `apiKey.group == 'sales'`.\n\nExample:\n\n\tapiVersion: v1\n\tkind: Secret\n\tmetadata:\n\t  name: api-key\n\tstringData:\n\t  client1: |\n\t    {\n\t      \"key\": \"k-123\",\n\t      \"metadata\": {\n\t        \"group\": \"sales\",\n\t        \"created_at\": \"2024-10-01T12:00:00Z\"\n\t      }\n\t    }\n\t  client2: \"k-456\"",
+                  "properties": {
+                    "group": {
+                      "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                      "type": "string"
+                    },
+                    "kind": {
+                      "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                      "type": "string"
+                    },
+                    "name": {
+                      "description": "The name of the referenced credential.",
+                      "maxLength": 253,
+                      "minLength": 1,
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "name"
+                  ],
+                  "type": "object",
+                  "x-kubernetes-map-type": "atomic",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "custom credential refs must set both group and kind",
+                      "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                    }
+                  ],
+                  "additionalProperties": false
+                },
+                "secretSelector": {
+                  "description": "Selects multiple Kubernetes `Secret` resources\ncontaining API keys. It is Secret-only; use `secretRef` for other\ncredential kinds. If the same key is defined in multiple secrets, the\nbehavior is undefined.\n\nEach entry in the `Secret` data represents one API key. The key is an\narbitrary identifier. The value can either be:\n* A string representing the API key.\n* A JSON object with two fields, `key` and `metadata`. `key` contains\n  the API key. `metadata` contains arbitrary JSON metadata associated\n  with the key, which may be used by other policies. For example, you\n  may write an authorization policy allowing `apiKey.group == 'sales'`.\n\nExample:\n\n\tapiVersion: v1\n\tkind: Secret\n\tmetadata:\n\t  name: api-key\n\tstringData:\n\t  client1: |\n\t    {\n\t      \"key\": \"k-123\",\n\t      \"metadata\": {\n\t        \"group\": \"sales\",\n\t        \"created_at\": \"2024-10-01T12:00:00Z\"\n\t      }\n\t    }\n\t  client2: \"k-456\"",
+                  "properties": {
+                    "matchLabels": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "Labels that must be present on each selected Secret.",
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "matchLabels"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "x-kubernetes-validations": [
+                {
+                  "message": "exactly one of the fields in [secretRef secretSelector] must be set",
+                  "rule": "[has(self.secretRef),has(self.secretSelector)].filter(x,x==true).size() == 1"
+                }
+              ],
+              "additionalProperties": false
+            },
+            "authorization": {
+              "description": "Access rules based on roles and\npermissions.\nIf multiple authorization rules are applied across different policies, at the same or different attachment points,\nall rules are merged.",
+              "properties": {
+                "action": {
+                  "default": "Allow",
+                  "description": "The effect of this rule when it matches.\nIf unspecified, defaults to `Allow`.\n`Require` rules are cumulative: all require rules must match.",
+                  "enum": [
+                    "Allow",
+                    "Deny",
+                    "Require"
+                  ],
+                  "type": "string"
+                },
+                "policy": {
+                  "description": "The authorization rule to evaluate.\n\n* `Allow`: any matching allow rule allows the request.\n* `Require`: every require rule must match for the request to be allowed.\n* `Deny`: any matching deny rule denies the request.\n\nA CEL expression that fails to evaluate does not match. Prefer `Require`\nfor deny-by-default behavior.\n\nIf at least one `Allow` rule is configured, requests are denied unless at\nleast one allow rule matches.",
+                  "properties": {
+                    "matchExpressions": {
+                      "description": "CEL expressions that must all evaluate to true for the rule to match.",
+                      "items": {
+                        "description": "A Common Expression Language (CEL) expression.",
+                        "maxLength": 16384,
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "maxItems": 256,
+                      "minItems": 1,
+                      "type": "array"
+                    }
+                  },
+                  "required": [
+                    "matchExpressions"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "required": [
+                "policy"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "basicAuthentication": {
+              "description": "Authenticates users based on the `Basic`\nauthentication scheme (RFC 7617), where a username and password are\nencoded in the request.",
+              "properties": {
+                "location": {
+                  "description": "Where Basic credentials are read from.\nIf omitted, credentials are read from the `Authorization` header with the `Basic ` prefix.",
+                  "properties": {
+                    "cookie": {
+                      "properties": {
+                        "name": {
+                          "maxLength": 256,
+                          "minLength": 1,
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "expression": {
+                      "description": "CEL expression that extracts the credential from the request.",
+                      "maxLength": 16384,
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "header": {
+                      "properties": {
+                        "name": {
+                          "description": "HTTPHeaderName is the name of an HTTP header.\n\nValid values include:\n\n* \"Authorization\"\n* \"Set-Cookie\"\n\nInvalid values include:\n\n  - \":method\" - \":\" is an invalid character. This means that HTTP/2 pseudo\n    headers are not currently supported by this type.\n  - \"/invalid\" - \"/ \" is an invalid character",
+                          "maxLength": 256,
+                          "minLength": 1,
+                          "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                          "type": "string"
+                        },
+                        "prefix": {
+                          "maxLength": 256,
+                          "minLength": 1,
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "queryParameter": {
+                      "properties": {
+                        "name": {
+                          "maxLength": 256,
+                          "minLength": 1,
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "exactly one of the fields in [header queryParameter cookie expression] must be set",
+                      "rule": "[has(self.header),has(self.queryParameter),has(self.cookie),has(self.expression)].filter(x,x==true).size() == 1"
+                    }
+                  ],
+                  "additionalProperties": false
+                },
+                "mode": {
+                  "default": "Strict",
+                  "description": "Validation mode for basic authentication.",
+                  "enum": [
+                    "Optional",
+                    "Strict"
+                  ],
+                  "type": "string"
+                },
+                "realm": {
+                  "description": "`realm` value to return in the `WWW-Authenticate`\nheader for failed authentication requests. If unset, `Restricted` will\nbe used.",
+                  "type": "string"
+                },
+                "secretRef": {
+                  "description": "Credential source, defaulting to a Kubernetes\n`Secret`, storing the `.htaccess` file. When using the default Secret\nresolver, the `Secret` must have a key named `.htaccess`, and should\ncontain the complete `.htaccess` file.\n\nNote: passwords should be the hash of the password, not the raw password. Use the `htpasswd` or similar commands\nto generate a hash. MD5, bcrypt, crypt, and SHA-1 are supported.\n\nExample:\n\n\tapiVersion: v1\n\tkind: Secret\n\tmetadata:\n\t  name: basic-auth\n\tstringData:\n\t  .htaccess: |\n\t    alice:$apr1$3zSE0Abt$IuETi4l5yO87MuOrbSE4V.\n\t    bob:$apr1$Ukb5LgRD$EPY2lIfY.A54jzLELNIId/",
+                  "properties": {
+                    "group": {
+                      "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                      "type": "string"
+                    },
+                    "kind": {
+                      "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                      "type": "string"
+                    },
+                    "name": {
+                      "description": "The name of the referenced credential.",
+                      "maxLength": 253,
+                      "minLength": 1,
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "name"
+                  ],
+                  "type": "object",
+                  "x-kubernetes-map-type": "atomic",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "custom credential refs must set both group and kind",
+                      "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                    }
+                  ],
+                  "additionalProperties": false
+                },
+                "users": {
+                  "description": "Inline list of username and password pairs that will\nbe accepted. Each entry represents one line of the `htpasswd` format:\nhttps://httpd.apache.org/docs/2.4/programs/htpasswd.html.\n\nNote: passwords should be the hash of the password, not the raw password. Use the `htpasswd` or similar commands\nto generate a hash. MD5, bcrypt, crypt, and SHA-1 are supported.\n\nExample:\n\n\tusers:\n\t- \"user1:$apr1$ivPt0D4C$DmRhnewfHRSrb3DQC.WHC.\"\n\t- \"user2:$2y$05$r3J4d3VepzFkedkd/q1vI.pBYIpSqjfN0qOARV3ScUHysatnS0cL2\"",
+                  "items": {
+                    "type": "string"
+                  },
+                  "maxItems": 256,
+                  "minItems": 1,
+                  "type": "array"
+                }
+              },
+              "type": "object",
+              "x-kubernetes-validations": [
+                {
+                  "message": "exactly one of the fields in [users secretRef] must be set",
+                  "rule": "[has(self.users),has(self.secretRef)].filter(x,x==true).size() == 1"
+                }
+              ],
+              "additionalProperties": false
+            },
+            "buffer": {
+              "description": "Buffers request and response bodies. Buffered bodies are accumulated in memory\nby the proxy until completion before being forwarded. This changes the proxies default behavior, which streams bodies.\n\nWarning: large bodies can lead to excessive memory usage in the proxy. Utilize with care, or with strict limits.",
+              "properties": {
+                "request": {
+                  "description": "Request body buffering settings.",
+                  "properties": {
+                    "maxBytes": {
+                      "anyOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ],
+                      "description": "Maximum number of bytes to buffer from the request or response body.\nIf unset, defaults to the global proxy setting, which defaults to 2Mi.",
+                      "maxLength": 32,
+                      "minLength": 1,
+                      "pattern": "^[+-]?([0-9]+(\\.[0-9]*)?|\\.[0-9]+)(([KMGTPE]i)|[numkMGTPE]|[eE](\\+?0*([0-9]|1[0-8])|-0*[0-9]))?$",
+                      "x-kubernetes-int-or-string": true,
+                      "x-kubernetes-validations": [
+                        {
+                          "message": "value must be at least 1 byte and fit within uint32",
+                          "rule": "(self >= 1 && self <= 4294967295) || self.size() > 0"
+                        }
+                      ]
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "response": {
+                  "description": "Response body buffering settings.",
+                  "properties": {
+                    "maxBytes": {
+                      "anyOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ],
+                      "description": "Maximum number of bytes to buffer from the request or response body.\nIf unset, defaults to the global proxy setting, which defaults to 2Mi.",
+                      "maxLength": 32,
+                      "minLength": 1,
+                      "pattern": "^[+-]?([0-9]+(\\.[0-9]*)?|\\.[0-9]+)(([KMGTPE]i)|[numkMGTPE]|[eE](\\+?0*([0-9]|1[0-8])|-0*[0-9]))?$",
+                      "x-kubernetes-int-or-string": true,
+                      "x-kubernetes-validations": [
+                        {
+                          "message": "value must be at least 1 byte and fit within uint32",
+                          "rule": "(self >= 1 && self <= 4294967295) || self.size() > 0"
+                        }
+                      ]
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "x-kubernetes-validations": [
+                {
+                  "message": "at least one of the fields in [request response] must be set",
+                  "rule": "[has(self.request),has(self.response)].filter(x,x==true).size() >= 1"
+                }
+              ],
+              "additionalProperties": false
+            },
+            "cors": {
+              "description": "CORS configuration for the policy.",
+              "properties": {
+                "allowCredentials": {
+                  "description": "AllowCredentials indicates whether the actual cross-origin request allows\nto include credentials.\n\nWhen set to true, the gateway will include the `Access-Control-Allow-Credentials`\nresponse header with value true (case-sensitive).\n\nWhen set to false or omitted the gateway will omit the header\n`Access-Control-Allow-Credentials` entirely (this is the standard CORS\nbehavior).\n\nSupport: Extended",
+                  "type": "boolean"
+                },
+                "allowHeaders": {
+                  "description": "AllowHeaders indicates which HTTP request headers are supported for\naccessing the requested resource.\n\nHeader names are not case-sensitive.\n\nMultiple header names in the value of the `Access-Control-Allow-Headers`\nresponse header are separated by a comma (\",\").\n\nWhen the `allowHeaders` field is configured with one or more headers, the\ngateway must return the `Access-Control-Allow-Headers` response header\nwhich value is present in the `allowHeaders` field.\n\nIf any header name in the `Access-Control-Request-Headers` request header\nis not included in the list of header names specified by the response\nheader `Access-Control-Allow-Headers`, it will present an error on the\nclient side.\n\nIf any header name in the `Access-Control-Allow-Headers` response header\ndoes not recognize by the client, it will also occur an error on the\nclient side.\n\nA wildcard indicates that the requests with all HTTP headers are allowed.\n\nIf the configuration contains the wildcard `*` in `allowHeaders` and\n`allowCredentials` is set to `false`, the `Access-Control-Allow-Headers`\nresponse header may either contain the wildcard `*` or echo the value\nof the `Access-Control-Request-Headers` request header.\n\nIf the configuration contains the wildcard `*` in `allowHeaders` and\n`allowCredentials` is set to `true`, the gateway must not return `*`\nin the `Access-Control-Allow-Headers` response header. Instead, it must\nreturn one or more header names matching the value of the\n`Access-Control-Request-Headers` request header.\nIf the `Access-Control-Request-Headers` header is not present in the\nrequest, the gateway must omit the `Access-Control-Allow-Headers`\nresponse header.\n\nSupport: Extended",
+                  "items": {
+                    "description": "HTTPHeaderName is the name of an HTTP header.\n\nValid values include:\n\n* \"Authorization\"\n* \"Set-Cookie\"\n\nInvalid values include:\n\n  - \":method\" - \":\" is an invalid character. This means that HTTP/2 pseudo\n    headers are not currently supported by this type.\n  - \"/invalid\" - \"/ \" is an invalid character",
+                    "maxLength": 256,
+                    "minLength": 1,
+                    "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                    "type": "string"
+                  },
+                  "maxItems": 64,
+                  "type": "array",
+                  "x-kubernetes-list-type": "set",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "AllowHeaders cannot contain '*' alongside other methods",
+                      "rule": "!('*' in self && self.size() > 1)"
+                    }
+                  ]
+                },
+                "allowMethods": {
+                  "description": "AllowMethods indicates which HTTP methods are supported for accessing the\nrequested resource.\n\nValid values are any method defined by RFC9110, along with the special\nvalue `*`, which represents all HTTP methods are allowed.\n\nMethod names are case-sensitive, so these values are also case-sensitive.\n(See https://www.rfc-editor.org/rfc/rfc2616#section-5.1.1)\n\nMultiple method names in the value of the `Access-Control-Allow-Methods`\nresponse header are separated by a comma (\",\").\n\nA CORS-safelisted method is a method that is `GET`, `HEAD`, or `POST`.\n(See https://fetch.spec.whatwg.org/#cors-safelisted-method) The\nCORS-safelisted methods are always allowed, regardless of whether they\nare specified in the `allowMethods` field.\n\nWhen the `allowMethods` field is configured with one or more methods, the\ngateway must return the `Access-Control-Allow-Methods` response header\nwhich value is present in the `allowMethods` field.\n\nIf the HTTP method of the `Access-Control-Request-Method` request header\nis not included in the list of methods specified by the response header\n`Access-Control-Allow-Methods`, it will present an error on the client\nside.\n\nIf the configuration contains the wildcard `*` in `allowMethods` and\n`allowCredentials` is set to `false`, the `Access-Control-Allow-Methods`\nresponse header may either contain the wildcard `*` or echo the value\nof the `Access-Control-Request-Method` request header.\n\nIf the configuration contains the wildcard `*` in `allowMethods` and\n`allowCredentials` is set to `true`, the gateway must not return `*`\nin the `Access-Control-Allow-Methods` response header. Instead, it must\nreturn a single HTTP method matching the value of the\n`Access-Control-Request-Method` request header.\nIf the `Access-Control-Request-Method` header is not present in the request,\nthe gateway must omit the `Access-Control-Allow-Methods` response header.\n\nSupport: Extended",
+                  "items": {
+                    "enum": [
+                      "GET",
+                      "HEAD",
+                      "POST",
+                      "PUT",
+                      "DELETE",
+                      "CONNECT",
+                      "OPTIONS",
+                      "TRACE",
+                      "PATCH",
+                      "*"
+                    ],
+                    "type": "string"
+                  },
+                  "maxItems": 9,
+                  "type": "array",
+                  "x-kubernetes-list-type": "set",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "AllowMethods cannot contain '*' alongside other methods",
+                      "rule": "!('*' in self && self.size() > 1)"
+                    }
+                  ]
+                },
+                "allowOrigins": {
+                  "description": "AllowOrigins indicates whether the response can be shared with requested\nresource from the given `Origin`.\n\nThe `Origin` consists of a scheme and a host, with an optional port, and\ntakes the form `<scheme>://<host>(:<port>)`.\n\nValid values for scheme are: `http` and `https`.\n\nValid values for port are any integer between 1 and 65535 (the list of\navailable TCP/UDP ports). Note that, if not included, port `80` is\nassumed for `http` scheme origins, and port `443` is assumed for `https`\norigins. This may affect origin matching.\n\nThe host part of the origin may contain the wildcard character `*`. These\nwildcard characters behave as follows:\n\n* `*` is a greedy match to the _left_, including any number of\n  DNS labels to the left of its position. This also means that\n  `*` will include any number of period `.` characters to the\n  left of its position.\n* A wildcard by itself matches all hosts.\n\nAn origin value that includes _only_ the `*` character indicates requests\nfrom all `Origin`s are allowed.\n\nWhen the `allowOrigins` field is configured with multiple origins, it\nmeans the server supports clients from multiple origins. If the request\n`Origin` matches the configured allowed origins, the gateway must return\nthe given `Origin` and sets value of the header\n`Access-Control-Allow-Origin` same as the `Origin` header provided by the\nclient.\n\nThe status code of a successful response to a \"preflight\" request is\nalways an OK status (i.e., 204 or 200).\n\nIf the request `Origin` does not match the configured allowed origins,\nthe gateway returns 204/200 response but doesn't set the relevant\ncross-origin response headers. Alternatively, the gateway responds with\n403 status to the \"preflight\" request is denied, coupled with omitting\nthe CORS headers. The cross-origin request fails on the client side.\nTherefore, the client doesn't attempt the actual cross-origin request.\n\nConversely, if the request `Origin` matches one of the configured\nallowed origins, the gateway sets the response header\n`Access-Control-Allow-Origin` to the same value as the `Origin`\nheader provided by the client.\n\nIf the configuration contains the wildcard `*` in `allowOrigins` and\n`allowCredentials` is set to `false`, the `Access-Control-Allow-Origin`\nresponse header may either contain the wildcard `*` or echo the value\nof the `Origin` request header.\n\nIf the configuration contains the wildcard `*` in `allowOrigins` and\n`allowCredentials` is set to `true`, the gateway must not return `*`\nin the `Access-Control-Allow-Origin` response header. Instead, it must\nreturn a single origin matching the value of the `Origin` request header.\n\nSupport: Extended",
+                  "items": {
+                    "description": "The CORSOrigin MUST NOT be a relative URI, and it MUST follow the URI syntax and\nencoding rules specified in RFC3986.  The CORSOrigin MUST include both a\nscheme (\"http\" or \"https\") and a scheme-specific-part, or it should be a single '*' character.\nURIs that include an authority MUST include a fully qualified domain name or\nIP address as the host.",
+                    "maxLength": 253,
+                    "minLength": 1,
+                    "pattern": "(^\\*$)|(^(http(s)?):\\/\\/(((\\*\\.)?([a-zA-Z0-9\\-]+\\.)*[a-zA-Z0-9-]+|\\*)(:([0-9]{1,5}))?)$)",
+                    "type": "string"
+                  },
+                  "maxItems": 64,
+                  "type": "array",
+                  "x-kubernetes-list-type": "set",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "AllowOrigins cannot contain '*' alongside other origins",
+                      "rule": "!('*' in self && self.size() > 1)"
+                    }
+                  ]
+                },
+                "exposeHeaders": {
+                  "description": "ExposeHeaders indicates which HTTP response headers can be exposed\nto client-side scripts in response to a cross-origin request.\n\nA CORS-safelisted response header is an HTTP header in a CORS response\nthat it is considered safe to expose to the client scripts.\nThe CORS-safelisted response headers include the following headers:\n`Cache-Control`\n`Content-Language`\n`Content-Length`\n`Content-Type`\n`Expires`\n`Last-Modified`\n`Pragma`\n(See https://fetch.spec.whatwg.org/#cors-safelisted-response-header-name)\nThe CORS-safelisted response headers are exposed to client by default.\n\nWhen an HTTP header name is specified using the `exposeHeaders` field,\nthis additional header will be exposed as part of the response to the\nclient.\n\nHeader names are not case-sensitive.\n\nMultiple header names in the value of the `Access-Control-Expose-Headers`\nresponse header are separated by a comma (\",\").\n\nA wildcard indicates that the responses with all HTTP headers are exposed\nto clients.\n\nIf the configuration contains the wildcard `*` in `exposeHeaders` and\n`allowCredentials` is set to `false`, the `Access-Control-Expose-Headers`\nresponse header can contain the wildcard `*`.\n\nIf the configuration contains the wildcard `*` in `exposeHeaders` and\n`allowCredentials` is set to `true`, the gateway cannot use the `*`\nin the `Access-Control-Expose-Headers` response header.\n\nSupport: Extended",
+                  "items": {
+                    "description": "HTTPHeaderName is the name of an HTTP header.\n\nValid values include:\n\n* \"Authorization\"\n* \"Set-Cookie\"\n\nInvalid values include:\n\n  - \":method\" - \":\" is an invalid character. This means that HTTP/2 pseudo\n    headers are not currently supported by this type.\n  - \"/invalid\" - \"/ \" is an invalid character",
+                    "maxLength": 256,
+                    "minLength": 1,
+                    "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                    "type": "string"
+                  },
+                  "maxItems": 64,
+                  "type": "array",
+                  "x-kubernetes-list-type": "set"
+                },
+                "maxAge": {
+                  "default": 5,
+                  "description": "MaxAge indicates the duration (in seconds) for the client to cache the\nresults of a \"preflight\" request.\n\nThe information provided by the `Access-Control-Allow-Methods` and\n`Access-Control-Allow-Headers` response headers can be cached by the\nclient until the time specified by `Access-Control-Max-Age` elapses.\n\nThe default value of `Access-Control-Max-Age` response header is 5\n(seconds).\n\nWhen the `MaxAge` field is unspecified, the gateway sets the response\nheader \"Access-Control-Max-Age: 5\" by default.",
+                  "format": "int32",
+                  "minimum": 1,
+                  "type": "integer"
+                }
+              },
+              "type": "object",
+              "x-kubernetes-preserve-unknown-fields": true,
+              "additionalProperties": false
+            },
+            "csrf": {
+              "description": "Cross-Site Request Forgery (CSRF) policy for this traffic policy.\n\nThe CSRF policy has the following behavior:\n* Safe methods (`GET`, `HEAD`, `OPTIONS`) are automatically allowed.\n* Requests without `Sec-Fetch-Site` or `Origin` headers are assumed to\n  be same-origin or non-browser requests and are allowed.\n* Otherwise, the `Sec-Fetch-Site` header is checked, with a fallback to\n  comparing the `Origin` header to the `Host` header.",
+              "properties": {
+                "additionalOrigins": {
+                  "description": "Additional source origins that will be\nallowed in addition to the destination origin. The `Origin` consists of\na scheme and a host, with an optional port, and takes the form\n`<scheme>://<host>(:<port>)`.",
+                  "items": {
+                    "maxLength": 256,
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "maxItems": 16,
+                  "minItems": 1,
+                  "type": "array"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "directResponse": {
+              "description": "Sends a direct response to the\nclient.",
+              "properties": {
+                "body": {
+                  "description": "Content to return in the HTTP response body.\nThe maximum length of the body is restricted to prevent excessively large responses.\nIf this field is omitted, no body is included in the response.",
+                  "maxLength": 4096,
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "bodyExpression": {
+                  "description": "CEL expression that produces the HTTP response body.\nStrings and bytes are written directly; other values are serialized as JSON.\nIf this field is omitted, no expression body is included in the response.",
+                  "maxLength": 16384,
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "conditional": {
+                  "description": "Conditional policy execution. Set this or the top-level directResponse fields.\nThe first matching policy will be executed.\nA single policy may be provided without a condition set; if so, it must be the last policy and will be the fallback\nin case no conditions are met.",
+                  "items": {
+                    "properties": {
+                      "condition": {
+                        "description": "CEL expression that must evaluate to true for this policy to execute.",
+                        "maxLength": 16384,
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "policy": {
+                        "description": "Policy to apply when the condition matches.",
+                        "properties": {
+                          "body": {
+                            "description": "Content to return in the HTTP response body.\nThe maximum length of the body is restricted to prevent excessively large responses.\nIf this field is omitted, no body is included in the response.",
+                            "maxLength": 4096,
+                            "minLength": 1,
+                            "type": "string"
+                          },
+                          "bodyExpression": {
+                            "description": "CEL expression that produces the HTTP response body.\nStrings and bytes are written directly; other values are serialized as JSON.\nIf this field is omitted, no expression body is included in the response.",
+                            "maxLength": 16384,
+                            "minLength": 1,
+                            "type": "string"
+                          },
+                          "headers": {
+                            "description": "Response headers to set on the direct response.",
+                            "items": {
+                              "properties": {
+                                "name": {
+                                  "description": "The name of the header to set.",
+                                  "maxLength": 256,
+                                  "minLength": 1,
+                                  "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                                  "type": "string"
+                                },
+                                "value": {
+                                  "description": "CEL expression that generates the output value for\nthe header.",
+                                  "maxLength": 16384,
+                                  "minLength": 1,
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "name",
+                                "value"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "maxItems": 16,
+                            "minItems": 1,
+                            "type": "array",
+                            "x-kubernetes-list-map-keys": [
+                              "name"
+                            ],
+                            "x-kubernetes-list-type": "map"
+                          },
+                          "status": {
+                            "description": "HTTP status code to return.",
+                            "format": "int32",
+                            "maximum": 599,
+                            "minimum": 200,
+                            "type": "integer"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-validations": [
+                          {
+                            "message": "status is required",
+                            "rule": "has(self.status)"
+                          },
+                          {
+                            "message": "body and bodyExpression may not both be set",
+                            "rule": "!(has(self.body) && has(self.bodyExpression))"
+                          }
+                        ],
+                        "additionalProperties": false
+                      }
+                    },
+                    "required": [
+                      "policy"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "maxItems": 16,
+                  "minItems": 1,
+                  "type": "array",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "conditional entries without condition must be last",
+                      "rule": "self.filter(e, !has(e.condition)).size() <= 1 && (!self.exists(e, !has(e.condition)) || !has(self[size(self) - 1].condition))"
+                    }
+                  ]
+                },
+                "headers": {
+                  "description": "Response headers to set on the direct response.",
+                  "items": {
+                    "properties": {
+                      "name": {
+                        "description": "The name of the header to set.",
+                        "maxLength": 256,
+                        "minLength": 1,
+                        "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                        "type": "string"
+                      },
+                      "value": {
+                        "description": "CEL expression that generates the output value for\nthe header.",
+                        "maxLength": 16384,
+                        "minLength": 1,
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "name",
+                      "value"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "maxItems": 16,
+                  "minItems": 1,
+                  "type": "array",
+                  "x-kubernetes-list-map-keys": [
+                    "name"
+                  ],
+                  "x-kubernetes-list-type": "map"
+                },
+                "status": {
+                  "description": "HTTP status code to return.",
+                  "format": "int32",
+                  "maximum": 599,
+                  "minimum": 200,
+                  "type": "integer"
+                }
+              },
+              "type": "object",
+              "x-kubernetes-validations": [
+                {
+                  "message": "body and bodyExpression may not both be set",
+                  "rule": "!(has(self.body) && has(self.bodyExpression))"
+                },
+                {
+                  "message": "conditional cannot be set with any other field",
+                  "rule": "has(self.conditional) ? [has(self.body),has(self.bodyExpression),has(self.headers),has(self.status)].filter(x,x==true).size() == 0 : true"
+                },
+                {
+                  "message": "status: Required value",
+                  "rule": "has(self.conditional) ? true : has(self.status)"
+                }
+              ],
+              "additionalProperties": false
+            },
+            "extAuth": {
+              "description": "External authentication configuration for the policy.\nThis selects the external server to send requests to for authentication.\n\nAn extAuth policy can be conditionally set by nesting configuration under the `conditional` field.",
+              "properties": {
+                "backendRef": {
+                  "description": "External Authorization server to reach.\n\nSupported types: `Service` and `Backend`.",
+                  "properties": {
+                    "group": {
+                      "default": "",
+                      "description": "Group is the group of the referent. For example, \"gateway.networking.k8s.io\".\nWhen unspecified or empty string, core API group is inferred.",
+                      "maxLength": 253,
+                      "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                      "type": "string"
+                    },
+                    "kind": {
+                      "default": "Service",
+                      "description": "Kind is the Kubernetes resource kind of the referent. For example\n\"Service\".\n\nDefaults to \"Service\" when not specified.\n\nExternalName services can refer to CNAME DNS records that may live\noutside of the cluster and as such are difficult to reason about in\nterms of conformance. They also may not be safe to forward to (see\nCVE-2021-25740 for more information). Implementations SHOULD NOT\nsupport ExternalName Services.\n\nSupport: Core (Services with a type other than ExternalName)\n\nSupport: Implementation-specific (Services with type ExternalName)",
+                      "maxLength": 63,
+                      "minLength": 1,
+                      "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
+                      "type": "string"
+                    },
+                    "name": {
+                      "description": "Name is the name of the referent.",
+                      "maxLength": 253,
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "namespace": {
+                      "description": "Namespace is the namespace of the backend. When unspecified, the local\nnamespace is inferred.\n\nNote that when a namespace different than the local namespace is specified,\na ReferenceGrant object is required in the referent namespace to allow that\nnamespace's owner to accept the reference. See the ReferenceGrant\ndocumentation for details.\n\nSupport: Core",
+                      "maxLength": 63,
+                      "minLength": 1,
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                      "type": "string"
+                    },
+                    "port": {
+                      "description": "Port specifies the destination port number to use for this resource.\nPort is required when the referent is a Kubernetes Service. In this\ncase, the port number is the service port number, not the target port.\nFor other resources, destination port might be derived from the referent\nresource or this field.",
+                      "format": "int32",
+                      "maximum": 65535,
+                      "minimum": 1,
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "name"
+                  ],
+                  "type": "object",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "Must have port for Service reference",
+                      "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
+                    }
+                  ],
+                  "additionalProperties": false
+                },
+                "cache": {
+                  "description": "Caches gRPC authorization results.\n\nWARNING: the safety of this feature depends on the cache key accurately\ncapturing every request property that the authorization service uses to\nmake a decision. For example, if the service returns different results\nbased on both path and authorization header, both must be included in\n`key`; otherwise, one request may incorrectly reuse another request's\nauthorization result.\n\nIf any key expression fails to evaluate or produces an unsupported value,\nthe request is still sent to the authorization service, but its result is\nnot read from or written to the cache.",
+                  "properties": {
+                    "key": {
+                      "description": "Ordered list of CEL expressions evaluated against the request\nto construct the cache key.",
+                      "items": {
+                        "description": "A Common Expression Language (CEL) expression.",
+                        "maxLength": 16384,
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "maxItems": 16,
+                      "minItems": 1,
+                      "type": "array"
+                    },
+                    "maxEntries": {
+                      "description": "Maximum number of authorization results to keep in\nthe cache. If unset, this defaults to 10000.",
+                      "format": "int32",
+                      "minimum": 1,
+                      "type": "integer"
+                    },
+                    "ttl": {
+                      "description": "Duration string, such as `5m`, or a CEL expression that\nreturns the duration that cached authorization results may be reused, or a\ntimestamp when the cached authorization result expires. The expression is\nevaluated after the authorization response has been applied to the request.",
+                      "maxLength": 16384,
+                      "minLength": 1,
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "key",
+                    "ttl"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "conditional": {
+                  "description": "Conditional policy execution. Set this or the top-level extAuth fields.\nThe first matching policy will be executed.\nA single policy may be provided without a condition set; if so, it must be the last policy and will be the fallback\nin case no conditions are met.",
+                  "items": {
+                    "properties": {
+                      "condition": {
+                        "description": "CEL expression that must evaluate to true for this policy to execute.",
+                        "maxLength": 16384,
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "policy": {
+                        "description": "Policy to apply when the condition matches.",
+                        "properties": {
+                          "backendRef": {
+                            "description": "External Authorization server to reach.\n\nSupported types: `Service` and `Backend`.",
+                            "properties": {
+                              "group": {
+                                "default": "",
+                                "description": "Group is the group of the referent. For example, \"gateway.networking.k8s.io\".\nWhen unspecified or empty string, core API group is inferred.",
+                                "maxLength": 253,
+                                "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                                "type": "string"
+                              },
+                              "kind": {
+                                "default": "Service",
+                                "description": "Kind is the Kubernetes resource kind of the referent. For example\n\"Service\".\n\nDefaults to \"Service\" when not specified.\n\nExternalName services can refer to CNAME DNS records that may live\noutside of the cluster and as such are difficult to reason about in\nterms of conformance. They also may not be safe to forward to (see\nCVE-2021-25740 for more information). Implementations SHOULD NOT\nsupport ExternalName Services.\n\nSupport: Core (Services with a type other than ExternalName)\n\nSupport: Implementation-specific (Services with type ExternalName)",
+                                "maxLength": 63,
+                                "minLength": 1,
+                                "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "Name is the name of the referent.",
+                                "maxLength": 253,
+                                "minLength": 1,
+                                "type": "string"
+                              },
+                              "namespace": {
+                                "description": "Namespace is the namespace of the backend. When unspecified, the local\nnamespace is inferred.\n\nNote that when a namespace different than the local namespace is specified,\na ReferenceGrant object is required in the referent namespace to allow that\nnamespace's owner to accept the reference. See the ReferenceGrant\ndocumentation for details.\n\nSupport: Core",
+                                "maxLength": 63,
+                                "minLength": 1,
+                                "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                                "type": "string"
+                              },
+                              "port": {
+                                "description": "Port specifies the destination port number to use for this resource.\nPort is required when the referent is a Kubernetes Service. In this\ncase, the port number is the service port number, not the target port.\nFor other resources, destination port might be derived from the referent\nresource or this field.",
+                                "format": "int32",
+                                "maximum": 65535,
+                                "minimum": 1,
+                                "type": "integer"
+                              }
+                            },
+                            "required": [
+                              "name"
+                            ],
+                            "type": "object",
+                            "x-kubernetes-validations": [
+                              {
+                                "message": "Must have port for Service reference",
+                                "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
+                              }
+                            ],
+                            "additionalProperties": false
+                          },
+                          "cache": {
+                            "description": "Caches gRPC authorization results.\n\nWARNING: the safety of this feature depends on the cache key accurately\ncapturing every request property that the authorization service uses to\nmake a decision. For example, if the service returns different results\nbased on both path and authorization header, both must be included in\n`key`; otherwise, one request may incorrectly reuse another request's\nauthorization result.\n\nIf any key expression fails to evaluate or produces an unsupported value,\nthe request is still sent to the authorization service, but its result is\nnot read from or written to the cache.",
+                            "properties": {
+                              "key": {
+                                "description": "Ordered list of CEL expressions evaluated against the request\nto construct the cache key.",
+                                "items": {
+                                  "description": "A Common Expression Language (CEL) expression.",
+                                  "maxLength": 16384,
+                                  "minLength": 1,
+                                  "type": "string"
+                                },
+                                "maxItems": 16,
+                                "minItems": 1,
+                                "type": "array"
+                              },
+                              "maxEntries": {
+                                "description": "Maximum number of authorization results to keep in\nthe cache. If unset, this defaults to 10000.",
+                                "format": "int32",
+                                "minimum": 1,
+                                "type": "integer"
+                              },
+                              "ttl": {
+                                "description": "Duration string, such as `5m`, or a CEL expression that\nreturns the duration that cached authorization results may be reused, or a\ntimestamp when the cached authorization result expires. The expression is\nevaluated after the authorization response has been applied to the request.",
+                                "maxLength": 16384,
+                                "minLength": 1,
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "key",
+                              "ttl"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "failureMode": {
+                            "description": "Behavior when the external authorization service is\nunavailable or returns an error. \"FailOpen\" allows the request to continue.\n\"FailClosed\" (default) denies the request.",
+                            "enum": [
+                              "FailClosed",
+                              "FailOpen"
+                            ],
+                            "type": "string"
+                          },
+                          "forwardBody": {
+                            "description": "Whether to include the HTTP body in the authorization request.\nIf enabled, the request body will be buffered.",
+                            "properties": {
+                              "maxSize": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "description": "Largest body, in bytes, that will be buffered\nand sent to the authorization server. If the body size is larger than\n`maxSize`, then the request will be rejected with a response.",
+                                "maxLength": 32,
+                                "minLength": 1,
+                                "pattern": "^[+-]?([0-9]+(\\.[0-9]*)?|\\.[0-9]+)(([KMGTPE]i)|[numkMGTPE]|[eE](\\+?0*([0-9]|1[0-8])|-0*[0-9]))?$",
+                                "x-kubernetes-int-or-string": true,
+                                "x-kubernetes-validations": [
+                                  {
+                                    "message": "value must be at least 1 byte and fit within uint32",
+                                    "rule": "(self >= 1 && self <= 4294967295) || self.size() > 0"
+                                  }
+                                ]
+                              }
+                            },
+                            "required": [
+                              "maxSize"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "grpc": {
+                            "description": "Uses the gRPC External Authorization\n[protocol](https://www.envoyproxy.io/docs/envoy/latest/api-v3/service/auth/v3/external_auth.proto) should be used.",
+                            "properties": {
+                              "contextExtensions": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "description": "Additional arbitrary key-value pairs to\nsend to the authorization server in the `context_extensions` field.",
+                                "maxProperties": 64,
+                                "type": "object"
+                              },
+                              "requestMetadata": {
+                                "additionalProperties": {
+                                  "description": "A Common Expression Language (CEL) expression.",
+                                  "maxLength": 16384,
+                                  "minLength": 1,
+                                  "type": "string"
+                                },
+                                "description": "Metadata to send to the authorization\nserver. This maps to the `metadata_context.filter_metadata` field of the\nrequest, and allows dynamic CEL expressions. If unset, by default the\n`envoy.filters.http.jwt_authn` key is set if the JWT policy is used as\nwell, for compatibility.",
+                                "maxProperties": 64,
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "http": {
+                            "description": "Uses HTTP to connect to\nthe authorization server. The authorization server must return a `200`\nstatus code, otherwise the request is considered an authorization\nfailure.",
+                            "properties": {
+                              "addRequestHeaders": {
+                                "additionalProperties": {
+                                  "description": "A Common Expression Language (CEL) expression.",
+                                  "maxLength": 16384,
+                                  "minLength": 1,
+                                  "type": "string"
+                                },
+                                "description": "Additional headers to add to the\nrequest to the authorization server. While `allowedRequestHeaders` just\npasses the original headers through, `addRequestHeaders` allows defining\ncustom headers based on CEL expressions.",
+                                "maxProperties": 64,
+                                "type": "object"
+                              },
+                              "allowedRequestHeaders": {
+                                "description": "Additional headers from the client request that\nwill be sent to the authorization server.\n\nIf unset, the following headers are sent by default: `Authorization`.",
+                                "items": {
+                                  "maxLength": 256,
+                                  "minLength": 1,
+                                  "type": "string"
+                                },
+                                "maxItems": 64,
+                                "type": "array"
+                              },
+                              "allowedResponseHeaders": {
+                                "description": "Headers from the authorization response that\nwill be copied into the request to the backend.",
+                                "items": {
+                                  "maxLength": 256,
+                                  "minLength": 1,
+                                  "type": "string"
+                                },
+                                "maxItems": 64,
+                                "type": "array"
+                              },
+                              "path": {
+                                "description": "Path to send to the authorization server. If\nunset, this defaults to the original request path.\nThis is a CEL expression, which allows customizing the path based on the\nincoming request. For example, to add a prefix, use\n`\"/prefix/\" + request.path`.",
+                                "maxLength": 16384,
+                                "minLength": 1,
+                                "type": "string"
+                              },
+                              "redirect": {
+                                "description": "Optional expression that determines a path to\nredirect to on authorization failure. This is useful to redirect to a\nsign-in page.",
+                                "maxLength": 16384,
+                                "minLength": 1,
+                                "type": "string"
+                              },
+                              "responseMetadata": {
+                                "additionalProperties": {
+                                  "description": "A Common Expression Language (CEL) expression.",
+                                  "maxLength": 16384,
+                                  "minLength": 1,
+                                  "type": "string"
+                                },
+                                "description": "Metadata fields to construct\nfrom the authorization response. These will be included under the\n`extauthz` variable in future CEL expressions. Setting this is useful\nfor things like logging usernames, without needing to include them as\nheaders to the backend, as `allowedResponseHeaders` would.",
+                                "maxProperties": 64,
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-validations": [
+                          {
+                            "message": "backendRef is required",
+                            "rule": "has(self.backendRef)"
+                          },
+                          {
+                            "message": "exactly one of the fields in [grpc http] must be set",
+                            "rule": "[has(self.grpc),has(self.http)].filter(x,x==true).size() == 1"
+                          },
+                          {
+                            "message": "cache requires grpc",
+                            "rule": "!has(self.cache) || has(self.grpc)"
+                          }
+                        ],
+                        "additionalProperties": false
+                      }
+                    },
+                    "required": [
+                      "policy"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "maxItems": 16,
+                  "minItems": 1,
+                  "type": "array",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "conditional entries without condition must be last",
+                      "rule": "self.filter(e, !has(e.condition)).size() <= 1 && (!self.exists(e, !has(e.condition)) || !has(self[size(self) - 1].condition))"
+                    }
+                  ]
+                },
+                "failureMode": {
+                  "description": "Behavior when the external authorization service is\nunavailable or returns an error. \"FailOpen\" allows the request to continue.\n\"FailClosed\" (default) denies the request.",
+                  "enum": [
+                    "FailClosed",
+                    "FailOpen"
+                  ],
+                  "type": "string"
+                },
+                "forwardBody": {
+                  "description": "Whether to include the HTTP body in the authorization request.\nIf enabled, the request body will be buffered.",
+                  "properties": {
+                    "maxSize": {
+                      "anyOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ],
+                      "description": "Largest body, in bytes, that will be buffered\nand sent to the authorization server. If the body size is larger than\n`maxSize`, then the request will be rejected with a response.",
+                      "maxLength": 32,
+                      "minLength": 1,
+                      "pattern": "^[+-]?([0-9]+(\\.[0-9]*)?|\\.[0-9]+)(([KMGTPE]i)|[numkMGTPE]|[eE](\\+?0*([0-9]|1[0-8])|-0*[0-9]))?$",
+                      "x-kubernetes-int-or-string": true,
+                      "x-kubernetes-validations": [
+                        {
+                          "message": "value must be at least 1 byte and fit within uint32",
+                          "rule": "(self >= 1 && self <= 4294967295) || self.size() > 0"
+                        }
+                      ]
+                    }
+                  },
+                  "required": [
+                    "maxSize"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "grpc": {
+                  "description": "Uses the gRPC External Authorization\n[protocol](https://www.envoyproxy.io/docs/envoy/latest/api-v3/service/auth/v3/external_auth.proto) should be used.",
+                  "properties": {
+                    "contextExtensions": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "Additional arbitrary key-value pairs to\nsend to the authorization server in the `context_extensions` field.",
+                      "maxProperties": 64,
+                      "type": "object"
+                    },
+                    "requestMetadata": {
+                      "additionalProperties": {
+                        "description": "A Common Expression Language (CEL) expression.",
+                        "maxLength": 16384,
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "description": "Metadata to send to the authorization\nserver. This maps to the `metadata_context.filter_metadata` field of the\nrequest, and allows dynamic CEL expressions. If unset, by default the\n`envoy.filters.http.jwt_authn` key is set if the JWT policy is used as\nwell, for compatibility.",
+                      "maxProperties": 64,
+                      "type": "object"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "http": {
+                  "description": "Uses HTTP to connect to\nthe authorization server. The authorization server must return a `200`\nstatus code, otherwise the request is considered an authorization\nfailure.",
+                  "properties": {
+                    "addRequestHeaders": {
+                      "additionalProperties": {
+                        "description": "A Common Expression Language (CEL) expression.",
+                        "maxLength": 16384,
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "description": "Additional headers to add to the\nrequest to the authorization server. While `allowedRequestHeaders` just\npasses the original headers through, `addRequestHeaders` allows defining\ncustom headers based on CEL expressions.",
+                      "maxProperties": 64,
+                      "type": "object"
+                    },
+                    "allowedRequestHeaders": {
+                      "description": "Additional headers from the client request that\nwill be sent to the authorization server.\n\nIf unset, the following headers are sent by default: `Authorization`.",
+                      "items": {
+                        "maxLength": 256,
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "maxItems": 64,
+                      "type": "array"
+                    },
+                    "allowedResponseHeaders": {
+                      "description": "Headers from the authorization response that\nwill be copied into the request to the backend.",
+                      "items": {
+                        "maxLength": 256,
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "maxItems": 64,
+                      "type": "array"
+                    },
+                    "path": {
+                      "description": "Path to send to the authorization server. If\nunset, this defaults to the original request path.\nThis is a CEL expression, which allows customizing the path based on the\nincoming request. For example, to add a prefix, use\n`\"/prefix/\" + request.path`.",
+                      "maxLength": 16384,
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "redirect": {
+                      "description": "Optional expression that determines a path to\nredirect to on authorization failure. This is useful to redirect to a\nsign-in page.",
+                      "maxLength": 16384,
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "responseMetadata": {
+                      "additionalProperties": {
+                        "description": "A Common Expression Language (CEL) expression.",
+                        "maxLength": 16384,
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "description": "Metadata fields to construct\nfrom the authorization response. These will be included under the\n`extauthz` variable in future CEL expressions. Setting this is useful\nfor things like logging usernames, without needing to include them as\nheaders to the backend, as `allowedResponseHeaders` would.",
+                      "maxProperties": 64,
+                      "type": "object"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "x-kubernetes-validations": [
+                {
+                  "message": "exactly one of the fields in [grpc http] must be set",
+                  "rule": "has(self.conditional) || [has(self.grpc),has(self.http)].filter(x,x==true).size() == 1"
+                },
+                {
+                  "message": "cache requires grpc",
+                  "rule": "!has(self.cache) || has(self.grpc)"
+                },
+                {
+                  "message": "conditional cannot be set with any other field",
+                  "rule": "has(self.conditional) ? [has(self.backendRef),has(self.cache),has(self.failureMode),has(self.forwardBody),has(self.grpc),has(self.http)].filter(x,x==true).size() == 0 : true"
+                },
+                {
+                  "message": "backendRef: Required value",
+                  "rule": "has(self.conditional) ? true : has(self.backendRef)"
+                }
+              ],
+              "additionalProperties": false
+            },
+            "extProc": {
+              "description": "External processing configuration for the policy.",
+              "properties": {
+                "backendRef": {
+                  "description": "External Processor server to reach.\nSupported types: `Service` and `Backend`.",
+                  "properties": {
+                    "group": {
+                      "default": "",
+                      "description": "Group is the group of the referent. For example, \"gateway.networking.k8s.io\".\nWhen unspecified or empty string, core API group is inferred.",
+                      "maxLength": 253,
+                      "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                      "type": "string"
+                    },
+                    "kind": {
+                      "default": "Service",
+                      "description": "Kind is the Kubernetes resource kind of the referent. For example\n\"Service\".\n\nDefaults to \"Service\" when not specified.\n\nExternalName services can refer to CNAME DNS records that may live\noutside of the cluster and as such are difficult to reason about in\nterms of conformance. They also may not be safe to forward to (see\nCVE-2021-25740 for more information). Implementations SHOULD NOT\nsupport ExternalName Services.\n\nSupport: Core (Services with a type other than ExternalName)\n\nSupport: Implementation-specific (Services with type ExternalName)",
+                      "maxLength": 63,
+                      "minLength": 1,
+                      "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
+                      "type": "string"
+                    },
+                    "name": {
+                      "description": "Name is the name of the referent.",
+                      "maxLength": 253,
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "namespace": {
+                      "description": "Namespace is the namespace of the backend. When unspecified, the local\nnamespace is inferred.\n\nNote that when a namespace different than the local namespace is specified,\na ReferenceGrant object is required in the referent namespace to allow that\nnamespace's owner to accept the reference. See the ReferenceGrant\ndocumentation for details.\n\nSupport: Core",
+                      "maxLength": 63,
+                      "minLength": 1,
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                      "type": "string"
+                    },
+                    "port": {
+                      "description": "Port specifies the destination port number to use for this resource.\nPort is required when the referent is a Kubernetes Service. In this\ncase, the port number is the service port number, not the target port.\nFor other resources, destination port might be derived from the referent\nresource or this field.",
+                      "format": "int32",
+                      "maximum": 65535,
+                      "minimum": 1,
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "name"
+                  ],
+                  "type": "object",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "Must have port for Service reference",
+                      "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
+                    }
+                  ],
+                  "additionalProperties": false
+                },
+                "conditional": {
+                  "description": "Conditional policy execution. Set this or the top-level extProc fields.\nThe first matching policy will be executed.\nA single policy may be provided without a condition set; if so, it must be the last policy and will be the fallback\nin case no conditions are met.",
+                  "items": {
+                    "properties": {
+                      "condition": {
+                        "description": "CEL expression that must evaluate to true for this policy to execute.",
+                        "maxLength": 16384,
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "policy": {
+                        "description": "Policy to apply when the condition matches.",
+                        "properties": {
+                          "backendRef": {
+                            "description": "External Processor server to reach.\nSupported types: `Service` and `Backend`.",
+                            "properties": {
+                              "group": {
+                                "default": "",
+                                "description": "Group is the group of the referent. For example, \"gateway.networking.k8s.io\".\nWhen unspecified or empty string, core API group is inferred.",
+                                "maxLength": 253,
+                                "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                                "type": "string"
+                              },
+                              "kind": {
+                                "default": "Service",
+                                "description": "Kind is the Kubernetes resource kind of the referent. For example\n\"Service\".\n\nDefaults to \"Service\" when not specified.\n\nExternalName services can refer to CNAME DNS records that may live\noutside of the cluster and as such are difficult to reason about in\nterms of conformance. They also may not be safe to forward to (see\nCVE-2021-25740 for more information). Implementations SHOULD NOT\nsupport ExternalName Services.\n\nSupport: Core (Services with a type other than ExternalName)\n\nSupport: Implementation-specific (Services with type ExternalName)",
+                                "maxLength": 63,
+                                "minLength": 1,
+                                "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "Name is the name of the referent.",
+                                "maxLength": 253,
+                                "minLength": 1,
+                                "type": "string"
+                              },
+                              "namespace": {
+                                "description": "Namespace is the namespace of the backend. When unspecified, the local\nnamespace is inferred.\n\nNote that when a namespace different than the local namespace is specified,\na ReferenceGrant object is required in the referent namespace to allow that\nnamespace's owner to accept the reference. See the ReferenceGrant\ndocumentation for details.\n\nSupport: Core",
+                                "maxLength": 63,
+                                "minLength": 1,
+                                "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                                "type": "string"
+                              },
+                              "port": {
+                                "description": "Port specifies the destination port number to use for this resource.\nPort is required when the referent is a Kubernetes Service. In this\ncase, the port number is the service port number, not the target port.\nFor other resources, destination port might be derived from the referent\nresource or this field.",
+                                "format": "int32",
+                                "maximum": 65535,
+                                "minimum": 1,
+                                "type": "integer"
+                              }
+                            },
+                            "required": [
+                              "name"
+                            ],
+                            "type": "object",
+                            "x-kubernetes-validations": [
+                              {
+                                "message": "Must have port for Service reference",
+                                "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
+                              }
+                            ],
+                            "additionalProperties": false
+                          },
+                          "processingOptions": {
+                            "description": "How request and response phases are sent to ext_proc.",
+                            "properties": {
+                              "allowModeOverride": {
+                                "default": false,
+                                "description": "Allows ext_proc `mode_override` values from matching header responses to update\nsubsequent request/response processing phases for this exchange. Defaults to `false`.",
+                                "type": "boolean"
+                              },
+                              "requestBodyMode": {
+                                "default": "FullDuplexStreamed",
+                                "description": "How request bodies are sent to the external processor.\n`Buffered` buffers the full body and returns an error if it exceeds 8KB.\n`BufferedPartial` buffers up to 8KB and sends the buffered prefix if the\nbody exceeds that limit. Defaults to `FullDuplexStreamed`.",
+                                "enum": [
+                                  "None",
+                                  "Buffered",
+                                  "BufferedPartial",
+                                  "FullDuplexStreamed"
+                                ],
+                                "type": "string"
+                              },
+                              "requestHeaderMode": {
+                                "default": "Send",
+                                "description": "Whether request headers are sent to the external processor.\nDefaults to `Send`.",
+                                "enum": [
+                                  "Send",
+                                  "Skip"
+                                ],
+                                "type": "string"
+                              },
+                              "requestTrailerMode": {
+                                "default": "Send",
+                                "description": "Whether request trailers are sent to the external processor.\nDefaults to `Send`.",
+                                "enum": [
+                                  "Skip",
+                                  "Send"
+                                ],
+                                "type": "string"
+                              },
+                              "responseBodyMode": {
+                                "default": "FullDuplexStreamed",
+                                "description": "How response bodies are sent to the external processor.\n`Buffered` buffers the full body and returns an error if it exceeds 8KB.\n`BufferedPartial` buffers up to 8KB and sends the buffered prefix if the\nbody exceeds that limit. Defaults to `FullDuplexStreamed`.",
+                                "enum": [
+                                  "None",
+                                  "Buffered",
+                                  "BufferedPartial",
+                                  "FullDuplexStreamed"
+                                ],
+                                "type": "string"
+                              },
+                              "responseHeaderMode": {
+                                "default": "Send",
+                                "description": "Whether response headers are sent to the external processor.\nDefaults to `Send`.",
+                                "enum": [
+                                  "Send",
+                                  "Skip"
+                                ],
+                                "type": "string"
+                              },
+                              "responseTrailerMode": {
+                                "default": "Send",
+                                "description": "Whether response trailers are sent to the external processor.\nDefaults to `Send`.",
+                                "enum": [
+                                  "Skip",
+                                  "Send"
+                                ],
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-validations": [
+                          {
+                            "message": "backendRef is required",
+                            "rule": "has(self.backendRef)"
+                          }
+                        ],
+                        "additionalProperties": false
+                      }
+                    },
+                    "required": [
+                      "policy"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "maxItems": 16,
+                  "minItems": 1,
+                  "type": "array",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "conditional entries without condition must be last",
+                      "rule": "self.filter(e, !has(e.condition)).size() <= 1 && (!self.exists(e, !has(e.condition)) || !has(self[size(self) - 1].condition))"
+                    }
+                  ]
+                },
+                "processingOptions": {
+                  "description": "How request and response phases are sent to ext_proc.",
+                  "properties": {
+                    "allowModeOverride": {
+                      "default": false,
+                      "description": "Allows ext_proc `mode_override` values from matching header responses to update\nsubsequent request/response processing phases for this exchange. Defaults to `false`.",
+                      "type": "boolean"
+                    },
+                    "requestBodyMode": {
+                      "default": "FullDuplexStreamed",
+                      "description": "How request bodies are sent to the external processor.\n`Buffered` buffers the full body and returns an error if it exceeds 8KB.\n`BufferedPartial` buffers up to 8KB and sends the buffered prefix if the\nbody exceeds that limit. Defaults to `FullDuplexStreamed`.",
+                      "enum": [
+                        "None",
+                        "Buffered",
+                        "BufferedPartial",
+                        "FullDuplexStreamed"
+                      ],
+                      "type": "string"
+                    },
+                    "requestHeaderMode": {
+                      "default": "Send",
+                      "description": "Whether request headers are sent to the external processor.\nDefaults to `Send`.",
+                      "enum": [
+                        "Send",
+                        "Skip"
+                      ],
+                      "type": "string"
+                    },
+                    "requestTrailerMode": {
+                      "default": "Send",
+                      "description": "Whether request trailers are sent to the external processor.\nDefaults to `Send`.",
+                      "enum": [
+                        "Skip",
+                        "Send"
+                      ],
+                      "type": "string"
+                    },
+                    "responseBodyMode": {
+                      "default": "FullDuplexStreamed",
+                      "description": "How response bodies are sent to the external processor.\n`Buffered` buffers the full body and returns an error if it exceeds 8KB.\n`BufferedPartial` buffers up to 8KB and sends the buffered prefix if the\nbody exceeds that limit. Defaults to `FullDuplexStreamed`.",
+                      "enum": [
+                        "None",
+                        "Buffered",
+                        "BufferedPartial",
+                        "FullDuplexStreamed"
+                      ],
+                      "type": "string"
+                    },
+                    "responseHeaderMode": {
+                      "default": "Send",
+                      "description": "Whether response headers are sent to the external processor.\nDefaults to `Send`.",
+                      "enum": [
+                        "Send",
+                        "Skip"
+                      ],
+                      "type": "string"
+                    },
+                    "responseTrailerMode": {
+                      "default": "Send",
+                      "description": "Whether response trailers are sent to the external processor.\nDefaults to `Send`.",
+                      "enum": [
+                        "Skip",
+                        "Send"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "x-kubernetes-validations": [
+                {
+                  "message": "conditional cannot be set with any other field",
+                  "rule": "has(self.conditional) ? [has(self.backendRef),has(self.processingOptions)].filter(x,x==true).size() == 0 : true"
+                },
+                {
+                  "message": "backendRef: Required value",
+                  "rule": "has(self.conditional) ? true : has(self.backendRef)"
+                }
+              ],
+              "additionalProperties": false
+            },
+            "headerModifiers": {
+              "description": "Request and response header modification policy.",
+              "properties": {
+                "request": {
+                  "description": "Header changes to apply before forwarding a request.",
+                  "properties": {
+                    "add": {
+                      "description": "Add adds the given header(s) (name, value) to the request\nbefore the action. It appends to any existing values associated\nwith the header name.\n\nInput:\n  GET /foo HTTP/1.1\n  my-header: foo\n\nConfig:\n  add:\n  - name: \"my-header\"\n    value: \"bar,baz\"\n\nOutput:\n  GET /foo HTTP/1.1\n  my-header: foo,bar,baz",
+                      "items": {
+                        "description": "HTTPHeader represents an HTTP Header name and value as defined by RFC 7230.",
+                        "properties": {
+                          "name": {
+                            "description": "Name is the name of the HTTP Header to be matched. Name matching MUST be\ncase-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).\n\nIf multiple entries specify equivalent header names, the first entry with\nan equivalent name MUST be considered for a match. Subsequent entries\nwith an equivalent header name MUST be ignored. Due to the\ncase-insensitivity of header names, \"foo\" and \"Foo\" are considered\nequivalent.",
+                            "maxLength": 256,
+                            "minLength": 1,
+                            "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                            "type": "string"
+                          },
+                          "value": {
+                            "description": "Value is the value of HTTP Header to be matched.\n<gateway:experimental:description>\nMust consist of printable US-ASCII characters, optionally separated\nby single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2\n</gateway:experimental:description>\n\n<gateway:experimental:validation:Pattern=`^[!-~]+([\\t ]?[!-~]+)*$`>",
+                            "maxLength": 4096,
+                            "minLength": 1,
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "name",
+                          "value"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "maxItems": 16,
+                      "type": "array",
+                      "x-kubernetes-list-map-keys": [
+                        "name"
+                      ],
+                      "x-kubernetes-list-type": "map"
+                    },
+                    "remove": {
+                      "description": "Remove the given header(s) from the HTTP request before the action. The\nvalue of Remove is a list of HTTP header names. Note that the header\nnames are case-insensitive (see\nhttps://datatracker.ietf.org/doc/html/rfc2616#section-4.2).\n\nInput:\n  GET /foo HTTP/1.1\n  my-header1: foo\n  my-header2: bar\n  my-header3: baz\n\nConfig:\n  remove: [\"my-header1\", \"my-header3\"]\n\nOutput:\n  GET /foo HTTP/1.1\n  my-header2: bar",
+                      "items": {
+                        "type": "string"
+                      },
+                      "maxItems": 16,
+                      "type": "array",
+                      "x-kubernetes-list-type": "set"
+                    },
+                    "set": {
+                      "description": "Set overwrites the request with the given header (name, value)\nbefore the action.\n\nInput:\n  GET /foo HTTP/1.1\n  my-header: foo\n\nConfig:\n  set:\n  - name: \"my-header\"\n    value: \"bar\"\n\nOutput:\n  GET /foo HTTP/1.1\n  my-header: bar",
+                      "items": {
+                        "description": "HTTPHeader represents an HTTP Header name and value as defined by RFC 7230.",
+                        "properties": {
+                          "name": {
+                            "description": "Name is the name of the HTTP Header to be matched. Name matching MUST be\ncase-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).\n\nIf multiple entries specify equivalent header names, the first entry with\nan equivalent name MUST be considered for a match. Subsequent entries\nwith an equivalent header name MUST be ignored. Due to the\ncase-insensitivity of header names, \"foo\" and \"Foo\" are considered\nequivalent.",
+                            "maxLength": 256,
+                            "minLength": 1,
+                            "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                            "type": "string"
+                          },
+                          "value": {
+                            "description": "Value is the value of HTTP Header to be matched.\n<gateway:experimental:description>\nMust consist of printable US-ASCII characters, optionally separated\nby single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2\n</gateway:experimental:description>\n\n<gateway:experimental:validation:Pattern=`^[!-~]+([\\t ]?[!-~]+)*$`>",
+                            "maxLength": 4096,
+                            "minLength": 1,
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "name",
+                          "value"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "maxItems": 16,
+                      "type": "array",
+                      "x-kubernetes-list-map-keys": [
+                        "name"
+                      ],
+                      "x-kubernetes-list-type": "map"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "response": {
+                  "description": "Header changes to apply before returning a response.",
+                  "properties": {
+                    "add": {
+                      "description": "Add adds the given header(s) (name, value) to the request\nbefore the action. It appends to any existing values associated\nwith the header name.\n\nInput:\n  GET /foo HTTP/1.1\n  my-header: foo\n\nConfig:\n  add:\n  - name: \"my-header\"\n    value: \"bar,baz\"\n\nOutput:\n  GET /foo HTTP/1.1\n  my-header: foo,bar,baz",
+                      "items": {
+                        "description": "HTTPHeader represents an HTTP Header name and value as defined by RFC 7230.",
+                        "properties": {
+                          "name": {
+                            "description": "Name is the name of the HTTP Header to be matched. Name matching MUST be\ncase-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).\n\nIf multiple entries specify equivalent header names, the first entry with\nan equivalent name MUST be considered for a match. Subsequent entries\nwith an equivalent header name MUST be ignored. Due to the\ncase-insensitivity of header names, \"foo\" and \"Foo\" are considered\nequivalent.",
+                            "maxLength": 256,
+                            "minLength": 1,
+                            "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                            "type": "string"
+                          },
+                          "value": {
+                            "description": "Value is the value of HTTP Header to be matched.\n<gateway:experimental:description>\nMust consist of printable US-ASCII characters, optionally separated\nby single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2\n</gateway:experimental:description>\n\n<gateway:experimental:validation:Pattern=`^[!-~]+([\\t ]?[!-~]+)*$`>",
+                            "maxLength": 4096,
+                            "minLength": 1,
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "name",
+                          "value"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "maxItems": 16,
+                      "type": "array",
+                      "x-kubernetes-list-map-keys": [
+                        "name"
+                      ],
+                      "x-kubernetes-list-type": "map"
+                    },
+                    "remove": {
+                      "description": "Remove the given header(s) from the HTTP request before the action. The\nvalue of Remove is a list of HTTP header names. Note that the header\nnames are case-insensitive (see\nhttps://datatracker.ietf.org/doc/html/rfc2616#section-4.2).\n\nInput:\n  GET /foo HTTP/1.1\n  my-header1: foo\n  my-header2: bar\n  my-header3: baz\n\nConfig:\n  remove: [\"my-header1\", \"my-header3\"]\n\nOutput:\n  GET /foo HTTP/1.1\n  my-header2: bar",
+                      "items": {
+                        "type": "string"
+                      },
+                      "maxItems": 16,
+                      "type": "array",
+                      "x-kubernetes-list-type": "set"
+                    },
+                    "set": {
+                      "description": "Set overwrites the request with the given header (name, value)\nbefore the action.\n\nInput:\n  GET /foo HTTP/1.1\n  my-header: foo\n\nConfig:\n  set:\n  - name: \"my-header\"\n    value: \"bar\"\n\nOutput:\n  GET /foo HTTP/1.1\n  my-header: bar",
+                      "items": {
+                        "description": "HTTPHeader represents an HTTP Header name and value as defined by RFC 7230.",
+                        "properties": {
+                          "name": {
+                            "description": "Name is the name of the HTTP Header to be matched. Name matching MUST be\ncase-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).\n\nIf multiple entries specify equivalent header names, the first entry with\nan equivalent name MUST be considered for a match. Subsequent entries\nwith an equivalent header name MUST be ignored. Due to the\ncase-insensitivity of header names, \"foo\" and \"Foo\" are considered\nequivalent.",
+                            "maxLength": 256,
+                            "minLength": 1,
+                            "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                            "type": "string"
+                          },
+                          "value": {
+                            "description": "Value is the value of HTTP Header to be matched.\n<gateway:experimental:description>\nMust consist of printable US-ASCII characters, optionally separated\nby single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2\n</gateway:experimental:description>\n\n<gateway:experimental:validation:Pattern=`^[!-~]+([\\t ]?[!-~]+)*$`>",
+                            "maxLength": 4096,
+                            "minLength": 1,
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "name",
+                          "value"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "maxItems": 16,
+                      "type": "array",
+                      "x-kubernetes-list-map-keys": [
+                        "name"
+                      ],
+                      "x-kubernetes-list-type": "map"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "x-kubernetes-validations": [
+                {
+                  "message": "at least one of the fields in [request response] must be set",
+                  "rule": "[has(self.request),has(self.response)].filter(x,x==true).size() >= 1"
+                }
+              ],
+              "additionalProperties": false
+            },
+            "hostRewrite": {
+              "description": "How to rewrite the `Host` header for requests.\n\nIf the `HTTPRoute` `urlRewrite` filter already specifies a host rewrite,\nthis setting is ignored.",
+              "properties": {
+                "mode": {
+                  "description": "Hostname rewrite mode.\n\nThe following may be specified:\n* `Auto`: automatically set the `Host` header based on the destination.\n* `None`: do not rewrite the `Host` header. The original `Host` header\n  will be passed through.\n\nThis setting defaults to `Auto` when connecting to hostname-based\n`Backend` types, and `None` otherwise, for `Service` or IP-based\nbackends.",
+                  "enum": [
+                    "Auto",
+                    "None"
+                  ],
+                  "type": "string"
+                }
+              },
+              "required": [
+                "mode"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "jwtAuthentication": {
+              "description": "Authenticates users based on JWT tokens.",
+              "properties": {
+                "location": {
+                  "description": "Where JWT credentials are read from.\nIf omitted, credentials are read from the `Authorization` header with the `Bearer ` prefix.",
+                  "properties": {
+                    "cookie": {
+                      "properties": {
+                        "name": {
+                          "maxLength": 256,
+                          "minLength": 1,
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "expression": {
+                      "description": "CEL expression that extracts the credential from the request.",
+                      "maxLength": 16384,
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "header": {
+                      "properties": {
+                        "name": {
+                          "description": "HTTPHeaderName is the name of an HTTP header.\n\nValid values include:\n\n* \"Authorization\"\n* \"Set-Cookie\"\n\nInvalid values include:\n\n  - \":method\" - \":\" is an invalid character. This means that HTTP/2 pseudo\n    headers are not currently supported by this type.\n  - \"/invalid\" - \"/ \" is an invalid character",
+                          "maxLength": 256,
+                          "minLength": 1,
+                          "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                          "type": "string"
+                        },
+                        "prefix": {
+                          "maxLength": 256,
+                          "minLength": 1,
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "queryParameter": {
+                      "properties": {
+                        "name": {
+                          "maxLength": 256,
+                          "minLength": 1,
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "exactly one of the fields in [header queryParameter cookie expression] must be set",
+                      "rule": "[has(self.header),has(self.queryParameter),has(self.cookie),has(self.expression)].filter(x,x==true).size() == 1"
+                    }
+                  ],
+                  "additionalProperties": false
+                },
+                "mcp": {
+                  "description": "Enables MCP OAuth metadata endpoint handling\nand MCP-specific authentication behavior on top of standard JWT validation.\nWhen set, the gateway will serve the MCP OAuth metadata discovery endpoints.",
+                  "properties": {
+                    "clientId": {
+                      "description": "Client ID to use for short-circuiting Dynamic Client Registration.\nIf set, the gateway will not proxy registration requests to the IDP and instead return this client ID.",
+                      "type": "string"
+                    },
+                    "provider": {
+                      "description": "Identity provider to use for MCP authentication flows.",
+                      "enum": [
+                        "Auth0",
+                        "Keycloak",
+                        "Okta"
+                      ],
+                      "type": "string"
+                    },
+                    "resourceMetadata": {
+                      "additionalProperties": {
+                        "x-kubernetes-preserve-unknown-fields": true
+                      },
+                      "description": "Metadata to use for MCP resources,\nserved at the MCP OAuth metadata endpoints.",
+                      "type": "object"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "mode": {
+                  "default": "Strict",
+                  "description": "Validation mode for JWT authentication.",
+                  "enum": [
+                    "Optional",
+                    "Permissive",
+                    "Strict"
+                  ],
+                  "type": "string"
+                },
+                "providers": {
+                  "items": {
+                    "properties": {
+                      "audiences": {
+                        "description": "Allowed audiences that are allowed\naccess. This corresponds to the `aud` claim\n([RFC 7519 \u00a74.1.3](https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.3)).\nIf unset, any audience is allowed.",
+                        "items": {
+                          "type": "string"
+                        },
+                        "maxItems": 64,
+                        "minItems": 1,
+                        "type": "array"
+                      },
+                      "issuer": {
+                        "description": "IdP that issued the JWT. This corresponds to the\n`iss` claim ([RFC 7519 \u00a74.1.1](https://tools.ietf.org/html/rfc7519#section-4.1.1)).",
+                        "maxLength": 256,
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "jwks": {
+                        "description": "JSON Web Key Set used to validate the signature of the\nJWT.",
+                        "properties": {
+                          "inline": {
+                            "description": "Inline JSON Web Key Set used to validate the\nsignature of the JWT.",
+                            "maxLength": 65536,
+                            "minLength": 2,
+                            "type": "string"
+                          },
+                          "remote": {
+                            "description": "How to reach the JSON Web Key Set from a remote\naddress.",
+                            "properties": {
+                              "backendRef": {
+                                "description": "Remote JWKS server to reach.\nSupported types are `Service` and static `Backend`. An\n`AgentgatewayPolicy` containing backend TLS config can then be attached\nto the `Service` or `Backend` in order to set TLS options for a\nconnection to the remote `jwks` source.",
+                                "properties": {
+                                  "group": {
+                                    "default": "",
+                                    "description": "Group is the group of the referent. For example, \"gateway.networking.k8s.io\".\nWhen unspecified or empty string, core API group is inferred.",
+                                    "maxLength": 253,
+                                    "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                                    "type": "string"
+                                  },
+                                  "kind": {
+                                    "default": "Service",
+                                    "description": "Kind is the Kubernetes resource kind of the referent. For example\n\"Service\".\n\nDefaults to \"Service\" when not specified.\n\nExternalName services can refer to CNAME DNS records that may live\noutside of the cluster and as such are difficult to reason about in\nterms of conformance. They also may not be safe to forward to (see\nCVE-2021-25740 for more information). Implementations SHOULD NOT\nsupport ExternalName Services.\n\nSupport: Core (Services with a type other than ExternalName)\n\nSupport: Implementation-specific (Services with type ExternalName)",
+                                    "maxLength": 63,
+                                    "minLength": 1,
+                                    "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "description": "Name is the name of the referent.",
+                                    "maxLength": 253,
+                                    "minLength": 1,
+                                    "type": "string"
+                                  },
+                                  "namespace": {
+                                    "description": "Namespace is the namespace of the backend. When unspecified, the local\nnamespace is inferred.\n\nNote that when a namespace different than the local namespace is specified,\na ReferenceGrant object is required in the referent namespace to allow that\nnamespace's owner to accept the reference. See the ReferenceGrant\ndocumentation for details.\n\nSupport: Core",
+                                    "maxLength": 63,
+                                    "minLength": 1,
+                                    "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "description": "Port specifies the destination port number to use for this resource.\nPort is required when the referent is a Kubernetes Service. In this\ncase, the port number is the service port number, not the target port.\nFor other resources, destination port might be derived from the referent\nresource or this field.",
+                                    "format": "int32",
+                                    "maximum": 65535,
+                                    "minimum": 1,
+                                    "type": "integer"
+                                  }
+                                },
+                                "required": [
+                                  "name"
+                                ],
+                                "type": "object",
+                                "x-kubernetes-validations": [
+                                  {
+                                    "message": "Must have port for Service reference",
+                                    "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
+                                  }
+                                ],
+                                "additionalProperties": false
+                              },
+                              "cacheDuration": {
+                                "default": "5m",
+                                "type": "string",
+                                "x-kubernetes-validations": [
+                                  {
+                                    "message": "invalid duration value",
+                                    "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                  },
+                                  {
+                                    "message": "cacheDuration must be at least 5m.",
+                                    "rule": "duration(self) >= duration('5m')"
+                                  }
+                                ]
+                              },
+                              "jwksPath": {
+                                "description": "Path to the IdP `jwks` endpoint, relative to the root, commonly\n`\".well-known/jwks.json\"`.",
+                                "maxLength": 2000,
+                                "minLength": 1,
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "backendRef",
+                              "jwksPath"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-validations": [
+                          {
+                            "message": "exactly one of the fields in [remote inline] must be set",
+                            "rule": "[has(self.remote),has(self.inline)].filter(x,x==true).size() == 1"
+                          }
+                        ],
+                        "additionalProperties": false
+                      }
+                    },
+                    "required": [
+                      "issuer",
+                      "jwks"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "maxItems": 64,
+                  "minItems": 1,
+                  "type": "array"
+                }
+              },
+              "required": [
+                "providers"
+              ],
+              "type": "object",
+              "x-kubernetes-validations": [
+                {
+                  "message": "jwtAuthentication.mcp requires exactly one provider",
+                  "rule": "!has(self.mcp) || size(self.providers) == 1"
+                },
+                {
+                  "message": "jwtAuthentication.mcp requires mode Strict",
+                  "rule": "!has(self.mcp) || !has(self.mode) || self.mode == 'Strict'"
+                }
+              ],
+              "additionalProperties": false
+            },
+            "phase": {
+              "description": "The phase to apply the traffic policy to. If the phase is `PreRouting`,\nthe `targetRef` must be a `Gateway` or a `Listener`. `PreRouting` is\ntypically used only when a policy needs to influence the routing\ndecision.\n\nEven when using `PostRouting` mode, the policy can target the\n`Gateway` or `Listener`. This is a helper for applying the policy to all\nroutes under that `Gateway` or `Listener`, and follows the merging logic\ndescribed above.\n\nNote: `PreRouting` and `PostRouting` rules do not merge together. These\nare independent execution phases. That is, all `PreRouting` rules will\nmerge and execute, then all `PostRouting` rules will merge and execute.\n\nIf unset, this defaults to `PostRouting`.",
+              "enum": [
+                "PostRouting",
+                "PreRouting"
+              ],
+              "type": "string"
+            },
+            "rateLimit": {
+              "description": "Rate limiting configuration for the policy.\nThis limits the rate at which requests are processed.",
+              "properties": {
+                "conditional": {
+                  "description": "Conditional policy execution. Set this or the top-level rateLimit fields.\nThe first matching policy will be executed.\nA single policy may be provided without a condition set; if so, it must be the last policy and will be the fallback\nin case no conditions are met.",
+                  "items": {
+                    "properties": {
+                      "condition": {
+                        "description": "CEL expression that must evaluate to true for this policy to execute.",
+                        "maxLength": 16384,
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "policy": {
+                        "description": "Policy to apply when the condition matches.",
+                        "properties": {
+                          "global": {
+                            "description": "Global rate limiting policy using an external service.",
+                            "properties": {
+                              "backendRef": {
+                                "description": "Rate limit server to reach.\nSupported types: `Service` and `Backend`.",
+                                "properties": {
+                                  "group": {
+                                    "default": "",
+                                    "description": "Group is the group of the referent. For example, \"gateway.networking.k8s.io\".\nWhen unspecified or empty string, core API group is inferred.",
+                                    "maxLength": 253,
+                                    "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                                    "type": "string"
+                                  },
+                                  "kind": {
+                                    "default": "Service",
+                                    "description": "Kind is the Kubernetes resource kind of the referent. For example\n\"Service\".\n\nDefaults to \"Service\" when not specified.\n\nExternalName services can refer to CNAME DNS records that may live\noutside of the cluster and as such are difficult to reason about in\nterms of conformance. They also may not be safe to forward to (see\nCVE-2021-25740 for more information). Implementations SHOULD NOT\nsupport ExternalName Services.\n\nSupport: Core (Services with a type other than ExternalName)\n\nSupport: Implementation-specific (Services with type ExternalName)",
+                                    "maxLength": 63,
+                                    "minLength": 1,
+                                    "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "description": "Name is the name of the referent.",
+                                    "maxLength": 253,
+                                    "minLength": 1,
+                                    "type": "string"
+                                  },
+                                  "namespace": {
+                                    "description": "Namespace is the namespace of the backend. When unspecified, the local\nnamespace is inferred.\n\nNote that when a namespace different than the local namespace is specified,\na ReferenceGrant object is required in the referent namespace to allow that\nnamespace's owner to accept the reference. See the ReferenceGrant\ndocumentation for details.\n\nSupport: Core",
+                                    "maxLength": 63,
+                                    "minLength": 1,
+                                    "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "description": "Port specifies the destination port number to use for this resource.\nPort is required when the referent is a Kubernetes Service. In this\ncase, the port number is the service port number, not the target port.\nFor other resources, destination port might be derived from the referent\nresource or this field.",
+                                    "format": "int32",
+                                    "maximum": 65535,
+                                    "minimum": 1,
+                                    "type": "integer"
+                                  }
+                                },
+                                "required": [
+                                  "name"
+                                ],
+                                "type": "object",
+                                "x-kubernetes-validations": [
+                                  {
+                                    "message": "Must have port for Service reference",
+                                    "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
+                                  }
+                                ],
+                                "additionalProperties": false
+                              },
+                              "descriptors": {
+                                "description": "Dimensions for rate limiting. These values are\npassed to the rate limit service which applies configured limits based\non them. Each descriptor represents a single rate limit rule with one or\nmore entries.",
+                                "items": {
+                                  "properties": {
+                                    "cost": {
+                                      "description": "Common Expression Language (`CEL`) expression that determines\nthe cost of the request for this descriptor. If unset, `Requests` costs\ndefault to 1, and `Tokens` costs default to the total token count.\n\n`Tokens` cost are evaluated after the request has completed. For non-streaming requests, `request`, `llm`, and\n`response` fields are all available; for streaming requests, `response` is not available (however, all LLM\nattributes are in `llm`). For `Requests`, cost is computed during the request phase.\n\nSee https://agentgateway.dev/docs/standalone/latest/reference/cel/ for more info.",
+                                      "maxLength": 16384,
+                                      "minLength": 1,
+                                      "type": "string"
+                                    },
+                                    "entries": {
+                                      "description": "Individual components that make up this descriptor.",
+                                      "items": {
+                                        "description": "Entry in a rate limit descriptor.",
+                                        "properties": {
+                                          "expression": {
+                                            "description": "Common Expression Language (`CEL`) expression that\ndefines the value for the descriptor.\n\nFor example, to rate limit based on the Client IP: `source.address`.\n\nSee https://agentgateway.dev/docs/standalone/latest/reference/cel/ for more info.",
+                                            "maxLength": 16384,
+                                            "minLength": 1,
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "description": "Name of the descriptor.",
+                                            "maxLength": 64,
+                                            "minLength": 1,
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "expression",
+                                          "name"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "maxItems": 16,
+                                      "minItems": 1,
+                                      "type": "array"
+                                    },
+                                    "unit": {
+                                      "description": "Cost unit. If unspecified,\n`Requests` is used.",
+                                      "enum": [
+                                        "Requests",
+                                        "Tokens"
+                                      ],
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "entries"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "maxItems": 16,
+                                "minItems": 1,
+                                "type": "array"
+                              },
+                              "domain": {
+                                "description": "Domain under which this limit should apply.\nThis is an arbitrary string that enables a rate limit server to distinguish between different applications.",
+                                "maxLength": 256,
+                                "minLength": 1,
+                                "type": "string"
+                              },
+                              "failureMode": {
+                                "description": "Behavior when the remote rate limit service is\nunavailable or returns an error. `FailOpen` allows the request to continue.\n`FailClosed` (default) denies the request.",
+                                "enum": [
+                                  "FailClosed",
+                                  "FailOpen"
+                                ],
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "backendRef",
+                              "descriptors",
+                              "domain"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "local": {
+                            "description": "Local rate limiting policy.",
+                            "items": {
+                              "description": "Local rate limiting policy. Local rate limits are handled on a per-proxy basis, without coordination\nbetween instances of the proxy.",
+                              "properties": {
+                                "burst": {
+                                  "description": "Allowance of requests above the request-per-unit\nthat should be allowed within a short period of time.",
+                                  "format": "int32",
+                                  "type": "integer"
+                                },
+                                "requests": {
+                                  "description": "Number of HTTP requests per unit of time that\nare allowed. Requests exceeding this limit will fail with a `429`\nerror.",
+                                  "format": "int32",
+                                  "minimum": 1,
+                                  "type": "integer"
+                                },
+                                "tokens": {
+                                  "description": "Number of LLM tokens per unit of time that are\nallowed. Requests exceeding this limit will fail with a `429` error.\n\nBoth input and output tokens are counted. However, token counts are not known until the request completes. As a\nresult, token-based rate limits will apply to future requests only.",
+                                  "format": "int32",
+                                  "minimum": 1,
+                                  "type": "integer"
+                                },
+                                "unit": {
+                                  "description": "Unit of time for the limit.",
+                                  "enum": [
+                                    "Hours",
+                                    "Minutes",
+                                    "Seconds"
+                                  ],
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "unit"
+                              ],
+                              "type": "object",
+                              "x-kubernetes-validations": [
+                                {
+                                  "message": "exactly one of the fields in [requests tokens] must be set",
+                                  "rule": "[has(self.requests),has(self.tokens)].filter(x,x==true).size() == 1"
+                                }
+                              ],
+                              "additionalProperties": false
+                            },
+                            "maxItems": 16,
+                            "minItems": 1,
+                            "type": "array"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-validations": [
+                          {
+                            "message": "at least one of the fields in [global local] must be set",
+                            "rule": "[has(self.global),has(self.local)].filter(x,x==true).size() >= 1"
+                          }
+                        ],
+                        "additionalProperties": false
+                      }
+                    },
+                    "required": [
+                      "policy"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "maxItems": 16,
+                  "minItems": 1,
+                  "type": "array",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "conditional entries without condition must be last",
+                      "rule": "self.filter(e, !has(e.condition)).size() <= 1 && (!self.exists(e, !has(e.condition)) || !has(self[size(self) - 1].condition))"
+                    }
+                  ]
+                },
+                "global": {
+                  "description": "Global rate limiting policy using an external service.",
+                  "properties": {
+                    "backendRef": {
+                      "description": "Rate limit server to reach.\nSupported types: `Service` and `Backend`.",
+                      "properties": {
+                        "group": {
+                          "default": "",
+                          "description": "Group is the group of the referent. For example, \"gateway.networking.k8s.io\".\nWhen unspecified or empty string, core API group is inferred.",
+                          "maxLength": 253,
+                          "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                          "type": "string"
+                        },
+                        "kind": {
+                          "default": "Service",
+                          "description": "Kind is the Kubernetes resource kind of the referent. For example\n\"Service\".\n\nDefaults to \"Service\" when not specified.\n\nExternalName services can refer to CNAME DNS records that may live\noutside of the cluster and as such are difficult to reason about in\nterms of conformance. They also may not be safe to forward to (see\nCVE-2021-25740 for more information). Implementations SHOULD NOT\nsupport ExternalName Services.\n\nSupport: Core (Services with a type other than ExternalName)\n\nSupport: Implementation-specific (Services with type ExternalName)",
+                          "maxLength": 63,
+                          "minLength": 1,
+                          "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
+                          "type": "string"
+                        },
+                        "name": {
+                          "description": "Name is the name of the referent.",
+                          "maxLength": 253,
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "namespace": {
+                          "description": "Namespace is the namespace of the backend. When unspecified, the local\nnamespace is inferred.\n\nNote that when a namespace different than the local namespace is specified,\na ReferenceGrant object is required in the referent namespace to allow that\nnamespace's owner to accept the reference. See the ReferenceGrant\ndocumentation for details.\n\nSupport: Core",
+                          "maxLength": 63,
+                          "minLength": 1,
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                          "type": "string"
+                        },
+                        "port": {
+                          "description": "Port specifies the destination port number to use for this resource.\nPort is required when the referent is a Kubernetes Service. In this\ncase, the port number is the service port number, not the target port.\nFor other resources, destination port might be derived from the referent\nresource or this field.",
+                          "format": "int32",
+                          "maximum": 65535,
+                          "minimum": 1,
+                          "type": "integer"
+                        }
+                      },
+                      "required": [
+                        "name"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-validations": [
+                        {
+                          "message": "Must have port for Service reference",
+                          "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
+                        }
+                      ],
+                      "additionalProperties": false
+                    },
+                    "descriptors": {
+                      "description": "Dimensions for rate limiting. These values are\npassed to the rate limit service which applies configured limits based\non them. Each descriptor represents a single rate limit rule with one or\nmore entries.",
+                      "items": {
+                        "properties": {
+                          "cost": {
+                            "description": "Common Expression Language (`CEL`) expression that determines\nthe cost of the request for this descriptor. If unset, `Requests` costs\ndefault to 1, and `Tokens` costs default to the total token count.\n\n`Tokens` cost are evaluated after the request has completed. For non-streaming requests, `request`, `llm`, and\n`response` fields are all available; for streaming requests, `response` is not available (however, all LLM\nattributes are in `llm`). For `Requests`, cost is computed during the request phase.\n\nSee https://agentgateway.dev/docs/standalone/latest/reference/cel/ for more info.",
+                            "maxLength": 16384,
+                            "minLength": 1,
+                            "type": "string"
+                          },
+                          "entries": {
+                            "description": "Individual components that make up this descriptor.",
+                            "items": {
+                              "description": "Entry in a rate limit descriptor.",
+                              "properties": {
+                                "expression": {
+                                  "description": "Common Expression Language (`CEL`) expression that\ndefines the value for the descriptor.\n\nFor example, to rate limit based on the Client IP: `source.address`.\n\nSee https://agentgateway.dev/docs/standalone/latest/reference/cel/ for more info.",
+                                  "maxLength": 16384,
+                                  "minLength": 1,
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "description": "Name of the descriptor.",
+                                  "maxLength": 64,
+                                  "minLength": 1,
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "expression",
+                                "name"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "maxItems": 16,
+                            "minItems": 1,
+                            "type": "array"
+                          },
+                          "unit": {
+                            "description": "Cost unit. If unspecified,\n`Requests` is used.",
+                            "enum": [
+                              "Requests",
+                              "Tokens"
+                            ],
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "entries"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "maxItems": 16,
+                      "minItems": 1,
+                      "type": "array"
+                    },
+                    "domain": {
+                      "description": "Domain under which this limit should apply.\nThis is an arbitrary string that enables a rate limit server to distinguish between different applications.",
+                      "maxLength": 256,
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "failureMode": {
+                      "description": "Behavior when the remote rate limit service is\nunavailable or returns an error. `FailOpen` allows the request to continue.\n`FailClosed` (default) denies the request.",
+                      "enum": [
+                        "FailClosed",
+                        "FailOpen"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "backendRef",
+                    "descriptors",
+                    "domain"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "local": {
+                  "description": "Local rate limiting policy.",
+                  "items": {
+                    "description": "Local rate limiting policy. Local rate limits are handled on a per-proxy basis, without coordination\nbetween instances of the proxy.",
+                    "properties": {
+                      "burst": {
+                        "description": "Allowance of requests above the request-per-unit\nthat should be allowed within a short period of time.",
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "requests": {
+                        "description": "Number of HTTP requests per unit of time that\nare allowed. Requests exceeding this limit will fail with a `429`\nerror.",
+                        "format": "int32",
+                        "minimum": 1,
+                        "type": "integer"
+                      },
+                      "tokens": {
+                        "description": "Number of LLM tokens per unit of time that are\nallowed. Requests exceeding this limit will fail with a `429` error.\n\nBoth input and output tokens are counted. However, token counts are not known until the request completes. As a\nresult, token-based rate limits will apply to future requests only.",
+                        "format": "int32",
+                        "minimum": 1,
+                        "type": "integer"
+                      },
+                      "unit": {
+                        "description": "Unit of time for the limit.",
+                        "enum": [
+                          "Hours",
+                          "Minutes",
+                          "Seconds"
+                        ],
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "unit"
+                    ],
+                    "type": "object",
+                    "x-kubernetes-validations": [
+                      {
+                        "message": "exactly one of the fields in [requests tokens] must be set",
+                        "rule": "[has(self.requests),has(self.tokens)].filter(x,x==true).size() == 1"
+                      }
+                    ],
+                    "additionalProperties": false
+                  },
+                  "maxItems": 16,
+                  "minItems": 1,
+                  "type": "array"
+                }
+              },
+              "type": "object",
+              "x-kubernetes-validations": [
+                {
+                  "message": "at least one of the fields in [conditional global local] must be set",
+                  "rule": "[has(self.conditional),has(self.global),has(self.local)].filter(x,x==true).size() >= 1"
+                },
+                {
+                  "message": "conditional cannot be set with any other field",
+                  "rule": "has(self.conditional) ? [has(self.global),has(self.local)].filter(x,x==true).size() == 0 : true"
+                }
+              ],
+              "additionalProperties": false
+            },
+            "retry": {
+              "description": "Retry policy.",
+              "properties": {
+                "attempts": {
+                  "description": "Attempts specifies the maximum number of times an individual request\nfrom the gateway to a backend should be retried.\n\nIf the maximum number of retries has been attempted without a successful\nresponse from the backend, the Gateway MUST return an error.\n\nWhen this field is unspecified, the number of times to attempt to retry\na backend request is implementation-specific.\n\nSupport: Extended",
+                  "minimum": 1,
+                  "type": "integer"
+                },
+                "backoff": {
+                  "description": "Backoff specifies the minimum duration a Gateway should wait between\nretry attempts and is represented in Gateway API Duration formatting.\n\nFor example, setting the `rules[].retry.backoff` field to the value\n`100ms` will cause a backend request to first be retried approximately\n100 milliseconds after timing out or receiving a response code configured\nto be retriable.\n\nAn implementation MAY use an exponential or alternative backoff strategy\nfor subsequent retry attempts, MAY cap the maximum backoff duration to\nsome amount greater than the specified minimum, and MAY add arbitrary\njitter to stagger requests, as long as unsuccessful backend requests are\nnot retried before the configured minimum duration.\n\nIf a Request timeout (`rules[].timeouts.request`) is configured on the\nroute, the entire duration of the initial request and any retry attempts\nMUST not exceed the Request timeout duration. If any retry attempts are\nstill in progress when the Request timeout duration has been reached,\nthese SHOULD be canceled if possible and the Gateway MUST immediately\nreturn a timeout error.\n\nIf a BackendRequest timeout (`rules[].timeouts.backendRequest`) is\nconfigured on the route, any retry attempts which reach the configured\nBackendRequest timeout duration without a response SHOULD be canceled if\npossible and the Gateway should wait for at least the specified backoff\nduration before attempting to retry the backend request again.\n\nIf a BackendRequest timeout is _not_ configured on the route, retry\nattempts MAY time out after an implementation default duration, or MAY\nremain pending until a configured Request timeout or implementation\ndefault duration for total request time is reached.\n\nWhen this field is unspecified, the time to wait between retry attempts\nis implementation-specific.\n\nSupport: Extended",
+                  "pattern": "^([0-9]{1,5}(h|m|s|ms)){1,4}$",
+                  "type": "string"
+                },
+                "codes": {
+                  "description": "Codes defines the HTTP response status codes for which a backend request\nshould be retried.\n\nSupport: Extended",
+                  "items": {
+                    "description": "HTTPRouteRetryStatusCode defines an HTTP response status code for\nwhich a backend request should be retried.\n\nImplementations MUST support the following status codes as retriable:\n\n* 500\n* 502\n* 503\n* 504\n\nImplementations MAY support specifying additional discrete values in the\n500-599 range.\n\nImplementations MAY support specifying discrete values in the 400-499 range,\nwhich are often inadvisable to retry.\n\n<gateway:experimental>",
+                    "maximum": 599,
+                    "minimum": 400,
+                    "type": "integer"
+                  },
+                  "type": "array",
+                  "x-kubernetes-list-type": "set"
+                },
+                "condition": {
+                  "description": "`condition` is a CEL expression evaluated against each response to decide\nwhether to retry. A response is retried when its status code is in `codes` or\nthis expression evaluates to `true`.",
+                  "maxLength": 16384,
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "precondition": {
+                  "description": "`precondition` is a CEL expression evaluated against the request before any\nattempt is made. When it evaluates to `false`, retries are disabled and only\nthe initial attempt is made, for example `request.method == \"GET\"`.\nRetrying requires buffering the request body in memory for replay, so this lets\nus skip that cost when the request is known to be non-retriable (for example\nstreaming uploads or long-lived connections like websockets).",
+                  "maxLength": 16384,
+                  "minLength": 1,
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "timeouts": {
+              "description": "Request timeouts.\nIt is applicable to `HTTPRoute` resources and ignored for other targeted\nkinds.",
+              "properties": {
+                "request": {
+                  "description": "Timeout for an individual request from the gateway to a backend. This covers the time from when\nthe request first starts being sent from the gateway to when the full response has been received from the backend.",
+                  "type": "string",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "invalid duration value",
+                      "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                    },
+                    {
+                      "message": "request must be at least 1ms",
+                      "rule": "duration(self) >= duration('100ms')"
+                    }
+                  ]
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "transformation": {
+              "description": "Mutates and transforms requests and responses\nbefore forwarding them to the destination.",
+              "properties": {
+                "conditional": {
+                  "description": "Conditional policy execution. Set this or the top-level transformation fields.\nThe first matching policy will be executed.\nA single policy may be provided without a condition set; if so, it must be the last policy and will be the fallback\nin case no conditions are met.",
+                  "items": {
+                    "properties": {
+                      "condition": {
+                        "description": "CEL expression that must evaluate to true for this policy to execute.",
+                        "maxLength": 16384,
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "policy": {
+                        "description": "Policy to apply when the condition matches.",
+                        "properties": {
+                          "request": {
+                            "description": "Request transformation settings.",
+                            "properties": {
+                              "add": {
+                                "description": "Headers to add to the request and what each value\nshould be set to. If there is already a header with these values then\nappend the value as an extra entry.",
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "description": "The name of the header to add.",
+                                      "maxLength": 256,
+                                      "minLength": 1,
+                                      "pattern": "^:?[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                                      "type": "string",
+                                      "x-kubernetes-validations": [
+                                        {
+                                          "message": "pseudo-headers must be one of :authority, :method, :path, :scheme, or :status",
+                                          "rule": "!self.startsWith(':') || self in [':authority', ':method', ':path', ':scheme', ':status']"
+                                        }
+                                      ]
+                                    },
+                                    "value": {
+                                      "description": "CEL expression that generates the output value for\nthe header.",
+                                      "maxLength": 16384,
+                                      "minLength": 1,
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "name",
+                                    "value"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "maxItems": 16,
+                                "minItems": 1,
+                                "type": "array",
+                                "x-kubernetes-list-map-keys": [
+                                  "name"
+                                ],
+                                "x-kubernetes-list-type": "map"
+                              },
+                              "body": {
+                                "description": "HTTP body transformation.",
+                                "maxLength": 16384,
+                                "minLength": 1,
+                                "type": "string"
+                              },
+                              "metadata": {
+                                "additionalProperties": {
+                                  "description": "A Common Expression Language (CEL) expression.",
+                                  "maxLength": 16384,
+                                  "minLength": 1,
+                                  "type": "string"
+                                },
+                                "description": "Stores CEL-evaluated values under the `metadata` CEL variable\nfor subsequent policy evaluations. `metadata` is evaluated before header\nor body transformations.",
+                                "maxProperties": 16,
+                                "minProperties": 1,
+                                "type": "object"
+                              },
+                              "remove": {
+                                "description": "Header names to remove from the request or\nresponse.",
+                                "items": {
+                                  "description": "HTTP header name.",
+                                  "maxLength": 256,
+                                  "minLength": 1,
+                                  "pattern": "^:?[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                                  "type": "string",
+                                  "x-kubernetes-validations": [
+                                    {
+                                      "message": "pseudo-headers must be one of :authority, :method, :path, :scheme, or :status",
+                                      "rule": "!self.startsWith(':') || self in [':authority', ':method', ':path', ':scheme', ':status']"
+                                    }
+                                  ]
+                                },
+                                "maxItems": 16,
+                                "minItems": 1,
+                                "type": "array",
+                                "x-kubernetes-list-type": "set"
+                              },
+                              "set": {
+                                "description": "Headers to set and the values to use.",
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "description": "The name of the header to add.",
+                                      "maxLength": 256,
+                                      "minLength": 1,
+                                      "pattern": "^:?[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                                      "type": "string",
+                                      "x-kubernetes-validations": [
+                                        {
+                                          "message": "pseudo-headers must be one of :authority, :method, :path, :scheme, or :status",
+                                          "rule": "!self.startsWith(':') || self in [':authority', ':method', ':path', ':scheme', ':status']"
+                                        }
+                                      ]
+                                    },
+                                    "value": {
+                                      "description": "CEL expression that generates the output value for\nthe header.",
+                                      "maxLength": 16384,
+                                      "minLength": 1,
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "name",
+                                    "value"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "maxItems": 16,
+                                "minItems": 1,
+                                "type": "array",
+                                "x-kubernetes-list-map-keys": [
+                                  "name"
+                                ],
+                                "x-kubernetes-list-type": "map"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-validations": [
+                              {
+                                "message": "at least one of the fields in [add body metadata remove set] must be set",
+                                "rule": "[has(self.add),has(self.body),has(self.metadata),has(self.remove),has(self.set)].filter(x,x==true).size() >= 1"
+                              }
+                            ],
+                            "additionalProperties": false
+                          },
+                          "response": {
+                            "description": "Response transformation settings.",
+                            "properties": {
+                              "add": {
+                                "description": "Headers to add to the request and what each value\nshould be set to. If there is already a header with these values then\nappend the value as an extra entry.",
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "description": "The name of the header to add.",
+                                      "maxLength": 256,
+                                      "minLength": 1,
+                                      "pattern": "^:?[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                                      "type": "string",
+                                      "x-kubernetes-validations": [
+                                        {
+                                          "message": "pseudo-headers must be one of :authority, :method, :path, :scheme, or :status",
+                                          "rule": "!self.startsWith(':') || self in [':authority', ':method', ':path', ':scheme', ':status']"
+                                        }
+                                      ]
+                                    },
+                                    "value": {
+                                      "description": "CEL expression that generates the output value for\nthe header.",
+                                      "maxLength": 16384,
+                                      "minLength": 1,
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "name",
+                                    "value"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "maxItems": 16,
+                                "minItems": 1,
+                                "type": "array",
+                                "x-kubernetes-list-map-keys": [
+                                  "name"
+                                ],
+                                "x-kubernetes-list-type": "map"
+                              },
+                              "body": {
+                                "description": "HTTP body transformation.",
+                                "maxLength": 16384,
+                                "minLength": 1,
+                                "type": "string"
+                              },
+                              "metadata": {
+                                "additionalProperties": {
+                                  "description": "A Common Expression Language (CEL) expression.",
+                                  "maxLength": 16384,
+                                  "minLength": 1,
+                                  "type": "string"
+                                },
+                                "description": "Stores CEL-evaluated values under the `metadata` CEL variable\nfor subsequent policy evaluations. `metadata` is evaluated before header\nor body transformations.",
+                                "maxProperties": 16,
+                                "minProperties": 1,
+                                "type": "object"
+                              },
+                              "remove": {
+                                "description": "Header names to remove from the request or\nresponse.",
+                                "items": {
+                                  "description": "HTTP header name.",
+                                  "maxLength": 256,
+                                  "minLength": 1,
+                                  "pattern": "^:?[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                                  "type": "string",
+                                  "x-kubernetes-validations": [
+                                    {
+                                      "message": "pseudo-headers must be one of :authority, :method, :path, :scheme, or :status",
+                                      "rule": "!self.startsWith(':') || self in [':authority', ':method', ':path', ':scheme', ':status']"
+                                    }
+                                  ]
+                                },
+                                "maxItems": 16,
+                                "minItems": 1,
+                                "type": "array",
+                                "x-kubernetes-list-type": "set"
+                              },
+                              "set": {
+                                "description": "Headers to set and the values to use.",
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "description": "The name of the header to add.",
+                                      "maxLength": 256,
+                                      "minLength": 1,
+                                      "pattern": "^:?[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                                      "type": "string",
+                                      "x-kubernetes-validations": [
+                                        {
+                                          "message": "pseudo-headers must be one of :authority, :method, :path, :scheme, or :status",
+                                          "rule": "!self.startsWith(':') || self in [':authority', ':method', ':path', ':scheme', ':status']"
+                                        }
+                                      ]
+                                    },
+                                    "value": {
+                                      "description": "CEL expression that generates the output value for\nthe header.",
+                                      "maxLength": 16384,
+                                      "minLength": 1,
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "name",
+                                    "value"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "maxItems": 16,
+                                "minItems": 1,
+                                "type": "array",
+                                "x-kubernetes-list-map-keys": [
+                                  "name"
+                                ],
+                                "x-kubernetes-list-type": "map"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-validations": [
+                              {
+                                "message": "at least one of the fields in [add body metadata remove set] must be set",
+                                "rule": "[has(self.add),has(self.body),has(self.metadata),has(self.remove),has(self.set)].filter(x,x==true).size() >= 1"
+                              }
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-validations": [
+                          {
+                            "message": "at least one of the fields in [request response] must be set",
+                            "rule": "[has(self.request),has(self.response)].filter(x,x==true).size() >= 1"
+                          }
+                        ],
+                        "additionalProperties": false
+                      }
+                    },
+                    "required": [
+                      "policy"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "maxItems": 16,
+                  "minItems": 1,
+                  "type": "array",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "conditional entries without condition must be last",
+                      "rule": "self.filter(e, !has(e.condition)).size() <= 1 && (!self.exists(e, !has(e.condition)) || !has(self[size(self) - 1].condition))"
+                    }
+                  ]
+                },
+                "request": {
+                  "description": "Request transformation settings.",
+                  "properties": {
+                    "add": {
+                      "description": "Headers to add to the request and what each value\nshould be set to. If there is already a header with these values then\nappend the value as an extra entry.",
+                      "items": {
+                        "properties": {
+                          "name": {
+                            "description": "The name of the header to add.",
+                            "maxLength": 256,
+                            "minLength": 1,
+                            "pattern": "^:?[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                            "type": "string",
+                            "x-kubernetes-validations": [
+                              {
+                                "message": "pseudo-headers must be one of :authority, :method, :path, :scheme, or :status",
+                                "rule": "!self.startsWith(':') || self in [':authority', ':method', ':path', ':scheme', ':status']"
+                              }
+                            ]
+                          },
+                          "value": {
+                            "description": "CEL expression that generates the output value for\nthe header.",
+                            "maxLength": 16384,
+                            "minLength": 1,
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "name",
+                          "value"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "maxItems": 16,
+                      "minItems": 1,
+                      "type": "array",
+                      "x-kubernetes-list-map-keys": [
+                        "name"
+                      ],
+                      "x-kubernetes-list-type": "map"
+                    },
+                    "body": {
+                      "description": "HTTP body transformation.",
+                      "maxLength": 16384,
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "metadata": {
+                      "additionalProperties": {
+                        "description": "A Common Expression Language (CEL) expression.",
+                        "maxLength": 16384,
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "description": "Stores CEL-evaluated values under the `metadata` CEL variable\nfor subsequent policy evaluations. `metadata` is evaluated before header\nor body transformations.",
+                      "maxProperties": 16,
+                      "minProperties": 1,
+                      "type": "object"
+                    },
+                    "remove": {
+                      "description": "Header names to remove from the request or\nresponse.",
+                      "items": {
+                        "description": "HTTP header name.",
+                        "maxLength": 256,
+                        "minLength": 1,
+                        "pattern": "^:?[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                        "type": "string",
+                        "x-kubernetes-validations": [
+                          {
+                            "message": "pseudo-headers must be one of :authority, :method, :path, :scheme, or :status",
+                            "rule": "!self.startsWith(':') || self in [':authority', ':method', ':path', ':scheme', ':status']"
+                          }
+                        ]
+                      },
+                      "maxItems": 16,
+                      "minItems": 1,
+                      "type": "array",
+                      "x-kubernetes-list-type": "set"
+                    },
+                    "set": {
+                      "description": "Headers to set and the values to use.",
+                      "items": {
+                        "properties": {
+                          "name": {
+                            "description": "The name of the header to add.",
+                            "maxLength": 256,
+                            "minLength": 1,
+                            "pattern": "^:?[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                            "type": "string",
+                            "x-kubernetes-validations": [
+                              {
+                                "message": "pseudo-headers must be one of :authority, :method, :path, :scheme, or :status",
+                                "rule": "!self.startsWith(':') || self in [':authority', ':method', ':path', ':scheme', ':status']"
+                              }
+                            ]
+                          },
+                          "value": {
+                            "description": "CEL expression that generates the output value for\nthe header.",
+                            "maxLength": 16384,
+                            "minLength": 1,
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "name",
+                          "value"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "maxItems": 16,
+                      "minItems": 1,
+                      "type": "array",
+                      "x-kubernetes-list-map-keys": [
+                        "name"
+                      ],
+                      "x-kubernetes-list-type": "map"
+                    }
+                  },
+                  "type": "object",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "at least one of the fields in [add body metadata remove set] must be set",
+                      "rule": "[has(self.add),has(self.body),has(self.metadata),has(self.remove),has(self.set)].filter(x,x==true).size() >= 1"
+                    }
+                  ],
+                  "additionalProperties": false
+                },
+                "response": {
+                  "description": "Response transformation settings.",
+                  "properties": {
+                    "add": {
+                      "description": "Headers to add to the request and what each value\nshould be set to. If there is already a header with these values then\nappend the value as an extra entry.",
+                      "items": {
+                        "properties": {
+                          "name": {
+                            "description": "The name of the header to add.",
+                            "maxLength": 256,
+                            "minLength": 1,
+                            "pattern": "^:?[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                            "type": "string",
+                            "x-kubernetes-validations": [
+                              {
+                                "message": "pseudo-headers must be one of :authority, :method, :path, :scheme, or :status",
+                                "rule": "!self.startsWith(':') || self in [':authority', ':method', ':path', ':scheme', ':status']"
+                              }
+                            ]
+                          },
+                          "value": {
+                            "description": "CEL expression that generates the output value for\nthe header.",
+                            "maxLength": 16384,
+                            "minLength": 1,
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "name",
+                          "value"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "maxItems": 16,
+                      "minItems": 1,
+                      "type": "array",
+                      "x-kubernetes-list-map-keys": [
+                        "name"
+                      ],
+                      "x-kubernetes-list-type": "map"
+                    },
+                    "body": {
+                      "description": "HTTP body transformation.",
+                      "maxLength": 16384,
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "metadata": {
+                      "additionalProperties": {
+                        "description": "A Common Expression Language (CEL) expression.",
+                        "maxLength": 16384,
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "description": "Stores CEL-evaluated values under the `metadata` CEL variable\nfor subsequent policy evaluations. `metadata` is evaluated before header\nor body transformations.",
+                      "maxProperties": 16,
+                      "minProperties": 1,
+                      "type": "object"
+                    },
+                    "remove": {
+                      "description": "Header names to remove from the request or\nresponse.",
+                      "items": {
+                        "description": "HTTP header name.",
+                        "maxLength": 256,
+                        "minLength": 1,
+                        "pattern": "^:?[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                        "type": "string",
+                        "x-kubernetes-validations": [
+                          {
+                            "message": "pseudo-headers must be one of :authority, :method, :path, :scheme, or :status",
+                            "rule": "!self.startsWith(':') || self in [':authority', ':method', ':path', ':scheme', ':status']"
+                          }
+                        ]
+                      },
+                      "maxItems": 16,
+                      "minItems": 1,
+                      "type": "array",
+                      "x-kubernetes-list-type": "set"
+                    },
+                    "set": {
+                      "description": "Headers to set and the values to use.",
+                      "items": {
+                        "properties": {
+                          "name": {
+                            "description": "The name of the header to add.",
+                            "maxLength": 256,
+                            "minLength": 1,
+                            "pattern": "^:?[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                            "type": "string",
+                            "x-kubernetes-validations": [
+                              {
+                                "message": "pseudo-headers must be one of :authority, :method, :path, :scheme, or :status",
+                                "rule": "!self.startsWith(':') || self in [':authority', ':method', ':path', ':scheme', ':status']"
+                              }
+                            ]
+                          },
+                          "value": {
+                            "description": "CEL expression that generates the output value for\nthe header.",
+                            "maxLength": 16384,
+                            "minLength": 1,
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "name",
+                          "value"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "maxItems": 16,
+                      "minItems": 1,
+                      "type": "array",
+                      "x-kubernetes-list-map-keys": [
+                        "name"
+                      ],
+                      "x-kubernetes-list-type": "map"
+                    }
+                  },
+                  "type": "object",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "at least one of the fields in [add body metadata remove set] must be set",
+                      "rule": "[has(self.add),has(self.body),has(self.metadata),has(self.remove),has(self.set)].filter(x,x==true).size() >= 1"
+                    }
+                  ],
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "x-kubernetes-validations": [
+                {
+                  "message": "at least one of the fields in [conditional request response] must be set",
+                  "rule": "[has(self.conditional),has(self.request),has(self.response)].filter(x,x==true).size() >= 1"
+                },
+                {
+                  "message": "conditional cannot be set with any other field",
+                  "rule": "has(self.conditional) ? [has(self.request),has(self.response)].filter(x,x==true).size() == 0 : true"
+                }
+              ],
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "x-kubernetes-validations": [
+            {
+              "message": "phase PreRouting only supports extAuth, authorization, transformation, extProc, jwtAuthentication, basicAuthentication, apiKeyAuthentication and cors",
+              "rule": "has(self.phase) && self.phase == 'PreRouting' ? [has(self.buffer),has(self.csrf),has(self.directResponse),has(self.headerModifiers),has(self.hostRewrite),has(self.rateLimit),has(self.retry),has(self.timeouts)].filter(x,x==true).size() == 0 : true"
+            }
+          ],
+          "additionalProperties": false
+        }
+      },
+      "type": "object",
+      "x-kubernetes-validations": [
+        {
+          "message": "At least one of traffic, frontend, or backend must be provided.",
+          "rule": "has(self.traffic) || has(self.frontend) || has(self.backend)"
+        },
+        {
+          "message": "strategy.inheritance may only be set on traffic policies",
+          "rule": "!has(self.strategy) || !has(self.strategy.inheritance) || (has(self.traffic) && !has(self.frontend) && !has(self.backend))"
+        },
+        {
+          "message": "backend.mcp may not be used with a Service target",
+          "rule": "!has(self.backend) || !has(self.backend.mcp) || ((!has(self.targetRefs) || !self.targetRefs.exists(t, t.kind == 'Service')) && (!has(self.targetSelectors) || !self.targetSelectors.exists(t, t.kind == 'Service')))"
+        },
+        {
+          "message": "backend.mcp may not target an AgentgatewayBackend sectionName",
+          "rule": "!has(self.backend) || !has(self.backend.mcp) || ((!has(self.targetRefs) || !self.targetRefs.exists(t, t.kind == 'AgentgatewayBackend' && has(t.sectionName))) && (!has(self.targetSelectors) || !self.targetSelectors.exists(t, t.kind == 'AgentgatewayBackend' && has(t.sectionName))))"
+        },
+        {
+          "message": "backend.ai may not be used with a Service target",
+          "rule": "!has(self.backend) || !has(self.backend.ai) || ((!has(self.targetRefs) || !self.targetRefs.exists(t, t.kind == 'Service')) && (!has(self.targetSelectors) || !self.targetSelectors.exists(t, t.kind == 'Service')))"
+        },
+        {
+          "message": "traffic.jwtAuthentication may not be used with backend.mcp.authentication in the same policy",
+          "rule": "!(has(self.traffic) && has(self.traffic.jwtAuthentication) && has(self.backend) && has(self.backend.mcp) && has(self.backend.mcp.authentication))"
+        },
+        {
+          "message": "the 'frontend' field can only target a Gateway",
+          "rule": "has(self.frontend) && has(self.targetRefs) ? self.targetRefs.all(t, t.kind == 'Gateway' && !has(t.sectionName)) : true"
+        },
+        {
+          "message": "the 'frontend' field can only target a Gateway",
+          "rule": "has(self.frontend) && has(self.targetSelectors) ? self.targetSelectors.all(t, t.kind == 'Gateway' && !has(t.sectionName)) : true"
+        },
+        {
+          "message": "the 'traffic' field can only target a Gateway, ListenerSet, GRPCRoute, HTTPRoute, or InferencePool",
+          "rule": "has(self.traffic) && has(self.targetRefs) ? self.targetRefs.all(t, t.kind in ['Gateway', 'HTTPRoute', 'GRPCRoute', 'ListenerSet', 'InferencePool']) : true"
+        },
+        {
+          "message": "the 'traffic' field can only target a Gateway, ListenerSet, GRPCRoute, HTTPRoute, or InferencePool",
+          "rule": "has(self.traffic) && has(self.targetSelectors) ? self.targetSelectors.all(t, t.kind in ['Gateway', 'HTTPRoute', 'GRPCRoute', 'ListenerSet', 'InferencePool']) : true"
+        },
+        {
+          "message": "the 'traffic.phase=PreRouting' field can only target a Gateway or ListenerSet",
+          "rule": "has(self.targetRefs) && has(self.traffic) && has(self.traffic.phase) && self.traffic.phase == 'PreRouting' ? self.targetRefs.all(t, t.kind in ['Gateway', 'ListenerSet']) : true"
+        },
+        {
+          "message": "the 'traffic.phase=PreRouting' field can only target a Gateway or ListenerSet",
+          "rule": "has(self.targetSelectors) && has(self.traffic) && has(self.traffic.phase) && self.traffic.phase == 'PreRouting' ? self.targetSelectors.all(t, t.kind in ['Gateway', 'ListenerSet']) : true"
+        },
+        {
+          "message": "exactly one of the fields in [targetRefs targetSelectors] must be set",
+          "rule": "[has(self.targetRefs),has(self.targetSelectors)].filter(x,x==true).size() == 1"
+        }
+      ],
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "Current policy status.",
+      "properties": {
+        "ancestors": {
+          "description": "Ancestors is a list of ancestor resources (usually Gateways) that are\nassociated with the policy, and the status of the policy with respect to\neach ancestor. When this policy attaches to a parent, the controller that\nmanages the parent and the ancestors MUST add an entry to this list when\nthe controller first sees the policy and SHOULD update the entry as\nappropriate when the relevant ancestor is modified.\n\nNote that choosing the relevant ancestor is left to the Policy designers;\nan important part of Policy design is designing the right object level at\nwhich to namespace this status.\n\nNote also that implementations MUST ONLY populate ancestor status for\nthe Ancestor resources they are responsible for. Implementations MUST\nuse the ControllerName field to uniquely identify the entries in this list\nthat they are responsible for.\n\nNote that to achieve this, the list of PolicyAncestorStatus structs\nMUST be treated as a map with a composite key, made up of the AncestorRef\nand ControllerName fields combined.\n\nA maximum of 16 ancestors will be represented in this list. An empty list\nmeans the Policy is not relevant for any ancestors.\n\nIf this slice is full, implementations MUST NOT add further entries.\nInstead they MUST consider the policy unimplementable and signal that\non any related resources such as the ancestor that would be referenced\nhere. For example, if this list was full on BackendTLSPolicy, no\nadditional Gateways would be able to reference the Service targeted by\nthe BackendTLSPolicy.",
+          "items": {
+            "description": "PolicyAncestorStatus describes the status of a route with respect to an\nassociated Ancestor.\n\nAncestors refer to objects that are either the Target of a policy or above it\nin terms of object hierarchy. For example, if a policy targets a Service, the\nPolicy's Ancestors are, in order, the Service, the HTTPRoute, the Gateway, and\nthe GatewayClass. Almost always, in this hierarchy, the Gateway will be the most\nuseful object to place Policy status on, so we recommend that implementations\nSHOULD use Gateway as the PolicyAncestorStatus object unless the designers\nhave a _very_ good reason otherwise.\n\nIn the context of policy attachment, the Ancestor is used to distinguish which\nresource results in a distinct application of this policy. For example, if a policy\ntargets a Service, it may have a distinct result per attached Gateway.\n\nPolicies targeting the same resource may have different effects depending on the\nancestors of those resources. For example, different Gateways targeting the same\nService may have different capabilities, especially if they have different underlying\nimplementations.\n\nFor example, in BackendTLSPolicy, the Policy attaches to a Service that is\nused as a backend in a HTTPRoute that is itself attached to a Gateway.\nIn this case, the relevant object for status is the Gateway, and that is the\nancestor object referred to in this status.\n\nNote that a parent is also an ancestor, so for objects where the parent is the\nrelevant object for status, this struct SHOULD still be used.\n\nThis struct is intended to be used in a slice that's effectively a map,\nwith a composite key made up of the AncestorRef and the ControllerName.",
+            "properties": {
+              "ancestorRef": {
+                "description": "AncestorRef corresponds with a ParentRef in the spec that this\nPolicyAncestorStatus struct describes the status of.",
+                "properties": {
+                  "group": {
+                    "default": "gateway.networking.k8s.io",
+                    "description": "Group is the group of the referent.\nWhen unspecified, \"gateway.networking.k8s.io\" is inferred.\nTo set the core API group (such as for a \"Service\" kind referent),\nGroup must be explicitly set to \"\" (empty string).\n\nSupport: Core",
+                    "maxLength": 253,
+                    "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                    "type": "string"
+                  },
+                  "kind": {
+                    "default": "Gateway",
+                    "description": "Kind is kind of the referent.\n\nThere are two kinds of parent resources with \"Core\" support:\n\n* Gateway (Gateway conformance profile)\n* Service (Mesh conformance profile, ClusterIP Services only)\n\nSupport for other resources is Implementation-Specific.",
+                    "maxLength": 63,
+                    "minLength": 1,
+                    "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
+                    "type": "string"
+                  },
+                  "name": {
+                    "description": "Name is the name of the referent.\n\nSupport: Core",
+                    "maxLength": 253,
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "namespace": {
+                    "description": "Namespace is the namespace of the referent. When unspecified, this refers\nto the local namespace of the Route.\n\nNote that there are specific rules for ParentRefs which cross namespace\nboundaries. Cross-namespace references are only valid if they are explicitly\nallowed by something in the namespace they are referring to. For example:\nGateway has the AllowedRoutes field, and ReferenceGrant provides a\ngeneric way to enable any other kind of cross-namespace reference.\n\n<gateway:experimental:description>\nParentRefs from a Route to a Service in the same namespace are \"producer\"\nroutes, which apply default routing rules to inbound connections from\nany namespace to the Service.\n\nParentRefs from a Route to a Service in a different namespace are\n\"consumer\" routes, and these routing rules are only applied to outbound\nconnections originating from the same namespace as the Route, for which\nthe intended destination of the connections are a Service targeted as a\nParentRef of the Route.\n</gateway:experimental:description>\n\nSupport: Core",
+                    "maxLength": 63,
+                    "minLength": 1,
+                    "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                    "type": "string"
+                  },
+                  "port": {
+                    "description": "Port is the network port this Route targets. It can be interpreted\ndifferently based on the type of parent resource.\n\nWhen the parent resource is a Gateway, this targets all listeners\nlistening on the specified port that also support this kind of Route(and\nselect this Route). It's not recommended to set `Port` unless the\nnetworking behaviors specified in a Route must apply to a specific port\nas opposed to a listener(s) whose port(s) may be changed. When both Port\nand SectionName are specified, the name and port of the selected listener\nmust match both specified values.\n\n<gateway:experimental:description>\nWhen the parent resource is a Service, this targets a specific port in the\nService spec. When both Port (experimental) and SectionName are specified,\nthe name and port of the selected port must match both specified values.\n</gateway:experimental:description>\n\nImplementations MAY choose to support other parent resources.\nImplementations supporting other types of parent resources MUST clearly\ndocument how/if Port is interpreted.\n\nFor the purpose of status, an attachment is considered successful as\nlong as the parent resource accepts it partially. For example, Gateway\nlisteners can restrict which Routes can attach to them by Route kind,\nnamespace, or hostname. If 1 of 2 Gateway listeners accept attachment\nfrom the referencing Route, the Route MUST be considered successfully\nattached. If no Gateway listeners accept attachment from this Route,\nthe Route MUST be considered detached from the Gateway.\n\nSupport: Extended",
+                    "format": "int32",
+                    "maximum": 65535,
+                    "minimum": 1,
+                    "type": "integer"
+                  },
+                  "sectionName": {
+                    "description": "SectionName is the name of a section within the target resource. In the\nfollowing resources, SectionName is interpreted as the following:\n\n* Gateway: Listener name. When both Port (experimental) and SectionName\nare specified, the name and port of the selected listener must match\nboth specified values.\n* Service: Port name. When both Port (experimental) and SectionName\nare specified, the name and port of the selected listener must match\nboth specified values.\n\nImplementations MAY choose to support attaching Routes to other resources.\nIf that is the case, they MUST clearly document how SectionName is\ninterpreted.\n\nWhen unspecified (empty string), this will reference the entire resource.\nFor the purpose of status, an attachment is considered successful if at\nleast one section in the parent resource accepts it. For example, Gateway\nlisteners can restrict which Routes can attach to them by Route kind,\nnamespace, or hostname. If 1 of 2 Gateway listeners accept attachment from\nthe referencing Route, the Route MUST be considered successfully\nattached. If no Gateway listeners accept attachment from this Route, the\nRoute MUST be considered detached from the Gateway.\n\nSupport: Core",
+                    "maxLength": 253,
+                    "minLength": 1,
+                    "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "conditions": {
+                "description": "Conditions describes the status of the Policy with respect to the given Ancestor.\n\n<gateway:util:excludeFromCRD>\n\nNotes for implementors:\n\nConditions are a listType `map`, which means that they function like a\nmap with a key of the `type` field _in the k8s apiserver_.\n\nThis means that implementations must obey some rules when updating this\nsection.\n\n* Implementations MUST perform a read-modify-write cycle on this field\n  before modifying it. That is, when modifying this field, implementations\n  must be confident they have fetched the most recent version of this field,\n  and ensure that changes they make are on that recent version.\n* Implementations MUST NOT remove or reorder Conditions that they are not\n  directly responsible for. For example, if an implementation sees a Condition\n  with type `special.io/SomeField`, it MUST NOT remove, change or update that\n  Condition.\n* Implementations MUST always _merge_ changes into Conditions of the same Type,\n  rather than creating more than one Condition of the same Type.\n* Implementations MUST always update the `observedGeneration` field of the\n  Condition to the `metadata.generation` of the Gateway at the time of update creation.\n* If the `observedGeneration` of a Condition is _greater than_ the value the\n  implementation knows about, then it MUST NOT perform the update on that Condition,\n  but must wait for a future reconciliation and status update. (The assumption is that\n  the implementation's copy of the object is stale and an update will be re-triggered\n  if relevant.)\n\n</gateway:util:excludeFromCRD>",
+                "items": {
+                  "description": "Condition contains details for one aspect of the current state of this API Resource.",
+                  "properties": {
+                    "lastTransitionTime": {
+                      "description": "lastTransitionTime is the last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
+                      "format": "date-time",
+                      "type": "string"
+                    },
+                    "message": {
+                      "description": "message is a human readable message indicating details about the transition.\nThis may be an empty string.",
+                      "maxLength": 32768,
+                      "type": "string"
+                    },
+                    "observedGeneration": {
+                      "description": "observedGeneration represents the .metadata.generation that the condition was set based upon.\nFor instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date\nwith respect to the current state of the instance.",
+                      "format": "int64",
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "reason": {
+                      "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition.\nProducers of specific condition types may define expected values and meanings for this field,\nand whether the values are considered a guaranteed API.\nThe value should be a CamelCase string.\nThis field may not be empty.",
+                      "maxLength": 1024,
+                      "minLength": 1,
+                      "pattern": "^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$",
+                      "type": "string"
+                    },
+                    "status": {
+                      "description": "status of the condition, one of True, False, Unknown.",
+                      "enum": [
+                        "True",
+                        "False",
+                        "Unknown"
+                      ],
+                      "type": "string"
+                    },
+                    "type": {
+                      "description": "type of condition in CamelCase or in foo.example.com/CamelCase.",
+                      "maxLength": 316,
+                      "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "lastTransitionTime",
+                    "message",
+                    "reason",
+                    "status",
+                    "type"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "maxItems": 8,
+                "minItems": 1,
+                "type": "array",
+                "x-kubernetes-list-map-keys": [
+                  "type"
+                ],
+                "x-kubernetes-list-type": "map"
+              },
+              "controllerName": {
+                "description": "ControllerName is a domain/path string that indicates the name of the\ncontroller that wrote this status. This corresponds with the\ncontrollerName field on GatewayClass.\n\nExample: \"example.net/gateway-controller\".\n\nThe format of this field is DOMAIN \"/\" PATH, where DOMAIN and PATH are\nvalid Kubernetes names\n(https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names).\n\nControllers MUST populate this field when writing status. Controllers should ensure that\nentries to status populated with their ControllerName are cleaned up when they are no\nlonger necessary.",
+                "maxLength": 253,
+                "minLength": 1,
+                "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\\/[A-Za-z0-9\\/\\-._~%!$&'()*+,;=:]+$",
+                "type": "string"
+              }
+            },
+            "required": [
+              "ancestorRef",
+              "conditions",
+              "controllerName"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "maxItems": 16,
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        }
+      },
+      "required": [
+        "ancestors"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "required": [
+    "spec"
+  ],
+  "type": "object"
+}


### PR DESCRIPTION
## What

Adds JSON schemas for the [agentgateway](https://agentgateway.dev/) project's CRDs (`agentgateway.dev/v1alpha1`):

- `AgentgatewayBackend`
- `AgentgatewayParameters`
- `AgentgatewayPolicy`

This is the complete CRD set shipped by the official `agentgateway-crds` Helm chart **v1.3.1** (controller-gen v0.20.0).

## How

Extracted from a cluster running agentgateway v1.3.1 and converted with kubeconform's `openapi2jsonschema.py`, following the catalog's `{group}/{kind}_{version}.json` convention.

## Verification

Validated real rendered manifests (2 Backends, 1 Parameters, 1 Policy) with kubeconform against this catalog: 4/4 valid, and confirmed the schemas reject invalid input (e.g. an empty `accessLog.attributes.add` list violating `minItems: 1`).