### PR TITLE
Update nvidia.com schemas based on gpu-operator 26.3.3 CRDs

### DIFF
--- a/nvidia.com/clusterpolicy_v1.json
+++ b/nvidia.com/clusterpolicy_v1.json
@@ -60,6 +60,10 @@
               },
               "type": "array"
             },
+            "hostNetwork": {
+              "description": "HostNetwork indicates whether the CC Manager pod uses the host's network namespace.",
+              "type": "boolean"
+            },
             "image": {
               "description": "CC Manager image name",
               "pattern": "[a-zA-Z0-9\\-]+",
@@ -412,6 +416,10 @@
               },
               "type": "array"
             },
+            "hostNetwork": {
+              "description": "HostNetwork indicates whether the DCGM pod uses the host's network namespace.",
+              "type": "boolean"
+            },
             "hostPort": {
               "description": "Deprecated: HostPort represents host port that needs to be bound for DCGM engine (Default: 5555)",
               "format": "int32",
@@ -487,6 +495,13 @@
         "dcgmExporter": {
           "description": "DCGMExporter spec",
           "properties": {
+            "annotations": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "Optional: Annotations is an unstructured key value map stored with a resource that may be\nset by external tools to store and retrieve arbitrary metadata. They are not\nqueryable and should be preserved when modifying objects.",
+              "type": "object"
+            },
             "args": {
               "description": "Optional: List of arguments",
               "items": {
@@ -504,6 +519,14 @@
               },
               "type": "object",
               "additionalProperties": false
+            },
+            "enablePodLabels": {
+              "description": "Enable Kubernetes pod labels as Prometheus label dimensions in DCGM exporter metrics.\n(Requires cluster-level read access to pods.)",
+              "type": "boolean"
+            },
+            "enablePodUID": {
+              "description": "Enable Kubernetes pod UID as a Prometheus label dimension in DCGM exporter metrics.\n(Requires cluster-level read access to pods.)",
+              "type": "boolean"
             },
             "enabled": {
               "description": "Enabled indicates if deployment of NVIDIA DCGM Exporter through operator is enabled",
@@ -570,6 +593,13 @@
               },
               "type": "array"
             },
+            "podLabelAllowlistRegex": {
+              "description": "Regex list for filtering which Kubernetes pod labels are included in DCGM exporter metrics.\nEmpty means all pod labels are included.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
             "repository": {
               "description": "NVIDIA DCGM Exporter image repository",
               "type": "string"
@@ -608,21 +638,6 @@
                   },
                   "description": "Requests describes the minimum amount of compute resources required.\nIf Requests is omitted for a container, it defaults to Limits if that is explicitly specified,\notherwise to an implementation-defined value. Requests cannot exceed Limits.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
                   "type": "object"
-                }
-              },
-              "type": "object",
-              "additionalProperties": false
-            },
-            "service": {
-              "description": "Optional: Service configuration for NVIDIA DCGM Exporter",
-              "properties": {
-                "internalTrafficPolicy": {
-                  "description": "InternalTrafficPolicy describes how nodes distribute service traffic they receive on the ClusterIP.",
-                  "type": "string"
-                },
-                "type": {
-                  "description": "Type represents the ServiceType which describes ingress methods for a service",
-                  "type": "string"
                 }
               },
               "type": "object",
@@ -798,6 +813,10 @@
               },
               "type": "array"
             },
+            "hostNetwork": {
+              "description": "HostNetwork indicates whether the Device Plugin pod uses the host's network namespace.",
+              "type": "boolean"
+            },
             "image": {
               "description": "NVIDIA Device Plugin image name",
               "pattern": "[a-zA-Z0-9\\-]+",
@@ -923,6 +942,10 @@
               },
               "type": "array"
             },
+            "hostNetwork": {
+              "description": "HostNetwork indicates whether the Driver pod uses the host's network namespace.",
+              "type": "boolean"
+            },
             "image": {
               "description": "NVIDIA Driver image name",
               "pattern": "[a-zA-Z0-9\\-]+",
@@ -948,16 +971,6 @@
               },
               "type": "object",
               "additionalProperties": false
-            },
-            "kernelModuleType": {
-              "default": "auto",
-              "description": "KernelModuleType represents the type of driver kernel modules to be used when installing the GPU driver.\nAccepted values are auto, proprietary and open. NOTE: If auto is chosen, it means that the recommended kernel module\ntype is chosen based on the GPU devices on the host and the driver branch used",
-              "enum": [
-                "auto",
-                "open",
-                "proprietary"
-              ],
-              "type": "string"
             },
             "kernelModuleType": {
               "default": "auto",
@@ -1180,10 +1193,6 @@
               },
               "type": "object",
               "additionalProperties": false
-            },
-            "secretEnv": {
-              "description": "Optional: SecretEnv represents the name of the Kubernetes Secret with secret environment variables for the NVIDIA Driver",
-              "type": "string"
             },
             "secretEnv": {
               "description": "Optional: SecretEnv represents the name of the Kubernetes Secret with secret environment variables for the NVIDIA Driver",
@@ -1523,6 +1532,10 @@
               },
               "type": "array"
             },
+            "hostNetwork": {
+              "description": "HostNetwork indicates whether the GPU Feature Discovery pod uses the host's network namespace.",
+              "type": "boolean"
+            },
             "image": {
               "description": "GFD image name",
               "pattern": "[a-zA-Z0-9\\-]+",
@@ -1697,6 +1710,10 @@
               },
               "type": "array"
             },
+            "hostNetwork": {
+              "description": "HostNetwork indicates whether the Kata Manager pod uses the host's network namespace.",
+              "type": "boolean"
+            },
             "image": {
               "description": "Kata Manager image name",
               "pattern": "[a-zA-Z0-9\\-]+",
@@ -1799,6 +1816,10 @@
                 "additionalProperties": false
               },
               "type": "array"
+            },
+            "hostNetwork": {
+              "description": "HostNetwork indicates whether the Kata Sandbox Device Plugin pod uses the host's network namespace.",
+              "type": "boolean"
             },
             "image": {
               "description": "NVIDIA component image name",
@@ -1950,6 +1971,10 @@
               "type": "object",
               "additionalProperties": false
             },
+            "hostNetwork": {
+              "description": "HostNetwork indicates whether the MIG Manager pod uses the host's network namespace.",
+              "type": "boolean"
+            },
             "image": {
               "description": "NVIDIA MIG Manager image name",
               "pattern": "[a-zA-Z0-9\\-]+",
@@ -2052,6 +2077,10 @@
                 "additionalProperties": false
               },
               "type": "array"
+            },
+            "hostNetwork": {
+              "description": "HostNetwork indicates whether the Node Status Exporter pod uses the host's network namespace.",
+              "type": "boolean"
             },
             "image": {
               "description": "Node Status Exporter image name",
@@ -2242,6 +2271,10 @@
               },
               "type": "array"
             },
+            "hostNetwork": {
+              "description": "HostNetwork indicates whether the Sandbox Device Plugin pod uses the host's network namespace.",
+              "type": "boolean"
+            },
             "image": {
               "description": "NVIDIA Sandbox Device Plugin image name",
               "pattern": "[a-zA-Z0-9\\-]+",
@@ -2374,6 +2407,10 @@
                 "additionalProperties": false
               },
               "type": "array"
+            },
+            "hostNetwork": {
+              "description": "HostNetwork indicates whether the Container Toolkit pod uses the host's network namespace.",
+              "type": "boolean"
             },
             "image": {
               "description": "NVIDIA Container Toolkit image name",
@@ -2536,6 +2573,10 @@
                 "additionalProperties": false
               },
               "type": "array"
+            },
+            "hostNetwork": {
+              "description": "HostNetwork indicates whether the Validator pod uses the host's network namespace.",
+              "type": "boolean"
             },
             "image": {
               "description": "Validator image name",
@@ -2838,6 +2879,10 @@
               },
               "type": "array"
             },
+            "hostNetwork": {
+              "description": "HostNetwork indicates whether the VFIO Manager pod uses the host's network namespace.",
+              "type": "boolean"
+            },
             "image": {
               "description": "VFIO Manager image name",
               "pattern": "[a-zA-Z0-9\\-]+",
@@ -2956,6 +3001,10 @@
                 "additionalProperties": false
               },
               "type": "array"
+            },
+            "hostNetwork": {
+              "description": "HostNetwork indicates whether the vGPU Device Manager pod uses the host's network namespace.",
+              "type": "boolean"
             },
             "image": {
               "description": "NVIDIA vGPU Device Manager image name",
@@ -3112,6 +3161,10 @@
                 "additionalProperties": false
               },
               "type": "array"
+            },
+            "hostNetwork": {
+              "description": "HostNetwork indicates whether the vGPU Manager pod uses the host's network namespace.",
+              "type": "boolean"
             },
             "image": {
               "description": "NVIDIA vGPU Manager  image name",

--- a/nvidia.com/nvidiadriver_v1alpha1.json
+++ b/nvidia.com/nvidiadriver_v1alpha1.json
@@ -205,6 +205,10 @@
           "type": "object",
           "additionalProperties": false
         },
+        "hostNetwork": {
+          "description": "HostNetwork indicates whether the Driver pod uses the host's network namespace.",
+          "type": "boolean"
+        },
         "image": {
           "default": "nvcr.io/nvidia/driver",
           "description": "NVIDIA Driver container image name",
@@ -231,6 +235,16 @@
           "type": "object",
           "additionalProperties": false
         },
+        "kernelModuleType": {
+          "default": "auto",
+          "description": "KernelModuleType represents the type of driver kernel modules to be used when installing the GPU driver.\nAccepted values are auto, proprietary and open. NOTE: If auto is chosen, it means that the recommended kernel module\ntype is chosen based on the GPU devices on the host and the driver branch used",
+          "enum": [
+            "auto",
+            "open",
+            "proprietary"
+          ],
+          "type": "string"
+        },
         "labels": {
           "additionalProperties": {
             "type": "string"
@@ -242,11 +256,15 @@
           "description": "Optional: Licensing configuration for NVIDIA vGPU licensing",
           "properties": {
             "name": {
+              "description": "Deprecated: ConfigMapName has been deprecated in favour of SecretName. Please use secrets to handle the licensing server configuration more securely",
               "type": "string"
             },
             "nlsEnabled": {
               "description": "NLSEnabled indicates if NVIDIA Licensing System is used for licensing.",
               "type": "boolean"
+            },
+            "secretName": {
+              "type": "string"
             }
           },
           "type": "object",
@@ -536,6 +554,159 @@
           "description": "NodeSelector specifies a selector for installation of NVIDIA driver",
           "type": "object"
         },
+        "podSecurityContext": {
+          "description": "Optional: Set pod-level security context for driver pod",
+          "properties": {
+            "appArmorProfile": {
+              "description": "appArmorProfile is the AppArmor options to use by the containers in this pod.\nNote that this field cannot be set when spec.os.name is windows.",
+              "properties": {
+                "localhostProfile": {
+                  "description": "localhostProfile indicates a profile loaded on the node that should be used.\nThe profile must be preconfigured on the node to work.\nMust match the loaded name of the profile.\nMust be set if and only if type is \"Localhost\".",
+                  "type": "string"
+                },
+                "type": {
+                  "description": "type indicates which kind of AppArmor profile will be applied.\nValid options are:\n  Localhost - a profile pre-loaded on the node.\n  RuntimeDefault - the container runtime's default profile.\n  Unconfined - no AppArmor enforcement.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "fsGroup": {
+              "description": "A special supplemental group that applies to all containers in a pod.\nSome volume types allow the Kubelet to change the ownership of that volume\nto be owned by the pod:\n\n1. The owning GID will be the FSGroup\n2. The setgid bit is set (new files created in the volume will be owned by FSGroup)\n3. The permission bits are OR'd with rw-rw----\n\nIf unset, the Kubelet will not modify the ownership and permissions of any volume.\nNote that this field cannot be set when spec.os.name is windows.",
+              "format": "int64",
+              "type": "integer"
+            },
+            "fsGroupChangePolicy": {
+              "description": "fsGroupChangePolicy defines behavior of changing ownership and permission of the volume\nbefore being exposed inside Pod. This field will only apply to\nvolume types which support fsGroup based ownership(and permissions).\nIt will have no effect on ephemeral volume types such as: secret, configmaps\nand emptydir.\nValid values are \"OnRootMismatch\" and \"Always\". If not specified, \"Always\" is used.\nNote that this field cannot be set when spec.os.name is windows.",
+              "type": "string"
+            },
+            "runAsGroup": {
+              "description": "The GID to run the entrypoint of the container process.\nUses runtime default if unset.\nMay also be set in SecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence\nfor that container.\nNote that this field cannot be set when spec.os.name is windows.",
+              "format": "int64",
+              "type": "integer"
+            },
+            "runAsNonRoot": {
+              "description": "Indicates that the container must run as a non-root user.\nIf true, the Kubelet will validate the image at runtime to ensure that it\ndoes not run as UID 0 (root) and fail to start the container if it does.\nIf unset or false, no such validation will be performed.\nMay also be set in SecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.",
+              "type": "boolean"
+            },
+            "runAsUser": {
+              "description": "The UID to run the entrypoint of the container process.\nDefaults to user specified in image metadata if unspecified.\nMay also be set in SecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence\nfor that container.\nNote that this field cannot be set when spec.os.name is windows.",
+              "format": "int64",
+              "type": "integer"
+            },
+            "seLinuxChangePolicy": {
+              "description": "seLinuxChangePolicy defines how the container's SELinux label is applied to all volumes used by the Pod.\nIt has no effect on nodes that do not support SELinux or to volumes does not support SELinux.\nValid values are \"MountOption\" and \"Recursive\".\n\n\"Recursive\" means relabeling of all files on all Pod volumes by the container runtime.\nThis may be slow for large volumes, but allows mixing privileged and unprivileged Pods sharing the same volume on the same node.\n\n\"MountOption\" mounts all eligible Pod volumes with `-o context` mount option.\nThis requires all Pods that share the same volume to use the same SELinux label.\nIt is not possible to share the same volume among privileged and unprivileged Pods.\nEligible volumes are in-tree FibreChannel and iSCSI volumes, and all CSI volumes\nwhose CSI driver announces SELinux support by setting spec.seLinuxMount: true in their\nCSIDriver instance. Other volumes are always re-labelled recursively.\n\"MountOption\" value is allowed only when SELinuxMount feature gate is enabled.\n\nIf not specified and SELinuxMount feature gate is enabled, \"MountOption\" is used.\nIf not specified and SELinuxMount feature gate is disabled, \"MountOption\" is used for ReadWriteOncePod volumes\nand \"Recursive\" for all other volumes.\n\nThis field affects only Pods that have SELinux label set, either in PodSecurityContext or in SecurityContext of all containers.\n\nAll Pods that use the same volume should use the same seLinuxChangePolicy, otherwise some pods can get stuck in ContainerCreating state.\nNote that this field cannot be set when spec.os.name is windows.",
+              "type": "string"
+            },
+            "seLinuxOptions": {
+              "description": "The SELinux context to be applied to all containers.\nIf unspecified, the container runtime will allocate a random SELinux context for each\ncontainer.  May also be set in SecurityContext.  If set in\nboth SecurityContext and PodSecurityContext, the value specified in SecurityContext\ntakes precedence for that container.\nNote that this field cannot be set when spec.os.name is windows.",
+              "properties": {
+                "level": {
+                  "description": "Level is SELinux level label that applies to the container.",
+                  "type": "string"
+                },
+                "role": {
+                  "description": "Role is a SELinux role label that applies to the container.",
+                  "type": "string"
+                },
+                "type": {
+                  "description": "Type is a SELinux type label that applies to the container.",
+                  "type": "string"
+                },
+                "user": {
+                  "description": "User is a SELinux user label that applies to the container.",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "seccompProfile": {
+              "description": "The seccomp options to use by the containers in this pod.\nNote that this field cannot be set when spec.os.name is windows.",
+              "properties": {
+                "localhostProfile": {
+                  "description": "localhostProfile indicates a profile defined in a file on the node should be used.\nThe profile must be preconfigured on the node to work.\nMust be a descending path, relative to the kubelet's configured seccomp profile location.\nMust be set if type is \"Localhost\". Must NOT be set for any other type.",
+                  "type": "string"
+                },
+                "type": {
+                  "description": "type indicates which kind of seccomp profile will be applied.\nValid options are:\n\nLocalhost - a profile defined in a file on the node should be used.\nRuntimeDefault - the container runtime default profile should be used.\nUnconfined - no profile should be applied.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "supplementalGroups": {
+              "description": "A list of groups applied to the first process run in each container, in\naddition to the container's primary GID and fsGroup (if specified).  If\nthe SupplementalGroupsPolicy feature is enabled, the\nsupplementalGroupsPolicy field determines whether these are in addition\nto or instead of any group memberships defined in the container image.\nIf unspecified, no additional groups are added, though group memberships\ndefined in the container image may still be used, depending on the\nsupplementalGroupsPolicy field.\nNote that this field cannot be set when spec.os.name is windows.",
+              "items": {
+                "format": "int64",
+                "type": "integer"
+              },
+              "type": "array",
+              "x-kubernetes-list-type": "atomic"
+            },
+            "supplementalGroupsPolicy": {
+              "description": "Defines how supplemental groups of the first container processes are calculated.\nValid values are \"Merge\" and \"Strict\". If not specified, \"Merge\" is used.\n(Alpha) Using the field requires the SupplementalGroupsPolicy feature gate to be enabled\nand the container runtime must implement support for this feature.\nNote that this field cannot be set when spec.os.name is windows.",
+              "type": "string"
+            },
+            "sysctls": {
+              "description": "Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported\nsysctls (by the container runtime) might fail to launch.\nNote that this field cannot be set when spec.os.name is windows.",
+              "items": {
+                "description": "Sysctl defines a kernel parameter to be set",
+                "properties": {
+                  "name": {
+                    "description": "Name of a property to set",
+                    "type": "string"
+                  },
+                  "value": {
+                    "description": "Value of a property to set",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name",
+                  "value"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array",
+              "x-kubernetes-list-type": "atomic"
+            },
+            "windowsOptions": {
+              "description": "The Windows specific settings applied to all containers.\nIf unspecified, the options within a container's SecurityContext will be used.\nIf set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is linux.",
+              "properties": {
+                "gmsaCredentialSpec": {
+                  "description": "GMSACredentialSpec is where the GMSA admission webhook\n(https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the\nGMSA credential spec named by the GMSACredentialSpecName field.",
+                  "type": "string"
+                },
+                "gmsaCredentialSpecName": {
+                  "description": "GMSACredentialSpecName is the name of the GMSA credential spec to use.",
+                  "type": "string"
+                },
+                "hostProcess": {
+                  "description": "HostProcess determines if a container should be run as a 'Host Process' container.\nAll of a Pod's containers must have the same effective HostProcess value\n(it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).\nIn addition, if HostProcess is true then HostNetwork must also be set to true.",
+                  "type": "boolean"
+                },
+                "runAsUserName": {
+                  "description": "The UserName in Windows to run the entrypoint of the container process.\nDefaults to the user specified in image metadata if unspecified.\nMay also be set in PodSecurityContext. If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
         "priorityClassName": {
           "description": "Optional: Set priorityClassName",
           "type": "string"
@@ -644,6 +815,10 @@
           "type": "object",
           "additionalProperties": false
         },
+        "secretEnv": {
+          "description": "Optional: SecretEnv represents the name of the Kubernetes Secret with secret environment variables for the NVIDIA Driver",
+          "type": "string"
+        },
         "startupProbe": {
           "description": "NVIDIA Driver container startup probe settings",
           "properties": {
@@ -694,7 +869,7 @@
                 "type": "string"
               },
               "operator": {
-                "description": "Operator represents a key's relationship to the value.\nValid operators are Exists and Equal. Defaults to Equal.\nExists is equivalent to wildcard for value, so that a pod can\ntolerate all taints of a particular category.",
+                "description": "Operator represents a key's relationship to the value.\nValid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.\nExists is equivalent to wildcard for value, so that a pod can\ntolerate all taints of a particular category.\nLt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).",
                 "type": "string"
               },
               "tolerationSeconds": {
@@ -713,7 +888,7 @@
           "type": "array"
         },
         "useOpenKernelModules": {
-          "description": "UseOpenKernelModules indicates if the open GPU kernel modules should be used",
+          "description": "Deprecated: This field is no longer honored by the gpu-operator. Please use KernelModuleType instead.\nUseOpenKernelModules indicates if the open GPU kernel modules should be used",
           "type": "boolean"
         },
         "usePrecompiled": {
@@ -817,7 +992,8 @@
           "enum": [
             "ignored",
             "ready",
-            "notReady"
+            "notReady",
+            "disabled"
           ],
           "type": "string"
         }


### PR DESCRIPTION
Generated with openapi2jsonschema.py against the CRD yaml files.

## PR Checklist
- [ ] I generated these CRs using the [CRD Extractor tool](https://github.com/datreeio/CRDs-catalog?tab=readme-ov-file#crd-extractor). If I used a different method, I have described the method in this PR.
- [X] I am updating existing schemas and have specified the updated schema version.
- [ ] I am adding new schemas and included a link to the GitHub repository that contains the source of these schemas.
