### PR TITLE
fix: add InPlace to VerticalPodAutoscaler v1 updateMode enum

### DIFF
--- a/autoscaling.k8s.io/verticalpodautoscaler_v1.json
+++ b/autoscaling.k8s.io/verticalpodautoscaler_v1.json
@@ -181,7 +181,8 @@
                 "Initial",
                 "Recreate",
                 "InPlaceOrRecreate",
-                "Auto"
+                "Auto",
+                "InPlace"
               ],
               "type": "string"
             }


### PR DESCRIPTION
## Summary

Add `InPlace` as a valid `updateMode` value for the VerticalPodAutoscaler v1 schema (`autoscaling.k8s.io/verticalpodautoscaler_v1.json`).

## Context

The `InPlace` update mode was introduced in VPA 1.7.0 as an alpha feature. It resizes pod resources (CPU/memory) without restart or eviction — if a resize cannot be applied, it defers and retries on the next reconciliation loop.

Currently, users with VPA 1.7.0+ using `updateMode: InPlace` get false validation failures from kubeconform when using this catalog as a schema source.

## Change

```diff
 "enum": [
   "Off",
   "Initial",
   "Recreate",
   "InPlaceOrRecreate",
-  "Auto"
+  "Auto",
+  "InPlace"
 ]
```

## References

- Kubernetes docs: https://kubernetes.io/docs/concepts/workloads/autoscaling/vertical-pod-autoscale/#updateMode-InPlace
- VPA 1.7.0 release: https://github.com/kubernetes/autoscaler/releases/tag/vertical-pod-autoscaler-1.7.0
- Requires K8s 1.33+ with `InPlacePodVerticalScaling` feature gate + VPA `--feature-gates=InPlace=true`

Fixes #913