### PR TITLE
chore(CAPOSC): Update CRD schemas: add fGPU support, subregionMode (v1.5.0)

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -71,6 +71,19 @@ acme.cert-manager.io:
     filename: acme.cert-manager.io/order_v1.json
     kind: Order
     name: order_v1
+acmpca.services.k8s.aws:
+  - apiVersion: acmpca.services.k8s.aws/v1alpha1
+    filename: acmpca.services.k8s.aws/certificate_v1alpha1.json
+    kind: Certificate
+    name: certificate_v1alpha1
+  - apiVersion: acmpca.services.k8s.aws/v1alpha1
+    filename: acmpca.services.k8s.aws/certificateauthorityactivation_v1alpha1.json
+    kind: CertificateAuthorityActivation
+    name: certificateauthorityactivation_v1alpha1
+  - apiVersion: acmpca.services.k8s.aws/v1alpha1
+    filename: acmpca.services.k8s.aws/certificateauthority_v1alpha1.json
+    kind: CertificateAuthority
+    name: certificateauthority_v1alpha1
 actions.github.com:
   - apiVersion: actions.github.com/v1alpha1
     filename: actions.github.com/ephemeralrunner_v1alpha1.json
@@ -109,6 +122,23 @@ actions.summerwind.dev:
     filename: actions.summerwind.dev/horizontalrunnerautoscaler_v1alpha1.json
     kind: HorizontalRunnerAutoscaler
     name: horizontalrunnerautoscaler_v1alpha1
+addon.open-cluster-management.io:
+  - apiVersion: addon.open-cluster-management.io/v1alpha1
+    filename: addon.open-cluster-management.io/addontemplate_v1alpha1.json
+    kind: AddOnTemplate
+    name: addontemplate_v1alpha1
+  - apiVersion: addon.open-cluster-management.io/v1alpha1
+    filename: addon.open-cluster-management.io/clustermanagementaddon_v1alpha1.json
+    kind: ClusterManagementAddOn
+    name: clustermanagementaddon_v1alpha1
+  - apiVersion: addon.open-cluster-management.io/v1alpha1
+    filename: addon.open-cluster-management.io/managedclusteraddon_v1alpha1.json
+    kind: ManagedClusterAddOn
+    name: managedclusteraddon_v1alpha1
+  - apiVersion: addon.open-cluster-management.io/v1alpha1
+    filename: addon.open-cluster-management.io/addondeploymentconfig_v1alpha1.json
+    kind: AddOnDeploymentConfig
+    name: addondeploymentconfig_v1alpha1
 addons.cluster.x-k8s.io:
   - apiVersion: addons.cluster.x-k8s.io/v1alpha4
     filename: addons.cluster.x-k8s.io/clusterresourceset_v1alpha4.json
@@ -134,11 +164,95 @@ addons.cluster.x-k8s.io:
     filename: addons.cluster.x-k8s.io/clusterresourceset_v1alpha3.json
     kind: ClusterResourceSet
     name: clusterresourceset_v1alpha3
+  - apiVersion: addons.cluster.x-k8s.io/v1alpha1
+    filename: addons.cluster.x-k8s.io/helmchartproxy_v1alpha1.json
+    kind: HelmChartProxy
+    name: helmchartproxy_v1alpha1
+  - apiVersion: addons.cluster.x-k8s.io/v1beta2
+    filename: addons.cluster.x-k8s.io/clusterresourcesetbinding_v1beta2.json
+    kind: ClusterResourceSetBinding
+    name: clusterresourcesetbinding_v1beta2
+  - apiVersion: addons.cluster.x-k8s.io/v1beta2
+    filename: addons.cluster.x-k8s.io/clusterresourceset_v1beta2.json
+    kind: ClusterResourceSet
+    name: clusterresourceset_v1beta2
+  - apiVersion: addons.cluster.x-k8s.io/v1alpha1
+    filename: addons.cluster.x-k8s.io/helmreleaseproxy_v1alpha1.json
+    kind: HelmReleaseProxy
+    name: helmreleaseproxy_v1alpha1
+aga.k8s.aws:
+  - apiVersion: aga.k8s.aws/v1beta1
+    filename: aga.k8s.aws/globalaccelerator_v1beta1.json
+    kind: GlobalAccelerator
+    name: globalaccelerator_v1beta1
 agent.k8s.elastic.co:
   - apiVersion: agent.k8s.elastic.co/v1alpha1
     filename: agent.k8s.elastic.co/agent_v1alpha1.json
     kind: Agent
     name: agent_v1alpha1
+agentgateway.dev:
+  - apiVersion: agentgateway.dev/v1alpha1
+    filename: agentgateway.dev/agentgatewayparameters_v1alpha1.json
+    kind: agentgatewayparameters
+    name: agentgatewayparameters_v1alpha1
+  - apiVersion: agentgateway.dev/v1alpha1
+    filename: agentgateway.dev/agentgatewaypolicy_v1alpha1.json
+    kind: agentgatewaypolicy
+    name: agentgatewaypolicy_v1alpha1
+  - apiVersion: agentgateway.dev/v1alpha1
+    filename: agentgateway.dev/agentgatewaybackend_v1alpha1.json
+    kind: agentgatewaybackend
+    name: agentgatewaybackend_v1alpha1
+aigateway.envoyproxy.io:
+  - apiVersion: aigateway.envoyproxy.io/v1beta1
+    filename: aigateway.envoyproxy.io/gatewayconfig_v1beta1.json
+    kind: GatewayConfig
+    name: gatewayconfig_v1beta1
+  - apiVersion: aigateway.envoyproxy.io/v1beta1
+    filename: aigateway.envoyproxy.io/aiservicebackend_v1beta1.json
+    kind: AIServiceBackend
+    name: aiservicebackend_v1beta1
+  - apiVersion: aigateway.envoyproxy.io/v1alpha1
+    filename: aigateway.envoyproxy.io/aiservicebackend_v1alpha1.json
+    kind: AIServiceBackend
+    name: aiservicebackend_v1alpha1
+  - apiVersion: aigateway.envoyproxy.io/v1alpha1
+    filename: aigateway.envoyproxy.io/quotapolicy_v1alpha1.json
+    kind: QuotaPolicy
+    name: quotapolicy_v1alpha1
+  - apiVersion: aigateway.envoyproxy.io/v1alpha1
+    filename: aigateway.envoyproxy.io/backendsecuritypolicy_v1alpha1.json
+    kind: BackendSecurityPolicy
+    name: backendsecuritypolicy_v1alpha1
+  - apiVersion: aigateway.envoyproxy.io/v1beta1
+    filename: aigateway.envoyproxy.io/backendsecuritypolicy_v1beta1.json
+    kind: BackendSecurityPolicy
+    name: backendsecuritypolicy_v1beta1
+  - apiVersion: aigateway.envoyproxy.io/v1alpha1
+    filename: aigateway.envoyproxy.io/gatewayconfig_v1alpha1.json
+    kind: GatewayConfig
+    name: gatewayconfig_v1alpha1
+  - apiVersion: aigateway.envoyproxy.io/v1beta1
+    filename: aigateway.envoyproxy.io/aigatewayroute_v1beta1.json
+    kind: AIGatewayRoute
+    name: aigatewayroute_v1beta1
+  - apiVersion: aigateway.envoyproxy.io/v1alpha1
+    filename: aigateway.envoyproxy.io/mcproute_v1alpha1.json
+    kind: MCPRoute
+    name: mcproute_v1alpha1
+  - apiVersion: aigateway.envoyproxy.io/v1beta1
+    filename: aigateway.envoyproxy.io/mcproute_v1beta1.json
+    kind: MCPRoute
+    name: mcproute_v1beta1
+  - apiVersion: aigateway.envoyproxy.io/v1alpha1
+    filename: aigateway.envoyproxy.io/aigatewayroute_v1alpha1.json
+    kind: AIGatewayRoute
+    name: aigatewayroute_v1alpha1
+ais.nvidia.com:
+  - apiVersion: ais.nvidia.com/v1beta1
+    filename: ais.nvidia.com/aistore_v1beta1.json
+    kind: AIStore
+    name: aistore_v1beta1
 aiven.io:
   - apiVersion: aiven.io/v1alpha1
     filename: aiven.io/clickhouseuser_v1alpha1.json
@@ -236,6 +350,15 @@ aiven.io:
     filename: aiven.io/postgresql_v1alpha1.json
     kind: PostgreSQL
     name: postgresql_v1alpha1
+akri.sh:
+  - apiVersion: akri.sh/v0
+    filename: akri.sh/configuration_v0.json
+    kind: configuration
+    name: configuration_v0
+  - apiVersion: akri.sh/v0
+    filename: akri.sh/instance_v0.json
+    kind: Instance
+    name: instance_v0
 alerting.grafana.crossplane.io:
   - apiVersion: alerting.grafana.crossplane.io/v1alpha1
     filename: alerting.grafana.crossplane.io/messagetemplate_v1alpha1.json
@@ -257,6 +380,68 @@ alerting.grafana.crossplane.io:
     filename: alerting.grafana.crossplane.io/mutetiming_v1alpha1.json
     kind: MuteTiming
     name: mutetiming_v1alpha1
+  - apiVersion: alerting.grafana.crossplane.io/v1alpha1
+    filename: alerting.grafana.crossplane.io/inhibitionrulev1beta1_v1alpha1.json
+    kind: InhibitionruleV1Beta1
+    name: inhibitionrulev1beta1_v1alpha1
+  - apiVersion: alerting.grafana.crossplane.io/v1alpha1
+    filename: alerting.grafana.crossplane.io/alertrulev0alpha1_v1alpha1.json
+    kind: AlertruleV0Alpha1
+    name: alertrulev0alpha1_v1alpha1
+  - apiVersion: alerting.grafana.crossplane.io/v1alpha1
+    filename: alerting.grafana.crossplane.io/alertenrichmentv1beta1_v1alpha1.json
+    kind: AlertenrichmentV1Beta1
+    name: alertenrichmentv1beta1_v1alpha1
+  - apiVersion: alerting.grafana.crossplane.io/v1alpha1
+    filename: alerting.grafana.crossplane.io/recordingrulev0alpha1_v1alpha1.json
+    kind: RecordingruleV0Alpha1
+    name: recordingrulev0alpha1_v1alpha1
+alerting.grafana.m.crossplane.io:
+  - apiVersion: alerting.grafana.m.crossplane.io/v1alpha1
+    filename: alerting.grafana.m.crossplane.io/inhibitionrulev1beta1_v1alpha1.json
+    kind: InhibitionruleV1Beta1
+    name: inhibitionrulev1beta1_v1alpha1
+  - apiVersion: alerting.grafana.m.crossplane.io/v1alpha1
+    filename: alerting.grafana.m.crossplane.io/mutetiming_v1alpha1.json
+    kind: MuteTiming
+    name: mutetiming_v1alpha1
+  - apiVersion: alerting.grafana.m.crossplane.io/v1alpha1
+    filename: alerting.grafana.m.crossplane.io/alertrulev0alpha1_v1alpha1.json
+    kind: AlertruleV0Alpha1
+    name: alertrulev0alpha1_v1alpha1
+  - apiVersion: alerting.grafana.m.crossplane.io/v1alpha1
+    filename: alerting.grafana.m.crossplane.io/notificationpolicy_v1alpha1.json
+    kind: NotificationPolicy
+    name: notificationpolicy_v1alpha1
+  - apiVersion: alerting.grafana.m.crossplane.io/v1alpha1
+    filename: alerting.grafana.m.crossplane.io/contactpoint_v1alpha1.json
+    kind: ContactPoint
+    name: contactpoint_v1alpha1
+  - apiVersion: alerting.grafana.m.crossplane.io/v1alpha1
+    filename: alerting.grafana.m.crossplane.io/messagetemplate_v1alpha1.json
+    kind: MessageTemplate
+    name: messagetemplate_v1alpha1
+  - apiVersion: alerting.grafana.m.crossplane.io/v1alpha1
+    filename: alerting.grafana.m.crossplane.io/alertenrichmentv1beta1_v1alpha1.json
+    kind: AlertenrichmentV1Beta1
+    name: alertenrichmentv1beta1_v1alpha1
+  - apiVersion: alerting.grafana.m.crossplane.io/v1alpha1
+    filename: alerting.grafana.m.crossplane.io/rulegroup_v1alpha1.json
+    kind: RuleGroup
+    name: rulegroup_v1alpha1
+  - apiVersion: alerting.grafana.m.crossplane.io/v1alpha1
+    filename: alerting.grafana.m.crossplane.io/recordingrulev0alpha1_v1alpha1.json
+    kind: RecordingruleV0Alpha1
+    name: recordingrulev0alpha1_v1alpha1
+alertsmanagement.azure.com:
+  - apiVersion: alertsmanagement.azure.com/v1api20230301
+    filename: alertsmanagement.azure.com/prometheusrulegroup_v1api20230301.json
+    kind: PrometheusRuleGroup
+    name: prometheusrulegroup_v1api20230301
+  - apiVersion: alertsmanagement.azure.com/v1api20210401
+    filename: alertsmanagement.azure.com/smartdetectoralertrule_v1api20210401.json
+    kind: SmartDetectorAlertRule
+    name: smartdetectoralertrule_v1api20210401
 alloydb.cnrm.cloud.google.com:
   - apiVersion: alloydb.cnrm.cloud.google.com/v1beta1
     filename: alloydb.cnrm.cloud.google.com/alloydbuser_v1beta1.json
@@ -508,6 +693,18 @@ apiextensions.crossplane.io:
     filename: apiextensions.crossplane.io/compositionrevision_v1beta1.json
     kind: CompositionRevision
     name: compositionrevision_v1beta1
+  - apiVersion: apiextensions.crossplane.io/v1alpha1
+    filename: apiextensions.crossplane.io/managedresourcedefinition_v1alpha1.json
+    kind: ManagedResourceDefinition
+    name: managedresourcedefinition_v1alpha1
+  - apiVersion: apiextensions.crossplane.io/v2
+    filename: apiextensions.crossplane.io/compositeresourcedefinition_v2.json
+    kind: CompositeResourceDefinition
+    name: compositeresourcedefinition_v2
+  - apiVersion: apiextensions.crossplane.io/v1alpha1
+    filename: apiextensions.crossplane.io/managedresourceactivationpolicy_v1alpha1.json
+    kind: ManagedResourceActivationPolicy
+    name: managedresourceactivationpolicy_v1alpha1
 apigateway.cnrm.cloud.google.com:
   - apiVersion: apigateway.cnrm.cloud.google.com/v1alpha1
     filename: apigateway.cnrm.cloud.google.com/apigatewayapiconfig_v1alpha1.json
@@ -521,6 +718,10 @@ apigateway.cnrm.cloud.google.com:
     filename: apigateway.cnrm.cloud.google.com/apigatewayapi_v1alpha1.json
     kind: apigatewayapi
     name: apigatewayapi_v1alpha1
+  - apiVersion: apigateway.cnrm.cloud.google.com/v1beta1
+    filename: apigateway.cnrm.cloud.google.com/apigatewayapi_v1beta1.json
+    kind: APIGatewayAPI
+    name: apigatewayapi_v1beta1
 apigatewayv2.services.k8s.aws:
   - apiVersion: apigatewayv2.services.k8s.aws/v1alpha1
     filename: apigatewayv2.services.k8s.aws/deployment_v1alpha1.json
@@ -591,11 +792,144 @@ apigee.cnrm.cloud.google.com:
     filename: apigee.cnrm.cloud.google.com/apigeeenvgroupattachment_v1alpha1.json
     kind: apigeeenvgroupattachment
     name: apigeeenvgroupattachment_v1alpha1
+  - apiVersion: apigee.cnrm.cloud.google.com/v1beta1
+    filename: apigee.cnrm.cloud.google.com/apigeeenvgroup_v1beta1.json
+    kind: ApigeeEnvgroup
+    name: apigeeenvgroup_v1beta1
+  - apiVersion: apigee.cnrm.cloud.google.com/v1beta1
+    filename: apigee.cnrm.cloud.google.com/apigeeendpointattachment_v1beta1.json
+    kind: ApigeeEndpointAttachment
+    name: apigeeendpointattachment_v1beta1
+  - apiVersion: apigee.cnrm.cloud.google.com/v1beta1
+    filename: apigee.cnrm.cloud.google.com/apigeeinstance_v1beta1.json
+    kind: ApigeeInstance
+    name: apigeeinstance_v1beta1
+  - apiVersion: apigee.cnrm.cloud.google.com/v1beta1
+    filename: apigee.cnrm.cloud.google.com/apigeeenvgroupattachment_v1beta1.json
+    kind: ApigeeEnvgroupAttachment
+    name: apigeeenvgroupattachment_v1beta1
+  - apiVersion: apigee.cnrm.cloud.google.com/v1beta1
+    filename: apigee.cnrm.cloud.google.com/apigeeinstanceattachment_v1beta1.json
+    kind: ApigeeInstanceAttachment
+    name: apigeeinstanceattachment_v1beta1
 apikeys.cnrm.cloud.google.com:
   - apiVersion: apikeys.cnrm.cloud.google.com/v1alpha1
     filename: apikeys.cnrm.cloud.google.com/apikeyskey_v1alpha1.json
     kind: APIKeysKey
     name: apikeyskey_v1alpha1
+apimanagement.azure.com:
+  - apiVersion: apimanagement.azure.com/v1api20220801
+    filename: apimanagement.azure.com/apiversionset_v1api20220801.json
+    kind: apiversionset
+    name: apiversionset_v1api20220801
+  - apiVersion: apimanagement.azure.com/v1api20230501preview
+    filename: apimanagement.azure.com/backend_v1api20230501preview.json
+    kind: backend
+    name: backend_v1api20230501preview
+  - apiVersion: apimanagement.azure.com/v1api20230501preview
+    filename: apimanagement.azure.com/service_v1api20230501preview.json
+    kind: service
+    name: service_v1api20230501preview
+  - apiVersion: apimanagement.azure.com/v1api20220801
+    filename: apimanagement.azure.com/api_v1api20220801.json
+    kind: api
+    name: api_v1api20220801
+  - apiVersion: apimanagement.azure.com/v1api20230501preview
+    filename: apimanagement.azure.com/authorizationprovider_v1api20230501preview.json
+    kind: authorizationprovider
+    name: authorizationprovider_v1api20230501preview
+  - apiVersion: apimanagement.azure.com/v1api20220801
+    filename: apimanagement.azure.com/policy_v1api20220801.json
+    kind: policy
+    name: policy_v1api20220801
+  - apiVersion: apimanagement.azure.com/v1api20220801
+    filename: apimanagement.azure.com/authorizationprovidersauthorization_v1api20220801.json
+    kind: authorizationprovidersauthorization
+    name: authorizationprovidersauthorization_v1api20220801
+  - apiVersion: apimanagement.azure.com/v1api20230501preview
+    filename: apimanagement.azure.com/namedvalue_v1api20230501preview.json
+    kind: namedvalue
+    name: namedvalue_v1api20230501preview
+  - apiVersion: apimanagement.azure.com/v1api20220801
+    filename: apimanagement.azure.com/service_v1api20220801.json
+    kind: service
+    name: service_v1api20220801
+  - apiVersion: apimanagement.azure.com/v1api20220801
+    filename: apimanagement.azure.com/policyfragment_v1api20220801.json
+    kind: policyfragment
+    name: policyfragment_v1api20220801
+  - apiVersion: apimanagement.azure.com/v1api20230501preview
+    filename: apimanagement.azure.com/apiversionset_v1api20230501preview.json
+    kind: apiversionset
+    name: apiversionset_v1api20230501preview
+  - apiVersion: apimanagement.azure.com/v1api20230501preview
+    filename: apimanagement.azure.com/authorizationprovidersauthorization_v1api20230501preview.json
+    kind: authorizationprovidersauthorization
+    name: authorizationprovidersauthorization_v1api20230501preview
+  - apiVersion: apimanagement.azure.com/v1api20230501preview
+    filename: apimanagement.azure.com/policy_v1api20230501preview.json
+    kind: policy
+    name: policy_v1api20230501preview
+  - apiVersion: apimanagement.azure.com/v1api20230501preview
+    filename: apimanagement.azure.com/productpolicy_v1api20230501preview.json
+    kind: productpolicy
+    name: productpolicy_v1api20230501preview
+  - apiVersion: apimanagement.azure.com/v1api20220801
+    filename: apimanagement.azure.com/namedvalue_v1api20220801.json
+    kind: namedvalue
+    name: namedvalue_v1api20220801
+  - apiVersion: apimanagement.azure.com/v1api20220801
+    filename: apimanagement.azure.com/authorizationprovider_v1api20220801.json
+    kind: authorizationprovider
+    name: authorizationprovider_v1api20220801
+  - apiVersion: apimanagement.azure.com/v1api20230501preview
+    filename: apimanagement.azure.com/authorizationprovidersauthorizationsaccesspolicy_v1api20230501preview.json
+    kind: authorizationprovidersauthorizationsaccesspolicy
+    name: authorizationprovidersauthorizationsaccesspolicy_v1api20230501preview
+  - apiVersion: apimanagement.azure.com/v1api20220801
+    filename: apimanagement.azure.com/backend_v1api20220801.json
+    kind: backend
+    name: backend_v1api20220801
+  - apiVersion: apimanagement.azure.com/v1api20230501preview
+    filename: apimanagement.azure.com/subscription_v1api20230501preview.json
+    kind: subscription
+    name: subscription_v1api20230501preview
+  - apiVersion: apimanagement.azure.com/v1api20220801
+    filename: apimanagement.azure.com/subscription_v1api20220801.json
+    kind: subscription
+    name: subscription_v1api20220801
+  - apiVersion: apimanagement.azure.com/v1api20230501preview
+    filename: apimanagement.azure.com/policyfragment_v1api20230501preview.json
+    kind: policyfragment
+    name: policyfragment_v1api20230501preview
+  - apiVersion: apimanagement.azure.com/v1api20230501preview
+    filename: apimanagement.azure.com/productapi_v1api20230501preview.json
+    kind: productapi
+    name: productapi_v1api20230501preview
+  - apiVersion: apimanagement.azure.com/v1api20230501preview
+    filename: apimanagement.azure.com/product_v1api20230501preview.json
+    kind: product
+    name: product_v1api20230501preview
+  - apiVersion: apimanagement.azure.com/v1api20220801
+    filename: apimanagement.azure.com/productapi_v1api20220801.json
+    kind: productapi
+    name: productapi_v1api20220801
+  - apiVersion: apimanagement.azure.com/v1api20220801
+    filename: apimanagement.azure.com/product_v1api20220801.json
+    kind: product
+    name: product_v1api20220801
+  - apiVersion: apimanagement.azure.com/v1api20230501preview
+    filename: apimanagement.azure.com/api_v1api20230501preview.json
+    kind: api
+    name: api_v1api20230501preview
+  - apiVersion: apimanagement.azure.com/v1api20220801
+    filename: apimanagement.azure.com/productpolicy_v1api20220801.json
+    kind: productpolicy
+    name: productpolicy_v1api20220801
+  - apiVersion: apimanagement.azure.com/v1api20220801
+    filename: apimanagement.azure.com/authorizationprovidersauthorizationsaccesspolicy_v1api20220801.json
+    kind: authorizationprovidersauthorizationsaccesspolicy
+    name: authorizationprovidersauthorizationsaccesspolicy_v1api20220801
 apisix.apache.org:
   - apiVersion: apisix.apache.org/v2
     filename: apisix.apache.org/apisixroute_v2.json
@@ -649,6 +983,26 @@ apisix.apache.org:
     filename: apisix.apache.org/apisixtls_v2beta3.json
     kind: ApisixTls
     name: apisixtls_v2beta3
+  - apiVersion: apisix.apache.org/v1alpha1
+    filename: apisix.apache.org/backendtrafficpolicy_v1alpha1.json
+    kind: BackendTrafficPolicy
+    name: backendtrafficpolicy_v1alpha1
+  - apiVersion: apisix.apache.org/v1alpha1
+    filename: apisix.apache.org/gatewayproxy_v1alpha1.json
+    kind: GatewayProxy
+    name: gatewayproxy_v1alpha1
+  - apiVersion: apisix.apache.org/v1alpha1
+    filename: apisix.apache.org/pluginconfig_v1alpha1.json
+    kind: PluginConfig
+    name: pluginconfig_v1alpha1
+  - apiVersion: apisix.apache.org/v1alpha1
+    filename: apisix.apache.org/httproutepolicy_v1alpha1.json
+    kind: HTTPRoutePolicy
+    name: httproutepolicy_v1alpha1
+  - apiVersion: apisix.apache.org/v1alpha1
+    filename: apisix.apache.org/consumer_v1alpha1.json
+    kind: Consumer
+    name: consumer_v1alpha1
 apm.k8s.elastic.co:
   - apiVersion: apm.k8s.elastic.co/v1
     filename: apm.k8s.elastic.co/apmserver_v1.json
@@ -662,6 +1016,23 @@ apm.k8s.elastic.co:
     filename: apm.k8s.elastic.co/apmserver_v1alpha1.json
     kind: ApmServer
     name: apmserver_v1alpha1
+app.azure.com:
+  - apiVersion: app.azure.com/v1api20240301
+    filename: app.azure.com/job_v1api20240301.json
+    kind: Job
+    name: job_v1api20240301
+  - apiVersion: app.azure.com/v1api20240301
+    filename: app.azure.com/containerapp_v1api20240301.json
+    kind: ContainerApp
+    name: containerapp_v1api20240301
+  - apiVersion: app.azure.com/v1api20240301
+    filename: app.azure.com/authconfig_v1api20240301.json
+    kind: AuthConfig
+    name: authconfig_v1api20240301
+  - apiVersion: app.azure.com/v1api20240301
+    filename: app.azure.com/managedenvironment_v1api20240301.json
+    kind: ManagedEnvironment
+    name: managedenvironment_v1api20240301
 app.redislabs.com:
   - apiVersion: app.redislabs.com/v1alpha1
     filename: app.redislabs.com/redisenterprisecluster_v1alpha1.json
@@ -692,6 +1063,11 @@ appcat.vshn.io:
     filename: appcat.vshn.io/objectbucket_v1.json
     kind: ObjectBucket
     name: objectbucket_v1
+appconfiguration.azure.com:
+  - apiVersion: appconfiguration.azure.com/v1api20220501
+    filename: appconfiguration.azure.com/configurationstore_v1api20220501.json
+    kind: configurationStore
+    name: configurationstore_v1api20220501
 appengine.cnrm.cloud.google.com:
   - apiVersion: appengine.cnrm.cloud.google.com/v1alpha1
     filename: appengine.cnrm.cloud.google.com/appenginestandardappversion_v1alpha1.json
@@ -713,6 +1089,46 @@ appengine.cnrm.cloud.google.com:
     filename: appengine.cnrm.cloud.google.com/appenginefirewallrule_v1alpha1.json
     kind: appenginefirewallrule
     name: appenginefirewallrule_v1alpha1
+appgw.ingress.azure.io:
+  - apiVersion: appgw.ingress.azure.io/v1beta1
+    filename: appgw.ingress.azure.io/azureapplicationgatewayrewrite_v1beta1.json
+    kind: azureapplicationgatewayrewrite
+    name: azureapplicationgatewayrewrite_v1beta1
+appgw.ingress.k8s.io:
+  - apiVersion: appgw.ingress.k8s.io/v1
+    filename: appgw.ingress.k8s.io/azureingressprohibitedtarget_v1.json
+    kind: azureingressprohibitedtarget
+    name: azureingressprohibitedtarget_v1
+apphub.cnrm.cloud.google.com:
+  - apiVersion: apphub.cnrm.cloud.google.com/v1beta1
+    filename: apphub.cnrm.cloud.google.com/apphubapplication_v1beta1.json
+    kind: AppHubApplication
+    name: apphubapplication_v1beta1
+  - apiVersion: apphub.cnrm.cloud.google.com/v1alpha1
+    filename: apphub.cnrm.cloud.google.com/apphubapplication_v1alpha1.json
+    kind: AppHubApplication
+    name: apphubapplication_v1alpha1
+application-networking.k8s.aws:
+  - apiVersion: application-networking.k8s.aws/v1alpha1
+    filename: application-networking.k8s.aws/vpcassociationpolicy_v1alpha1.json
+    kind: vpcassociationpolicy
+    name: vpcassociationpolicy_v1alpha1
+  - apiVersion: application-networking.k8s.aws/v1alpha1
+    filename: application-networking.k8s.aws/accesslogpolicy_v1alpha1.json
+    kind: accesslogpolicy
+    name: accesslogpolicy_v1alpha1
+  - apiVersion: application-networking.k8s.aws/v1alpha1
+    filename: application-networking.k8s.aws/targetgrouppolicy_v1alpha1.json
+    kind: targetgrouppolicy
+    name: targetgrouppolicy_v1alpha1
+  - apiVersion: application-networking.k8s.aws/v1alpha1
+    filename: application-networking.k8s.aws/serviceimport_v1alpha1.json
+    kind: ServiceImport
+    name: serviceimport_v1alpha1
+  - apiVersion: application-networking.k8s.aws/v1alpha1
+    filename: application-networking.k8s.aws/serviceexport_v1alpha1.json
+    kind: ServiceExport
+    name: serviceexport_v1alpha1
 applicationautoscaling.services.k8s.aws:
   - apiVersion: applicationautoscaling.services.k8s.aws/v1alpha1
     filename: applicationautoscaling.services.k8s.aws/scalabletarget_v1alpha1.json
@@ -794,11 +1210,24 @@ apps.gitlab.com:
     filename: apps.gitlab.com/gitlab_v1beta1.json
     kind: GitLab
     name: gitlab_v1beta1
+  - apiVersion: apps.gitlab.com/v1beta2
+    filename: apps.gitlab.com/runner_v1beta2.json
+    kind: Runner
+    name: runner_v1beta2
 apps.jfrog.com:
   - apiVersion: apps.jfrog.com/v1alpha1
     filename: apps.jfrog.com/secretrotator_v1alpha1.json
     kind: SecretRotator
     name: secretrotator_v1alpha1
+apps.projectsveltos.io:
+  - apiVersion: apps.projectsveltos.io/v1alpha1
+    filename: apps.projectsveltos.io/report_v1alpha1.json
+    kind: Report
+    name: report_v1alpha1
+  - apiVersion: apps.projectsveltos.io/v1alpha1
+    filename: apps.projectsveltos.io/cleaner_v1alpha1.json
+    kind: Cleaner
+    name: cleaner_v1alpha1
 aquasecurity.github.io:
   - apiVersion: aquasecurity.github.io/v1alpha1
     filename: aquasecurity.github.io/clustersbomreport_v1alpha1.json
@@ -848,6 +1277,11 @@ aquasecurity.github.io:
     filename: aquasecurity.github.io/exposedsecretreport_v1alpha1.json
     kind: ExposedSecretReport
     name: exposedsecretreport_v1alpha1
+argocd-image-updater.argoproj.io:
+  - apiVersion: argocd-image-updater.argoproj.io/v1alpha1
+    filename: argocd-image-updater.argoproj.io/imageupdater_v1alpha1.json
+    kind: ImageUpdater
+    name: imageupdater_v1alpha1
 argoproj.io:
   - apiVersion: argoproj.io/v1alpha1
     filename: argoproj.io/analysisrun_v1alpha1.json
@@ -930,6 +1364,200 @@ artifactregistry.cnrm.cloud.google.com:
     filename: artifactregistry.cnrm.cloud.google.com/artifactregistryrepository_v1beta1.json
     kind: artifactregistryrepository
     name: artifactregistryrepository_v1beta1
+asserts.grafana.crossplane.io:
+  - apiVersion: asserts.grafana.crossplane.io/v1alpha1
+    filename: asserts.grafana.crossplane.io/stack_v1alpha1.json
+    kind: Stack
+    name: stack_v1alpha1
+  - apiVersion: asserts.grafana.crossplane.io/v1alpha1
+    filename: asserts.grafana.crossplane.io/notificationalertsconfig_v1alpha1.json
+    kind: NotificationAlertsConfig
+    name: notificationalertsconfig_v1alpha1
+  - apiVersion: asserts.grafana.crossplane.io/v1alpha1
+    filename: asserts.grafana.crossplane.io/custommodelrules_v1alpha1.json
+    kind: CustomModelRules
+    name: custommodelrules_v1alpha1
+  - apiVersion: asserts.grafana.crossplane.io/v1alpha1
+    filename: asserts.grafana.crossplane.io/suppressedassertionsconfig_v1alpha1.json
+    kind: SuppressedAssertionsConfig
+    name: suppressedassertionsconfig_v1alpha1
+  - apiVersion: asserts.grafana.crossplane.io/v1alpha1
+    filename: asserts.grafana.crossplane.io/traceconfig_v1alpha1.json
+    kind: TraceConfig
+    name: traceconfig_v1alpha1
+  - apiVersion: asserts.grafana.crossplane.io/v1alpha1
+    filename: asserts.grafana.crossplane.io/thresholds_v1alpha1.json
+    kind: Thresholds
+    name: thresholds_v1alpha1
+  - apiVersion: asserts.grafana.crossplane.io/v1alpha1
+    filename: asserts.grafana.crossplane.io/promrulefile_v1alpha1.json
+    kind: PromRuleFile
+    name: promrulefile_v1alpha1
+  - apiVersion: asserts.grafana.crossplane.io/v1alpha1
+    filename: asserts.grafana.crossplane.io/logconfig_v1alpha1.json
+    kind: LogConfig
+    name: logconfig_v1alpha1
+  - apiVersion: asserts.grafana.crossplane.io/v1alpha1
+    filename: asserts.grafana.crossplane.io/profileconfig_v1alpha1.json
+    kind: ProfileConfig
+    name: profileconfig_v1alpha1
+asserts.grafana.m.crossplane.io:
+  - apiVersion: asserts.grafana.m.crossplane.io/v1alpha1
+    filename: asserts.grafana.m.crossplane.io/stack_v1alpha1.json
+    kind: Stack
+    name: stack_v1alpha1
+  - apiVersion: asserts.grafana.m.crossplane.io/v1alpha1
+    filename: asserts.grafana.m.crossplane.io/notificationalertsconfig_v1alpha1.json
+    kind: NotificationAlertsConfig
+    name: notificationalertsconfig_v1alpha1
+  - apiVersion: asserts.grafana.m.crossplane.io/v1alpha1
+    filename: asserts.grafana.m.crossplane.io/custommodelrules_v1alpha1.json
+    kind: CustomModelRules
+    name: custommodelrules_v1alpha1
+  - apiVersion: asserts.grafana.m.crossplane.io/v1alpha1
+    filename: asserts.grafana.m.crossplane.io/suppressedassertionsconfig_v1alpha1.json
+    kind: SuppressedAssertionsConfig
+    name: suppressedassertionsconfig_v1alpha1
+  - apiVersion: asserts.grafana.m.crossplane.io/v1alpha1
+    filename: asserts.grafana.m.crossplane.io/traceconfig_v1alpha1.json
+    kind: TraceConfig
+    name: traceconfig_v1alpha1
+  - apiVersion: asserts.grafana.m.crossplane.io/v1alpha1
+    filename: asserts.grafana.m.crossplane.io/thresholds_v1alpha1.json
+    kind: Thresholds
+    name: thresholds_v1alpha1
+  - apiVersion: asserts.grafana.m.crossplane.io/v1alpha1
+    filename: asserts.grafana.m.crossplane.io/promrulefile_v1alpha1.json
+    kind: PromRuleFile
+    name: promrulefile_v1alpha1
+  - apiVersion: asserts.grafana.m.crossplane.io/v1alpha1
+    filename: asserts.grafana.m.crossplane.io/logconfig_v1alpha1.json
+    kind: LogConfig
+    name: logconfig_v1alpha1
+  - apiVersion: asserts.grafana.m.crossplane.io/v1alpha1
+    filename: asserts.grafana.m.crossplane.io/profileconfig_v1alpha1.json
+    kind: ProfileConfig
+    name: profileconfig_v1alpha1
+asset.cnrm.cloud.google.com:
+  - apiVersion: asset.cnrm.cloud.google.com/v1beta1
+    filename: asset.cnrm.cloud.google.com/assetsavedquery_v1beta1.json
+    kind: AssetSavedQuery
+    name: assetsavedquery_v1beta1
+  - apiVersion: asset.cnrm.cloud.google.com/v1beta1
+    filename: asset.cnrm.cloud.google.com/assetfeed_v1beta1.json
+    kind: AssetFeed
+    name: assetfeed_v1beta1
+  - apiVersion: asset.cnrm.cloud.google.com/v1alpha1
+    filename: asset.cnrm.cloud.google.com/assetsavedquery_v1alpha1.json
+    kind: AssetSavedQuery
+    name: assetsavedquery_v1alpha1
+  - apiVersion: asset.cnrm.cloud.google.com/v1alpha1
+    filename: asset.cnrm.cloud.google.com/assetfeed_v1alpha1.json
+    kind: AssetFeed
+    name: assetfeed_v1alpha1
+atlas.generated.mongodb.com:
+  - apiVersion: atlas.generated.mongodb.com/v1
+    filename: atlas.generated.mongodb.com/group_v1.json
+    kind: group
+    name: group_v1
+  - apiVersion: atlas.generated.mongodb.com/v1
+    filename: atlas.generated.mongodb.com/cluster_v1.json
+    kind: cluster
+    name: cluster_v1
+  - apiVersion: atlas.generated.mongodb.com/v1
+    filename: atlas.generated.mongodb.com/flexcluster_v1.json
+    kind: flexcluster
+    name: flexcluster_v1
+  - apiVersion: atlas.generated.mongodb.com/v1
+    filename: atlas.generated.mongodb.com/ipaccesslistentry_v1.json
+    kind: ipaccesslistentry
+    name: ipaccesslistentry_v1
+  - apiVersion: atlas.generated.mongodb.com/v1
+    filename: atlas.generated.mongodb.com/databaseuser_v1.json
+    kind: databaseuser
+    name: databaseuser_v1
+atlas.mongodb.com:
+  - apiVersion: atlas.mongodb.com/v1
+    filename: atlas.mongodb.com/atlasteam_v1.json
+    kind: AtlasTeam
+    name: atlasteam_v1
+  - apiVersion: atlas.mongodb.com/v1
+    filename: atlas.mongodb.com/atlasnetworkcontainer_v1.json
+    kind: AtlasNetworkContainer
+    name: atlasnetworkcontainer_v1
+  - apiVersion: atlas.mongodb.com/v1
+    filename: atlas.mongodb.com/atlasdatafederation_v1.json
+    kind: AtlasDataFederation
+    name: atlasdatafederation_v1
+  - apiVersion: atlas.mongodb.com/v1
+    filename: atlas.mongodb.com/atlasdatabaseuser_v1.json
+    kind: AtlasDatabaseUser
+    name: atlasdatabaseuser_v1
+  - apiVersion: atlas.mongodb.com/v1
+    filename: atlas.mongodb.com/atlasbackupcompliancepolicy_v1.json
+    kind: AtlasBackupCompliancePolicy
+    name: atlasbackupcompliancepolicy_v1
+  - apiVersion: atlas.mongodb.com/v1
+    filename: atlas.mongodb.com/atlasprivateendpoint_v1.json
+    kind: AtlasPrivateEndpoint
+    name: atlasprivateendpoint_v1
+  - apiVersion: atlas.mongodb.com/v1
+    filename: atlas.mongodb.com/atlascustomrole_v1.json
+    kind: AtlasCustomRole
+    name: atlascustomrole_v1
+  - apiVersion: atlas.mongodb.com/v1
+    filename: atlas.mongodb.com/atlasnetworkpeering_v1.json
+    kind: AtlasNetworkPeering
+    name: atlasnetworkpeering_v1
+  - apiVersion: atlas.mongodb.com/v1
+    filename: atlas.mongodb.com/atlasdeployment_v1.json
+    kind: AtlasDeployment
+    name: atlasdeployment_v1
+  - apiVersion: atlas.mongodb.com/v1
+    filename: atlas.mongodb.com/atlasfederatedauth_v1.json
+    kind: AtlasFederatedAuth
+    name: atlasfederatedauth_v1
+  - apiVersion: atlas.mongodb.com/v1
+    filename: atlas.mongodb.com/atlasbackuppolicy_v1.json
+    kind: AtlasBackupPolicy
+    name: atlasbackuppolicy_v1
+  - apiVersion: atlas.mongodb.com/v1
+    filename: atlas.mongodb.com/atlasthirdpartyintegration_v1.json
+    kind: AtlasThirdPartyIntegration
+    name: atlasthirdpartyintegration_v1
+  - apiVersion: atlas.mongodb.com/v1
+    filename: atlas.mongodb.com/atlasbackupschedule_v1.json
+    kind: AtlasBackupSchedule
+    name: atlasbackupschedule_v1
+  - apiVersion: atlas.mongodb.com/v1
+    filename: atlas.mongodb.com/atlasstreaminstance_v1.json
+    kind: AtlasStreamInstance
+    name: atlasstreaminstance_v1
+  - apiVersion: atlas.mongodb.com/v1
+    filename: atlas.mongodb.com/atlasproject_v1.json
+    kind: AtlasProject
+    name: atlasproject_v1
+  - apiVersion: atlas.mongodb.com/v1
+    filename: atlas.mongodb.com/atlasorgsettings_v1.json
+    kind: atlasorgsettings
+    name: atlasorgsettings_v1
+  - apiVersion: atlas.mongodb.com/v1
+    filename: atlas.mongodb.com/atlassearchindexconfig_v1.json
+    kind: AtlasSearchIndexConfig
+    name: atlassearchindexconfig_v1
+  - apiVersion: atlas.mongodb.com/v1
+    filename: atlas.mongodb.com/atlasstreamconnection_v1.json
+    kind: AtlasStreamConnection
+    name: atlasstreamconnection_v1
+  - apiVersion: atlas.mongodb.com/v1
+    filename: atlas.mongodb.com/atlasipaccesslist_v1.json
+    kind: AtlasIPAccessList
+    name: atlasipaccesslist_v1
+auditlog.cattle.io:
+  - apiVersion: auditlog.cattle.io/v1
+    filename: auditlog.cattle.io/auditpolicy_v1.json
+    kind: auditpolicy
+    name: auditpolicy_v1
 authentication.concierge.pinniped.dev:
   - apiVersion: authentication.concierge.pinniped.dev/v1alpha1
     filename: authentication.concierge.pinniped.dev/jwtauthenticator_v1alpha1.json
@@ -939,6 +1567,24 @@ authentication.concierge.pinniped.dev:
     filename: authentication.concierge.pinniped.dev/webhookauthenticator_v1alpha1.json
     kind: WebhookAuthenticator
     name: webhookauthenticator_v1alpha1
+authorization.azure.com:
+  - apiVersion: authorization.azure.com/v1api20220401
+    filename: authorization.azure.com/roleassignment_v1api20220401.json
+    kind: RoleAssignment
+    name: roleassignment_v1api20220401
+  - apiVersion: authorization.azure.com/v1api20200801preview
+    filename: authorization.azure.com/roleassignment_v1api20200801preview.json
+    kind: RoleAssignment
+    name: roleassignment_v1api20200801preview
+  - apiVersion: authorization.azure.com/v1api20220401
+    filename: authorization.azure.com/roledefinition_v1api20220401.json
+    kind: RoleDefinition
+    name: roledefinition_v1api20220401
+authzed.com:
+  - apiVersion: authzed.com/v1alpha1
+    filename: authzed.com/spicedbcluster_v1alpha1.json
+    kind: SpiceDBCluster
+    name: spicedbcluster_v1alpha1
 autopilot.k0sproject.io:
   - apiVersion: autopilot.k0sproject.io/v1beta2
     filename: autopilot.k0sproject.io/updateconfig_v1beta2.json
@@ -952,6 +1598,20 @@ autopilot.k0sproject.io:
     filename: autopilot.k0sproject.io/plan_v1beta2.json
     kind: Plan
     name: plan_v1beta2
+autoscaling.cast.ai:
+  - apiVersion: autoscaling.cast.ai/v1
+    filename: autoscaling.cast.ai/recommendations_v1.json
+    kind: recommendations
+    name: recommendations_v1
+autoscaling.internal.knative.dev:
+  - apiVersion: autoscaling.internal.knative.dev/v1alpha1
+    filename: autoscaling.internal.knative.dev/metric_v1alpha1.json
+    kind: Metric
+    name: metric_v1alpha1
+  - apiVersion: autoscaling.internal.knative.dev/v1alpha1
+    filename: autoscaling.internal.knative.dev/podautoscaler_v1alpha1.json
+    kind: PodAutoscaler
+    name: podautoscaler_v1alpha1
 autoscaling.k8s.elastic.co:
   - apiVersion: autoscaling.k8s.elastic.co/v1alpha1
     filename: autoscaling.k8s.elastic.co/elasticsearchautoscaler_v1alpha1.json
@@ -974,6 +1634,28 @@ autoscaling.k8s.io:
     filename: autoscaling.k8s.io/verticalpodautoscalercheckpoint_v1.json
     kind: VerticalPodAutoscalerCheckpoint
     name: verticalpodautoscalercheckpoint_v1
+aws.m.upbound.io:
+  - apiVersion: aws.m.upbound.io/v1beta1
+    filename: aws.m.upbound.io/providerconfig_v1beta1.json
+    kind: ProviderConfig
+    name: providerconfig_v1beta1
+  - apiVersion: aws.m.upbound.io/v1beta1
+    filename: aws.m.upbound.io/providerconfigusage_v1beta1.json
+    kind: ProviderConfigUsage
+    name: providerconfigusage_v1beta1
+  - apiVersion: aws.m.upbound.io/v1beta1
+    filename: aws.m.upbound.io/clusterproviderconfig_v1beta1.json
+    kind: ClusterProviderConfig
+    name: clusterproviderconfig_v1beta1
+aws.upbound.io:
+  - apiVersion: aws.upbound.io/v1beta1
+    filename: aws.upbound.io/providerconfig_v1beta1.json
+    kind: ProviderConfig
+    name: providerconfig_v1beta1
+  - apiVersion: aws.upbound.io/v1beta1
+    filename: aws.upbound.io/providerconfigusage_v1beta1.json
+    kind: ProviderConfigUsage
+    name: providerconfigusage_v1beta1
 awspca.cert-manager.io:
   - apiVersion: awspca.cert-manager.io/v1beta1
     filename: awspca.cert-manager.io/awspcaissuer_v1beta1.json
@@ -1026,6 +1708,11 @@ azmonitoring.coreos.com:
     filename: azmonitoring.coreos.com/podmonitor_v1.json
     kind: podmonitor
     name: podmonitor_v1
+azure.upbound.io:
+  - apiVersion: azure.upbound.io/v1beta1
+    filename: azure.upbound.io/providerconfig_v1beta1.json
+    kind: ProviderConfig
+    name: providerconfig_v1beta1
 azureprovider.k8s.io:
   - apiVersion: azureprovider.k8s.io/v1alpha1
     filename: azureprovider.k8s.io/azuremachineproviderstatus_v1alpha1.json
@@ -1043,6 +1730,41 @@ azureprovider.k8s.io:
     filename: azureprovider.k8s.io/azureclusterproviderspec_v1alpha1.json
     kind: azureclusterproviderspec
     name: azureclusterproviderspec_v1alpha1
+backupdr.cnrm.cloud.google.com:
+  - apiVersion: backupdr.cnrm.cloud.google.com/v1alpha1
+    filename: backupdr.cnrm.cloud.google.com/backupdrbackupplanassociation_v1alpha1.json
+    kind: BackupDRBackupPlanAssociation
+    name: backupdrbackupplanassociation_v1alpha1
+  - apiVersion: backupdr.cnrm.cloud.google.com/v1alpha1
+    filename: backupdr.cnrm.cloud.google.com/backupdrbackupvault_v1alpha1.json
+    kind: BackupDRBackupVault
+    name: backupdrbackupvault_v1alpha1
+  - apiVersion: backupdr.cnrm.cloud.google.com/v1beta1
+    filename: backupdr.cnrm.cloud.google.com/backupdrbackupplan_v1beta1.json
+    kind: BackupDRBackupPlan
+    name: backupdrbackupplan_v1beta1
+  - apiVersion: backupdr.cnrm.cloud.google.com/v1alpha1
+    filename: backupdr.cnrm.cloud.google.com/backupdrbackupplan_v1alpha1.json
+    kind: BackupDRBackupPlan
+    name: backupdrbackupplan_v1alpha1
+  - apiVersion: backupdr.cnrm.cloud.google.com/v1beta1
+    filename: backupdr.cnrm.cloud.google.com/backupdrbackupvault_v1beta1.json
+    kind: BackupDRBackupVault
+    name: backupdrbackupvault_v1beta1
+  - apiVersion: backupdr.cnrm.cloud.google.com/v1beta1
+    filename: backupdr.cnrm.cloud.google.com/backupdrbackupplanassociation_v1beta1.json
+    kind: BackupDRBackupPlanAssociation
+    name: backupdrbackupplanassociation_v1beta1
+barmancloud.cnpg.io:
+  - apiVersion: barmancloud.cnpg.io/v1
+    filename: barmancloud.cnpg.io/objectstore_v1.json
+    kind: ObjectStore
+    name: objectstore_v1
+batch.azure.com:
+  - apiVersion: batch.azure.com/v1api20210101
+    filename: batch.azure.com/batchaccount_v1api20210101.json
+    kind: batchAccount
+    name: batchaccount_v1api20210101
 beat.k8s.elastic.co:
   - apiVersion: beat.k8s.elastic.co/v1beta1
     filename: beat.k8s.elastic.co/beat_v1beta1.json
@@ -1095,6 +1817,19 @@ bigqueryanalyticshub.cnrm.cloud.google.com:
     filename: bigqueryanalyticshub.cnrm.cloud.google.com/bigqueryanalyticshubdataexchange_v1beta1.json
     kind: BigQueryAnalyticsHubDataExchange
     name: bigqueryanalyticshubdataexchange_v1beta1
+  - apiVersion: bigqueryanalyticshub.cnrm.cloud.google.com/v1beta1
+    filename: bigqueryanalyticshub.cnrm.cloud.google.com/bigqueryanalyticshublisting_v1beta1.json
+    kind: BigQueryAnalyticsHubListing
+    name: bigqueryanalyticshublisting_v1beta1
+bigquerybiglake.cnrm.cloud.google.com:
+  - apiVersion: bigquerybiglake.cnrm.cloud.google.com/v1alpha1
+    filename: bigquerybiglake.cnrm.cloud.google.com/biglaketable_v1alpha1.json
+    kind: BigLakeTable
+    name: biglaketable_v1alpha1
+  - apiVersion: bigquerybiglake.cnrm.cloud.google.com/v1beta1
+    filename: bigquerybiglake.cnrm.cloud.google.com/biglaketable_v1beta1.json
+    kind: BigLakeTable
+    name: biglaketable_v1beta1
 bigqueryconnection.cnrm.cloud.google.com:
   - apiVersion: bigqueryconnection.cnrm.cloud.google.com/v1alpha1
     filename: bigqueryconnection.cnrm.cloud.google.com/bigqueryconnectionconnection_v1alpha1.json
@@ -1127,6 +1862,18 @@ bigqueryreservation.cnrm.cloud.google.com:
     filename: bigqueryreservation.cnrm.cloud.google.com/bigqueryreservationcapacitycommitment_v1alpha1.json
     kind: bigqueryreservationcapacitycommitment
     name: bigqueryreservationcapacitycommitment_v1alpha1
+  - apiVersion: bigqueryreservation.cnrm.cloud.google.com/v1beta1
+    filename: bigqueryreservation.cnrm.cloud.google.com/bigqueryreservationassignment_v1beta1.json
+    kind: BigQueryReservationAssignment
+    name: bigqueryreservationassignment_v1beta1
+  - apiVersion: bigqueryreservation.cnrm.cloud.google.com/v1beta1
+    filename: bigqueryreservation.cnrm.cloud.google.com/bigqueryreservationreservation_v1beta1.json
+    kind: BigQueryReservationReservation
+    name: bigqueryreservationreservation_v1beta1
+  - apiVersion: bigqueryreservation.cnrm.cloud.google.com/v1alpha1
+    filename: bigqueryreservation.cnrm.cloud.google.com/bigqueryreservationassignment_v1alpha1.json
+    kind: BigQueryReservationAssignment
+    name: bigqueryreservationassignment_v1alpha1
 bigtable.cnrm.cloud.google.com:
   - apiVersion: bigtable.cnrm.cloud.google.com/v1beta1
     filename: bigtable.cnrm.cloud.google.com/bigtableinstance_v1beta1.json
@@ -1249,6 +1996,96 @@ bootstrap.cluster.x-k8s.io:
     filename: bootstrap.cluster.x-k8s.io/talosconfig_v1alpha3.json
     kind: TalosConfig
     name: talosconfig_v1alpha3
+  - apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+    filename: bootstrap.cluster.x-k8s.io/k0scontrollerconfig_v1beta1.json
+    kind: K0sControllerConfig
+    name: k0scontrollerconfig_v1beta1
+  - apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+    filename: bootstrap.cluster.x-k8s.io/k0sworkerconfig_v1beta1.json
+    kind: K0sWorkerConfig
+    name: k0sworkerconfig_v1beta1
+  - apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
+    filename: bootstrap.cluster.x-k8s.io/kubeadmconfigtemplate_v1beta2.json
+    kind: KubeadmConfigTemplate
+    name: kubeadmconfigtemplate_v1beta2
+  - apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
+    filename: bootstrap.cluster.x-k8s.io/kubeadmconfig_v1beta2.json
+    kind: KubeadmConfig
+    name: kubeadmconfig_v1beta2
+  - apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+    filename: bootstrap.cluster.x-k8s.io/k0sworkerconfigtemplate_v1beta1.json
+    kind: K0sWorkerConfigTemplate
+    name: k0sworkerconfigtemplate_v1beta1
+cache.azure.com:
+  - apiVersion: cache.azure.com/v1api20230801
+    filename: cache.azure.com/redisfirewallrule_v1api20230801.json
+    kind: redisfirewallrule
+    name: redisfirewallrule_v1api20230801
+  - apiVersion: cache.azure.com/v1api20201201
+    filename: cache.azure.com/redisfirewallrule_v1api20201201.json
+    kind: redisfirewallrule
+    name: redisfirewallrule_v1api20201201
+  - apiVersion: cache.azure.com/v1api20230401
+    filename: cache.azure.com/redispatchschedule_v1api20230401.json
+    kind: redispatchschedule
+    name: redispatchschedule_v1api20230401
+  - apiVersion: cache.azure.com/v1api20210301
+    filename: cache.azure.com/redisenterprisedatabase_v1api20210301.json
+    kind: redisenterprisedatabase
+    name: redisenterprisedatabase_v1api20210301
+  - apiVersion: cache.azure.com/v1api20230401
+    filename: cache.azure.com/redislinkedserver_v1api20230401.json
+    kind: redislinkedserver
+    name: redislinkedserver_v1api20230401
+  - apiVersion: cache.azure.com/v1api20230701
+    filename: cache.azure.com/redisenterprise_v1api20230701.json
+    kind: redisenterprise
+    name: redisenterprise_v1api20230701
+  - apiVersion: cache.azure.com/v1api20201201
+    filename: cache.azure.com/redispatchschedule_v1api20201201.json
+    kind: redispatchschedule
+    name: redispatchschedule_v1api20201201
+  - apiVersion: cache.azure.com/v1api20230801
+    filename: cache.azure.com/redispatchschedule_v1api20230801.json
+    kind: redispatchschedule
+    name: redispatchschedule_v1api20230801
+  - apiVersion: cache.azure.com/v1api20201201
+    filename: cache.azure.com/redis_v1api20201201.json
+    kind: redis
+    name: redis_v1api20201201
+  - apiVersion: cache.azure.com/v1api20230801
+    filename: cache.azure.com/redis_v1api20230801.json
+    kind: redis
+    name: redis_v1api20230801
+  - apiVersion: cache.azure.com/v1api20230401
+    filename: cache.azure.com/redis_v1api20230401.json
+    kind: redis
+    name: redis_v1api20230401
+  - apiVersion: cache.azure.com/v1api20230701
+    filename: cache.azure.com/redisenterprisedatabase_v1api20230701.json
+    kind: redisenterprisedatabase
+    name: redisenterprisedatabase_v1api20230701
+  - apiVersion: cache.azure.com/v1api20201201
+    filename: cache.azure.com/redislinkedserver_v1api20201201.json
+    kind: redislinkedserver
+    name: redislinkedserver_v1api20201201
+  - apiVersion: cache.azure.com/v1api20210301
+    filename: cache.azure.com/redisenterprise_v1api20210301.json
+    kind: redisenterprise
+    name: redisenterprise_v1api20210301
+  - apiVersion: cache.azure.com/v1api20230401
+    filename: cache.azure.com/redisfirewallrule_v1api20230401.json
+    kind: redisfirewallrule
+    name: redisfirewallrule_v1api20230401
+  - apiVersion: cache.azure.com/v1api20230801
+    filename: cache.azure.com/redislinkedserver_v1api20230801.json
+    kind: redislinkedserver
+    name: redislinkedserver_v1api20230801
+caching.internal.knative.dev:
+  - apiVersion: caching.internal.knative.dev/v1alpha1
+    filename: caching.internal.knative.dev/image_v1alpha1.json
+    kind: Image
+    name: image_v1alpha1
 capi.weave.works:
   - apiVersion: capi.weave.works/v1alpha1
     filename: capi.weave.works/clusterbootstrapconfig_v1alpha1.json
@@ -1287,6 +2124,133 @@ capsule.clastix.io:
     filename: capsule.clastix.io/tenant_v1beta1.json
     kind: Tenant
     name: tenant_v1beta1
+  - apiVersion: capsule.clastix.io/v1beta1
+    filename: capsule.clastix.io/globalproxysettings_v1beta1.json
+    kind: GlobalProxySettings
+    name: globalproxysettings_v1beta1
+  - apiVersion: capsule.clastix.io/v1beta2
+    filename: capsule.clastix.io/tenantowner_v1beta2.json
+    kind: TenantOwner
+    name: tenantowner_v1beta2
+  - apiVersion: capsule.clastix.io/v1beta2
+    filename: capsule.clastix.io/resourcepool_v1beta2.json
+    kind: Resourcepool
+    name: resourcepool_v1beta2
+  - apiVersion: capsule.clastix.io/v1beta1
+    filename: capsule.clastix.io/proxysetting_v1beta1.json
+    kind: ProxySetting
+    name: proxysetting_v1beta1
+  - apiVersion: capsule.clastix.io/v1beta2
+    filename: capsule.clastix.io/resourcepoolclaim_v1beta2.json
+    kind: ResourcePoolClaim
+    name: resourcepoolclaim_v1beta2
+catalog.cattle.io:
+  - apiVersion: catalog.cattle.io/v1
+    filename: catalog.cattle.io/app_v1.json
+    kind: app
+    name: app_v1
+  - apiVersion: catalog.cattle.io/v1
+    filename: catalog.cattle.io/uiplugin_v1.json
+    kind: uiplugin
+    name: uiplugin_v1
+  - apiVersion: catalog.cattle.io/v1
+    filename: catalog.cattle.io/clusterrepo_v1.json
+    kind: ClusterRepo
+    name: clusterrepo_v1
+cdi.kubevirt.io:
+  - apiVersion: cdi.kubevirt.io/v1beta1
+    filename: cdi.kubevirt.io/dataimportcron_v1beta1.json
+    kind: DataImportCron
+    name: dataimportcron_v1beta1
+  - apiVersion: cdi.kubevirt.io/v1beta1
+    filename: cdi.kubevirt.io/volumeclonesource_v1beta1.json
+    kind: VolumeCloneSource
+    name: volumeclonesource_v1beta1
+  - apiVersion: cdi.kubevirt.io/v1alpha1
+    filename: cdi.kubevirt.io/cdi_v1alpha1.json
+    kind: CDI
+    name: cdi_v1alpha1
+  - apiVersion: cdi.kubevirt.io/v1beta1
+    filename: cdi.kubevirt.io/objecttransfer_v1beta1.json
+    kind: ObjectTransfer
+    name: objecttransfer_v1beta1
+  - apiVersion: cdi.kubevirt.io/v1beta1
+    filename: cdi.kubevirt.io/volumeuploadsource_v1beta1.json
+    kind: VolumeUploadSource
+    name: volumeuploadsource_v1beta1
+  - apiVersion: cdi.kubevirt.io/v1beta1
+    filename: cdi.kubevirt.io/volumeimportsource_v1beta1.json
+    kind: VolumeImportSource
+    name: volumeimportsource_v1beta1
+  - apiVersion: cdi.kubevirt.io/v1beta1
+    filename: cdi.kubevirt.io/storageprofile_v1beta1.json
+    kind: StorageProfile
+    name: storageprofile_v1beta1
+  - apiVersion: cdi.kubevirt.io/v1beta1
+    filename: cdi.kubevirt.io/datavolume_v1beta1.json
+    kind: DataVolume
+    name: datavolume_v1beta1
+  - apiVersion: cdi.kubevirt.io/v1beta1
+    filename: cdi.kubevirt.io/datasource_v1beta1.json
+    kind: DataSource
+    name: datasource_v1beta1
+  - apiVersion: cdi.kubevirt.io/v1beta1
+    filename: cdi.kubevirt.io/cdiconfig_v1beta1.json
+    kind: CDIConfig
+    name: cdiconfig_v1beta1
+  - apiVersion: cdi.kubevirt.io/v1beta1
+    filename: cdi.kubevirt.io/cdi_v1beta1.json
+    kind: CDI
+    name: cdi_v1beta1
+cdn.azure.com:
+  - apiVersion: cdn.azure.com/v1api20230501
+    filename: cdn.azure.com/secret_v1api20230501.json
+    kind: secret
+    name: secret_v1api20230501
+  - apiVersion: cdn.azure.com/v1api20230501
+    filename: cdn.azure.com/afdorigingroup_v1api20230501.json
+    kind: afdorigingroup
+    name: afdorigingroup_v1api20230501
+  - apiVersion: cdn.azure.com/v1api20230501
+    filename: cdn.azure.com/profile_v1api20230501.json
+    kind: profile
+    name: profile_v1api20230501
+  - apiVersion: cdn.azure.com/v1api20230501
+    filename: cdn.azure.com/securitypolicy_v1api20230501.json
+    kind: securityPolicy
+    name: securitypolicy_v1api20230501
+  - apiVersion: cdn.azure.com/v1api20230501
+    filename: cdn.azure.com/rule_v1api20230501.json
+    kind: rule
+    name: rule_v1api20230501
+  - apiVersion: cdn.azure.com/v1api20210601
+    filename: cdn.azure.com/profile_v1api20210601.json
+    kind: profile
+    name: profile_v1api20210601
+  - apiVersion: cdn.azure.com/v1api20230501
+    filename: cdn.azure.com/afdcustomdomain_v1api20230501.json
+    kind: afdcustomdomain
+    name: afdcustomdomain_v1api20230501
+  - apiVersion: cdn.azure.com/v1api20230501
+    filename: cdn.azure.com/afdorigin_v1api20230501.json
+    kind: afdorigin
+    name: afdorigin_v1api20230501
+  - apiVersion: cdn.azure.com/v1api20230501
+    filename: cdn.azure.com/afdendpoint_v1api20230501.json
+    kind: afdEndpoint
+    name: afdendpoint_v1api20230501
+  - apiVersion: cdn.azure.com/v1api20230501
+    filename: cdn.azure.com/ruleset_v1api20230501.json
+    kind: ruleSet
+    name: ruleset_v1api20230501
+  - apiVersion: cdn.azure.com/v1api20210601
+    filename: cdn.azure.com/profilesendpoint_v1api20210601.json
+    kind: profilesendpoint
+    name: profilesendpoint_v1api20210601
+  - apiVersion: cdn.azure.com/v1api20230501
+    filename: cdn.azure.com/route_v1api20230501.json
+    kind: route
+    name: route_v1api20230501
 ceph.rook.io:
   - apiVersion: ceph.rook.io/v1
     filename: ceph.rook.io/cephbucketnotification_v1.json
@@ -1378,6 +2342,10 @@ cert-manager.k8s.cloudflare.com:
     filename: cert-manager.k8s.cloudflare.com/originissuer_v1.json
     kind: OriginIssuer
     name: originissuer_v1
+  - apiVersion: cert-manager.k8s.cloudflare.com/v1
+    filename: cert-manager.k8s.cloudflare.com/clusteroriginissuer_v1.json
+    kind: ClusterOriginIssuer
+    name: clusteroriginissuer_v1
 certificatemanager.cnrm.cloud.google.com:
   - apiVersion: certificatemanager.cnrm.cloud.google.com/v1alpha1
     filename: certificatemanager.cnrm.cloud.google.com/certificatemanagercertificate_v1alpha1.json
@@ -1522,6 +2490,70 @@ cilium.io:
     filename: cilium.io/ciliumbgpnodeconfig_v2alpha1.json
     kind: CiliumBGPNodeConfig
     name: ciliumbgpnodeconfig_v2alpha1
+  - apiVersion: cilium.io/v2
+    filename: cilium.io/ciliumbgppeerconfig_v2.json
+    kind: ciliumbgppeerconfig
+    name: ciliumbgppeerconfig_v2
+  - apiVersion: cilium.io/v2
+    filename: cilium.io/ciliumcidrgroup_v2.json
+    kind: CiliumCIDRGroup
+    name: ciliumcidrgroup_v2
+  - apiVersion: cilium.io/v2
+    filename: cilium.io/ciliumbgpnodeconfig_v2.json
+    kind: CiliumBGPNodeConfig
+    name: ciliumbgpnodeconfig_v2
+  - apiVersion: cilium.io/v2
+    filename: cilium.io/ciliumloadbalancerippool_v2.json
+    kind: CiliumLoadBalancerIPPool
+    name: ciliumloadbalancerippool_v2
+  - apiVersion: cilium.io/v2
+    filename: cilium.io/ciliumbgpnodeconfigoverride_v2.json
+    kind: CiliumBGPNodeConfigOverride
+    name: ciliumbgpnodeconfigoverride_v2
+  - apiVersion: cilium.io/v2
+    filename: cilium.io/ciliumbgpadvertisement_v2.json
+    kind: CiliumBGPAdvertisement
+    name: ciliumbgpadvertisement_v2
+  - apiVersion: cilium.io/v2
+    filename: cilium.io/ciliumbgpclusterconfig_v2.json
+    kind: CiliumBGPClusterConfig
+    name: ciliumbgpclusterconfig_v2
+clickhouse-keeper.altinity.com:
+  - apiVersion: clickhouse-keeper.altinity.com/v1
+    filename: clickhouse-keeper.altinity.com/clickhousekeeperinstallation_v1.json
+    kind: clickhousekeeperinstallation
+    name: clickhousekeeperinstallation_v1
+clickhouse.altinity.com:
+  - apiVersion: clickhouse.altinity.com/v1
+    filename: clickhouse.altinity.com/clickhouseoperatorconfiguration_v1.json
+    kind: clickhouseoperatorconfiguration
+    name: clickhouseoperatorconfiguration_v1
+  - apiVersion: clickhouse.altinity.com/v1
+    filename: clickhouse.altinity.com/clickhouseinstallationtemplate_v1.json
+    kind: clickhouseinstallationtemplate
+    name: clickhouseinstallationtemplate_v1
+  - apiVersion: clickhouse.altinity.com/v1
+    filename: clickhouse.altinity.com/clickhouseinstallation_v1.json
+    kind: clickhouseinstallation
+    name: clickhouseinstallation_v1
+clickhouse.com:
+  - apiVersion: clickhouse.com/v1alpha1
+    filename: clickhouse.com/clickhousecluster_v1alpha1.json
+    kind: ClickHouseCluster
+    name: clickhousecluster_v1alpha1
+  - apiVersion: clickhouse.com/v1alpha1
+    filename: clickhouse.com/keepercluster_v1alpha1.json
+    kind: KeeperCluster
+    name: keepercluster_v1alpha1
+clone.kubevirt.io:
+  - apiVersion: clone.kubevirt.io/v1alpha1
+    filename: clone.kubevirt.io/virtualmachineclone_v1alpha1.json
+    kind: VirtualMachineClone
+    name: virtualmachineclone_v1alpha1
+  - apiVersion: clone.kubevirt.io/v1beta1
+    filename: clone.kubevirt.io/virtualmachineclone_v1beta1.json
+    kind: VirtualMachineClone
+    name: virtualmachineclone_v1beta1
 cloud.google.com:
   - apiVersion: cloud.google.com/v1beta1
     filename: cloud.google.com/backendconfig_v1beta1.json
@@ -1564,6 +2596,116 @@ cloud.grafana.crossplane.io:
     filename: cloud.grafana.crossplane.io/apikey_v1alpha1.json
     kind: APIKey
     name: apikey_v1alpha1
+  - apiVersion: cloud.grafana.crossplane.io/v1alpha1
+    filename: cloud.grafana.crossplane.io/stackserviceaccountrotatingtoken_v1alpha1.json
+    kind: StackServiceAccountRotatingToken
+    name: stackserviceaccountrotatingtoken_v1alpha1
+  - apiVersion: cloud.grafana.crossplane.io/v1alpha1
+    filename: cloud.grafana.crossplane.io/orgmember_v1alpha1.json
+    kind: OrgMember
+    name: orgmember_v1alpha1
+  - apiVersion: cloud.grafana.crossplane.io/v1alpha1
+    filename: cloud.grafana.crossplane.io/k8so11yconfigv1alpha1_v1alpha1.json
+    kind: K8So11YconfigV1Alpha1
+    name: k8so11yconfigv1alpha1_v1alpha1
+  - apiVersion: cloud.grafana.crossplane.io/v1alpha1
+    filename: cloud.grafana.crossplane.io/dbo11yconfigv1alpha1_v1alpha1.json
+    kind: Dbo11YconfigV1Alpha1
+    name: dbo11yconfigv1alpha1_v1alpha1
+  - apiVersion: cloud.grafana.crossplane.io/v1alpha1
+    filename: cloud.grafana.crossplane.io/privatedatasourceconnectnetworktoken_v1alpha1.json
+    kind: PrivateDataSourceConnectNetworkToken
+    name: privatedatasourceconnectnetworktoken_v1alpha1
+  - apiVersion: cloud.grafana.crossplane.io/v1alpha1
+    filename: cloud.grafana.crossplane.io/accesspolicyrotatingtoken_v1alpha1.json
+    kind: AccessPolicyRotatingToken
+    name: accesspolicyrotatingtoken_v1alpha1
+  - apiVersion: cloud.grafana.crossplane.io/v1alpha1
+    filename: cloud.grafana.crossplane.io/appo11yconfigv1alpha1_v1alpha1.json
+    kind: Appo11YconfigV1Alpha1
+    name: appo11yconfigv1alpha1_v1alpha1
+  - apiVersion: cloud.grafana.crossplane.io/v1alpha1
+    filename: cloud.grafana.crossplane.io/privatedatasourceconnectnetwork_v1alpha1.json
+    kind: PrivateDataSourceConnectNetwork
+    name: privatedatasourceconnectnetwork_v1alpha1
+cloud.grafana.m.crossplane.io:
+  - apiVersion: cloud.grafana.m.crossplane.io/v1alpha1
+    filename: cloud.grafana.m.crossplane.io/stackserviceaccount_v1alpha1.json
+    kind: StackServiceAccount
+    name: stackserviceaccount_v1alpha1
+  - apiVersion: cloud.grafana.m.crossplane.io/v1alpha1
+    filename: cloud.grafana.m.crossplane.io/stackserviceaccountrotatingtoken_v1alpha1.json
+    kind: StackServiceAccountRotatingToken
+    name: stackserviceaccountrotatingtoken_v1alpha1
+  - apiVersion: cloud.grafana.m.crossplane.io/v1alpha1
+    filename: cloud.grafana.m.crossplane.io/orgmember_v1alpha1.json
+    kind: OrgMember
+    name: orgmember_v1alpha1
+  - apiVersion: cloud.grafana.m.crossplane.io/v1alpha1
+    filename: cloud.grafana.m.crossplane.io/stack_v1alpha1.json
+    kind: Stack
+    name: stack_v1alpha1
+  - apiVersion: cloud.grafana.m.crossplane.io/v1alpha1
+    filename: cloud.grafana.m.crossplane.io/stackserviceaccounttoken_v1alpha1.json
+    kind: StackServiceAccountToken
+    name: stackserviceaccounttoken_v1alpha1
+  - apiVersion: cloud.grafana.m.crossplane.io/v1alpha1
+    filename: cloud.grafana.m.crossplane.io/k8so11yconfigv1alpha1_v1alpha1.json
+    kind: K8So11YconfigV1Alpha1
+    name: k8so11yconfigv1alpha1_v1alpha1
+  - apiVersion: cloud.grafana.m.crossplane.io/v1alpha1
+    filename: cloud.grafana.m.crossplane.io/dbo11yconfigv1alpha1_v1alpha1.json
+    kind: Dbo11YconfigV1Alpha1
+    name: dbo11yconfigv1alpha1_v1alpha1
+  - apiVersion: cloud.grafana.m.crossplane.io/v1alpha1
+    filename: cloud.grafana.m.crossplane.io/accesspolicytoken_v1alpha1.json
+    kind: AccessPolicyToken
+    name: accesspolicytoken_v1alpha1
+  - apiVersion: cloud.grafana.m.crossplane.io/v1alpha1
+    filename: cloud.grafana.m.crossplane.io/privatedatasourceconnectnetworktoken_v1alpha1.json
+    kind: PrivateDataSourceConnectNetworkToken
+    name: privatedatasourceconnectnetworktoken_v1alpha1
+  - apiVersion: cloud.grafana.m.crossplane.io/v1alpha1
+    filename: cloud.grafana.m.crossplane.io/accesspolicyrotatingtoken_v1alpha1.json
+    kind: AccessPolicyRotatingToken
+    name: accesspolicyrotatingtoken_v1alpha1
+  - apiVersion: cloud.grafana.m.crossplane.io/v1alpha1
+    filename: cloud.grafana.m.crossplane.io/plugininstallation_v1alpha1.json
+    kind: PluginInstallation
+    name: plugininstallation_v1alpha1
+  - apiVersion: cloud.grafana.m.crossplane.io/v1alpha1
+    filename: cloud.grafana.m.crossplane.io/appo11yconfigv1alpha1_v1alpha1.json
+    kind: Appo11YconfigV1Alpha1
+    name: appo11yconfigv1alpha1_v1alpha1
+  - apiVersion: cloud.grafana.m.crossplane.io/v1alpha1
+    filename: cloud.grafana.m.crossplane.io/privatedatasourceconnectnetwork_v1alpha1.json
+    kind: PrivateDataSourceConnectNetwork
+    name: privatedatasourceconnectnetwork_v1alpha1
+  - apiVersion: cloud.grafana.m.crossplane.io/v1alpha1
+    filename: cloud.grafana.m.crossplane.io/accesspolicy_v1alpha1.json
+    kind: AccessPolicy
+    name: accesspolicy_v1alpha1
+cloud.grafana.o.crossplane.io:
+  - apiVersion: cloud.grafana.o.crossplane.io/v1alpha1
+    filename: cloud.grafana.o.crossplane.io/organization_v1alpha1.json
+    kind: Organization
+    name: organization_v1alpha1
+  - apiVersion: cloud.grafana.o.crossplane.io/v1alpha1
+    filename: cloud.grafana.o.crossplane.io/stack_v1alpha1.json
+    kind: Stack
+    name: stack_v1alpha1
+  - apiVersion: cloud.grafana.o.crossplane.io/v1alpha1
+    filename: cloud.grafana.o.crossplane.io/accesspolicies_v1alpha1.json
+    kind: AccessPolicies
+    name: accesspolicies_v1alpha1
+  - apiVersion: cloud.grafana.o.crossplane.io/v1alpha1
+    filename: cloud.grafana.o.crossplane.io/ips_v1alpha1.json
+    kind: IPS
+    name: ips_v1alpha1
+  - apiVersion: cloud.grafana.o.crossplane.io/v1alpha1
+    filename: cloud.grafana.o.crossplane.io/privatedatasourceconnectnetworks_v1alpha1.json
+    kind: PrivateDataSourceConnectNetworks
+    name: privatedatasourceconnectnetworks_v1alpha1
 cloudasset.cnrm.cloud.google.com:
   - apiVersion: cloudasset.cnrm.cloud.google.com/v1alpha1
     filename: cloudasset.cnrm.cloud.google.com/cloudassetfolderfeed_v1alpha1.json
@@ -1590,6 +2732,15 @@ cloudbuild.cnrm.cloud.google.com:
     filename: cloudbuild.cnrm.cloud.google.com/cloudbuildworkerpool_v1beta1.json
     kind: CloudBuildWorkerPool
     name: cloudbuildworkerpool_v1beta1
+clouddeploy.cnrm.cloud.google.com:
+  - apiVersion: clouddeploy.cnrm.cloud.google.com/v1alpha1
+    filename: clouddeploy.cnrm.cloud.google.com/clouddeploydeliverypipeline_v1alpha1.json
+    kind: CloudDeployDeliveryPipeline
+    name: clouddeploydeliverypipeline_v1alpha1
+  - apiVersion: clouddeploy.cnrm.cloud.google.com/v1beta1
+    filename: clouddeploy.cnrm.cloud.google.com/clouddeploydeliverypipeline_v1beta1.json
+    kind: CloudDeployDeliveryPipeline
+    name: clouddeploydeliverypipeline_v1beta1
 cloudflare-operator.io:
   - apiVersion: cloudflare-operator.io/v1
     filename: cloudflare-operator.io/ip_v1.json
@@ -1640,6 +2791,16 @@ cloudids.cnrm.cloud.google.com:
     filename: cloudids.cnrm.cloud.google.com/cloudidsendpoint_v1beta1.json
     kind: cloudidsendpoint
     name: cloudidsendpoint_v1beta1
+cloudintegrations.grafana.crossplane.io:
+  - apiVersion: cloudintegrations.grafana.crossplane.io/v1alpha1
+    filename: cloudintegrations.grafana.crossplane.io/cloudintegration_v1alpha1.json
+    kind: CloudIntegration
+    name: cloudintegration_v1alpha1
+cloudintegrations.grafana.m.crossplane.io:
+  - apiVersion: cloudintegrations.grafana.m.crossplane.io/v1alpha1
+    filename: cloudintegrations.grafana.m.crossplane.io/cloudintegration_v1alpha1.json
+    kind: CloudIntegration
+    name: cloudintegration_v1alpha1
 cloudiot.cnrm.cloud.google.com:
   - apiVersion: cloudiot.cnrm.cloud.google.com/v1alpha1
     filename: cloudiot.cnrm.cloud.google.com/cloudiotdeviceregistry_v1alpha1.json
@@ -1649,6 +2810,70 @@ cloudiot.cnrm.cloud.google.com:
     filename: cloudiot.cnrm.cloud.google.com/cloudiotdevice_v1alpha1.json
     kind: cloudiotdevice
     name: cloudiotdevice_v1alpha1
+cloudprovider.grafana.crossplane.io:
+  - apiVersion: cloudprovider.grafana.crossplane.io/v1alpha1
+    filename: cloudprovider.grafana.crossplane.io/azurecredential_v1alpha1.json
+    kind: AzureCredential
+    name: azurecredential_v1alpha1
+  - apiVersion: cloudprovider.grafana.crossplane.io/v1alpha1
+    filename: cloudprovider.grafana.crossplane.io/awsresourcemetadatascrapejob_v1alpha1.json
+    kind: AwsResourceMetadataScrapeJob
+    name: awsresourcemetadatascrapejob_v1alpha1
+  - apiVersion: cloudprovider.grafana.crossplane.io/v1alpha1
+    filename: cloudprovider.grafana.crossplane.io/awscloudwatchscrapejob_v1alpha1.json
+    kind: AwsCloudwatchScrapeJob
+    name: awscloudwatchscrapejob_v1alpha1
+  - apiVersion: cloudprovider.grafana.crossplane.io/v1alpha1
+    filename: cloudprovider.grafana.crossplane.io/awsaccount_v1alpha1.json
+    kind: AwsAccount
+    name: awsaccount_v1alpha1
+cloudprovider.grafana.m.crossplane.io:
+  - apiVersion: cloudprovider.grafana.m.crossplane.io/v1alpha1
+    filename: cloudprovider.grafana.m.crossplane.io/azurecredential_v1alpha1.json
+    kind: AzureCredential
+    name: azurecredential_v1alpha1
+  - apiVersion: cloudprovider.grafana.m.crossplane.io/v1alpha1
+    filename: cloudprovider.grafana.m.crossplane.io/awsresourcemetadatascrapejob_v1alpha1.json
+    kind: AwsResourceMetadataScrapeJob
+    name: awsresourcemetadatascrapejob_v1alpha1
+  - apiVersion: cloudprovider.grafana.m.crossplane.io/v1alpha1
+    filename: cloudprovider.grafana.m.crossplane.io/awscloudwatchscrapejob_v1alpha1.json
+    kind: AwsCloudwatchScrapeJob
+    name: awscloudwatchscrapejob_v1alpha1
+  - apiVersion: cloudprovider.grafana.m.crossplane.io/v1alpha1
+    filename: cloudprovider.grafana.m.crossplane.io/awsaccount_v1alpha1.json
+    kind: AwsAccount
+    name: awsaccount_v1alpha1
+cloudprovider.grafana.o.crossplane.io:
+  - apiVersion: cloudprovider.grafana.o.crossplane.io/v1alpha1
+    filename: cloudprovider.grafana.o.crossplane.io/azurecredential_v1alpha1.json
+    kind: AzureCredential
+    name: azurecredential_v1alpha1
+  - apiVersion: cloudprovider.grafana.o.crossplane.io/v1alpha1
+    filename: cloudprovider.grafana.o.crossplane.io/awscloudwatchscrapejob_v1alpha1.json
+    kind: AwsCloudwatchScrapeJob
+    name: awscloudwatchscrapejob_v1alpha1
+  - apiVersion: cloudprovider.grafana.o.crossplane.io/v1alpha1
+    filename: cloudprovider.grafana.o.crossplane.io/awscloudwatchscrapejobset_v1alpha1.json
+    kind: AwsCloudwatchScrapeJobSet
+    name: awscloudwatchscrapejobset_v1alpha1
+  - apiVersion: cloudprovider.grafana.o.crossplane.io/v1alpha1
+    filename: cloudprovider.grafana.o.crossplane.io/awsaccount_v1alpha1.json
+    kind: AwsAccount
+    name: awsaccount_v1alpha1
+cloudquota.cnrm.cloud.google.com:
+  - apiVersion: cloudquota.cnrm.cloud.google.com/v1beta1
+    filename: cloudquota.cnrm.cloud.google.com/apiquotaadjustersettings_v1beta1.json
+    kind: APIQuotaAdjusterSettings
+    name: apiquotaadjustersettings_v1beta1
+  - apiVersion: cloudquota.cnrm.cloud.google.com/v1alpha1
+    filename: cloudquota.cnrm.cloud.google.com/apiquotaadjustersettings_v1alpha1.json
+    kind: APIQuotaAdjusterSettings
+    name: apiquotaadjustersettings_v1alpha1
+  - apiVersion: cloudquota.cnrm.cloud.google.com/v1beta1
+    filename: cloudquota.cnrm.cloud.google.com/apiquotapreference_v1beta1.json
+    kind: APIQuotaPreference
+    name: apiquotapreference_v1beta1
 cloudscheduler.cnrm.cloud.google.com:
   - apiVersion: cloudscheduler.cnrm.cloud.google.com/v1beta1
     filename: cloudscheduler.cnrm.cloud.google.com/cloudschedulerjob_v1beta1.json
@@ -1678,11 +2903,143 @@ cloudwatch.services.k8s.aws:
     filename: cloudwatch.services.k8s.aws/metricalarm_v1alpha1.json
     kind: MetricAlarm
     name: metricalarm_v1alpha1
+cloudwatchevents.aws.m.upbound.io:
+  - apiVersion: cloudwatchevents.aws.m.upbound.io/v1beta1
+    filename: cloudwatchevents.aws.m.upbound.io/bus_v1beta1.json
+    kind: Bus
+    name: bus_v1beta1
+  - apiVersion: cloudwatchevents.aws.m.upbound.io/v1beta1
+    filename: cloudwatchevents.aws.m.upbound.io/rule_v1beta1.json
+    kind: Rule
+    name: rule_v1beta1
+  - apiVersion: cloudwatchevents.aws.m.upbound.io/v1beta1
+    filename: cloudwatchevents.aws.m.upbound.io/permission_v1beta1.json
+    kind: Permission
+    name: permission_v1beta1
+  - apiVersion: cloudwatchevents.aws.m.upbound.io/v1beta1
+    filename: cloudwatchevents.aws.m.upbound.io/archive_v1beta1.json
+    kind: Archive
+    name: archive_v1beta1
+  - apiVersion: cloudwatchevents.aws.m.upbound.io/v1beta1
+    filename: cloudwatchevents.aws.m.upbound.io/apidestination_v1beta1.json
+    kind: APIDestination
+    name: apidestination_v1beta1
+  - apiVersion: cloudwatchevents.aws.m.upbound.io/v1beta1
+    filename: cloudwatchevents.aws.m.upbound.io/buspolicy_v1beta1.json
+    kind: BusPolicy
+    name: buspolicy_v1beta1
+  - apiVersion: cloudwatchevents.aws.m.upbound.io/v1beta1
+    filename: cloudwatchevents.aws.m.upbound.io/target_v1beta1.json
+    kind: Target
+    name: target_v1beta1
+  - apiVersion: cloudwatchevents.aws.m.upbound.io/v1beta1
+    filename: cloudwatchevents.aws.m.upbound.io/connection_v1beta1.json
+    kind: Connection
+    name: connection_v1beta1
+cloudwatchevents.aws.upbound.io:
+  - apiVersion: cloudwatchevents.aws.upbound.io/v1beta1
+    filename: cloudwatchevents.aws.upbound.io/bus_v1beta1.json
+    kind: Bus
+    name: bus_v1beta1
+  - apiVersion: cloudwatchevents.aws.upbound.io/v1beta1
+    filename: cloudwatchevents.aws.upbound.io/rule_v1beta1.json
+    kind: Rule
+    name: rule_v1beta1
+  - apiVersion: cloudwatchevents.aws.upbound.io/v1beta1
+    filename: cloudwatchevents.aws.upbound.io/permission_v1beta1.json
+    kind: Permission
+    name: permission_v1beta1
+  - apiVersion: cloudwatchevents.aws.upbound.io/v1beta2
+    filename: cloudwatchevents.aws.upbound.io/connection_v1beta2.json
+    kind: Connection
+    name: connection_v1beta2
+  - apiVersion: cloudwatchevents.aws.upbound.io/v1beta2
+    filename: cloudwatchevents.aws.upbound.io/permission_v1beta2.json
+    kind: Permission
+    name: permission_v1beta2
+  - apiVersion: cloudwatchevents.aws.upbound.io/v1beta1
+    filename: cloudwatchevents.aws.upbound.io/archive_v1beta1.json
+    kind: Archive
+    name: archive_v1beta1
+  - apiVersion: cloudwatchevents.aws.upbound.io/v1beta1
+    filename: cloudwatchevents.aws.upbound.io/apidestination_v1beta1.json
+    kind: APIDestination
+    name: apidestination_v1beta1
+  - apiVersion: cloudwatchevents.aws.upbound.io/v1beta1
+    filename: cloudwatchevents.aws.upbound.io/buspolicy_v1beta1.json
+    kind: BusPolicy
+    name: buspolicy_v1beta1
+  - apiVersion: cloudwatchevents.aws.upbound.io/v1beta2
+    filename: cloudwatchevents.aws.upbound.io/target_v1beta2.json
+    kind: Target
+    name: target_v1beta2
+  - apiVersion: cloudwatchevents.aws.upbound.io/v1beta1
+    filename: cloudwatchevents.aws.upbound.io/target_v1beta1.json
+    kind: Target
+    name: target_v1beta1
+  - apiVersion: cloudwatchevents.aws.upbound.io/v1beta1
+    filename: cloudwatchevents.aws.upbound.io/connection_v1beta1.json
+    kind: Connection
+    name: connection_v1beta1
 cloudwatchlogs.services.k8s.aws:
   - apiVersion: cloudwatchlogs.services.k8s.aws/v1alpha1
     filename: cloudwatchlogs.services.k8s.aws/loggroup_v1alpha1.json
     kind: LogGroup
     name: loggroup_v1alpha1
+cluster.open-cluster-management.io:
+  - apiVersion: cluster.open-cluster-management.io/v1beta2
+    filename: cluster.open-cluster-management.io/managedclustersetbinding_v1beta2.json
+    kind: ManagedClusterSetBinding
+    name: managedclustersetbinding_v1beta2
+  - apiVersion: cluster.open-cluster-management.io/v1beta1
+    filename: cluster.open-cluster-management.io/placement_v1beta1.json
+    kind: Placement
+    name: placement_v1beta1
+  - apiVersion: cluster.open-cluster-management.io/v1beta1
+    filename: cluster.open-cluster-management.io/placementdecision_v1beta1.json
+    kind: PlacementDecision
+    name: placementdecision_v1beta1
+  - apiVersion: cluster.open-cluster-management.io/v1alpha1
+    filename: cluster.open-cluster-management.io/clusterclaim_v1alpha1.json
+    kind: ClusterClaim
+    name: clusterclaim_v1alpha1
+  - apiVersion: cluster.open-cluster-management.io/v1beta2
+    filename: cluster.open-cluster-management.io/managedclusterset_v1beta2.json
+    kind: ManagedClusterSet
+    name: managedclusterset_v1beta2
+  - apiVersion: cluster.open-cluster-management.io/v1alpha1
+    filename: cluster.open-cluster-management.io/addonplacementscore_v1alpha1.json
+    kind: AddOnPlacementScore
+    name: addonplacementscore_v1alpha1
+  - apiVersion: cluster.open-cluster-management.io/v1
+    filename: cluster.open-cluster-management.io/managedcluster_v1.json
+    kind: ManagedCluster
+    name: managedcluster_v1
+cluster.redpanda.com:
+  - apiVersion: cluster.redpanda.com/v1alpha2
+    filename: cluster.redpanda.com/redpanda_v1alpha2.json
+    kind: Redpanda
+    name: redpanda_v1alpha2
+  - apiVersion: cluster.redpanda.com/v1alpha2
+    filename: cluster.redpanda.com/topic_v1alpha2.json
+    kind: Topic
+    name: topic_v1alpha2
+  - apiVersion: cluster.redpanda.com/v1alpha1
+    filename: cluster.redpanda.com/redpanda_v1alpha1.json
+    kind: Redpanda
+    name: redpanda_v1alpha1
+  - apiVersion: cluster.redpanda.com/v1alpha1
+    filename: cluster.redpanda.com/topic_v1alpha1.json
+    kind: Topic
+    name: topic_v1alpha1
+  - apiVersion: cluster.redpanda.com/v1alpha2
+    filename: cluster.redpanda.com/user_v1alpha2.json
+    kind: User
+    name: user_v1alpha2
+  - apiVersion: cluster.redpanda.com/v1alpha2
+    filename: cluster.redpanda.com/schema_v1alpha2.json
+    kind: Schema
+    name: schema_v1alpha2
 cluster.x-k8s.io:
   - apiVersion: cluster.x-k8s.io/v1beta1
     filename: cluster.x-k8s.io/machinedeployment_v1beta1.json
@@ -1804,6 +3161,38 @@ cluster.x-k8s.io:
     filename: cluster.x-k8s.io/machinedrainrule_v1beta1.json
     kind: MachineDrainRule
     name: machinedrainrule_v1beta1
+  - apiVersion: cluster.x-k8s.io/v1beta2
+    filename: cluster.x-k8s.io/machine_v1beta2.json
+    kind: Machine
+    name: machine_v1beta2
+  - apiVersion: cluster.x-k8s.io/v1beta2
+    filename: cluster.x-k8s.io/machinedrainrule_v1beta2.json
+    kind: MachineDrainRule
+    name: machinedrainrule_v1beta2
+  - apiVersion: cluster.x-k8s.io/v1beta2
+    filename: cluster.x-k8s.io/machinehealthcheck_v1beta2.json
+    kind: MachineHealthCheck
+    name: machinehealthcheck_v1beta2
+  - apiVersion: cluster.x-k8s.io/v1beta2
+    filename: cluster.x-k8s.io/clusterclass_v1beta2.json
+    kind: ClusterClass
+    name: clusterclass_v1beta2
+  - apiVersion: cluster.x-k8s.io/v1beta2
+    filename: cluster.x-k8s.io/machineset_v1beta2.json
+    kind: MachineSet
+    name: machineset_v1beta2
+  - apiVersion: cluster.x-k8s.io/v1beta2
+    filename: cluster.x-k8s.io/machinepool_v1beta2.json
+    kind: MachinePool
+    name: machinepool_v1beta2
+  - apiVersion: cluster.x-k8s.io/v1beta2
+    filename: cluster.x-k8s.io/machinedeployment_v1beta2.json
+    kind: MachineDeployment
+    name: machinedeployment_v1beta2
+  - apiVersion: cluster.x-k8s.io/v1beta2
+    filename: cluster.x-k8s.io/cluster_v1beta2.json
+    kind: Cluster
+    name: cluster_v1beta2
 clusterctl.cluster.x-k8s.io:
   - apiVersion: clusterctl.cluster.x-k8s.io/v1alpha3
     filename: clusterctl.cluster.x-k8s.io/provider_v1alpha3.json
@@ -1814,6 +3203,94 @@ clustersecret.io:
     filename: clustersecret.io/clustersecret_v1.json
     kind: clustersecret
     name: clustersecret_v1
+cognitoidentityprovider.services.k8s.aws:
+  - apiVersion: cognitoidentityprovider.services.k8s.aws/v1alpha1
+    filename: cognitoidentityprovider.services.k8s.aws/userpool_v1alpha1.json
+    kind: UserPool
+    name: userpool_v1alpha1
+collectors.grafana.com:
+  - apiVersion: collectors.grafana.com/v1alpha1
+    filename: collectors.grafana.com/alloy_v1alpha1.json
+    kind: Alloy
+    name: alloy_v1alpha1
+composer.cnrm.cloud.google.com:
+  - apiVersion: composer.cnrm.cloud.google.com/v1beta1
+    filename: composer.cnrm.cloud.google.com/composerenvironment_v1beta1.json
+    kind: ComposerEnvironment
+    name: composerenvironment_v1beta1
+  - apiVersion: composer.cnrm.cloud.google.com/v1alpha1
+    filename: composer.cnrm.cloud.google.com/composerenvironment_v1alpha1.json
+    kind: ComposerEnvironment
+    name: composerenvironment_v1alpha1
+compute.azure.com:
+  - apiVersion: compute.azure.com/v1api20200930
+    filename: compute.azure.com/snapshot_v1api20200930.json
+    kind: snapshot
+    name: snapshot_v1api20200930
+  - apiVersion: compute.azure.com/v1api20201201
+    filename: compute.azure.com/virtualmachinescalesetsextension_v1api20201201.json
+    kind: virtualmachinescalesetsextension
+    name: virtualmachinescalesetsextension_v1api20201201
+  - apiVersion: compute.azure.com/v1api20220301
+    filename: compute.azure.com/virtualmachinescaleset_v1api20220301.json
+    kind: virtualMachineScaleSet
+    name: virtualmachinescaleset_v1api20220301
+  - apiVersion: compute.azure.com/v1api20220301
+    filename: compute.azure.com/virtualmachinesextension_v1api20220301.json
+    kind: virtualmachinesextension
+    name: virtualmachinesextension_v1api20220301
+  - apiVersion: compute.azure.com/v1api20201201
+    filename: compute.azure.com/virtualmachinescaleset_v1api20201201.json
+    kind: virtualMachineScaleSet
+    name: virtualmachinescaleset_v1api20201201
+  - apiVersion: compute.azure.com/v1api20220301
+    filename: compute.azure.com/image_v1api20220301.json
+    kind: image
+    name: image_v1api20220301
+  - apiVersion: compute.azure.com/v1api20210701
+    filename: compute.azure.com/image_v1api20210701.json
+    kind: image
+    name: image_v1api20210701
+  - apiVersion: compute.azure.com/v1api20240302
+    filename: compute.azure.com/disk_v1api20240302.json
+    kind: Disk
+    name: disk_v1api20240302
+  - apiVersion: compute.azure.com/v1api20220301
+    filename: compute.azure.com/virtualmachinescalesetsextension_v1api20220301.json
+    kind: virtualmachinescalesetsextension
+    name: virtualmachinescalesetsextension_v1api20220301
+  - apiVersion: compute.azure.com/v1api20200930
+    filename: compute.azure.com/disk_v1api20200930.json
+    kind: Disk
+    name: disk_v1api20200930
+  - apiVersion: compute.azure.com/v1api20220702
+    filename: compute.azure.com/diskencryptionset_v1api20220702.json
+    kind: diskEncryptionSet
+    name: diskencryptionset_v1api20220702
+  - apiVersion: compute.azure.com/v1api20201201
+    filename: compute.azure.com/virtualmachine_v1api20201201.json
+    kind: virtualMachine
+    name: virtualmachine_v1api20201201
+  - apiVersion: compute.azure.com/v1api20201201
+    filename: compute.azure.com/virtualmachinesextension_v1api20201201.json
+    kind: virtualmachinesextension
+    name: virtualmachinesextension_v1api20201201
+  - apiVersion: compute.azure.com/v1api20220301
+    filename: compute.azure.com/virtualmachine_v1api20220301.json
+    kind: virtualMachine
+    name: virtualmachine_v1api20220301
+  - apiVersion: compute.azure.com/v1api20240302
+    filename: compute.azure.com/snapshot_v1api20240302.json
+    kind: snapshot
+    name: snapshot_v1api20240302
+  - apiVersion: compute.azure.com/v1api20240302
+    filename: compute.azure.com/diskencryptionset_v1api20240302.json
+    kind: diskEncryptionSet
+    name: diskencryptionset_v1api20240302
+  - apiVersion: compute.azure.com/v1api20240302
+    filename: compute.azure.com/diskaccess_v1api20240302.json
+    kind: diskAccess
+    name: diskaccess_v1api20240302
 compute.cnrm.cloud.google.com:
   - apiVersion: compute.cnrm.cloud.google.com/v1beta1
     filename: compute.cnrm.cloud.google.com/computetargetvpngateway_v1beta1.json
@@ -2119,6 +3596,15 @@ compute.cnrm.cloud.google.com:
     filename: compute.cnrm.cloud.google.com/computesslpolicy_v1beta1.json
     kind: computesslpolicy
     name: computesslpolicy_v1beta1
+  - apiVersion: compute.cnrm.cloud.google.com/v1
+    filename: compute.cnrm.cloud.google.com/computeclass_v1.json
+    kind: ComputeClass
+    name: computeclass_v1
+compute.coreweave.com:
+  - apiVersion: compute.coreweave.com/v1alpha1
+    filename: compute.coreweave.com/nodepool_v1alpha1.json
+    kind: NodePool
+    name: nodepool_v1alpha1
 config.concierge.pinniped.dev:
   - apiVersion: config.concierge.pinniped.dev/v1alpha1
     filename: config.concierge.pinniped.dev/credentialissuer_v1alpha1.json
@@ -2129,6 +3615,31 @@ config.gatekeeper.sh:
     filename: config.gatekeeper.sh/config_v1alpha1.json
     kind: Config
     name: config_v1alpha1
+config.projectsveltos.io:
+  - apiVersion: config.projectsveltos.io/v1beta1
+    filename: config.projectsveltos.io/clusterreport_v1beta1.json
+    kind: ClusterReport
+    name: clusterreport_v1beta1
+  - apiVersion: config.projectsveltos.io/v1beta1
+    filename: config.projectsveltos.io/clusterpromotion_v1beta1.json
+    kind: ClusterPromotion
+    name: clusterpromotion_v1beta1
+  - apiVersion: config.projectsveltos.io/v1beta1
+    filename: config.projectsveltos.io/profile_v1beta1.json
+    kind: Profile
+    name: profile_v1beta1
+  - apiVersion: config.projectsveltos.io/v1beta1
+    filename: config.projectsveltos.io/clustersummary_v1beta1.json
+    kind: ClusterSummary
+    name: clustersummary_v1beta1
+  - apiVersion: config.projectsveltos.io/v1beta1
+    filename: config.projectsveltos.io/clusterprofile_v1beta1.json
+    kind: ClusterProfile
+    name: clusterprofile_v1beta1
+  - apiVersion: config.projectsveltos.io/v1beta1
+    filename: config.projectsveltos.io/clusterconfiguration_v1beta1.json
+    kind: ClusterConfiguration
+    name: clusterconfiguration_v1beta1
 config.supervisor.pinniped.dev:
   - apiVersion: config.supervisor.pinniped.dev/v1alpha1
     filename: config.supervisor.pinniped.dev/federationdomain_v1alpha1.json
@@ -2172,6 +3683,41 @@ configuration.konghq.com:
     filename: configuration.konghq.com/tcpingress_v1beta1.json
     kind: TCPIngress
     name: tcpingress_v1beta1
+  - apiVersion: configuration.konghq.com/v1alpha1
+    filename: configuration.konghq.com/konglicense_v1alpha1.json
+    kind: KongLicense
+    name: konglicense_v1alpha1
+  - apiVersion: configuration.konghq.com/v1alpha1
+    filename: configuration.konghq.com/kongcustomentity_v1alpha1.json
+    kind: KongCustomEntity
+    name: kongcustomentity_v1alpha1
+  - apiVersion: configuration.konghq.com/v1beta1
+    filename: configuration.konghq.com/kongupstreampolicy_v1beta1.json
+    kind: KongUpstreamPolicy
+    name: kongupstreampolicy_v1beta1
+  - apiVersion: configuration.konghq.com/v1beta1
+    filename: configuration.konghq.com/kongconsumergroup_v1beta1.json
+    kind: KongConsumerGroup
+    name: kongconsumergroup_v1beta1
+  - apiVersion: configuration.konghq.com/v1alpha1
+    filename: configuration.konghq.com/kongvault_v1alpha1.json
+    kind: KongVault
+    name: kongvault_v1alpha1
+connections.grafana.crossplane.io:
+  - apiVersion: connections.grafana.crossplane.io/v1alpha1
+    filename: connections.grafana.crossplane.io/metricsendpointscrapejob_v1alpha1.json
+    kind: MetricsEndpointScrapeJob
+    name: metricsendpointscrapejob_v1alpha1
+connections.grafana.m.crossplane.io:
+  - apiVersion: connections.grafana.m.crossplane.io/v1alpha1
+    filename: connections.grafana.m.crossplane.io/metricsendpointscrapejob_v1alpha1.json
+    kind: MetricsEndpointScrapeJob
+    name: metricsendpointscrapejob_v1alpha1
+connections.grafana.o.crossplane.io:
+  - apiVersion: connections.grafana.o.crossplane.io/v1alpha1
+    filename: connections.grafana.o.crossplane.io/metricsendpointscrapejob_v1alpha1.json
+    kind: MetricsEndpointScrapeJob
+    name: metricsendpointscrapejob_v1alpha1
 container.cnrm.cloud.google.com:
   - apiVersion: container.cnrm.cloud.google.com/v1beta1
     filename: container.cnrm.cloud.google.com/containernodepool_v1beta1.json
@@ -2195,6 +3741,101 @@ containerattached.cnrm.cloud.google.com:
     filename: containerattached.cnrm.cloud.google.com/containerattachedcluster_v1beta1.json
     kind: ContainerAttachedCluster
     name: containerattachedcluster_v1beta1
+containerinstance.azure.com:
+  - apiVersion: containerinstance.azure.com/v1api20211001
+    filename: containerinstance.azure.com/containergroup_v1api20211001.json
+    kind: containerGroup
+    name: containergroup_v1api20211001
+containerregistry.azure.com:
+  - apiVersion: containerregistry.azure.com/v1api20230701
+    filename: containerregistry.azure.com/registryreplication_v1api20230701.json
+    kind: registryreplication
+    name: registryreplication_v1api20230701
+  - apiVersion: containerregistry.azure.com/v1api20230701
+    filename: containerregistry.azure.com/registry_v1api20230701.json
+    kind: registry
+    name: registry_v1api20230701
+  - apiVersion: containerregistry.azure.com/v1api20210901
+    filename: containerregistry.azure.com/registry_v1api20210901.json
+    kind: registry
+    name: registry_v1api20210901
+containerservice.azure.com:
+  - apiVersion: containerservice.azure.com/v1api20230315preview
+    filename: containerservice.azure.com/fleetsupdaterun_v1api20230315preview.json
+    kind: fleetsupdaterun
+    name: fleetsupdaterun_v1api20230315preview
+  - apiVersion: containerservice.azure.com/v1api20230201
+    filename: containerservice.azure.com/managedclustersagentpool_v1api20230201.json
+    kind: managedclustersagentpool
+    name: managedclustersagentpool_v1api20230201
+  - apiVersion: containerservice.azure.com/v1api20240901
+    filename: containerservice.azure.com/managedcluster_v1api20240901.json
+    kind: managedCluster
+    name: managedcluster_v1api20240901
+  - apiVersion: containerservice.azure.com/v1api20240402preview
+    filename: containerservice.azure.com/trustedaccessrolebinding_v1api20240402preview.json
+    kind: trustedAccessRoleBinding
+    name: trustedaccessrolebinding_v1api20240402preview
+  - apiVersion: containerservice.azure.com/v1api20231001
+    filename: containerservice.azure.com/managedclustersagentpool_v1api20231001.json
+    kind: managedclustersagentpool
+    name: managedclustersagentpool_v1api20231001
+  - apiVersion: containerservice.azure.com/v1api20240901
+    filename: containerservice.azure.com/managedclustersagentpool_v1api20240901.json
+    kind: managedclustersagentpool
+    name: managedclustersagentpool_v1api20240901
+  - apiVersion: containerservice.azure.com/v1api20210501
+    filename: containerservice.azure.com/managedclustersagentpool_v1api20210501.json
+    kind: managedclustersagentpool
+    name: managedclustersagentpool_v1api20210501
+  - apiVersion: containerservice.azure.com/v1api20231102preview
+    filename: containerservice.azure.com/managedcluster_v1api20231102preview.json
+    kind: managedcluster
+    name: managedcluster_v1api20231102preview
+  - apiVersion: containerservice.azure.com/v1api20230201
+    filename: containerservice.azure.com/managedcluster_v1api20230201.json
+    kind: managedcluster
+    name: managedcluster_v1api20230201
+  - apiVersion: containerservice.azure.com/v1api20240402preview
+    filename: containerservice.azure.com/managedclustersagentpool_v1api20240402preview.json
+    kind: managedclustersagentpool
+    name: managedclustersagentpool_v1api20240402preview
+  - apiVersion: containerservice.azure.com/v1api20231102preview
+    filename: containerservice.azure.com/managedclustersagentpool_v1api20231102preview.json
+    kind: managedclustersagentpool
+    name: managedclustersagentpool_v1api20231102preview
+  - apiVersion: containerservice.azure.com/v1api20240901
+    filename: containerservice.azure.com/maintenanceconfiguration_v1api20240901.json
+    kind: maintenanceConfiguration
+    name: maintenanceconfiguration_v1api20240901
+  - apiVersion: containerservice.azure.com/v1api20210501
+    filename: containerservice.azure.com/managedcluster_v1api20210501.json
+    kind: managedcluster
+    name: managedcluster_v1api20210501
+  - apiVersion: containerservice.azure.com/v1api20240901
+    filename: containerservice.azure.com/trustedaccessrolebinding_v1api20240901.json
+    kind: trustedAccessRoleBinding
+    name: trustedaccessrolebinding_v1api20240901
+  - apiVersion: containerservice.azure.com/v1api20230315preview
+    filename: containerservice.azure.com/fleetsmember_v1api20230315preview.json
+    kind: fleetsmember
+    name: fleetsmember_v1api20230315preview
+  - apiVersion: containerservice.azure.com/v1api20231001
+    filename: containerservice.azure.com/managedcluster_v1api20231001.json
+    kind: managedCluster
+    name: managedcluster_v1api20231001
+  - apiVersion: containerservice.azure.com/v1api20240402preview
+    filename: containerservice.azure.com/managedcluster_v1api20240402preview.json
+    kind: managedCluster
+    name: managedcluster_v1api20240402preview
+  - apiVersion: containerservice.azure.com/v1api20231001
+    filename: containerservice.azure.com/trustedaccessrolebinding_v1api20231001.json
+    kind: trustedAccessRoleBinding
+    name: trustedaccessrolebinding_v1api20231001
+  - apiVersion: containerservice.azure.com/v1api20230315preview
+    filename: containerservice.azure.com/fleet_v1api20230315preview.json
+    kind: fleet
+    name: fleet_v1api20230315preview
 controlplane.cluster.x-k8s.io:
   - apiVersion: controlplane.cluster.x-k8s.io/v1beta2
     filename: controlplane.cluster.x-k8s.io/awsmanagedcontrolplane_v1beta2.json
@@ -2240,6 +3881,38 @@ controlplane.cluster.x-k8s.io:
     filename: controlplane.cluster.x-k8s.io/taloscontrolplane_v1alpha3.json
     kind: TalosControlPlane
     name: taloscontrolplane_v1alpha3
+  - apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    filename: controlplane.cluster.x-k8s.io/k0scontrolplanetemplate_v1beta1.json
+    kind: K0sControlPlaneTemplate
+    name: k0scontrolplanetemplate_v1beta1
+  - apiVersion: controlplane.cluster.x-k8s.io/v1alpha1
+    filename: controlplane.cluster.x-k8s.io/kamajicontrolplanetemplate_v1alpha1.json
+    kind: KamajiControlPlaneTemplate
+    name: kamajicontrolplanetemplate_v1alpha1
+  - apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+    filename: controlplane.cluster.x-k8s.io/kubeadmcontrolplane_v1beta2.json
+    kind: KubeadmControlPlane
+    name: kubeadmcontrolplane_v1beta2
+  - apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+    filename: controlplane.cluster.x-k8s.io/kubeadmcontrolplanetemplate_v1beta2.json
+    kind: KubeadmControlPlaneTemplate
+    name: kubeadmcontrolplanetemplate_v1beta2
+  - apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    filename: controlplane.cluster.x-k8s.io/k0smotroncontrolplane_v1beta1.json
+    kind: K0smotronControlPlane
+    name: k0smotroncontrolplane_v1beta1
+  - apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    filename: controlplane.cluster.x-k8s.io/k0smotroncontrolplanetemplate_v1beta1.json
+    kind: K0smotronControlPlaneTemplate
+    name: k0smotroncontrolplanetemplate_v1beta1
+  - apiVersion: controlplane.cluster.x-k8s.io/v1alpha1
+    filename: controlplane.cluster.x-k8s.io/kamajicontrolplane_v1alpha1.json
+    kind: KamajiControlPlane
+    name: kamajicontrolplane_v1alpha1
+  - apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    filename: controlplane.cluster.x-k8s.io/k0scontrolplane_v1beta1.json
+    kind: K0sControlPlane
+    name: k0scontrolplane_v1beta1
 core.cnrm.cloud.google.com:
   - apiVersion: core.cnrm.cloud.google.com/v1beta1
     filename: core.cnrm.cloud.google.com/configconnector_v1beta1.json
@@ -2253,6 +3926,23 @@ core.cnrm.cloud.google.com:
     filename: core.cnrm.cloud.google.com/configconnectorcontext_v1beta1.json
     kind: ConfigConnectorContext
     name: configconnectorcontext_v1beta1
+core.openfeature.dev:
+  - apiVersion: core.openfeature.dev/v1beta1
+    filename: core.openfeature.dev/featureflag_v1beta1.json
+    kind: FeatureFlag
+    name: featureflag_v1beta1
+  - apiVersion: core.openfeature.dev/v1beta1
+    filename: core.openfeature.dev/featureflagsource_v1beta1.json
+    kind: FeatureFlagSource
+    name: featureflagsource_v1beta1
+  - apiVersion: core.openfeature.dev/v1beta1
+    filename: core.openfeature.dev/flagd_v1beta1.json
+    kind: Flagd
+    name: flagd_v1beta1
+  - apiVersion: core.openfeature.dev/v1beta1
+    filename: core.openfeature.dev/inprocessconfiguration_v1beta1.json
+    kind: InProcessConfiguration
+    name: inprocessconfiguration_v1beta1
 core.strimzi.io:
   - apiVersion: core.strimzi.io/v1beta2
     filename: core.strimzi.io/strimzipodset_v1beta2.json
@@ -2268,6 +3958,47 @@ crd.k8s.amazonaws.com:
     filename: crd.k8s.amazonaws.com/eniconfig_v1alpha1.json
     kind: ENIConfig
     name: eniconfig_v1alpha1
+csi.ceph.io:
+  - apiVersion: csi.ceph.io/v1alpha1
+    filename: csi.ceph.io/driver_v1alpha1.json
+    kind: Driver
+    name: driver_v1alpha1
+  - apiVersion: csi.ceph.io/v1
+    filename: csi.ceph.io/clientprofilemapping_v1.json
+    kind: ClientProfileMapping
+    name: clientprofilemapping_v1
+  - apiVersion: csi.ceph.io/v1
+    filename: csi.ceph.io/cephconnection_v1.json
+    kind: CephConnection
+    name: cephconnection_v1
+  - apiVersion: csi.ceph.io/v1alpha1
+    filename: csi.ceph.io/operatorconfig_v1alpha1.json
+    kind: OperatorConfig
+    name: operatorconfig_v1alpha1
+  - apiVersion: csi.ceph.io/v1
+    filename: csi.ceph.io/operatorconfig_v1.json
+    kind: OperatorConfig
+    name: operatorconfig_v1
+  - apiVersion: csi.ceph.io/v1alpha1
+    filename: csi.ceph.io/cephconnection_v1alpha1.json
+    kind: CephConnection
+    name: cephconnection_v1alpha1
+  - apiVersion: csi.ceph.io/v1alpha1
+    filename: csi.ceph.io/clientprofile_v1alpha1.json
+    kind: ClientProfile
+    name: clientprofile_v1alpha1
+  - apiVersion: csi.ceph.io/v1
+    filename: csi.ceph.io/driver_v1.json
+    kind: Driver
+    name: driver_v1
+  - apiVersion: csi.ceph.io/v1
+    filename: csi.ceph.io/clientprofile_v1.json
+    kind: ClientProfile
+    name: clientprofile_v1
+  - apiVersion: csi.ceph.io/v1alpha1
+    filename: csi.ceph.io/clientprofilemapping_v1alpha1.json
+    kind: ClientProfileMapping
+    name: clientprofilemapping_v1alpha1
 customize.core.cnrm.cloud.google.com:
   - apiVersion: customize.core.cnrm.cloud.google.com/v1alpha1
     filename: customize.core.cnrm.cloud.google.com/controllerresource_v1alpha1.json
@@ -2301,6 +4032,22 @@ customize.core.cnrm.cloud.google.com:
     filename: customize.core.cnrm.cloud.google.com/controllerresource_v1beta1.json
     kind: ControllerResource
     name: controllerresource_v1beta1
+  - apiVersion: customize.core.cnrm.cloud.google.com/v1beta1
+    filename: customize.core.cnrm.cloud.google.com/namespacedcontrollerreconciler_v1beta1.json
+    kind: NamespacedControllerReconciler
+    name: namespacedcontrollerreconciler_v1beta1
+  - apiVersion: customize.core.cnrm.cloud.google.com/v1alpha1
+    filename: customize.core.cnrm.cloud.google.com/namespacedcontrollerreconciler_v1alpha1.json
+    kind: NamespacedControllerReconciler
+    name: namespacedcontrollerreconciler_v1alpha1
+  - apiVersion: customize.core.cnrm.cloud.google.com/v1beta1
+    filename: customize.core.cnrm.cloud.google.com/controllerreconciler_v1beta1.json
+    kind: ControllerReconciler
+    name: controllerreconciler_v1beta1
+  - apiVersion: customize.core.cnrm.cloud.google.com/v1alpha1
+    filename: customize.core.cnrm.cloud.google.com/controllerreconciler_v1alpha1.json
+    kind: ControllerReconciler
+    name: controllerreconciler_v1alpha1
 dapr.io:
   - apiVersion: dapr.io/v1alpha1
     filename: dapr.io/component_v1alpha1.json
@@ -2322,6 +4069,10 @@ dapr.io:
     filename: dapr.io/resiliency_v1alpha1.json
     kind: resiliency
     name: resiliency_v1alpha1
+  - apiVersion: dapr.io/v1alpha1
+    filename: dapr.io/httpendpoint_v1alpha1.json
+    kind: HTTPEndpoint
+    name: httpendpoint_v1alpha1
 databases.spotahome.com:
   - apiVersion: databases.spotahome.com/v1
     filename: databases.spotahome.com/redisfailover_v1.json
@@ -2393,6 +4144,15 @@ datadoghq.com:
     filename: datadoghq.com/datadoggenericresource_v1alpha1.json
     kind: DatadogGenericResource
     name: datadoggenericresource_v1alpha1
+  - apiVersion: datadoghq.com/v1alpha1
+    filename: datadoghq.com/datadogagentinternal_v1alpha1.json
+    kind: DatadogAgentInternal
+    name: datadogagentinternal_v1alpha1
+datafactory.azure.com:
+  - apiVersion: datafactory.azure.com/v1api20180601
+    filename: datafactory.azure.com/factory_v1api20180601.json
+    kind: factory
+    name: factory_v1api20180601
 dataflow.cnrm.cloud.google.com:
   - apiVersion: dataflow.cnrm.cloud.google.com/v1beta1
     filename: dataflow.cnrm.cloud.google.com/dataflowflextemplatejob_v1beta1.json
@@ -2429,6 +4189,27 @@ dataproc.cnrm.cloud.google.com:
     filename: dataproc.cnrm.cloud.google.com/dataprocautoscalingpolicy_v1beta1.json
     kind: dataprocautoscalingpolicy
     name: dataprocautoscalingpolicy_v1beta1
+dataprotection.azure.com:
+  - apiVersion: dataprotection.azure.com/v1api20231101
+    filename: dataprotection.azure.com/backupvault_v1api20231101.json
+    kind: backupVault
+    name: backupvault_v1api20231101
+  - apiVersion: dataprotection.azure.com/v1api20230101
+    filename: dataprotection.azure.com/backupvault_v1api20230101.json
+    kind: backupVault
+    name: backupvault_v1api20230101
+  - apiVersion: dataprotection.azure.com/v1api20231101
+    filename: dataprotection.azure.com/backupvaultsbackuppolicy_v1api20231101.json
+    kind: backupvaultsbackuppolicy
+    name: backupvaultsbackuppolicy_v1api20231101
+  - apiVersion: dataprotection.azure.com/v1api20230101
+    filename: dataprotection.azure.com/backupvaultsbackuppolicy_v1api20230101.json
+    kind: backupvaultsbackuppolicy
+    name: backupvaultsbackuppolicy_v1api20230101
+  - apiVersion: dataprotection.azure.com/v1api20231101
+    filename: dataprotection.azure.com/backupvaultsbackupinstance_v1api20231101.json
+    kind: backupvaultsbackupinstance
+    name: backupvaultsbackupinstance_v1api20231101
 datastore.cnrm.cloud.google.com:
   - apiVersion: datastore.cnrm.cloud.google.com/v1alpha1
     filename: datastore.cnrm.cloud.google.com/datastoreindex_v1alpha1.json
@@ -2447,6 +4228,15 @@ datastream.cnrm.cloud.google.com:
     filename: datastream.cnrm.cloud.google.com/datastreamconnectionprofile_v1alpha1.json
     kind: datastreamconnectionprofile
     name: datastreamconnectionprofile_v1alpha1
+db.atlasgo.io:
+  - apiVersion: db.atlasgo.io/v1alpha1
+    filename: db.atlasgo.io/atlasschema_v1alpha1.json
+    kind: AtlasSchema
+    name: atlasschema_v1alpha1
+  - apiVersion: db.atlasgo.io/v1alpha1
+    filename: db.atlasgo.io/atlasmigration_v1alpha1.json
+    kind: AtlasMigration
+    name: atlasmigration_v1alpha1
 dbaas.percona.com:
   - apiVersion: dbaas.percona.com/v1
     filename: dbaas.percona.com/databasecluster_v1.json
@@ -2460,11 +4250,191 @@ dbaas.percona.com:
     filename: dbaas.percona.com/databaseengine_v1.json
     kind: DatabaseEngine
     name: databaseengine_v1
+dbformariadb.azure.com:
+  - apiVersion: dbformariadb.azure.com/v1api20180601
+    filename: dbformariadb.azure.com/database_v1api20180601.json
+    kind: database
+    name: database_v1api20180601
+  - apiVersion: dbformariadb.azure.com/v1api20180601
+    filename: dbformariadb.azure.com/server_v1api20180601.json
+    kind: server
+    name: server_v1api20180601
+  - apiVersion: dbformariadb.azure.com/v1api20180601
+    filename: dbformariadb.azure.com/configuration_v1api20180601.json
+    kind: configuration
+    name: configuration_v1api20180601
+dbformysql.azure.com:
+  - apiVersion: dbformysql.azure.com/v1api20231230
+    filename: dbformysql.azure.com/flexibleserversconfiguration_v1api20231230.json
+    kind: flexibleserversconfiguration
+    name: flexibleserversconfiguration_v1api20231230
+  - apiVersion: dbformysql.azure.com/v1api20210501
+    filename: dbformysql.azure.com/flexibleserver_v1api20210501.json
+    kind: flexibleServer
+    name: flexibleserver_v1api20210501
+  - apiVersion: dbformysql.azure.com/v1api20230630
+    filename: dbformysql.azure.com/flexibleserver_v1api20230630.json
+    kind: FlexibleServer
+    name: flexibleserver_v1api20230630
+  - apiVersion: dbformysql.azure.com/v1api20230630
+    filename: dbformysql.azure.com/flexibleserversconfiguration_v1api20230630.json
+    kind: flexibleserversconfiguration
+    name: flexibleserversconfiguration_v1api20230630
+  - apiVersion: dbformysql.azure.com/v1api20231230
+    filename: dbformysql.azure.com/flexibleserver_v1api20231230.json
+    kind: FlexibleServer
+    name: flexibleserver_v1api20231230
+  - apiVersion: dbformysql.azure.com/v1api20230630
+    filename: dbformysql.azure.com/flexibleserversadministrator_v1api20230630.json
+    kind: flexibleserversadministrator
+    name: flexibleserversadministrator_v1api20230630
+  - apiVersion: dbformysql.azure.com/v1api20210501
+    filename: dbformysql.azure.com/flexibleserversfirewallrule_v1api20210501.json
+    kind: flexibleserversfirewallrule
+    name: flexibleserversfirewallrule_v1api20210501
+  - apiVersion: dbformysql.azure.com/v1api20231230
+    filename: dbformysql.azure.com/flexibleserversadministrator_v1api20231230.json
+    kind: flexibleserversadministrator
+    name: flexibleserversadministrator_v1api20231230
+  - apiVersion: dbformysql.azure.com/v1
+    filename: dbformysql.azure.com/user_v1.json
+    kind: User
+    name: user_v1
+  - apiVersion: dbformysql.azure.com/v1api20220101
+    filename: dbformysql.azure.com/flexibleserversadministrator_v1api20220101.json
+    kind: flexibleserversadministrator
+    name: flexibleserversadministrator_v1api20220101
+  - apiVersion: dbformysql.azure.com/v1api20230630
+    filename: dbformysql.azure.com/flexibleserversdatabase_v1api20230630.json
+    kind: flexibleserversdatabase
+    name: flexibleserversdatabase_v1api20230630
+  - apiVersion: dbformysql.azure.com/v1api20220101
+    filename: dbformysql.azure.com/flexibleserversconfiguration_v1api20220101.json
+    kind: flexibleserversconfiguration
+    name: flexibleserversconfiguration_v1api20220101
+  - apiVersion: dbformysql.azure.com/v1api20231230
+    filename: dbformysql.azure.com/flexibleserversdatabase_v1api20231230.json
+    kind: flexibleserversdatabase
+    name: flexibleserversdatabase_v1api20231230
+  - apiVersion: dbformysql.azure.com/v1api20230630
+    filename: dbformysql.azure.com/flexibleserversfirewallrule_v1api20230630.json
+    kind: flexibleserversfirewallrule
+    name: flexibleserversfirewallrule_v1api20230630
+  - apiVersion: dbformysql.azure.com/v1api20231230
+    filename: dbformysql.azure.com/flexibleserversfirewallrule_v1api20231230.json
+    kind: flexibleserversfirewallrule
+    name: flexibleserversfirewallrule_v1api20231230
+  - apiVersion: dbformysql.azure.com/v1api20210501
+    filename: dbformysql.azure.com/flexibleserversdatabase_v1api20210501.json
+    kind: flexibleserversdatabase
+    name: flexibleserversdatabase_v1api20210501
+dbforpostgresql.azure.com:
+  - apiVersion: dbforpostgresql.azure.com/v1api20230601preview
+    filename: dbforpostgresql.azure.com/flexibleserversconfiguration_v1api20230601preview.json
+    kind: flexibleserversconfiguration
+    name: flexibleserversconfiguration_v1api20230601preview
+  - apiVersion: dbforpostgresql.azure.com/v1api20221201
+    filename: dbforpostgresql.azure.com/flexibleserversdatabase_v1api20221201.json
+    kind: flexibleserversdatabase
+    name: flexibleserversdatabase_v1api20221201
+  - apiVersion: dbforpostgresql.azure.com/v1api20240801
+    filename: dbforpostgresql.azure.com/flexibleserversfirewallrule_v1api20240801.json
+    kind: flexibleserversfirewallrule
+    name: flexibleserversfirewallrule_v1api20240801
+  - apiVersion: dbforpostgresql.azure.com/v1api20221201
+    filename: dbforpostgresql.azure.com/flexibleserver_v1api20221201.json
+    kind: FlexibleServer
+    name: flexibleserver_v1api20221201
+  - apiVersion: dbforpostgresql.azure.com/v1api20240801
+    filename: dbforpostgresql.azure.com/flexibleserversbackup_v1api20240801.json
+    kind: flexibleserversbackup
+    name: flexibleserversbackup_v1api20240801
+  - apiVersion: dbforpostgresql.azure.com/v1api20210601
+    filename: dbforpostgresql.azure.com/flexibleserversdatabase_v1api20210601.json
+    kind: flexibleserversdatabase
+    name: flexibleserversdatabase_v1api20210601
+  - apiVersion: dbforpostgresql.azure.com/v1api20240801
+    filename: dbforpostgresql.azure.com/flexibleserversconfiguration_v1api20240801.json
+    kind: flexibleserversconfiguration
+    name: flexibleserversconfiguration_v1api20240801
+  - apiVersion: dbforpostgresql.azure.com/v1api20230601preview
+    filename: dbforpostgresql.azure.com/flexibleserver_v1api20230601preview.json
+    kind: FlexibleServer
+    name: flexibleserver_v1api20230601preview
+  - apiVersion: dbforpostgresql.azure.com/v1api20240801
+    filename: dbforpostgresql.azure.com/flexibleserversvirtualendpoint_v1api20240801.json
+    kind: flexibleserversvirtualendpoint
+    name: flexibleserversvirtualendpoint_v1api20240801
+  - apiVersion: dbforpostgresql.azure.com/v1
+    filename: dbforpostgresql.azure.com/user_v1.json
+    kind: User
+    name: user_v1
+  - apiVersion: dbforpostgresql.azure.com/v1api20210601
+    filename: dbforpostgresql.azure.com/flexibleserversfirewallrule_v1api20210601.json
+    kind: flexibleserversfirewallrule
+    name: flexibleserversfirewallrule_v1api20210601
+  - apiVersion: dbforpostgresql.azure.com/v1api20221201
+    filename: dbforpostgresql.azure.com/flexibleserversconfiguration_v1api20221201.json
+    kind: flexibleserversconfiguration
+    name: flexibleserversconfiguration_v1api20221201
+  - apiVersion: dbforpostgresql.azure.com/v1api20220120preview
+    filename: dbforpostgresql.azure.com/flexibleserversconfiguration_v1api20220120preview.json
+    kind: flexibleserversconfiguration
+    name: flexibleserversconfiguration_v1api20220120preview
+  - apiVersion: dbforpostgresql.azure.com/v1api20220120preview
+    filename: dbforpostgresql.azure.com/flexibleserversdatabase_v1api20220120preview.json
+    kind: flexibleserversdatabase
+    name: flexibleserversdatabase_v1api20220120preview
+  - apiVersion: dbforpostgresql.azure.com/v1api20240801
+    filename: dbforpostgresql.azure.com/flexibleserversadvancedthreatprotectionsettings_v1api20240801.json
+    kind: flexibleserversadvancedthreatprotectionsettings
+    name: flexibleserversadvancedthreatprotectionsettings_v1api20240801
+  - apiVersion: dbforpostgresql.azure.com/v1api20210601
+    filename: dbforpostgresql.azure.com/flexibleserver_v1api20210601.json
+    kind: flexibleServer
+    name: flexibleserver_v1api20210601
+  - apiVersion: dbforpostgresql.azure.com/v1api20240801
+    filename: dbforpostgresql.azure.com/flexibleserver_v1api20240801.json
+    kind: FlexibleServer
+    name: flexibleserver_v1api20240801
+  - apiVersion: dbforpostgresql.azure.com/v1api20220120preview
+    filename: dbforpostgresql.azure.com/flexibleserver_v1api20220120preview.json
+    kind: flexibleServer
+    name: flexibleserver_v1api20220120preview
+  - apiVersion: dbforpostgresql.azure.com/v1api20210601
+    filename: dbforpostgresql.azure.com/flexibleserversconfiguration_v1api20210601.json
+    kind: flexibleserversconfiguration
+    name: flexibleserversconfiguration_v1api20210601
+  - apiVersion: dbforpostgresql.azure.com/v1api20220120preview
+    filename: dbforpostgresql.azure.com/flexibleserversfirewallrule_v1api20220120preview.json
+    kind: flexibleserversfirewallrule
+    name: flexibleserversfirewallrule_v1api20220120preview
+  - apiVersion: dbforpostgresql.azure.com/v1api20230601preview
+    filename: dbforpostgresql.azure.com/flexibleserversfirewallrule_v1api20230601preview.json
+    kind: flexibleserversfirewallrule
+    name: flexibleserversfirewallrule_v1api20230601preview
+  - apiVersion: dbforpostgresql.azure.com/v1api20230601preview
+    filename: dbforpostgresql.azure.com/flexibleserversdatabase_v1api20230601preview.json
+    kind: flexibleserversdatabase
+    name: flexibleserversdatabase_v1api20230601preview
+  - apiVersion: dbforpostgresql.azure.com/v1api20240801
+    filename: dbforpostgresql.azure.com/flexibleserversdatabase_v1api20240801.json
+    kind: flexibleserversdatabase
+    name: flexibleserversdatabase_v1api20240801
+  - apiVersion: dbforpostgresql.azure.com/v1api20221201
+    filename: dbforpostgresql.azure.com/flexibleserversfirewallrule_v1api20221201.json
+    kind: flexibleserversfirewallrule
+    name: flexibleserversfirewallrule_v1api20221201
 deploymentmanager.cnrm.cloud.google.com:
   - apiVersion: deploymentmanager.cnrm.cloud.google.com/v1alpha1
     filename: deploymentmanager.cnrm.cloud.google.com/deploymentmanagerdeployment_v1alpha1.json
     kind: deploymentmanagerdeployment
     name: deploymentmanagerdeployment_v1alpha1
+devices.azure.com:
+  - apiVersion: devices.azure.com/v1api20210702
+    filename: devices.azure.com/iothub_v1api20210702.json
+    kind: iothub
+    name: iothub_v1api20210702
 dex.coreos.com:
   - apiVersion: dex.coreos.com/v1
     filename: dex.coreos.com/oauth2client_v1.json
@@ -2605,6 +4575,175 @@ documentai.cnrm.cloud.google.com:
     filename: documentai.cnrm.cloud.google.com/documentaiprocessordefaultversion_v1alpha1.json
     kind: documentaiprocessordefaultversion
     name: documentaiprocessordefaultversion_v1alpha1
+  - apiVersion: documentai.cnrm.cloud.google.com/v1beta1
+    filename: documentai.cnrm.cloud.google.com/documentaiprocessorversion_v1beta1.json
+    kind: DocumentAIProcessorVersion
+    name: documentaiprocessorversion_v1beta1
+  - apiVersion: documentai.cnrm.cloud.google.com/v1alpha1
+    filename: documentai.cnrm.cloud.google.com/documentaiprocessorversion_v1alpha1.json
+    kind: DocumentAIProcessorVersion
+    name: documentaiprocessorversion_v1alpha1
+documentdb.azure.com:
+  - apiVersion: documentdb.azure.com/v1api20240815
+    filename: documentdb.azure.com/sqldatabasecontainer_v1api20240815.json
+    kind: sqldatabasecontainer
+    name: sqldatabasecontainer_v1api20240815
+  - apiVersion: documentdb.azure.com/v1api20210515
+    filename: documentdb.azure.com/sqldatabase_v1api20210515.json
+    kind: sqlDatabase
+    name: sqldatabase_v1api20210515
+  - apiVersion: documentdb.azure.com/v1api20240815
+    filename: documentdb.azure.com/mongodbdatabasecollection_v1api20240815.json
+    kind: mongodbdatabasecollection
+    name: mongodbdatabasecollection_v1api20240815
+  - apiVersion: documentdb.azure.com/v1api20231115
+    filename: documentdb.azure.com/sqlroleassignment_v1api20231115.json
+    kind: sqlRoleAssignment
+    name: sqlroleassignment_v1api20231115
+  - apiVersion: documentdb.azure.com/v1api20210515
+    filename: documentdb.azure.com/databaseaccount_v1api20210515.json
+    kind: databaseAccount
+    name: databaseaccount_v1api20210515
+  - apiVersion: documentdb.azure.com/v1api20231115
+    filename: documentdb.azure.com/sqldatabasethroughputsetting_v1api20231115.json
+    kind: sqldatabasethroughputsetting
+    name: sqldatabasethroughputsetting_v1api20231115
+  - apiVersion: documentdb.azure.com/v1api20240815
+    filename: documentdb.azure.com/sqldatabasecontainerstoredprocedure_v1api20240815.json
+    kind: sqldatabasecontainerstoredprocedure
+    name: sqldatabasecontainerstoredprocedure_v1api20240815
+  - apiVersion: documentdb.azure.com/v1api20210515
+    filename: documentdb.azure.com/sqldatabasecontainerthroughputsetting_v1api20210515.json
+    kind: sqldatabasecontainerthroughputsetting
+    name: sqldatabasecontainerthroughputsetting_v1api20210515
+  - apiVersion: documentdb.azure.com/v1api20231115
+    filename: documentdb.azure.com/mongodbdatabasecollection_v1api20231115.json
+    kind: mongodbdatabasecollection
+    name: mongodbdatabasecollection_v1api20231115
+  - apiVersion: documentdb.azure.com/v1api20231115
+    filename: documentdb.azure.com/sqldatabasecontaineruserdefinedfunction_v1api20231115.json
+    kind: sqldatabasecontaineruserdefinedfunction
+    name: sqldatabasecontaineruserdefinedfunction_v1api20231115
+  - apiVersion: documentdb.azure.com/v1api20231115
+    filename: documentdb.azure.com/sqldatabasecontainer_v1api20231115.json
+    kind: sqldatabasecontainer
+    name: sqldatabasecontainer_v1api20231115
+  - apiVersion: documentdb.azure.com/v1api20240815
+    filename: documentdb.azure.com/mongodbdatabase_v1api20240815.json
+    kind: mongodbDatabase
+    name: mongodbdatabase_v1api20240815
+  - apiVersion: documentdb.azure.com/v1api20210515
+    filename: documentdb.azure.com/mongodbdatabase_v1api20210515.json
+    kind: mongodbDatabase
+    name: mongodbdatabase_v1api20210515
+  - apiVersion: documentdb.azure.com/v1api20231115
+    filename: documentdb.azure.com/databaseaccount_v1api20231115.json
+    kind: databaseAccount
+    name: databaseaccount_v1api20231115
+  - apiVersion: documentdb.azure.com/v1api20240815
+    filename: documentdb.azure.com/sqldatabasethroughputsetting_v1api20240815.json
+    kind: sqldatabasethroughputsetting
+    name: sqldatabasethroughputsetting_v1api20240815
+  - apiVersion: documentdb.azure.com/v1api20231115
+    filename: documentdb.azure.com/sqldatabasecontainerthroughputsetting_v1api20231115.json
+    kind: sqldatabasecontainerthroughputsetting
+    name: sqldatabasecontainerthroughputsetting_v1api20231115
+  - apiVersion: documentdb.azure.com/v1api20231115
+    filename: documentdb.azure.com/mongodbdatabase_v1api20231115.json
+    kind: mongodbDatabase
+    name: mongodbdatabase_v1api20231115
+  - apiVersion: documentdb.azure.com/v1api20210515
+    filename: documentdb.azure.com/mongodbdatabasecollectionthroughputsetting_v1api20210515.json
+    kind: mongodbdatabasecollectionthroughputsetting
+    name: mongodbdatabasecollectionthroughputsetting_v1api20210515
+  - apiVersion: documentdb.azure.com/v1api20210515
+    filename: documentdb.azure.com/sqlroleassignment_v1api20210515.json
+    kind: sqlRoleAssignment
+    name: sqlroleassignment_v1api20210515
+  - apiVersion: documentdb.azure.com/v1api20210515
+    filename: documentdb.azure.com/sqldatabasecontainerstoredprocedure_v1api20210515.json
+    kind: sqldatabasecontainerstoredprocedure
+    name: sqldatabasecontainerstoredprocedure_v1api20210515
+  - apiVersion: documentdb.azure.com/v1api20210515
+    filename: documentdb.azure.com/sqldatabasecontainertrigger_v1api20210515.json
+    kind: sqldatabasecontainertrigger
+    name: sqldatabasecontainertrigger_v1api20210515
+  - apiVersion: documentdb.azure.com/v1api20240815
+    filename: documentdb.azure.com/sqldatabasecontainerthroughputsetting_v1api20240815.json
+    kind: sqldatabasecontainerthroughputsetting
+    name: sqldatabasecontainerthroughputsetting_v1api20240815
+  - apiVersion: documentdb.azure.com/v1api20210515
+    filename: documentdb.azure.com/sqldatabasethroughputsetting_v1api20210515.json
+    kind: sqldatabasethroughputsetting
+    name: sqldatabasethroughputsetting_v1api20210515
+  - apiVersion: documentdb.azure.com/v1api20210515
+    filename: documentdb.azure.com/mongodbdatabasecollection_v1api20210515.json
+    kind: mongodbdatabasecollection
+    name: mongodbdatabasecollection_v1api20210515
+  - apiVersion: documentdb.azure.com/v1api20231115
+    filename: documentdb.azure.com/sqldatabasecontainerstoredprocedure_v1api20231115.json
+    kind: sqldatabasecontainerstoredprocedure
+    name: sqldatabasecontainerstoredprocedure_v1api20231115
+  - apiVersion: documentdb.azure.com/v1api20240815
+    filename: documentdb.azure.com/sqldatabasecontainertrigger_v1api20240815.json
+    kind: sqldatabasecontainertrigger
+    name: sqldatabasecontainertrigger_v1api20240815
+  - apiVersion: documentdb.azure.com/v1api20231115
+    filename: documentdb.azure.com/sqldatabase_v1api20231115.json
+    kind: sqlDatabase
+    name: sqldatabase_v1api20231115
+  - apiVersion: documentdb.azure.com/v1api20231115
+    filename: documentdb.azure.com/mongodbdatabasethroughputsetting_v1api20231115.json
+    kind: mongodbdatabasethroughputsetting
+    name: mongodbdatabasethroughputsetting_v1api20231115
+  - apiVersion: documentdb.azure.com/v1api20240815
+    filename: documentdb.azure.com/sqldatabasecontaineruserdefinedfunction_v1api20240815.json
+    kind: sqldatabasecontaineruserdefinedfunction
+    name: sqldatabasecontaineruserdefinedfunction_v1api20240815
+  - apiVersion: documentdb.azure.com/v1api20231115
+    filename: documentdb.azure.com/mongodbdatabasecollectionthroughputsetting_v1api20231115.json
+    kind: mongodbdatabasecollectionthroughputsetting
+    name: mongodbdatabasecollectionthroughputsetting_v1api20231115
+  - apiVersion: documentdb.azure.com/v1api20231115
+    filename: documentdb.azure.com/sqldatabasecontainertrigger_v1api20231115.json
+    kind: sqldatabasecontainertrigger
+    name: sqldatabasecontainertrigger_v1api20231115
+  - apiVersion: documentdb.azure.com/v1api20240815
+    filename: documentdb.azure.com/mongodbdatabasecollectionthroughputsetting_v1api20240815.json
+    kind: mongodbdatabasecollectionthroughputsetting
+    name: mongodbdatabasecollectionthroughputsetting_v1api20240815
+  - apiVersion: documentdb.azure.com/v1api20210515
+    filename: documentdb.azure.com/sqldatabasecontaineruserdefinedfunction_v1api20210515.json
+    kind: sqldatabasecontaineruserdefinedfunction
+    name: sqldatabasecontaineruserdefinedfunction_v1api20210515
+  - apiVersion: documentdb.azure.com/v1api20210515
+    filename: documentdb.azure.com/mongodbdatabasethroughputsetting_v1api20210515.json
+    kind: mongodbdatabasethroughputsetting
+    name: mongodbdatabasethroughputsetting_v1api20210515
+  - apiVersion: documentdb.azure.com/v1api20240815
+    filename: documentdb.azure.com/mongodbdatabasethroughputsetting_v1api20240815.json
+    kind: mongodbdatabasethroughputsetting
+    name: mongodbdatabasethroughputsetting_v1api20240815
+  - apiVersion: documentdb.azure.com/v1api20240815
+    filename: documentdb.azure.com/sqlroleassignment_v1api20240815.json
+    kind: sqlRoleAssignment
+    name: sqlroleassignment_v1api20240815
+  - apiVersion: documentdb.azure.com/v1api20240815
+    filename: documentdb.azure.com/mongodbuserdefinition_v1api20240815.json
+    kind: mongodbUserDefinition
+    name: mongodbuserdefinition_v1api20240815
+  - apiVersion: documentdb.azure.com/v1api20210515
+    filename: documentdb.azure.com/sqldatabasecontainer_v1api20210515.json
+    kind: sqldatabasecontainer
+    name: sqldatabasecontainer_v1api20210515
+  - apiVersion: documentdb.azure.com/v1api20240815
+    filename: documentdb.azure.com/databaseaccount_v1api20240815.json
+    kind: databaseAccount
+    name: databaseaccount_v1api20240815
+  - apiVersion: documentdb.azure.com/v1api20240815
+    filename: documentdb.azure.com/sqldatabase_v1api20240815.json
+    kind: sqlDatabase
+    name: sqldatabase_v1api20240815
 dragonflydb.io:
   - apiVersion: dragonflydb.io/v1alpha1
     filename: dragonflydb.io/dragonfly_v1alpha1.json
@@ -2661,6 +4800,880 @@ dynatrace.com:
     filename: dynatrace.com/dynakube_v1beta3.json
     kind: DynaKube
     name: dynakube_v1beta3
+  - apiVersion: dynatrace.com/v1alpha5
+    filename: dynatrace.com/dynakube_v1alpha5.json
+    kind: dynakube
+    name: dynakube_v1alpha5
+  - apiVersion: dynatrace.com/v1beta5
+    filename: dynatrace.com/dynakube_v1beta5.json
+    kind: dynakube
+    name: dynakube_v1beta5
+ec2.aws.m.upbound.io:
+  - apiVersion: ec2.aws.m.upbound.io/v1beta1
+    filename: ec2.aws.m.upbound.io/transitgatewayconnectpeer_v1beta1.json
+    kind: TransitGatewayConnectPeer
+    name: transitgatewayconnectpeer_v1beta1
+  - apiVersion: ec2.aws.m.upbound.io/v1beta1
+    filename: ec2.aws.m.upbound.io/transitgatewayroutetableassociation_v1beta1.json
+    kind: TransitGatewayRouteTableAssociation
+    name: transitgatewayroutetableassociation_v1beta1
+  - apiVersion: ec2.aws.m.upbound.io/v1beta1
+    filename: ec2.aws.m.upbound.io/vpcdhcpoptions_v1beta1.json
+    kind: VPCDHCPOptions
+    name: vpcdhcpoptions_v1beta1
+  - apiVersion: ec2.aws.m.upbound.io/v1beta1
+    filename: ec2.aws.m.upbound.io/tag_v1beta1.json
+    kind: Tag
+    name: tag_v1beta1
+  - apiVersion: ec2.aws.m.upbound.io/v1beta1
+    filename: ec2.aws.m.upbound.io/securitygroup_v1beta1.json
+    kind: SecurityGroup
+    name: securitygroup_v1beta1
+  - apiVersion: ec2.aws.m.upbound.io/v1beta1
+    filename: ec2.aws.m.upbound.io/launchtemplate_v1beta1.json
+    kind: LaunchTemplate
+    name: launchtemplate_v1beta1
+  - apiVersion: ec2.aws.m.upbound.io/v1beta1
+    filename: ec2.aws.m.upbound.io/vpngateway_v1beta1.json
+    kind: VPNGateway
+    name: vpngateway_v1beta1
+  - apiVersion: ec2.aws.m.upbound.io/v1beta1
+    filename: ec2.aws.m.upbound.io/fleet_v1beta1.json
+    kind: Fleet
+    name: fleet_v1beta1
+  - apiVersion: ec2.aws.m.upbound.io/v1beta1
+    filename: ec2.aws.m.upbound.io/vpcendpointservice_v1beta1.json
+    kind: VPCEndpointService
+    name: vpcendpointservice_v1beta1
+  - apiVersion: ec2.aws.m.upbound.io/v1beta1
+    filename: ec2.aws.m.upbound.io/vpcipam_v1beta1.json
+    kind: VPCIpam
+    name: vpcipam_v1beta1
+  - apiVersion: ec2.aws.m.upbound.io/v1beta1
+    filename: ec2.aws.m.upbound.io/vpcpeeringconnection_v1beta1.json
+    kind: VPCPeeringConnection
+    name: vpcpeeringconnection_v1beta1
+  - apiVersion: ec2.aws.m.upbound.io/v1beta1
+    filename: ec2.aws.m.upbound.io/placementgroup_v1beta1.json
+    kind: PlacementGroup
+    name: placementgroup_v1beta1
+  - apiVersion: ec2.aws.m.upbound.io/v1beta1
+    filename: ec2.aws.m.upbound.io/vpcpeeringconnectionaccepter_v1beta1.json
+    kind: VPCPeeringConnectionAccepter
+    name: vpcpeeringconnectionaccepter_v1beta1
+  - apiVersion: ec2.aws.m.upbound.io/v1beta1
+    filename: ec2.aws.m.upbound.io/egressonlyinternetgateway_v1beta1.json
+    kind: EgressOnlyInternetGateway
+    name: egressonlyinternetgateway_v1beta1
+  - apiVersion: ec2.aws.m.upbound.io/v1beta1
+    filename: ec2.aws.m.upbound.io/defaultvpcdhcpoptions_v1beta1.json
+    kind: DefaultVPCDHCPOptions
+    name: defaultvpcdhcpoptions_v1beta1
+  - apiVersion: ec2.aws.m.upbound.io/v1beta1
+    filename: ec2.aws.m.upbound.io/networkacl_v1beta1.json
+    kind: NetworkACL
+    name: networkacl_v1beta1
+  - apiVersion: ec2.aws.m.upbound.io/v1beta1
+    filename: ec2.aws.m.upbound.io/networkaclrule_v1beta1.json
+    kind: NetworkACLRule
+    name: networkaclrule_v1beta1
+  - apiVersion: ec2.aws.m.upbound.io/v1beta1
+    filename: ec2.aws.m.upbound.io/securitygroupegressrule_v1beta1.json
+    kind: SecurityGroupEgressRule
+    name: securitygroupegressrule_v1beta1
+  - apiVersion: ec2.aws.m.upbound.io/v1beta1
+    filename: ec2.aws.m.upbound.io/ebssnapshotimport_v1beta1.json
+    kind: EBSSnapshotImport
+    name: ebssnapshotimport_v1beta1
+  - apiVersion: ec2.aws.m.upbound.io/v1beta1
+    filename: ec2.aws.m.upbound.io/defaultsubnet_v1beta1.json
+    kind: DefaultSubnet
+    name: defaultsubnet_v1beta1
+  - apiVersion: ec2.aws.m.upbound.io/v1beta1
+    filename: ec2.aws.m.upbound.io/transitgatewaypeeringattachment_v1beta1.json
+    kind: TransitGatewayPeeringAttachment
+    name: transitgatewaypeeringattachment_v1beta1
+  - apiVersion: ec2.aws.m.upbound.io/v1beta1
+    filename: ec2.aws.m.upbound.io/host_v1beta1.json
+    kind: Host
+    name: host_v1beta1
+  - apiVersion: ec2.aws.m.upbound.io/v1beta1
+    filename: ec2.aws.m.upbound.io/ami_v1beta1.json
+    kind: AMI
+    name: ami_v1beta1
+  - apiVersion: ec2.aws.m.upbound.io/v1beta1
+    filename: ec2.aws.m.upbound.io/transitgatewayconnect_v1beta1.json
+    kind: TransitGatewayConnect
+    name: transitgatewayconnect_v1beta1
+  - apiVersion: ec2.aws.m.upbound.io/v1beta1
+    filename: ec2.aws.m.upbound.io/vpcipampoolcidr_v1beta1.json
+    kind: VPCIpamPoolCidr
+    name: vpcipampoolcidr_v1beta1
+  - apiVersion: ec2.aws.m.upbound.io/v1beta1
+    filename: ec2.aws.m.upbound.io/vpcendpointconnectionnotification_v1beta1.json
+    kind: VPCEndpointConnectionNotification
+    name: vpcendpointconnectionnotification_v1beta1
+  - apiVersion: ec2.aws.m.upbound.io/v1beta1
+    filename: ec2.aws.m.upbound.io/ebssnapshotcopy_v1beta1.json
+    kind: EBSSnapshotCopy
+    name: ebssnapshotcopy_v1beta1
+  - apiVersion: ec2.aws.m.upbound.io/v1beta1
+    filename: ec2.aws.m.upbound.io/natgateway_v1beta1.json
+    kind: NATGateway
+    name: natgateway_v1beta1
+  - apiVersion: ec2.aws.m.upbound.io/v1beta1
+    filename: ec2.aws.m.upbound.io/snapshotcreatevolumepermission_v1beta1.json
+    kind: SnapshotCreateVolumePermission
+    name: snapshotcreatevolumepermission_v1beta1
+  - apiVersion: ec2.aws.m.upbound.io/v1beta1
+    filename: ec2.aws.m.upbound.io/managedprefixlist_v1beta1.json
+    kind: ManagedPrefixList
+    name: managedprefixlist_v1beta1
+  - apiVersion: ec2.aws.m.upbound.io/v1beta1
+    filename: ec2.aws.m.upbound.io/transitgatewaymulticastdomainassociation_v1beta1.json
+    kind: TransitGatewayMulticastDomainAssociation
+    name: transitgatewaymulticastdomainassociation_v1beta1
+  - apiVersion: ec2.aws.m.upbound.io/v1beta1
+    filename: ec2.aws.m.upbound.io/vpc_v1beta1.json
+    kind: VPC
+    name: vpc_v1beta1
+  - apiVersion: ec2.aws.m.upbound.io/v1beta1
+    filename: ec2.aws.m.upbound.io/vpnconnection_v1beta1.json
+    kind: VPNConnection
+    name: vpnconnection_v1beta1
+  - apiVersion: ec2.aws.m.upbound.io/v1beta1
+    filename: ec2.aws.m.upbound.io/ebsdefaultkmskey_v1beta1.json
+    kind: EBSDefaultKMSKey
+    name: ebsdefaultkmskey_v1beta1
+  - apiVersion: ec2.aws.m.upbound.io/v1beta1
+    filename: ec2.aws.m.upbound.io/instancestate_v1beta1.json
+    kind: InstanceState
+    name: instancestate_v1beta1
+  - apiVersion: ec2.aws.m.upbound.io/v1beta1
+    filename: ec2.aws.m.upbound.io/securitygrouprule_v1beta1.json
+    kind: SecurityGroupRule
+    name: securitygrouprule_v1beta1
+  - apiVersion: ec2.aws.m.upbound.io/v1beta1
+    filename: ec2.aws.m.upbound.io/transitgatewayprefixlistreference_v1beta1.json
+    kind: TransitGatewayPrefixListReference
+    name: transitgatewayprefixlistreference_v1beta1
+  - apiVersion: ec2.aws.m.upbound.io/v1beta1
+    filename: ec2.aws.m.upbound.io/vpcpeeringconnectionoptions_v1beta1.json
+    kind: VPCPeeringConnectionOptions
+    name: vpcpeeringconnectionoptions_v1beta1
+  - apiVersion: ec2.aws.m.upbound.io/v1beta1
+    filename: ec2.aws.m.upbound.io/spotdatafeedsubscription_v1beta1.json
+    kind: SpotDatafeedSubscription
+    name: spotdatafeedsubscription_v1beta1
+  - apiVersion: ec2.aws.m.upbound.io/v1beta1
+    filename: ec2.aws.m.upbound.io/transitgatewaymulticastgroupmember_v1beta1.json
+    kind: TransitGatewayMulticastGroupMember
+    name: transitgatewaymulticastgroupmember_v1beta1
+  - apiVersion: ec2.aws.m.upbound.io/v1beta1
+    filename: ec2.aws.m.upbound.io/spotinstancerequest_v1beta1.json
+    kind: SpotInstanceRequest
+    name: spotinstancerequest_v1beta1
+  - apiVersion: ec2.aws.m.upbound.io/v1beta1
+    filename: ec2.aws.m.upbound.io/eipassociation_v1beta1.json
+    kind: EIPAssociation
+    name: eipassociation_v1beta1
+  - apiVersion: ec2.aws.m.upbound.io/v1beta1
+    filename: ec2.aws.m.upbound.io/availabilityzonegroup_v1beta1.json
+    kind: AvailabilityZoneGroup
+    name: availabilityzonegroup_v1beta1
+  - apiVersion: ec2.aws.m.upbound.io/v1beta1
+    filename: ec2.aws.m.upbound.io/managedprefixlistentry_v1beta1.json
+    kind: ManagedPrefixListEntry
+    name: managedprefixlistentry_v1beta1
+  - apiVersion: ec2.aws.m.upbound.io/v1beta1
+    filename: ec2.aws.m.upbound.io/vpngatewayroutepropagation_v1beta1.json
+    kind: VPNGatewayRoutePropagation
+    name: vpngatewayroutepropagation_v1beta1
+  - apiVersion: ec2.aws.m.upbound.io/v1beta1
+    filename: ec2.aws.m.upbound.io/volumeattachment_v1beta1.json
+    kind: VolumeAttachment
+    name: volumeattachment_v1beta1
+  - apiVersion: ec2.aws.m.upbound.io/v1beta1
+    filename: ec2.aws.m.upbound.io/vpngatewayattachment_v1beta1.json
+    kind: VPNGatewayAttachment
+    name: vpngatewayattachment_v1beta1
+  - apiVersion: ec2.aws.m.upbound.io/v1beta1
+    filename: ec2.aws.m.upbound.io/eip_v1beta1.json
+    kind: EIP
+    name: eip_v1beta1
+  - apiVersion: ec2.aws.m.upbound.io/v1beta1
+    filename: ec2.aws.m.upbound.io/securitygroupingressrule_v1beta1.json
+    kind: SecurityGroupIngressRule
+    name: securitygroupingressrule_v1beta1
+  - apiVersion: ec2.aws.m.upbound.io/v1beta1
+    filename: ec2.aws.m.upbound.io/carriergateway_v1beta1.json
+    kind: CarrierGateway
+    name: carriergateway_v1beta1
+  - apiVersion: ec2.aws.m.upbound.io/v1beta1
+    filename: ec2.aws.m.upbound.io/capacityreservation_v1beta1.json
+    kind: CapacityReservation
+    name: capacityreservation_v1beta1
+  - apiVersion: ec2.aws.m.upbound.io/v1beta1
+    filename: ec2.aws.m.upbound.io/transitgatewayvpcattachmentaccepter_v1beta1.json
+    kind: TransitGatewayVPCAttachmentAccepter
+    name: transitgatewayvpcattachmentaccepter_v1beta1
+  - apiVersion: ec2.aws.m.upbound.io/v1beta1
+    filename: ec2.aws.m.upbound.io/vpcendpoint_v1beta1.json
+    kind: VPCEndpoint
+    name: vpcendpoint_v1beta1
+  - apiVersion: ec2.aws.m.upbound.io/v1beta1
+    filename: ec2.aws.m.upbound.io/networkinterface_v1beta1.json
+    kind: NetworkInterface
+    name: networkinterface_v1beta1
+  - apiVersion: ec2.aws.m.upbound.io/v1beta1
+    filename: ec2.aws.m.upbound.io/spotfleetrequest_v1beta1.json
+    kind: SpotFleetRequest
+    name: spotfleetrequest_v1beta1
+  - apiVersion: ec2.aws.m.upbound.io/v1beta1
+    filename: ec2.aws.m.upbound.io/transitgatewayroutetablepropagation_v1beta1.json
+    kind: TransitGatewayRouteTablePropagation
+    name: transitgatewayroutetablepropagation_v1beta1
+  - apiVersion: ec2.aws.m.upbound.io/v1beta1
+    filename: ec2.aws.m.upbound.io/vpcendpointserviceallowedprincipal_v1beta1.json
+    kind: VPCEndpointServiceAllowedPrincipal
+    name: vpcendpointserviceallowedprincipal_v1beta1
+  - apiVersion: ec2.aws.m.upbound.io/v1beta1
+    filename: ec2.aws.m.upbound.io/transitgatewaymulticastdomain_v1beta1.json
+    kind: TransitGatewayMulticastDomain
+    name: transitgatewaymulticastdomain_v1beta1
+  - apiVersion: ec2.aws.m.upbound.io/v1beta1
+    filename: ec2.aws.m.upbound.io/defaultvpc_v1beta1.json
+    kind: DefaultVPC
+    name: defaultvpc_v1beta1
+  - apiVersion: ec2.aws.m.upbound.io/v1beta1
+    filename: ec2.aws.m.upbound.io/vpcdhcpoptionsassociation_v1beta1.json
+    kind: VPCDHCPOptionsAssociation
+    name: vpcdhcpoptionsassociation_v1beta1
+  - apiVersion: ec2.aws.m.upbound.io/v1beta1
+    filename: ec2.aws.m.upbound.io/internetgateway_v1beta1.json
+    kind: InternetGateway
+    name: internetgateway_v1beta1
+  - apiVersion: ec2.aws.m.upbound.io/v1beta1
+    filename: ec2.aws.m.upbound.io/flowlog_v1beta1.json
+    kind: FlowLog
+    name: flowlog_v1beta1
+  - apiVersion: ec2.aws.m.upbound.io/v1beta1
+    filename: ec2.aws.m.upbound.io/route_v1beta1.json
+    kind: Route
+    name: route_v1beta1
+  - apiVersion: ec2.aws.m.upbound.io/v1beta1
+    filename: ec2.aws.m.upbound.io/defaultnetworkacl_v1beta1.json
+    kind: DefaultNetworkACL
+    name: defaultnetworkacl_v1beta1
+  - apiVersion: ec2.aws.m.upbound.io/v1beta1
+    filename: ec2.aws.m.upbound.io/subnet_v1beta1.json
+    kind: Subnet
+    name: subnet_v1beta1
+  - apiVersion: ec2.aws.m.upbound.io/v1beta1
+    filename: ec2.aws.m.upbound.io/transitgatewayroute_v1beta1.json
+    kind: TransitGatewayRoute
+    name: transitgatewayroute_v1beta1
+  - apiVersion: ec2.aws.m.upbound.io/v1beta1
+    filename: ec2.aws.m.upbound.io/customergateway_v1beta1.json
+    kind: CustomerGateway
+    name: customergateway_v1beta1
+  - apiVersion: ec2.aws.m.upbound.io/v1beta1
+    filename: ec2.aws.m.upbound.io/keypair_v1beta1.json
+    kind: KeyPair
+    name: keypair_v1beta1
+  - apiVersion: ec2.aws.m.upbound.io/v1beta1
+    filename: ec2.aws.m.upbound.io/networkinterfacesgattachment_v1beta1.json
+    kind: NetworkInterfaceSgAttachment
+    name: networkinterfacesgattachment_v1beta1
+  - apiVersion: ec2.aws.m.upbound.io/v1beta1
+    filename: ec2.aws.m.upbound.io/transitgateway_v1beta1.json
+    kind: TransitGateway
+    name: transitgateway_v1beta1
+  - apiVersion: ec2.aws.m.upbound.io/v1beta1
+    filename: ec2.aws.m.upbound.io/vpnconnectionroute_v1beta1.json
+    kind: VPNConnectionRoute
+    name: vpnconnectionroute_v1beta1
+  - apiVersion: ec2.aws.m.upbound.io/v1beta1
+    filename: ec2.aws.m.upbound.io/ebsvolume_v1beta1.json
+    kind: EBSVolume
+    name: ebsvolume_v1beta1
+  - apiVersion: ec2.aws.m.upbound.io/v1beta1
+    filename: ec2.aws.m.upbound.io/serialconsoleaccess_v1beta1.json
+    kind: SerialConsoleAccess
+    name: serialconsoleaccess_v1beta1
+  - apiVersion: ec2.aws.m.upbound.io/v1beta1
+    filename: ec2.aws.m.upbound.io/vpcendpointroutetableassociation_v1beta1.json
+    kind: VPCEndpointRouteTableAssociation
+    name: vpcendpointroutetableassociation_v1beta1
+  - apiVersion: ec2.aws.m.upbound.io/v1beta1
+    filename: ec2.aws.m.upbound.io/networkinsightsanalysis_v1beta1.json
+    kind: NetworkInsightsAnalysis
+    name: networkinsightsanalysis_v1beta1
+  - apiVersion: ec2.aws.m.upbound.io/v1beta1
+    filename: ec2.aws.m.upbound.io/networkinsightspath_v1beta1.json
+    kind: NetworkInsightsPath
+    name: networkinsightspath_v1beta1
+  - apiVersion: ec2.aws.m.upbound.io/v1beta1
+    filename: ec2.aws.m.upbound.io/transitgatewaypolicytable_v1beta1.json
+    kind: TransitGatewayPolicyTable
+    name: transitgatewaypolicytable_v1beta1
+  - apiVersion: ec2.aws.m.upbound.io/v1beta1
+    filename: ec2.aws.m.upbound.io/transitgatewayroutetable_v1beta1.json
+    kind: TransitGatewayRouteTable
+    name: transitgatewayroutetable_v1beta1
+  - apiVersion: ec2.aws.m.upbound.io/v1beta1
+    filename: ec2.aws.m.upbound.io/vpcendpointsubnetassociation_v1beta1.json
+    kind: VPCEndpointSubnetAssociation
+    name: vpcendpointsubnetassociation_v1beta1
+  - apiVersion: ec2.aws.m.upbound.io/v1beta1
+    filename: ec2.aws.m.upbound.io/ebssnapshot_v1beta1.json
+    kind: EBSSnapshot
+    name: ebssnapshot_v1beta1
+  - apiVersion: ec2.aws.m.upbound.io/v1beta1
+    filename: ec2.aws.m.upbound.io/trafficmirrorfilter_v1beta1.json
+    kind: TrafficMirrorFilter
+    name: trafficmirrorfilter_v1beta1
+  - apiVersion: ec2.aws.m.upbound.io/v1beta1
+    filename: ec2.aws.m.upbound.io/transitgatewaymulticastgroupsource_v1beta1.json
+    kind: TransitGatewayMulticastGroupSource
+    name: transitgatewaymulticastgroupsource_v1beta1
+  - apiVersion: ec2.aws.m.upbound.io/v1beta1
+    filename: ec2.aws.m.upbound.io/subnetcidrreservation_v1beta1.json
+    kind: SubnetCidrReservation
+    name: subnetcidrreservation_v1beta1
+  - apiVersion: ec2.aws.m.upbound.io/v1beta1
+    filename: ec2.aws.m.upbound.io/transitgatewayvpcattachment_v1beta1.json
+    kind: TransitGatewayVPCAttachment
+    name: transitgatewayvpcattachment_v1beta1
+  - apiVersion: ec2.aws.m.upbound.io/v1beta1
+    filename: ec2.aws.m.upbound.io/mainroutetableassociation_v1beta1.json
+    kind: MainRouteTableAssociation
+    name: mainroutetableassociation_v1beta1
+  - apiVersion: ec2.aws.m.upbound.io/v1beta1
+    filename: ec2.aws.m.upbound.io/transitgatewaypeeringattachmentaccepter_v1beta1.json
+    kind: TransitGatewayPeeringAttachmentAccepter
+    name: transitgatewaypeeringattachmentaccepter_v1beta1
+  - apiVersion: ec2.aws.m.upbound.io/v1beta1
+    filename: ec2.aws.m.upbound.io/vpcipamscope_v1beta1.json
+    kind: VPCIpamScope
+    name: vpcipamscope_v1beta1
+  - apiVersion: ec2.aws.m.upbound.io/v1beta1
+    filename: ec2.aws.m.upbound.io/defaultsecuritygroup_v1beta1.json
+    kind: DefaultSecurityGroup
+    name: defaultsecuritygroup_v1beta1
+  - apiVersion: ec2.aws.m.upbound.io/v1beta1
+    filename: ec2.aws.m.upbound.io/instance_v1beta1.json
+    kind: Instance
+    name: instance_v1beta1
+  - apiVersion: ec2.aws.m.upbound.io/v1beta1
+    filename: ec2.aws.m.upbound.io/routetable_v1beta1.json
+    kind: RouteTable
+    name: routetable_v1beta1
+  - apiVersion: ec2.aws.m.upbound.io/v1beta1
+    filename: ec2.aws.m.upbound.io/vpcipampoolcidrallocation_v1beta1.json
+    kind: VPCIpamPoolCidrAllocation
+    name: vpcipampoolcidrallocation_v1beta1
+  - apiVersion: ec2.aws.m.upbound.io/v1beta1
+    filename: ec2.aws.m.upbound.io/ebsencryptionbydefault_v1beta1.json
+    kind: EBSEncryptionByDefault
+    name: ebsencryptionbydefault_v1beta1
+  - apiVersion: ec2.aws.m.upbound.io/v1beta1
+    filename: ec2.aws.m.upbound.io/vpcipampool_v1beta1.json
+    kind: VPCIpamPool
+    name: vpcipampool_v1beta1
+  - apiVersion: ec2.aws.m.upbound.io/v1beta1
+    filename: ec2.aws.m.upbound.io/amicopy_v1beta1.json
+    kind: AMICopy
+    name: amicopy_v1beta1
+  - apiVersion: ec2.aws.m.upbound.io/v1beta1
+    filename: ec2.aws.m.upbound.io/defaultroutetable_v1beta1.json
+    kind: DefaultRouteTable
+    name: defaultroutetable_v1beta1
+  - apiVersion: ec2.aws.m.upbound.io/v1beta1
+    filename: ec2.aws.m.upbound.io/networkinterfaceattachment_v1beta1.json
+    kind: NetworkInterfaceAttachment
+    name: networkinterfaceattachment_v1beta1
+  - apiVersion: ec2.aws.m.upbound.io/v1beta1
+    filename: ec2.aws.m.upbound.io/amilaunchpermission_v1beta1.json
+    kind: AMILaunchPermission
+    name: amilaunchpermission_v1beta1
+  - apiVersion: ec2.aws.m.upbound.io/v1beta1
+    filename: ec2.aws.m.upbound.io/routetableassociation_v1beta1.json
+    kind: RouteTableAssociation
+    name: routetableassociation_v1beta1
+  - apiVersion: ec2.aws.m.upbound.io/v1beta1
+    filename: ec2.aws.m.upbound.io/vpcipv4cidrblockassociation_v1beta1.json
+    kind: VPCIPv4CidrBlockAssociation
+    name: vpcipv4cidrblockassociation_v1beta1
+  - apiVersion: ec2.aws.m.upbound.io/v1beta1
+    filename: ec2.aws.m.upbound.io/trafficmirrorfilterrule_v1beta1.json
+    kind: TrafficMirrorFilterRule
+    name: trafficmirrorfilterrule_v1beta1
+  - apiVersion: ec2.aws.m.upbound.io/v1beta1
+    filename: ec2.aws.m.upbound.io/vpcendpointsecuritygroupassociation_v1beta1.json
+    kind: VPCEndpointSecurityGroupAssociation
+    name: vpcendpointsecuritygroupassociation_v1beta1
+ec2.aws.upbound.io:
+  - apiVersion: ec2.aws.upbound.io/v1beta1
+    filename: ec2.aws.upbound.io/transitgatewayconnectpeer_v1beta1.json
+    kind: TransitGatewayConnectPeer
+    name: transitgatewayconnectpeer_v1beta1
+  - apiVersion: ec2.aws.upbound.io/v1beta1
+    filename: ec2.aws.upbound.io/transitgatewayroutetableassociation_v1beta1.json
+    kind: TransitGatewayRouteTableAssociation
+    name: transitgatewayroutetableassociation_v1beta1
+  - apiVersion: ec2.aws.upbound.io/v1beta1
+    filename: ec2.aws.upbound.io/vpcdhcpoptions_v1beta1.json
+    kind: VPCDHCPOptions
+    name: vpcdhcpoptions_v1beta1
+  - apiVersion: ec2.aws.upbound.io/v1beta2
+    filename: ec2.aws.upbound.io/vpcpeeringconnection_v1beta2.json
+    kind: VPCPeeringConnection
+    name: vpcpeeringconnection_v1beta2
+  - apiVersion: ec2.aws.upbound.io/v1beta1
+    filename: ec2.aws.upbound.io/tag_v1beta1.json
+    kind: Tag
+    name: tag_v1beta1
+  - apiVersion: ec2.aws.upbound.io/v1beta1
+    filename: ec2.aws.upbound.io/securitygroup_v1beta1.json
+    kind: SecurityGroup
+    name: securitygroup_v1beta1
+  - apiVersion: ec2.aws.upbound.io/v1beta2
+    filename: ec2.aws.upbound.io/spotinstancerequest_v1beta2.json
+    kind: SpotInstanceRequest
+    name: spotinstancerequest_v1beta2
+  - apiVersion: ec2.aws.upbound.io/v1beta1
+    filename: ec2.aws.upbound.io/launchtemplate_v1beta1.json
+    kind: LaunchTemplate
+    name: launchtemplate_v1beta1
+  - apiVersion: ec2.aws.upbound.io/v1beta2
+    filename: ec2.aws.upbound.io/flowlog_v1beta2.json
+    kind: FlowLog
+    name: flowlog_v1beta2
+  - apiVersion: ec2.aws.upbound.io/v1beta1
+    filename: ec2.aws.upbound.io/vpngateway_v1beta1.json
+    kind: VPNGateway
+    name: vpngateway_v1beta1
+  - apiVersion: ec2.aws.upbound.io/v1beta1
+    filename: ec2.aws.upbound.io/fleet_v1beta1.json
+    kind: Fleet
+    name: fleet_v1beta1
+  - apiVersion: ec2.aws.upbound.io/v1beta1
+    filename: ec2.aws.upbound.io/vpcendpointservice_v1beta1.json
+    kind: VPCEndpointService
+    name: vpcendpointservice_v1beta1
+  - apiVersion: ec2.aws.upbound.io/v1beta1
+    filename: ec2.aws.upbound.io/vpcipam_v1beta1.json
+    kind: VPCIpam
+    name: vpcipam_v1beta1
+  - apiVersion: ec2.aws.upbound.io/v1beta1
+    filename: ec2.aws.upbound.io/vpcpeeringconnection_v1beta1.json
+    kind: VPCPeeringConnection
+    name: vpcpeeringconnection_v1beta1
+  - apiVersion: ec2.aws.upbound.io/v1beta1
+    filename: ec2.aws.upbound.io/placementgroup_v1beta1.json
+    kind: PlacementGroup
+    name: placementgroup_v1beta1
+  - apiVersion: ec2.aws.upbound.io/v1beta1
+    filename: ec2.aws.upbound.io/vpcpeeringconnectionaccepter_v1beta1.json
+    kind: VPCPeeringConnectionAccepter
+    name: vpcpeeringconnectionaccepter_v1beta1
+  - apiVersion: ec2.aws.upbound.io/v1beta1
+    filename: ec2.aws.upbound.io/egressonlyinternetgateway_v1beta1.json
+    kind: EgressOnlyInternetGateway
+    name: egressonlyinternetgateway_v1beta1
+  - apiVersion: ec2.aws.upbound.io/v1beta2
+    filename: ec2.aws.upbound.io/spotfleetrequest_v1beta2.json
+    kind: SpotFleetRequest
+    name: spotfleetrequest_v1beta2
+  - apiVersion: ec2.aws.upbound.io/v1beta1
+    filename: ec2.aws.upbound.io/defaultvpcdhcpoptions_v1beta1.json
+    kind: DefaultVPCDHCPOptions
+    name: defaultvpcdhcpoptions_v1beta1
+  - apiVersion: ec2.aws.upbound.io/v1beta1
+    filename: ec2.aws.upbound.io/networkacl_v1beta1.json
+    kind: NetworkACL
+    name: networkacl_v1beta1
+  - apiVersion: ec2.aws.upbound.io/v1beta1
+    filename: ec2.aws.upbound.io/networkaclrule_v1beta1.json
+    kind: NetworkACLRule
+    name: networkaclrule_v1beta1
+  - apiVersion: ec2.aws.upbound.io/v1beta1
+    filename: ec2.aws.upbound.io/securitygroupegressrule_v1beta1.json
+    kind: SecurityGroupEgressRule
+    name: securitygroupegressrule_v1beta1
+  - apiVersion: ec2.aws.upbound.io/v1beta1
+    filename: ec2.aws.upbound.io/ebssnapshotimport_v1beta1.json
+    kind: EBSSnapshotImport
+    name: ebssnapshotimport_v1beta1
+  - apiVersion: ec2.aws.upbound.io/v1beta1
+    filename: ec2.aws.upbound.io/defaultsubnet_v1beta1.json
+    kind: DefaultSubnet
+    name: defaultsubnet_v1beta1
+  - apiVersion: ec2.aws.upbound.io/v1beta1
+    filename: ec2.aws.upbound.io/transitgatewaypeeringattachment_v1beta1.json
+    kind: TransitGatewayPeeringAttachment
+    name: transitgatewaypeeringattachment_v1beta1
+  - apiVersion: ec2.aws.upbound.io/v1beta1
+    filename: ec2.aws.upbound.io/host_v1beta1.json
+    kind: Host
+    name: host_v1beta1
+  - apiVersion: ec2.aws.upbound.io/v1beta1
+    filename: ec2.aws.upbound.io/ami_v1beta1.json
+    kind: AMI
+    name: ami_v1beta1
+  - apiVersion: ec2.aws.upbound.io/v1beta1
+    filename: ec2.aws.upbound.io/transitgatewayconnect_v1beta1.json
+    kind: TransitGatewayConnect
+    name: transitgatewayconnect_v1beta1
+  - apiVersion: ec2.aws.upbound.io/v1beta1
+    filename: ec2.aws.upbound.io/vpcipampoolcidr_v1beta1.json
+    kind: VPCIpamPoolCidr
+    name: vpcipampoolcidr_v1beta1
+  - apiVersion: ec2.aws.upbound.io/v1beta1
+    filename: ec2.aws.upbound.io/vpcendpointconnectionnotification_v1beta1.json
+    kind: VPCEndpointConnectionNotification
+    name: vpcendpointconnectionnotification_v1beta1
+  - apiVersion: ec2.aws.upbound.io/v1beta1
+    filename: ec2.aws.upbound.io/ebssnapshotcopy_v1beta1.json
+    kind: EBSSnapshotCopy
+    name: ebssnapshotcopy_v1beta1
+  - apiVersion: ec2.aws.upbound.io/v1beta1
+    filename: ec2.aws.upbound.io/natgateway_v1beta1.json
+    kind: NATGateway
+    name: natgateway_v1beta1
+  - apiVersion: ec2.aws.upbound.io/v1beta1
+    filename: ec2.aws.upbound.io/snapshotcreatevolumepermission_v1beta1.json
+    kind: SnapshotCreateVolumePermission
+    name: snapshotcreatevolumepermission_v1beta1
+  - apiVersion: ec2.aws.upbound.io/v1beta1
+    filename: ec2.aws.upbound.io/managedprefixlist_v1beta1.json
+    kind: ManagedPrefixList
+    name: managedprefixlist_v1beta1
+  - apiVersion: ec2.aws.upbound.io/v1beta1
+    filename: ec2.aws.upbound.io/transitgatewaymulticastdomainassociation_v1beta1.json
+    kind: TransitGatewayMulticastDomainAssociation
+    name: transitgatewaymulticastdomainassociation_v1beta1
+  - apiVersion: ec2.aws.upbound.io/v1beta1
+    filename: ec2.aws.upbound.io/vpc_v1beta1.json
+    kind: VPC
+    name: vpc_v1beta1
+  - apiVersion: ec2.aws.upbound.io/v1beta1
+    filename: ec2.aws.upbound.io/vpnconnection_v1beta1.json
+    kind: VPNConnection
+    name: vpnconnection_v1beta1
+  - apiVersion: ec2.aws.upbound.io/v1beta1
+    filename: ec2.aws.upbound.io/ebsdefaultkmskey_v1beta1.json
+    kind: EBSDefaultKMSKey
+    name: ebsdefaultkmskey_v1beta1
+  - apiVersion: ec2.aws.upbound.io/v1beta1
+    filename: ec2.aws.upbound.io/instancestate_v1beta1.json
+    kind: InstanceState
+    name: instancestate_v1beta1
+  - apiVersion: ec2.aws.upbound.io/v1beta1
+    filename: ec2.aws.upbound.io/securitygrouprule_v1beta1.json
+    kind: SecurityGroupRule
+    name: securitygrouprule_v1beta1
+  - apiVersion: ec2.aws.upbound.io/v1beta1
+    filename: ec2.aws.upbound.io/transitgatewayprefixlistreference_v1beta1.json
+    kind: TransitGatewayPrefixListReference
+    name: transitgatewayprefixlistreference_v1beta1
+  - apiVersion: ec2.aws.upbound.io/v1beta1
+    filename: ec2.aws.upbound.io/vpcpeeringconnectionoptions_v1beta1.json
+    kind: VPCPeeringConnectionOptions
+    name: vpcpeeringconnectionoptions_v1beta1
+  - apiVersion: ec2.aws.upbound.io/v1beta1
+    filename: ec2.aws.upbound.io/spotdatafeedsubscription_v1beta1.json
+    kind: SpotDatafeedSubscription
+    name: spotdatafeedsubscription_v1beta1
+  - apiVersion: ec2.aws.upbound.io/v1beta2
+    filename: ec2.aws.upbound.io/instance_v1beta2.json
+    kind: Instance
+    name: instance_v1beta2
+  - apiVersion: ec2.aws.upbound.io/v1beta1
+    filename: ec2.aws.upbound.io/transitgatewaymulticastgroupmember_v1beta1.json
+    kind: TransitGatewayMulticastGroupMember
+    name: transitgatewaymulticastgroupmember_v1beta1
+  - apiVersion: ec2.aws.upbound.io/v1beta1
+    filename: ec2.aws.upbound.io/spotinstancerequest_v1beta1.json
+    kind: SpotInstanceRequest
+    name: spotinstancerequest_v1beta1
+  - apiVersion: ec2.aws.upbound.io/v1beta1
+    filename: ec2.aws.upbound.io/eipassociation_v1beta1.json
+    kind: EIPAssociation
+    name: eipassociation_v1beta1
+  - apiVersion: ec2.aws.upbound.io/v1beta1
+    filename: ec2.aws.upbound.io/availabilityzonegroup_v1beta1.json
+    kind: AvailabilityZoneGroup
+    name: availabilityzonegroup_v1beta1
+  - apiVersion: ec2.aws.upbound.io/v1beta1
+    filename: ec2.aws.upbound.io/managedprefixlistentry_v1beta1.json
+    kind: ManagedPrefixListEntry
+    name: managedprefixlistentry_v1beta1
+  - apiVersion: ec2.aws.upbound.io/v1beta1
+    filename: ec2.aws.upbound.io/vpngatewayroutepropagation_v1beta1.json
+    kind: VPNGatewayRoutePropagation
+    name: vpngatewayroutepropagation_v1beta1
+  - apiVersion: ec2.aws.upbound.io/v1beta1
+    filename: ec2.aws.upbound.io/volumeattachment_v1beta1.json
+    kind: VolumeAttachment
+    name: volumeattachment_v1beta1
+  - apiVersion: ec2.aws.upbound.io/v1beta1
+    filename: ec2.aws.upbound.io/vpngatewayattachment_v1beta1.json
+    kind: VPNGatewayAttachment
+    name: vpngatewayattachment_v1beta1
+  - apiVersion: ec2.aws.upbound.io/v1beta2
+    filename: ec2.aws.upbound.io/vpnconnection_v1beta2.json
+    kind: VPNConnection
+    name: vpnconnection_v1beta2
+  - apiVersion: ec2.aws.upbound.io/v1beta1
+    filename: ec2.aws.upbound.io/eip_v1beta1.json
+    kind: EIP
+    name: eip_v1beta1
+  - apiVersion: ec2.aws.upbound.io/v1beta1
+    filename: ec2.aws.upbound.io/securitygroupingressrule_v1beta1.json
+    kind: SecurityGroupIngressRule
+    name: securitygroupingressrule_v1beta1
+  - apiVersion: ec2.aws.upbound.io/v1beta1
+    filename: ec2.aws.upbound.io/carriergateway_v1beta1.json
+    kind: CarrierGateway
+    name: carriergateway_v1beta1
+  - apiVersion: ec2.aws.upbound.io/v1beta1
+    filename: ec2.aws.upbound.io/capacityreservation_v1beta1.json
+    kind: CapacityReservation
+    name: capacityreservation_v1beta1
+  - apiVersion: ec2.aws.upbound.io/v1beta1
+    filename: ec2.aws.upbound.io/transitgatewayvpcattachmentaccepter_v1beta1.json
+    kind: TransitGatewayVPCAttachmentAccepter
+    name: transitgatewayvpcattachmentaccepter_v1beta1
+  - apiVersion: ec2.aws.upbound.io/v1beta1
+    filename: ec2.aws.upbound.io/vpcendpoint_v1beta1.json
+    kind: VPCEndpoint
+    name: vpcendpoint_v1beta1
+  - apiVersion: ec2.aws.upbound.io/v1beta2
+    filename: ec2.aws.upbound.io/vpcpeeringconnectionaccepter_v1beta2.json
+    kind: VPCPeeringConnectionAccepter
+    name: vpcpeeringconnectionaccepter_v1beta2
+  - apiVersion: ec2.aws.upbound.io/v1beta1
+    filename: ec2.aws.upbound.io/networkinterface_v1beta1.json
+    kind: NetworkInterface
+    name: networkinterface_v1beta1
+  - apiVersion: ec2.aws.upbound.io/v1beta1
+    filename: ec2.aws.upbound.io/spotfleetrequest_v1beta1.json
+    kind: SpotFleetRequest
+    name: spotfleetrequest_v1beta1
+  - apiVersion: ec2.aws.upbound.io/v1beta1
+    filename: ec2.aws.upbound.io/transitgatewayroutetablepropagation_v1beta1.json
+    kind: TransitGatewayRouteTablePropagation
+    name: transitgatewayroutetablepropagation_v1beta1
+  - apiVersion: ec2.aws.upbound.io/v1beta1
+    filename: ec2.aws.upbound.io/vpcendpointserviceallowedprincipal_v1beta1.json
+    kind: VPCEndpointServiceAllowedPrincipal
+    name: vpcendpointserviceallowedprincipal_v1beta1
+  - apiVersion: ec2.aws.upbound.io/v1beta2
+    filename: ec2.aws.upbound.io/vpcendpoint_v1beta2.json
+    kind: VPCEndpoint
+    name: vpcendpoint_v1beta2
+  - apiVersion: ec2.aws.upbound.io/v1beta1
+    filename: ec2.aws.upbound.io/transitgatewaymulticastdomain_v1beta1.json
+    kind: TransitGatewayMulticastDomain
+    name: transitgatewaymulticastdomain_v1beta1
+  - apiVersion: ec2.aws.upbound.io/v1beta2
+    filename: ec2.aws.upbound.io/trafficmirrorfilterrule_v1beta2.json
+    kind: TrafficMirrorFilterRule
+    name: trafficmirrorfilterrule_v1beta2
+  - apiVersion: ec2.aws.upbound.io/v1beta1
+    filename: ec2.aws.upbound.io/defaultvpc_v1beta1.json
+    kind: DefaultVPC
+    name: defaultvpc_v1beta1
+  - apiVersion: ec2.aws.upbound.io/v1beta1
+    filename: ec2.aws.upbound.io/vpcdhcpoptionsassociation_v1beta1.json
+    kind: VPCDHCPOptionsAssociation
+    name: vpcdhcpoptionsassociation_v1beta1
+  - apiVersion: ec2.aws.upbound.io/v1beta1
+    filename: ec2.aws.upbound.io/internetgateway_v1beta1.json
+    kind: InternetGateway
+    name: internetgateway_v1beta1
+  - apiVersion: ec2.aws.upbound.io/v1beta1
+    filename: ec2.aws.upbound.io/flowlog_v1beta1.json
+    kind: FlowLog
+    name: flowlog_v1beta1
+  - apiVersion: ec2.aws.upbound.io/v1beta1
+    filename: ec2.aws.upbound.io/route_v1beta1.json
+    kind: Route
+    name: route_v1beta1
+  - apiVersion: ec2.aws.upbound.io/v1beta1
+    filename: ec2.aws.upbound.io/defaultnetworkacl_v1beta1.json
+    kind: DefaultNetworkACL
+    name: defaultnetworkacl_v1beta1
+  - apiVersion: ec2.aws.upbound.io/v1beta1
+    filename: ec2.aws.upbound.io/subnet_v1beta1.json
+    kind: Subnet
+    name: subnet_v1beta1
+  - apiVersion: ec2.aws.upbound.io/v1beta1
+    filename: ec2.aws.upbound.io/transitgatewayroute_v1beta1.json
+    kind: TransitGatewayRoute
+    name: transitgatewayroute_v1beta1
+  - apiVersion: ec2.aws.upbound.io/v1beta1
+    filename: ec2.aws.upbound.io/customergateway_v1beta1.json
+    kind: CustomerGateway
+    name: customergateway_v1beta1
+  - apiVersion: ec2.aws.upbound.io/v1beta2
+    filename: ec2.aws.upbound.io/vpcpeeringconnectionoptions_v1beta2.json
+    kind: VPCPeeringConnectionOptions
+    name: vpcpeeringconnectionoptions_v1beta2
+  - apiVersion: ec2.aws.upbound.io/v1beta1
+    filename: ec2.aws.upbound.io/keypair_v1beta1.json
+    kind: KeyPair
+    name: keypair_v1beta1
+  - apiVersion: ec2.aws.upbound.io/v1beta1
+    filename: ec2.aws.upbound.io/networkinterfacesgattachment_v1beta1.json
+    kind: NetworkInterfaceSgAttachment
+    name: networkinterfacesgattachment_v1beta1
+  - apiVersion: ec2.aws.upbound.io/v1beta1
+    filename: ec2.aws.upbound.io/transitgateway_v1beta1.json
+    kind: TransitGateway
+    name: transitgateway_v1beta1
+  - apiVersion: ec2.aws.upbound.io/v1beta1
+    filename: ec2.aws.upbound.io/vpnconnectionroute_v1beta1.json
+    kind: VPNConnectionRoute
+    name: vpnconnectionroute_v1beta1
+  - apiVersion: ec2.aws.upbound.io/v1beta1
+    filename: ec2.aws.upbound.io/ebsvolume_v1beta1.json
+    kind: EBSVolume
+    name: ebsvolume_v1beta1
+  - apiVersion: ec2.aws.upbound.io/v1beta2
+    filename: ec2.aws.upbound.io/launchtemplate_v1beta2.json
+    kind: LaunchTemplate
+    name: launchtemplate_v1beta2
+  - apiVersion: ec2.aws.upbound.io/v1beta1
+    filename: ec2.aws.upbound.io/serialconsoleaccess_v1beta1.json
+    kind: SerialConsoleAccess
+    name: serialconsoleaccess_v1beta1
+  - apiVersion: ec2.aws.upbound.io/v1beta1
+    filename: ec2.aws.upbound.io/vpcendpointroutetableassociation_v1beta1.json
+    kind: VPCEndpointRouteTableAssociation
+    name: vpcendpointroutetableassociation_v1beta1
+  - apiVersion: ec2.aws.upbound.io/v1beta1
+    filename: ec2.aws.upbound.io/networkinsightsanalysis_v1beta1.json
+    kind: NetworkInsightsAnalysis
+    name: networkinsightsanalysis_v1beta1
+  - apiVersion: ec2.aws.upbound.io/v1beta1
+    filename: ec2.aws.upbound.io/networkinsightspath_v1beta1.json
+    kind: NetworkInsightsPath
+    name: networkinsightspath_v1beta1
+  - apiVersion: ec2.aws.upbound.io/v1beta1
+    filename: ec2.aws.upbound.io/transitgatewaypolicytable_v1beta1.json
+    kind: TransitGatewayPolicyTable
+    name: transitgatewaypolicytable_v1beta1
+  - apiVersion: ec2.aws.upbound.io/v1beta1
+    filename: ec2.aws.upbound.io/transitgatewayroutetable_v1beta1.json
+    kind: TransitGatewayRouteTable
+    name: transitgatewayroutetable_v1beta1
+  - apiVersion: ec2.aws.upbound.io/v1beta2
+    filename: ec2.aws.upbound.io/route_v1beta2.json
+    kind: Route
+    name: route_v1beta2
+  - apiVersion: ec2.aws.upbound.io/v1beta1
+    filename: ec2.aws.upbound.io/vpcendpointsubnetassociation_v1beta1.json
+    kind: VPCEndpointSubnetAssociation
+    name: vpcendpointsubnetassociation_v1beta1
+  - apiVersion: ec2.aws.upbound.io/v1beta1
+    filename: ec2.aws.upbound.io/ebssnapshot_v1beta1.json
+    kind: EBSSnapshot
+    name: ebssnapshot_v1beta1
+  - apiVersion: ec2.aws.upbound.io/v1beta1
+    filename: ec2.aws.upbound.io/trafficmirrorfilter_v1beta1.json
+    kind: TrafficMirrorFilter
+    name: trafficmirrorfilter_v1beta1
+  - apiVersion: ec2.aws.upbound.io/v1beta1
+    filename: ec2.aws.upbound.io/transitgatewaymulticastgroupsource_v1beta1.json
+    kind: TransitGatewayMulticastGroupSource
+    name: transitgatewaymulticastgroupsource_v1beta1
+  - apiVersion: ec2.aws.upbound.io/v1beta1
+    filename: ec2.aws.upbound.io/subnetcidrreservation_v1beta1.json
+    kind: SubnetCidrReservation
+    name: subnetcidrreservation_v1beta1
+  - apiVersion: ec2.aws.upbound.io/v1beta1
+    filename: ec2.aws.upbound.io/transitgatewayvpcattachment_v1beta1.json
+    kind: TransitGatewayVPCAttachment
+    name: transitgatewayvpcattachment_v1beta1
+  - apiVersion: ec2.aws.upbound.io/v1beta1
+    filename: ec2.aws.upbound.io/mainroutetableassociation_v1beta1.json
+    kind: MainRouteTableAssociation
+    name: mainroutetableassociation_v1beta1
+  - apiVersion: ec2.aws.upbound.io/v1beta1
+    filename: ec2.aws.upbound.io/transitgatewaypeeringattachmentaccepter_v1beta1.json
+    kind: TransitGatewayPeeringAttachmentAccepter
+    name: transitgatewaypeeringattachmentaccepter_v1beta1
+  - apiVersion: ec2.aws.upbound.io/v1beta1
+    filename: ec2.aws.upbound.io/vpcipamscope_v1beta1.json
+    kind: VPCIpamScope
+    name: vpcipamscope_v1beta1
+  - apiVersion: ec2.aws.upbound.io/v1beta1
+    filename: ec2.aws.upbound.io/defaultsecuritygroup_v1beta1.json
+    kind: DefaultSecurityGroup
+    name: defaultsecuritygroup_v1beta1
+  - apiVersion: ec2.aws.upbound.io/v1beta1
+    filename: ec2.aws.upbound.io/instance_v1beta1.json
+    kind: Instance
+    name: instance_v1beta1
+  - apiVersion: ec2.aws.upbound.io/v1beta1
+    filename: ec2.aws.upbound.io/routetable_v1beta1.json
+    kind: RouteTable
+    name: routetable_v1beta1
+  - apiVersion: ec2.aws.upbound.io/v1beta1
+    filename: ec2.aws.upbound.io/vpcipampoolcidrallocation_v1beta1.json
+    kind: VPCIpamPoolCidrAllocation
+    name: vpcipampoolcidrallocation_v1beta1
+  - apiVersion: ec2.aws.upbound.io/v1beta1
+    filename: ec2.aws.upbound.io/ebsencryptionbydefault_v1beta1.json
+    kind: EBSEncryptionByDefault
+    name: ebsencryptionbydefault_v1beta1
+  - apiVersion: ec2.aws.upbound.io/v1beta1
+    filename: ec2.aws.upbound.io/vpcipampool_v1beta1.json
+    kind: VPCIpamPool
+    name: vpcipampool_v1beta1
+  - apiVersion: ec2.aws.upbound.io/v1beta1
+    filename: ec2.aws.upbound.io/amicopy_v1beta1.json
+    kind: AMICopy
+    name: amicopy_v1beta1
+  - apiVersion: ec2.aws.upbound.io/v1beta1
+    filename: ec2.aws.upbound.io/defaultroutetable_v1beta1.json
+    kind: DefaultRouteTable
+    name: defaultroutetable_v1beta1
+  - apiVersion: ec2.aws.upbound.io/v1beta2
+    filename: ec2.aws.upbound.io/ebssnapshotimport_v1beta2.json
+    kind: EBSSnapshotImport
+    name: ebssnapshotimport_v1beta2
+  - apiVersion: ec2.aws.upbound.io/v1beta1
+    filename: ec2.aws.upbound.io/networkinterfaceattachment_v1beta1.json
+    kind: NetworkInterfaceAttachment
+    name: networkinterfaceattachment_v1beta1
+  - apiVersion: ec2.aws.upbound.io/v1beta1
+    filename: ec2.aws.upbound.io/amilaunchpermission_v1beta1.json
+    kind: AMILaunchPermission
+    name: amilaunchpermission_v1beta1
+  - apiVersion: ec2.aws.upbound.io/v1beta2
+    filename: ec2.aws.upbound.io/vpcipampoolcidr_v1beta2.json
+    kind: VPCIpamPoolCidr
+    name: vpcipampoolcidr_v1beta2
+  - apiVersion: ec2.aws.upbound.io/v1beta1
+    filename: ec2.aws.upbound.io/routetableassociation_v1beta1.json
+    kind: RouteTableAssociation
+    name: routetableassociation_v1beta1
+  - apiVersion: ec2.aws.upbound.io/v1beta1
+    filename: ec2.aws.upbound.io/vpcipv4cidrblockassociation_v1beta1.json
+    kind: VPCIPv4CidrBlockAssociation
+    name: vpcipv4cidrblockassociation_v1beta1
+  - apiVersion: ec2.aws.upbound.io/v1beta1
+    filename: ec2.aws.upbound.io/trafficmirrorfilterrule_v1beta1.json
+    kind: TrafficMirrorFilterRule
+    name: trafficmirrorfilterrule_v1beta1
+  - apiVersion: ec2.aws.upbound.io/v1beta1
+    filename: ec2.aws.upbound.io/vpcendpointsecuritygroupassociation_v1beta1.json
+    kind: VPCEndpointSecurityGroupAssociation
+    name: vpcendpointsecuritygroupassociation_v1beta1
 ec2.services.k8s.aws:
   - apiVersion: ec2.services.k8s.aws/v1alpha1
     filename: ec2.services.k8s.aws/dhcpoptions_v1alpha1.json
@@ -2782,6 +5795,92 @@ eks.amazonaws.com:
     filename: eks.amazonaws.com/nodediagnostic_v1alpha1.json
     kind: NodeDiagnostic
     name: nodediagnostic_v1alpha1
+eks.aws.m.upbound.io:
+  - apiVersion: eks.aws.m.upbound.io/v1beta1
+    filename: eks.aws.m.upbound.io/identityproviderconfig_v1beta1.json
+    kind: IdentityProviderConfig
+    name: identityproviderconfig_v1beta1
+  - apiVersion: eks.aws.m.upbound.io/v1beta1
+    filename: eks.aws.m.upbound.io/accesspolicyassociation_v1beta1.json
+    kind: AccessPolicyAssociation
+    name: accesspolicyassociation_v1beta1
+  - apiVersion: eks.aws.m.upbound.io/v1beta1
+    filename: eks.aws.m.upbound.io/addon_v1beta1.json
+    kind: Addon
+    name: addon_v1beta1
+  - apiVersion: eks.aws.m.upbound.io/v1beta1
+    filename: eks.aws.m.upbound.io/accessentry_v1beta1.json
+    kind: AccessEntry
+    name: accessentry_v1beta1
+  - apiVersion: eks.aws.m.upbound.io/v1beta1
+    filename: eks.aws.m.upbound.io/fargateprofile_v1beta1.json
+    kind: FargateProfile
+    name: fargateprofile_v1beta1
+  - apiVersion: eks.aws.m.upbound.io/v1beta1
+    filename: eks.aws.m.upbound.io/cluster_v1beta1.json
+    kind: Cluster
+    name: cluster_v1beta1
+  - apiVersion: eks.aws.m.upbound.io/v1beta1
+    filename: eks.aws.m.upbound.io/podidentityassociation_v1beta1.json
+    kind: PodIdentityAssociation
+    name: podidentityassociation_v1beta1
+  - apiVersion: eks.aws.m.upbound.io/v1beta1
+    filename: eks.aws.m.upbound.io/nodegroup_v1beta1.json
+    kind: NodeGroup
+    name: nodegroup_v1beta1
+  - apiVersion: eks.aws.m.upbound.io/v1beta1
+    filename: eks.aws.m.upbound.io/clusterauth_v1beta1.json
+    kind: ClusterAuth
+    name: clusterauth_v1beta1
+eks.aws.upbound.io:
+  - apiVersion: eks.aws.upbound.io/v1beta1
+    filename: eks.aws.upbound.io/identityproviderconfig_v1beta1.json
+    kind: IdentityProviderConfig
+    name: identityproviderconfig_v1beta1
+  - apiVersion: eks.aws.upbound.io/v1beta2
+    filename: eks.aws.upbound.io/identityproviderconfig_v1beta2.json
+    kind: IdentityProviderConfig
+    name: identityproviderconfig_v1beta2
+  - apiVersion: eks.aws.upbound.io/v1beta1
+    filename: eks.aws.upbound.io/accesspolicyassociation_v1beta1.json
+    kind: AccessPolicyAssociation
+    name: accesspolicyassociation_v1beta1
+  - apiVersion: eks.aws.upbound.io/v1beta1
+    filename: eks.aws.upbound.io/addon_v1beta1.json
+    kind: Addon
+    name: addon_v1beta1
+  - apiVersion: eks.aws.upbound.io/v1beta1
+    filename: eks.aws.upbound.io/accessentry_v1beta1.json
+    kind: AccessEntry
+    name: accessentry_v1beta1
+  - apiVersion: eks.aws.upbound.io/v1beta2
+    filename: eks.aws.upbound.io/nodegroup_v1beta2.json
+    kind: NodeGroup
+    name: nodegroup_v1beta2
+  - apiVersion: eks.aws.upbound.io/v1beta1
+    filename: eks.aws.upbound.io/fargateprofile_v1beta1.json
+    kind: FargateProfile
+    name: fargateprofile_v1beta1
+  - apiVersion: eks.aws.upbound.io/v1beta1
+    filename: eks.aws.upbound.io/cluster_v1beta1.json
+    kind: Cluster
+    name: cluster_v1beta1
+  - apiVersion: eks.aws.upbound.io/v1beta1
+    filename: eks.aws.upbound.io/podidentityassociation_v1beta1.json
+    kind: PodIdentityAssociation
+    name: podidentityassociation_v1beta1
+  - apiVersion: eks.aws.upbound.io/v1beta1
+    filename: eks.aws.upbound.io/nodegroup_v1beta1.json
+    kind: NodeGroup
+    name: nodegroup_v1beta1
+  - apiVersion: eks.aws.upbound.io/v1beta2
+    filename: eks.aws.upbound.io/cluster_v1beta2.json
+    kind: Cluster
+    name: cluster_v1beta2
+  - apiVersion: eks.aws.upbound.io/v1beta1
+    filename: eks.aws.upbound.io/clusterauth_v1beta1.json
+    kind: ClusterAuth
+    name: clusterauth_v1beta1
 eks.services.k8s.aws:
   - apiVersion: eks.services.k8s.aws/v1alpha1
     filename: eks.services.k8s.aws/fargateprofile_v1alpha1.json
@@ -2811,6 +5910,80 @@ eks.services.k8s.aws:
     filename: eks.services.k8s.aws/identityproviderconfig_v1alpha1.json
     kind: IdentityProviderConfig
     name: identityproviderconfig_v1alpha1
+elasticache.aws.m.upbound.io:
+  - apiVersion: elasticache.aws.m.upbound.io/v1beta1
+    filename: elasticache.aws.m.upbound.io/serverlesscache_v1beta1.json
+    kind: ServerlessCache
+    name: serverlesscache_v1beta1
+  - apiVersion: elasticache.aws.m.upbound.io/v1beta1
+    filename: elasticache.aws.m.upbound.io/subnetgroup_v1beta1.json
+    kind: SubnetGroup
+    name: subnetgroup_v1beta1
+  - apiVersion: elasticache.aws.m.upbound.io/v1beta1
+    filename: elasticache.aws.m.upbound.io/replicationgroup_v1beta1.json
+    kind: ReplicationGroup
+    name: replicationgroup_v1beta1
+  - apiVersion: elasticache.aws.m.upbound.io/v1beta1
+    filename: elasticache.aws.m.upbound.io/parametergroup_v1beta1.json
+    kind: ParameterGroup
+    name: parametergroup_v1beta1
+  - apiVersion: elasticache.aws.m.upbound.io/v1beta1
+    filename: elasticache.aws.m.upbound.io/usergroup_v1beta1.json
+    kind: UserGroup
+    name: usergroup_v1beta1
+  - apiVersion: elasticache.aws.m.upbound.io/v1beta1
+    filename: elasticache.aws.m.upbound.io/cluster_v1beta1.json
+    kind: Cluster
+    name: cluster_v1beta1
+  - apiVersion: elasticache.aws.m.upbound.io/v1beta1
+    filename: elasticache.aws.m.upbound.io/globalreplicationgroup_v1beta1.json
+    kind: GlobalReplicationGroup
+    name: globalreplicationgroup_v1beta1
+  - apiVersion: elasticache.aws.m.upbound.io/v1beta1
+    filename: elasticache.aws.m.upbound.io/user_v1beta1.json
+    kind: User
+    name: user_v1beta1
+elasticache.aws.upbound.io:
+  - apiVersion: elasticache.aws.upbound.io/v1beta1
+    filename: elasticache.aws.upbound.io/serverlesscache_v1beta1.json
+    kind: ServerlessCache
+    name: serverlesscache_v1beta1
+  - apiVersion: elasticache.aws.upbound.io/v1beta1
+    filename: elasticache.aws.upbound.io/subnetgroup_v1beta1.json
+    kind: SubnetGroup
+    name: subnetgroup_v1beta1
+  - apiVersion: elasticache.aws.upbound.io/v1beta1
+    filename: elasticache.aws.upbound.io/replicationgroup_v1beta1.json
+    kind: ReplicationGroup
+    name: replicationgroup_v1beta1
+  - apiVersion: elasticache.aws.upbound.io/v1beta2
+    filename: elasticache.aws.upbound.io/replicationgroup_v1beta2.json
+    kind: ReplicationGroup
+    name: replicationgroup_v1beta2
+  - apiVersion: elasticache.aws.upbound.io/v1beta1
+    filename: elasticache.aws.upbound.io/parametergroup_v1beta1.json
+    kind: ParameterGroup
+    name: parametergroup_v1beta1
+  - apiVersion: elasticache.aws.upbound.io/v1beta1
+    filename: elasticache.aws.upbound.io/usergroup_v1beta1.json
+    kind: UserGroup
+    name: usergroup_v1beta1
+  - apiVersion: elasticache.aws.upbound.io/v1beta1
+    filename: elasticache.aws.upbound.io/cluster_v1beta1.json
+    kind: Cluster
+    name: cluster_v1beta1
+  - apiVersion: elasticache.aws.upbound.io/v1beta1
+    filename: elasticache.aws.upbound.io/globalreplicationgroup_v1beta1.json
+    kind: GlobalReplicationGroup
+    name: globalreplicationgroup_v1beta1
+  - apiVersion: elasticache.aws.upbound.io/v1beta1
+    filename: elasticache.aws.upbound.io/user_v1beta1.json
+    kind: User
+    name: user_v1beta1
+  - apiVersion: elasticache.aws.upbound.io/v1beta2
+    filename: elasticache.aws.upbound.io/user_v1beta2.json
+    kind: User
+    name: user_v1beta2
 elasticache.services.k8s.aws:
   - apiVersion: elasticache.services.k8s.aws/v1alpha1
     filename: elasticache.services.k8s.aws/snapshot_v1alpha1.json
@@ -2853,6 +6026,80 @@ elasticsearch.k8s.elastic.co:
     filename: elasticsearch.k8s.elastic.co/elasticsearch_v1.json
     kind: Elasticsearch
     name: elasticsearch_v1
+elbv2.aws.m.upbound.io:
+  - apiVersion: elbv2.aws.m.upbound.io/v1beta1
+    filename: elbv2.aws.m.upbound.io/lbtruststore_v1beta1.json
+    kind: LBTrustStore
+    name: lbtruststore_v1beta1
+  - apiVersion: elbv2.aws.m.upbound.io/v1beta1
+    filename: elbv2.aws.m.upbound.io/lb_v1beta1.json
+    kind: LB
+    name: lb_v1beta1
+  - apiVersion: elbv2.aws.m.upbound.io/v1beta1
+    filename: elbv2.aws.m.upbound.io/lbtargetgroupattachment_v1beta1.json
+    kind: LBTargetGroupAttachment
+    name: lbtargetgroupattachment_v1beta1
+  - apiVersion: elbv2.aws.m.upbound.io/v1beta1
+    filename: elbv2.aws.m.upbound.io/lblistenercertificate_v1beta1.json
+    kind: LBListenerCertificate
+    name: lblistenercertificate_v1beta1
+  - apiVersion: elbv2.aws.m.upbound.io/v1beta1
+    filename: elbv2.aws.m.upbound.io/lbtargetgroup_v1beta1.json
+    kind: LBTargetGroup
+    name: lbtargetgroup_v1beta1
+  - apiVersion: elbv2.aws.m.upbound.io/v1beta1
+    filename: elbv2.aws.m.upbound.io/lblistener_v1beta1.json
+    kind: LBListener
+    name: lblistener_v1beta1
+  - apiVersion: elbv2.aws.m.upbound.io/v1beta1
+    filename: elbv2.aws.m.upbound.io/lblistenerrule_v1beta1.json
+    kind: LBListenerRule
+    name: lblistenerrule_v1beta1
+elbv2.aws.upbound.io:
+  - apiVersion: elbv2.aws.upbound.io/v1beta2
+    filename: elbv2.aws.upbound.io/lb_v1beta2.json
+    kind: LB
+    name: lb_v1beta2
+  - apiVersion: elbv2.aws.upbound.io/v1beta1
+    filename: elbv2.aws.upbound.io/lbtruststore_v1beta1.json
+    kind: LBTrustStore
+    name: lbtruststore_v1beta1
+  - apiVersion: elbv2.aws.upbound.io/v1beta1
+    filename: elbv2.aws.upbound.io/lb_v1beta1.json
+    kind: LB
+    name: lb_v1beta1
+  - apiVersion: elbv2.aws.upbound.io/v1beta2
+    filename: elbv2.aws.upbound.io/lblistenerrule_v1beta2.json
+    kind: LBListenerRule
+    name: lblistenerrule_v1beta2
+  - apiVersion: elbv2.aws.upbound.io/v1beta2
+    filename: elbv2.aws.upbound.io/lblistener_v1beta2.json
+    kind: LBListener
+    name: lblistener_v1beta2
+  - apiVersion: elbv2.aws.upbound.io/v1beta1
+    filename: elbv2.aws.upbound.io/lbtargetgroupattachment_v1beta1.json
+    kind: LBTargetGroupAttachment
+    name: lbtargetgroupattachment_v1beta1
+  - apiVersion: elbv2.aws.upbound.io/v1beta1
+    filename: elbv2.aws.upbound.io/lblistenercertificate_v1beta1.json
+    kind: LBListenerCertificate
+    name: lblistenercertificate_v1beta1
+  - apiVersion: elbv2.aws.upbound.io/v1beta1
+    filename: elbv2.aws.upbound.io/lbtargetgroup_v1beta1.json
+    kind: LBTargetGroup
+    name: lbtargetgroup_v1beta1
+  - apiVersion: elbv2.aws.upbound.io/v1beta1
+    filename: elbv2.aws.upbound.io/lblistener_v1beta1.json
+    kind: LBListener
+    name: lblistener_v1beta1
+  - apiVersion: elbv2.aws.upbound.io/v1beta2
+    filename: elbv2.aws.upbound.io/lbtargetgroup_v1beta2.json
+    kind: LBTargetGroup
+    name: lbtargetgroup_v1beta2
+  - apiVersion: elbv2.aws.upbound.io/v1beta1
+    filename: elbv2.aws.upbound.io/lblistenerrule_v1beta1.json
+    kind: LBListenerRule
+    name: lblistenerrule_v1beta1
 elbv2.k8s.aws:
   - apiVersion: elbv2.k8s.aws/v1alpha1
     filename: elbv2.k8s.aws/targetgroupbinding_v1alpha1.json
@@ -2901,6 +6148,96 @@ enterprise.grafana.crossplane.io:
     filename: enterprise.grafana.crossplane.io/role_v1alpha1.json
     kind: Role
     name: role_v1alpha1
+  - apiVersion: enterprise.grafana.crossplane.io/v1alpha1
+    filename: enterprise.grafana.crossplane.io/keeperv1beta1_v1alpha1.json
+    kind: KeeperV1Beta1
+    name: keeperv1beta1_v1alpha1
+  - apiVersion: enterprise.grafana.crossplane.io/v1alpha1
+    filename: enterprise.grafana.crossplane.io/keeperactivationv1beta1_v1alpha1.json
+    kind: KeeperActivationV1Beta1
+    name: keeperactivationv1beta1_v1alpha1
+  - apiVersion: enterprise.grafana.crossplane.io/v1alpha1
+    filename: enterprise.grafana.crossplane.io/datasourceconfiglbacrules_v1alpha1.json
+    kind: DataSourceConfigLbacRules
+    name: datasourceconfiglbacrules_v1alpha1
+  - apiVersion: enterprise.grafana.crossplane.io/v1alpha1
+    filename: enterprise.grafana.crossplane.io/datasourcecacheconfig_v1alpha1.json
+    kind: DataSourceCacheConfig
+    name: datasourcecacheconfig_v1alpha1
+  - apiVersion: enterprise.grafana.crossplane.io/v1alpha1
+    filename: enterprise.grafana.crossplane.io/datasourcepermissionitem_v1alpha1.json
+    kind: DataSourcePermissionItem
+    name: datasourcepermissionitem_v1alpha1
+  - apiVersion: enterprise.grafana.crossplane.io/v1alpha1
+    filename: enterprise.grafana.crossplane.io/scimconfig_v1alpha1.json
+    kind: ScimConfig
+    name: scimconfig_v1alpha1
+  - apiVersion: enterprise.grafana.crossplane.io/v1alpha1
+    filename: enterprise.grafana.crossplane.io/roleassignmentitem_v1alpha1.json
+    kind: RoleAssignmentItem
+    name: roleassignmentitem_v1alpha1
+  - apiVersion: enterprise.grafana.crossplane.io/v1alpha1
+    filename: enterprise.grafana.crossplane.io/securevaluev1beta1_v1alpha1.json
+    kind: SecurevalueV1Beta1
+    name: securevaluev1beta1_v1alpha1
+enterprise.grafana.m.crossplane.io:
+  - apiVersion: enterprise.grafana.m.crossplane.io/v1alpha1
+    filename: enterprise.grafana.m.crossplane.io/report_v1alpha1.json
+    kind: Report
+    name: report_v1alpha1
+  - apiVersion: enterprise.grafana.m.crossplane.io/v1alpha1
+    filename: enterprise.grafana.m.crossplane.io/datasourcepermission_v1alpha1.json
+    kind: DataSourcePermission
+    name: datasourcepermission_v1alpha1
+  - apiVersion: enterprise.grafana.m.crossplane.io/v1alpha1
+    filename: enterprise.grafana.m.crossplane.io/keeperv1beta1_v1alpha1.json
+    kind: KeeperV1Beta1
+    name: keeperv1beta1_v1alpha1
+  - apiVersion: enterprise.grafana.m.crossplane.io/v1alpha1
+    filename: enterprise.grafana.m.crossplane.io/teamexternalgroup_v1alpha1.json
+    kind: TeamExternalGroup
+    name: teamexternalgroup_v1alpha1
+  - apiVersion: enterprise.grafana.m.crossplane.io/v1alpha1
+    filename: enterprise.grafana.m.crossplane.io/keeperactivationv1beta1_v1alpha1.json
+    kind: KeeperActivationV1Beta1
+    name: keeperactivationv1beta1_v1alpha1
+  - apiVersion: enterprise.grafana.m.crossplane.io/v1alpha1
+    filename: enterprise.grafana.m.crossplane.io/datasourceconfiglbacrules_v1alpha1.json
+    kind: DataSourceConfigLbacRules
+    name: datasourceconfiglbacrules_v1alpha1
+  - apiVersion: enterprise.grafana.m.crossplane.io/v1alpha1
+    filename: enterprise.grafana.m.crossplane.io/datasourcecacheconfig_v1alpha1.json
+    kind: DataSourceCacheConfig
+    name: datasourcecacheconfig_v1alpha1
+  - apiVersion: enterprise.grafana.m.crossplane.io/v1alpha1
+    filename: enterprise.grafana.m.crossplane.io/datasourcepermissionitem_v1alpha1.json
+    kind: DataSourcePermissionItem
+    name: datasourcepermissionitem_v1alpha1
+  - apiVersion: enterprise.grafana.m.crossplane.io/v1alpha1
+    filename: enterprise.grafana.m.crossplane.io/scimconfig_v1alpha1.json
+    kind: ScimConfig
+    name: scimconfig_v1alpha1
+  - apiVersion: enterprise.grafana.m.crossplane.io/v1alpha1
+    filename: enterprise.grafana.m.crossplane.io/roleassignmentitem_v1alpha1.json
+    kind: RoleAssignmentItem
+    name: roleassignmentitem_v1alpha1
+  - apiVersion: enterprise.grafana.m.crossplane.io/v1alpha1
+    filename: enterprise.grafana.m.crossplane.io/role_v1alpha1.json
+    kind: Role
+    name: role_v1alpha1
+  - apiVersion: enterprise.grafana.m.crossplane.io/v1alpha1
+    filename: enterprise.grafana.m.crossplane.io/roleassignment_v1alpha1.json
+    kind: RoleAssignment
+    name: roleassignment_v1alpha1
+  - apiVersion: enterprise.grafana.m.crossplane.io/v1alpha1
+    filename: enterprise.grafana.m.crossplane.io/securevaluev1beta1_v1alpha1.json
+    kind: SecurevalueV1Beta1
+    name: securevaluev1beta1_v1alpha1
+enterprise.grafana.o.crossplane.io:
+  - apiVersion: enterprise.grafana.o.crossplane.io/v1alpha1
+    filename: enterprise.grafana.o.crossplane.io/role_v1alpha1.json
+    kind: Role
+    name: role_v1alpha1
 enterprisesearch.k8s.elastic.co:
   - apiVersion: enterprisesearch.k8s.elastic.co/v1beta1
     filename: enterprisesearch.k8s.elastic.co/enterprisesearch_v1beta1.json
@@ -2910,11 +6247,32 @@ enterprisesearch.k8s.elastic.co:
     filename: enterprisesearch.k8s.elastic.co/enterprisesearch_v1.json
     kind: EnterpriseSearch
     name: enterprisesearch_v1
+eraser.sh:
+  - apiVersion: eraser.sh/v1alpha1
+    filename: eraser.sh/imagejob_v1alpha1.json
+    kind: ImageJob
+    name: imagejob_v1alpha1
+  - apiVersion: eraser.sh/v1
+    filename: eraser.sh/imagejob_v1.json
+    kind: ImageJob
+    name: imagejob_v1
+  - apiVersion: eraser.sh/v1
+    filename: eraser.sh/imagelist_v1.json
+    kind: ImageList
+    name: imagelist_v1
+  - apiVersion: eraser.sh/v1alpha1
+    filename: eraser.sh/imagelist_v1alpha1.json
+    kind: ImageList
+    name: imagelist_v1alpha1
 essentialcontacts.cnrm.cloud.google.com:
   - apiVersion: essentialcontacts.cnrm.cloud.google.com/v1alpha1
     filename: essentialcontacts.cnrm.cloud.google.com/essentialcontactscontact_v1alpha1.json
     kind: essentialcontactscontact
     name: essentialcontactscontact_v1alpha1
+  - apiVersion: essentialcontacts.cnrm.cloud.google.com/v1beta1
+    filename: essentialcontacts.cnrm.cloud.google.com/essentialcontactscontact_v1beta1.json
+    kind: EssentialContactsContact
+    name: essentialcontactscontact_v1beta1
 etcd.k0sproject.io:
   - apiVersion: etcd.k0sproject.io/v1beta1
     filename: etcd.k0sproject.io/etcdmember_v1beta1.json
@@ -2942,6 +6300,106 @@ eventbridge.services.k8s.aws:
     filename: eventbridge.services.k8s.aws/endpoint_v1alpha1.json
     kind: Endpoint
     name: endpoint_v1alpha1
+eventgrid.azure.com:
+  - apiVersion: eventgrid.azure.com/v1api20200601
+    filename: eventgrid.azure.com/domain_v1api20200601.json
+    kind: domain
+    name: domain_v1api20200601
+  - apiVersion: eventgrid.azure.com/v1api20200601
+    filename: eventgrid.azure.com/domainstopic_v1api20200601.json
+    kind: domainstopic
+    name: domainstopic_v1api20200601
+  - apiVersion: eventgrid.azure.com/v1api20200601
+    filename: eventgrid.azure.com/eventsubscription_v1api20200601.json
+    kind: eventSubscription
+    name: eventsubscription_v1api20200601
+  - apiVersion: eventgrid.azure.com/v1api20200601
+    filename: eventgrid.azure.com/topic_v1api20200601.json
+    kind: topic
+    name: topic_v1api20200601
+eventhub.azure.com:
+  - apiVersion: eventhub.azure.com/v1api20240101
+    filename: eventhub.azure.com/namespaceseventhubsconsumergroup_v1api20240101.json
+    kind: namespaceseventhubsconsumergroup
+    name: namespaceseventhubsconsumergroup_v1api20240101
+  - apiVersion: eventhub.azure.com/v1api20240101
+    filename: eventhub.azure.com/namespaceseventhubsauthorizationrule_v1api20240101.json
+    kind: namespaceseventhubsauthorizationrule
+    name: namespaceseventhubsauthorizationrule_v1api20240101
+  - apiVersion: eventhub.azure.com/v1api20211101
+    filename: eventhub.azure.com/namespace_v1api20211101.json
+    kind: namespace
+    name: namespace_v1api20211101
+  - apiVersion: eventhub.azure.com/v1api20211101
+    filename: eventhub.azure.com/namespacesauthorizationrule_v1api20211101.json
+    kind: namespacesauthorizationrule
+    name: namespacesauthorizationrule_v1api20211101
+  - apiVersion: eventhub.azure.com/v1api20240101
+    filename: eventhub.azure.com/namespacesauthorizationrule_v1api20240101.json
+    kind: namespacesauthorizationrule
+    name: namespacesauthorizationrule_v1api20240101
+  - apiVersion: eventhub.azure.com/v1api20240101
+    filename: eventhub.azure.com/namespace_v1api20240101.json
+    kind: namespace
+    name: namespace_v1api20240101
+  - apiVersion: eventhub.azure.com/v1api20240101
+    filename: eventhub.azure.com/namespaceseventhub_v1api20240101.json
+    kind: namespaceseventhub
+    name: namespaceseventhub_v1api20240101
+  - apiVersion: eventhub.azure.com/v1api20211101
+    filename: eventhub.azure.com/namespaceseventhub_v1api20211101.json
+    kind: namespaceseventhub
+    name: namespaceseventhub_v1api20211101
+  - apiVersion: eventhub.azure.com/v1api20211101
+    filename: eventhub.azure.com/namespaceseventhubsauthorizationrule_v1api20211101.json
+    kind: namespaceseventhubsauthorizationrule
+    name: namespaceseventhubsauthorizationrule_v1api20211101
+  - apiVersion: eventhub.azure.com/v1api20211101
+    filename: eventhub.azure.com/namespaceseventhubsconsumergroup_v1api20211101.json
+    kind: namespaceseventhubsconsumergroup
+    name: namespaceseventhubsconsumergroup_v1api20211101
+eventing.keda.sh:
+  - apiVersion: eventing.keda.sh/v1alpha1
+    filename: eventing.keda.sh/cloudeventsource_v1alpha1.json
+    kind: CloudEventSource
+    name: cloudeventsource_v1alpha1
+  - apiVersion: eventing.keda.sh/v1alpha1
+    filename: eventing.keda.sh/clustercloudeventsource_v1alpha1.json
+    kind: clustercloudeventsource
+    name: clustercloudeventsource_v1alpha1
+eventing.knative.dev:
+  - apiVersion: eventing.knative.dev/v1alpha1
+    filename: eventing.knative.dev/eventpolicy_v1alpha1.json
+    kind: eventpolicy
+    name: eventpolicy_v1alpha1
+  - apiVersion: eventing.knative.dev/v1alpha1
+    filename: eventing.knative.dev/requestreply_v1alpha1.json
+    kind: requestreply
+    name: requestreply_v1alpha1
+  - apiVersion: eventing.knative.dev/v1
+    filename: eventing.knative.dev/trigger_v1.json
+    kind: Trigger
+    name: trigger_v1
+  - apiVersion: eventing.knative.dev/v1beta2
+    filename: eventing.knative.dev/eventtype_v1beta2.json
+    kind: EventType
+    name: eventtype_v1beta2
+  - apiVersion: eventing.knative.dev/v1
+    filename: eventing.knative.dev/broker_v1.json
+    kind: Broker
+    name: broker_v1
+  - apiVersion: eventing.knative.dev/v1beta1
+    filename: eventing.knative.dev/eventtype_v1beta1.json
+    kind: EventType
+    name: eventtype_v1beta1
+  - apiVersion: eventing.knative.dev/v1beta3
+    filename: eventing.knative.dev/eventtype_v1beta3.json
+    kind: EventType
+    name: eventtype_v1beta3
+  - apiVersion: eventing.knative.dev/v1alpha1
+    filename: eventing.knative.dev/eventtransform_v1alpha1.json
+    kind: eventtransform
+    name: eventtransform_v1alpha1
 executor.testkube.io:
   - apiVersion: executor.testkube.io/v1
     filename: executor.testkube.io/executor_v1.json
@@ -2985,6 +6443,15 @@ expansion.gatekeeper.sh:
     filename: expansion.gatekeeper.sh/expansiontemplate_v1beta1.json
     kind: ExpansionTemplate
     name: expansiontemplate_v1beta1
+export.kubevirt.io:
+  - apiVersion: export.kubevirt.io/v1alpha1
+    filename: export.kubevirt.io/virtualmachineexport_v1alpha1.json
+    kind: VirtualMachineExport
+    name: virtualmachineexport_v1alpha1
+  - apiVersion: export.kubevirt.io/v1beta1
+    filename: export.kubevirt.io/virtualmachineexport_v1beta1.json
+    kind: VirtualMachineExport
+    name: virtualmachineexport_v1beta1
 extensions.istio.io:
   - apiVersion: extensions.istio.io/v1alpha1
     filename: extensions.istio.io/wasmplugin_v1alpha1.json
@@ -3116,6 +6583,10 @@ firestore.cnrm.cloud.google.com:
     filename: firestore.cnrm.cloud.google.com/firestoredatabase_v1alpha1.json
     kind: FirestoreDatabase
     name: firestoredatabase_v1alpha1
+  - apiVersion: firestore.cnrm.cloud.google.com/v1beta1
+    filename: firestore.cnrm.cloud.google.com/firestoredatabase_v1beta1.json
+    kind: FirestoreDatabase
+    name: firestoredatabase_v1beta1
 flagger.app:
   - apiVersion: flagger.app/v1beta1
     filename: flagger.app/metrictemplate_v1beta1.json
@@ -3129,6 +6600,42 @@ flagger.app:
     filename: flagger.app/canary_v1beta1.json
     kind: Canary
     name: canary_v1beta1
+fleet.cattle.io:
+  - apiVersion: fleet.cattle.io/v1alpha1
+    filename: fleet.cattle.io/clustergroup_v1alpha1.json
+    kind: clustergroup
+    name: clustergroup_v1alpha1
+  - apiVersion: fleet.cattle.io/v1alpha1
+    filename: fleet.cattle.io/bundle_v1alpha1.json
+    kind: bundle
+    name: bundle_v1alpha1
+fleetmanagement.grafana.crossplane.io:
+  - apiVersion: fleetmanagement.grafana.crossplane.io/v1alpha1
+    filename: fleetmanagement.grafana.crossplane.io/pipeline_v1alpha1.json
+    kind: Pipeline
+    name: pipeline_v1alpha1
+  - apiVersion: fleetmanagement.grafana.crossplane.io/v1alpha1
+    filename: fleetmanagement.grafana.crossplane.io/collector_v1alpha1.json
+    kind: Collector
+    name: collector_v1alpha1
+fleetmanagement.grafana.m.crossplane.io:
+  - apiVersion: fleetmanagement.grafana.m.crossplane.io/v1alpha1
+    filename: fleetmanagement.grafana.m.crossplane.io/pipeline_v1alpha1.json
+    kind: Pipeline
+    name: pipeline_v1alpha1
+  - apiVersion: fleetmanagement.grafana.m.crossplane.io/v1alpha1
+    filename: fleetmanagement.grafana.m.crossplane.io/collector_v1alpha1.json
+    kind: Collector
+    name: collector_v1alpha1
+fleetmanagement.grafana.o.crossplane.io:
+  - apiVersion: fleetmanagement.grafana.o.crossplane.io/v1alpha1
+    filename: fleetmanagement.grafana.o.crossplane.io/collectorset_v1alpha1.json
+    kind: CollectorSet
+    name: collectorset_v1alpha1
+  - apiVersion: fleetmanagement.grafana.o.crossplane.io/v1alpha1
+    filename: fleetmanagement.grafana.o.crossplane.io/collector_v1alpha1.json
+    kind: Collector
+    name: collector_v1alpha1
 flink.apache.org:
   - apiVersion: flink.apache.org/v1beta1
     filename: flink.apache.org/flinkdeployment_v1beta1.json
@@ -3142,6 +6649,15 @@ flink.apache.org:
     filename: flink.apache.org/flinksessionjob_v1beta1.json
     kind: flinksessionjob
     name: flinksessionjob_v1beta1
+flows.knative.dev:
+  - apiVersion: flows.knative.dev/v1
+    filename: flows.knative.dev/sequence_v1.json
+    kind: Sequence
+    name: sequence_v1
+  - apiVersion: flows.knative.dev/v1
+    filename: flows.knative.dev/parallel_v1.json
+    kind: Parallel
+    name: parallel_v1
 fluentbit.fluent.io:
   - apiVersion: fluentbit.fluent.io/v1alpha2
     filename: fluentbit.fluent.io/collector_v1alpha2.json
@@ -3249,6 +6765,30 @@ fluxcd.controlplane.io:
     filename: fluxcd.controlplane.io/resourceset_v1.json
     kind: ResourceSet
     name: resourceset_v1
+forklift.cdi.kubevirt.io:
+  - apiVersion: forklift.cdi.kubevirt.io/v1beta1
+    filename: forklift.cdi.kubevirt.io/openstackvolumepopulator_v1beta1.json
+    kind: OpenstackVolumePopulator
+    name: openstackvolumepopulator_v1beta1
+  - apiVersion: forklift.cdi.kubevirt.io/v1beta1
+    filename: forklift.cdi.kubevirt.io/ovirtvolumepopulator_v1beta1.json
+    kind: OvirtVolumePopulator
+    name: ovirtvolumepopulator_v1beta1
+frontendobservability.grafana.crossplane.io:
+  - apiVersion: frontendobservability.grafana.crossplane.io/v1alpha1
+    filename: frontendobservability.grafana.crossplane.io/app_v1alpha1.json
+    kind: App
+    name: app_v1alpha1
+frontendobservability.grafana.m.crossplane.io:
+  - apiVersion: frontendobservability.grafana.m.crossplane.io/v1alpha1
+    filename: frontendobservability.grafana.m.crossplane.io/app_v1alpha1.json
+    kind: App
+    name: app_v1alpha1
+frontendobservability.grafana.o.crossplane.io:
+  - apiVersion: frontendobservability.grafana.o.crossplane.io/v1alpha1
+    filename: frontendobservability.grafana.o.crossplane.io/app_v1alpha1.json
+    kind: App
+    name: app_v1alpha1
 gameservices.cnrm.cloud.google.com:
   - apiVersion: gameservices.cnrm.cloud.google.com/v1beta1
     filename: gameservices.cnrm.cloud.google.com/gameservicesrealm_v1beta1.json
@@ -3287,6 +6827,52 @@ gateway.envoyproxy.io:
     filename: gateway.envoyproxy.io/backend_v1alpha1.json
     kind: Backend
     name: backend_v1alpha1
+gateway.k8s.aws:
+  - apiVersion: gateway.k8s.aws/v1beta1
+    filename: gateway.k8s.aws/targetgroupconfiguration_v1beta1.json
+    kind: TargetGroupConfiguration
+    name: targetgroupconfiguration_v1beta1
+  - apiVersion: gateway.k8s.aws/v1beta1
+    filename: gateway.k8s.aws/listenerruleconfiguration_v1beta1.json
+    kind: ListenerRuleConfiguration
+    name: listenerruleconfiguration_v1beta1
+  - apiVersion: gateway.k8s.aws/v1beta1
+    filename: gateway.k8s.aws/loadbalancerconfiguration_v1beta1.json
+    kind: LoadBalancerConfiguration
+    name: loadbalancerconfiguration_v1beta1
+gateway.kgateway.dev:
+  - apiVersion: gateway.kgateway.dev/v1alpha1
+    filename: gateway.kgateway.dev/directresponse_v1alpha1.json
+    kind: DirectResponse
+    name: directresponse_v1alpha1
+  - apiVersion: gateway.kgateway.dev/v1alpha1
+    filename: gateway.kgateway.dev/listenerpolicy_v1alpha1.json
+    kind: ListenerPolicy
+    name: listenerpolicy_v1alpha1
+  - apiVersion: gateway.kgateway.dev/v1alpha1
+    filename: gateway.kgateway.dev/httplistenerpolicy_v1alpha1.json
+    kind: HTTPListenerPolicy
+    name: httplistenerpolicy_v1alpha1
+  - apiVersion: gateway.kgateway.dev/v1alpha1
+    filename: gateway.kgateway.dev/trafficpolicy_v1alpha1.json
+    kind: trafficpolicy
+    name: trafficpolicy_v1alpha1
+  - apiVersion: gateway.kgateway.dev/v1alpha1
+    filename: gateway.kgateway.dev/gatewayparameters_v1alpha1.json
+    kind: GatewayParameters
+    name: gatewayparameters_v1alpha1
+  - apiVersion: gateway.kgateway.dev/v1alpha1
+    filename: gateway.kgateway.dev/gatewayextension_v1alpha1.json
+    kind: gatewayextension
+    name: gatewayextension_v1alpha1
+  - apiVersion: gateway.kgateway.dev/v1alpha1
+    filename: gateway.kgateway.dev/backend_v1alpha1.json
+    kind: backend
+    name: backend_v1alpha1
+  - apiVersion: gateway.kgateway.dev/v1alpha1
+    filename: gateway.kgateway.dev/backendconfigpolicy_v1alpha1.json
+    kind: backendconfigpolicy
+    name: backendconfigpolicy_v1alpha1
 gateway.networking.k8s.io:
   - apiVersion: gateway.networking.k8s.io/v1alpha2
     filename: gateway.networking.k8s.io/grpcroute_v1alpha2.json
@@ -3348,6 +6934,68 @@ gateway.networking.k8s.io:
     filename: gateway.networking.k8s.io/backendtlspolicy_v1alpha3.json
     kind: BackendTLSPolicy
     name: backendtlspolicy_v1alpha3
+  - apiVersion: gateway.networking.k8s.io/v1
+    filename: gateway.networking.k8s.io/referencegrant_v1.json
+    kind: ReferenceGrant
+    name: referencegrant_v1
+  - apiVersion: gateway.networking.k8s.io/v1alpha3
+    filename: gateway.networking.k8s.io/tlsroute_v1alpha3.json
+    kind: TLSRoute
+    name: tlsroute_v1alpha3
+  - apiVersion: gateway.networking.k8s.io/v1
+    filename: gateway.networking.k8s.io/listenerset_v1.json
+    kind: ListenerSet
+    name: listenerset_v1
+  - apiVersion: gateway.networking.k8s.io/v1
+    filename: gateway.networking.k8s.io/backendtlspolicy_v1.json
+    kind: BackendTLSPolicy
+    name: backendtlspolicy_v1
+  - apiVersion: gateway.networking.k8s.io/v1
+    filename: gateway.networking.k8s.io/tlsroute_v1.json
+    kind: TLSRoute
+    name: tlsroute_v1
+gateway.networking.x-k8s.io:
+  - apiVersion: gateway.networking.x-k8s.io/v1alpha1
+    filename: gateway.networking.x-k8s.io/xlistenerset_v1alpha1.json
+    kind: XListenerSet
+    name: xlistenerset_v1alpha1
+  - apiVersion: gateway.networking.x-k8s.io/v1alpha1
+    filename: gateway.networking.x-k8s.io/xbackendtrafficpolicy_v1alpha1.json
+    kind: XBackendTrafficPolicy
+    name: xbackendtrafficpolicy_v1alpha1
+  - apiVersion: gateway.networking.x-k8s.io/v1alpha1
+    filename: gateway.networking.x-k8s.io/xmesh_v1alpha1.json
+    kind: XMesh
+    name: xmesh_v1alpha1
+gateway.nginx.org:
+  - apiVersion: gateway.nginx.org/v1alpha1
+    filename: gateway.nginx.org/observabilitypolicy_v1alpha1.json
+    kind: ObservabilityPolicy
+    name: observabilitypolicy_v1alpha1
+  - apiVersion: gateway.nginx.org/v1alpha1
+    filename: gateway.nginx.org/nginxgateway_v1alpha1.json
+    kind: NginxGateway
+    name: nginxgateway_v1alpha1
+  - apiVersion: gateway.nginx.org/v1alpha1
+    filename: gateway.nginx.org/clientsettingspolicy_v1alpha1.json
+    kind: ClientSettingsPolicy
+    name: clientsettingspolicy_v1alpha1
+  - apiVersion: gateway.nginx.org/v1alpha2
+    filename: gateway.nginx.org/nginxproxy_v1alpha2.json
+    kind: NginxProxy
+    name: nginxproxy_v1alpha2
+  - apiVersion: gateway.nginx.org/v1alpha2
+    filename: gateway.nginx.org/observabilitypolicy_v1alpha2.json
+    kind: ObservabilityPolicy
+    name: observabilitypolicy_v1alpha2
+  - apiVersion: gateway.nginx.org/v1alpha1
+    filename: gateway.nginx.org/upstreamsettingspolicy_v1alpha1.json
+    kind: UpstreamSettingsPolicy
+    name: upstreamsettingspolicy_v1alpha1
+  - apiVersion: gateway.nginx.org/v1alpha1
+    filename: gateway.nginx.org/snippetsfilter_v1alpha1.json
+    kind: SnippetsFilter
+    name: snippetsfilter_v1alpha1
 gateway.solo.io:
   - apiVersion: gateway.solo.io/v1
     filename: gateway.solo.io/virtualservice_v1.json
@@ -3434,6 +7082,14 @@ generators.external-secrets.io:
     filename: generators.external-secrets.io/mfa_v1alpha1.json
     kind: MFA
     name: mfa_v1alpha1
+  - apiVersion: generators.external-secrets.io/v1alpha1
+    filename: generators.external-secrets.io/cloudsmithaccesstoken_v1alpha1.json
+    kind: CloudsmithAccessToken
+    name: cloudsmithaccesstoken_v1alpha1
+  - apiVersion: generators.external-secrets.io/v1alpha1
+    filename: generators.external-secrets.io/sshkey_v1alpha1.json
+    kind: SSHKey
+    name: sshkey_v1alpha1
 getambassador.io:
   - apiVersion: getambassador.io/v2
     filename: getambassador.io/host_v2.json
@@ -3728,11 +7384,77 @@ grafana.integreatly.org:
     filename: grafana.integreatly.org/grafananotificationpolicyroute_v1beta1.json
     kind: GrafanaNotificationPolicyRoute
     name: grafananotificationpolicyroute_v1beta1
+  - apiVersion: grafana.integreatly.org/v1beta1
+    filename: grafana.integreatly.org/grafanamanifest_v1beta1.json
+    kind: GrafanaManifest
+    name: grafanamanifest_v1beta1
+  - apiVersion: grafana.integreatly.org/v1beta1
+    filename: grafana.integreatly.org/grafanaserviceaccount_v1beta1.json
+    kind: GrafanaServiceAccount
+    name: grafanaserviceaccount_v1beta1
+grafana.m.crossplane.io:
+  - apiVersion: grafana.m.crossplane.io/v1beta1
+    filename: grafana.m.crossplane.io/providerconfig_v1beta1.json
+    kind: providerconfig
+    name: providerconfig_v1beta1
+  - apiVersion: grafana.m.crossplane.io/v1beta1
+    filename: grafana.m.crossplane.io/providerconfigusage_v1beta1.json
+    kind: providerconfigusage
+    name: providerconfigusage_v1beta1
+  - apiVersion: grafana.m.crossplane.io/v1beta1
+    filename: grafana.m.crossplane.io/clusterproviderconfig_v1beta1.json
+    kind: clusterproviderconfig
+    name: clusterproviderconfig_v1beta1
 graphql.gloo.solo.io:
   - apiVersion: graphql.gloo.solo.io/v1beta1
     filename: graphql.gloo.solo.io/graphqlapi_v1beta1.json
     kind: graphqlapi
     name: graphqlapi_v1beta1
+gravitee.io:
+  - apiVersion: gravitee.io/v1alpha1
+    filename: gravitee.io/apiv4definition_v1alpha1.json
+    kind: ApiV4Definition
+    name: apiv4definition_v1alpha1
+  - apiVersion: gravitee.io/v1alpha1
+    filename: gravitee.io/subscription_v1alpha1.json
+    kind: subscription
+    name: subscription_v1alpha1
+  - apiVersion: gravitee.io/v1alpha1
+    filename: gravitee.io/gatewayclassparameters_v1alpha1.json
+    kind: gatewayclassparameters
+    name: gatewayclassparameters_v1alpha1
+  - apiVersion: gravitee.io/v1alpha1
+    filename: gravitee.io/apiresource_v1alpha1.json
+    kind: apiresource
+    name: apiresource_v1alpha1
+  - apiVersion: gravitee.io/v1alpha1
+    filename: gravitee.io/managementcontext_v1alpha1.json
+    kind: managementcontext
+    name: managementcontext_v1alpha1
+  - apiVersion: gravitee.io/v1alpha1
+    filename: gravitee.io/notification_v1alpha1.json
+    kind: Notification
+    name: notification_v1alpha1
+  - apiVersion: gravitee.io/v1alpha1
+    filename: gravitee.io/apidefinition_v1alpha1.json
+    kind: ApiDefinition
+    name: apidefinition_v1alpha1
+  - apiVersion: gravitee.io/v1alpha1
+    filename: gravitee.io/sharedpolicygroup_v1alpha1.json
+    kind: SharedPolicyGroup
+    name: sharedpolicygroup_v1alpha1
+  - apiVersion: gravitee.io/v1alpha1
+    filename: gravitee.io/group_v1alpha1.json
+    kind: group
+    name: group_v1alpha1
+  - apiVersion: gravitee.io/v1alpha1
+    filename: gravitee.io/kafkaroute_v1alpha1.json
+    kind: kafkaroute
+    name: kafkaroute_v1alpha1
+  - apiVersion: gravitee.io/v1alpha1
+    filename: gravitee.io/application_v1alpha1.json
+    kind: application
+    name: application_v1alpha1
 groupsnapshot.storage.k8s.io:
   - apiVersion: groupsnapshot.storage.k8s.io/v1beta1
     filename: groupsnapshot.storage.k8s.io/volumegroupsnapshot_v1beta1.json
@@ -3767,6 +7489,15 @@ healthcare.cnrm.cloud.google.com:
     filename: healthcare.cnrm.cloud.google.com/healthcaredicomstore_v1alpha1.json
     kind: healthcaredicomstore
     name: healthcaredicomstore_v1alpha1
+helm.cattle.io:
+  - apiVersion: helm.cattle.io/v1
+    filename: helm.cattle.io/helmchartconfig_v1.json
+    kind: HelmChartConfig
+    name: helmchartconfig_v1
+  - apiVersion: helm.cattle.io/v1
+    filename: helm.cattle.io/helmchart_v1.json
+    kind: HelmChart
+    name: helmchart_v1
 helm.k0sproject.io:
   - apiVersion: helm.k0sproject.io/v1beta1
     filename: helm.k0sproject.io/chart_v1beta1.json
@@ -3794,6 +7525,210 @@ hivemq.com:
     filename: hivemq.com/hivemqplatform_v1.json
     kind: hivemqplatform
     name: hivemqplatform_v1
+  - apiVersion: hivemq.com/v1
+    filename: hivemq.com/hivemqcluster_v1.json
+    kind: hivemqcluster
+    name: hivemqcluster_v1
+holmesgpt.dev:
+  - apiVersion: holmesgpt.dev/v1alpha1
+    filename: holmesgpt.dev/healthcheck_v1alpha1.json
+    kind: healthcheck
+    name: healthcheck_v1alpha1
+  - apiVersion: holmesgpt.dev/v1alpha1
+    filename: holmesgpt.dev/scheduledhealthcheck_v1alpha1.json
+    kind: scheduledhealthcheck
+    name: scheduledhealthcheck_v1alpha1
+http.keda.sh:
+  - apiVersion: http.keda.sh/v1alpha1
+    filename: http.keda.sh/httpscaledobject_v1alpha1.json
+    kind: HTTPScaledObject
+    name: httpscaledobject_v1alpha1
+iam.aws.m.upbound.io:
+  - apiVersion: iam.aws.m.upbound.io/v1beta1
+    filename: iam.aws.m.upbound.io/accesskey_v1beta1.json
+    kind: AccessKey
+    name: accesskey_v1beta1
+  - apiVersion: iam.aws.m.upbound.io/v1beta1
+    filename: iam.aws.m.upbound.io/servicelinkedrole_v1beta1.json
+    kind: ServiceLinkedRole
+    name: servicelinkedrole_v1beta1
+  - apiVersion: iam.aws.m.upbound.io/v1beta1
+    filename: iam.aws.m.upbound.io/rolepolicy_v1beta1.json
+    kind: RolePolicy
+    name: rolepolicy_v1beta1
+  - apiVersion: iam.aws.m.upbound.io/v1beta1
+    filename: iam.aws.m.upbound.io/servicespecificcredential_v1beta1.json
+    kind: ServiceSpecificCredential
+    name: servicespecificcredential_v1beta1
+  - apiVersion: iam.aws.m.upbound.io/v1beta1
+    filename: iam.aws.m.upbound.io/accountpasswordpolicy_v1beta1.json
+    kind: AccountPasswordPolicy
+    name: accountpasswordpolicy_v1beta1
+  - apiVersion: iam.aws.m.upbound.io/v1beta1
+    filename: iam.aws.m.upbound.io/usergroupmembership_v1beta1.json
+    kind: UserGroupMembership
+    name: usergroupmembership_v1beta1
+  - apiVersion: iam.aws.m.upbound.io/v1beta1
+    filename: iam.aws.m.upbound.io/rolepolicyattachment_v1beta1.json
+    kind: RolePolicyAttachment
+    name: rolepolicyattachment_v1beta1
+  - apiVersion: iam.aws.m.upbound.io/v1beta1
+    filename: iam.aws.m.upbound.io/usersshkey_v1beta1.json
+    kind: UserSSHKey
+    name: usersshkey_v1beta1
+  - apiVersion: iam.aws.m.upbound.io/v1beta1
+    filename: iam.aws.m.upbound.io/servercertificate_v1beta1.json
+    kind: ServerCertificate
+    name: servercertificate_v1beta1
+  - apiVersion: iam.aws.m.upbound.io/v1beta1
+    filename: iam.aws.m.upbound.io/virtualmfadevice_v1beta1.json
+    kind: VirtualMfaDevice
+    name: virtualmfadevice_v1beta1
+  - apiVersion: iam.aws.m.upbound.io/v1beta1
+    filename: iam.aws.m.upbound.io/samlprovider_v1beta1.json
+    kind: SAMLProvider
+    name: samlprovider_v1beta1
+  - apiVersion: iam.aws.m.upbound.io/v1beta1
+    filename: iam.aws.m.upbound.io/openidconnectprovider_v1beta1.json
+    kind: OpenIDConnectProvider
+    name: openidconnectprovider_v1beta1
+  - apiVersion: iam.aws.m.upbound.io/v1beta1
+    filename: iam.aws.m.upbound.io/accountalias_v1beta1.json
+    kind: AccountAlias
+    name: accountalias_v1beta1
+  - apiVersion: iam.aws.m.upbound.io/v1beta1
+    filename: iam.aws.m.upbound.io/signingcertificate_v1beta1.json
+    kind: SigningCertificate
+    name: signingcertificate_v1beta1
+  - apiVersion: iam.aws.m.upbound.io/v1beta1
+    filename: iam.aws.m.upbound.io/userpolicyattachment_v1beta1.json
+    kind: UserPolicyAttachment
+    name: userpolicyattachment_v1beta1
+  - apiVersion: iam.aws.m.upbound.io/v1beta1
+    filename: iam.aws.m.upbound.io/role_v1beta1.json
+    kind: Role
+    name: role_v1beta1
+  - apiVersion: iam.aws.m.upbound.io/v1beta1
+    filename: iam.aws.m.upbound.io/groupmembership_v1beta1.json
+    kind: GroupMembership
+    name: groupmembership_v1beta1
+  - apiVersion: iam.aws.m.upbound.io/v1beta1
+    filename: iam.aws.m.upbound.io/instanceprofile_v1beta1.json
+    kind: InstanceProfile
+    name: instanceprofile_v1beta1
+  - apiVersion: iam.aws.m.upbound.io/v1beta1
+    filename: iam.aws.m.upbound.io/grouppolicyattachment_v1beta1.json
+    kind: GroupPolicyAttachment
+    name: grouppolicyattachment_v1beta1
+  - apiVersion: iam.aws.m.upbound.io/v1beta1
+    filename: iam.aws.m.upbound.io/group_v1beta1.json
+    kind: Group
+    name: group_v1beta1
+  - apiVersion: iam.aws.m.upbound.io/v1beta1
+    filename: iam.aws.m.upbound.io/user_v1beta1.json
+    kind: User
+    name: user_v1beta1
+  - apiVersion: iam.aws.m.upbound.io/v1beta1
+    filename: iam.aws.m.upbound.io/userloginprofile_v1beta1.json
+    kind: UserLoginProfile
+    name: userloginprofile_v1beta1
+  - apiVersion: iam.aws.m.upbound.io/v1beta1
+    filename: iam.aws.m.upbound.io/policy_v1beta1.json
+    kind: Policy
+    name: policy_v1beta1
+iam.aws.upbound.io:
+  - apiVersion: iam.aws.upbound.io/v1beta1
+    filename: iam.aws.upbound.io/accesskey_v1beta1.json
+    kind: AccessKey
+    name: accesskey_v1beta1
+  - apiVersion: iam.aws.upbound.io/v1beta1
+    filename: iam.aws.upbound.io/servicelinkedrole_v1beta1.json
+    kind: ServiceLinkedRole
+    name: servicelinkedrole_v1beta1
+  - apiVersion: iam.aws.upbound.io/v1beta1
+    filename: iam.aws.upbound.io/rolepolicy_v1beta1.json
+    kind: RolePolicy
+    name: rolepolicy_v1beta1
+  - apiVersion: iam.aws.upbound.io/v1beta1
+    filename: iam.aws.upbound.io/servicespecificcredential_v1beta1.json
+    kind: ServiceSpecificCredential
+    name: servicespecificcredential_v1beta1
+  - apiVersion: iam.aws.upbound.io/v1beta1
+    filename: iam.aws.upbound.io/accountpasswordpolicy_v1beta1.json
+    kind: AccountPasswordPolicy
+    name: accountpasswordpolicy_v1beta1
+  - apiVersion: iam.aws.upbound.io/v1beta1
+    filename: iam.aws.upbound.io/usergroupmembership_v1beta1.json
+    kind: UserGroupMembership
+    name: usergroupmembership_v1beta1
+  - apiVersion: iam.aws.upbound.io/v1beta1
+    filename: iam.aws.upbound.io/rolepolicyattachment_v1beta1.json
+    kind: RolePolicyAttachment
+    name: rolepolicyattachment_v1beta1
+  - apiVersion: iam.aws.upbound.io/v1beta1
+    filename: iam.aws.upbound.io/usersshkey_v1beta1.json
+    kind: UserSSHKey
+    name: usersshkey_v1beta1
+  - apiVersion: iam.aws.upbound.io/v1beta1
+    filename: iam.aws.upbound.io/servercertificate_v1beta1.json
+    kind: ServerCertificate
+    name: servercertificate_v1beta1
+  - apiVersion: iam.aws.upbound.io/v1beta1
+    filename: iam.aws.upbound.io/virtualmfadevice_v1beta1.json
+    kind: VirtualMfaDevice
+    name: virtualmfadevice_v1beta1
+  - apiVersion: iam.aws.upbound.io/v1beta1
+    filename: iam.aws.upbound.io/samlprovider_v1beta1.json
+    kind: SAMLProvider
+    name: samlprovider_v1beta1
+  - apiVersion: iam.aws.upbound.io/v1beta1
+    filename: iam.aws.upbound.io/openidconnectprovider_v1beta1.json
+    kind: OpenIDConnectProvider
+    name: openidconnectprovider_v1beta1
+  - apiVersion: iam.aws.upbound.io/v1beta1
+    filename: iam.aws.upbound.io/accountalias_v1beta1.json
+    kind: AccountAlias
+    name: accountalias_v1beta1
+  - apiVersion: iam.aws.upbound.io/v1beta1
+    filename: iam.aws.upbound.io/signingcertificate_v1beta1.json
+    kind: SigningCertificate
+    name: signingcertificate_v1beta1
+  - apiVersion: iam.aws.upbound.io/v1beta1
+    filename: iam.aws.upbound.io/userpolicyattachment_v1beta1.json
+    kind: UserPolicyAttachment
+    name: userpolicyattachment_v1beta1
+  - apiVersion: iam.aws.upbound.io/v1beta1
+    filename: iam.aws.upbound.io/role_v1beta1.json
+    kind: Role
+    name: role_v1beta1
+  - apiVersion: iam.aws.upbound.io/v1beta1
+    filename: iam.aws.upbound.io/groupmembership_v1beta1.json
+    kind: GroupMembership
+    name: groupmembership_v1beta1
+  - apiVersion: iam.aws.upbound.io/v1beta1
+    filename: iam.aws.upbound.io/instanceprofile_v1beta1.json
+    kind: InstanceProfile
+    name: instanceprofile_v1beta1
+  - apiVersion: iam.aws.upbound.io/v1beta1
+    filename: iam.aws.upbound.io/grouppolicyattachment_v1beta1.json
+    kind: GroupPolicyAttachment
+    name: grouppolicyattachment_v1beta1
+  - apiVersion: iam.aws.upbound.io/v1beta1
+    filename: iam.aws.upbound.io/group_v1beta1.json
+    kind: Group
+    name: group_v1beta1
+  - apiVersion: iam.aws.upbound.io/v1beta1
+    filename: iam.aws.upbound.io/user_v1beta1.json
+    kind: User
+    name: user_v1beta1
+  - apiVersion: iam.aws.upbound.io/v1beta1
+    filename: iam.aws.upbound.io/userloginprofile_v1beta1.json
+    kind: UserLoginProfile
+    name: userloginprofile_v1beta1
+  - apiVersion: iam.aws.upbound.io/v1beta1
+    filename: iam.aws.upbound.io/policy_v1beta1.json
+    kind: Policy
+    name: policy_v1beta1
 iam.cnrm.cloud.google.com:
   - apiVersion: iam.cnrm.cloud.google.com/v1beta1
     filename: iam.cnrm.cloud.google.com/iamserviceaccount_v1beta1.json
@@ -3877,6 +7812,14 @@ iap.cnrm.cloud.google.com:
     filename: iap.cnrm.cloud.google.com/iapidentityawareproxyclient_v1beta1.json
     kind: iapidentityawareproxyclient
     name: iapidentityawareproxyclient_v1beta1
+  - apiVersion: iap.cnrm.cloud.google.com/v1alpha1
+    filename: iap.cnrm.cloud.google.com/iapsettings_v1alpha1.json
+    kind: IAPSettings
+    name: iapsettings_v1alpha1
+  - apiVersion: iap.cnrm.cloud.google.com/v1beta1
+    filename: iap.cnrm.cloud.google.com/iapsettings_v1beta1.json
+    kind: IAPSettings
+    name: iapsettings_v1beta1
 identityplatform.cnrm.cloud.google.com:
   - apiVersion: identityplatform.cnrm.cloud.google.com/v1beta1
     filename: identityplatform.cnrm.cloud.google.com/identityplatformoauthidpconfig_v1beta1.json
@@ -3980,6 +7923,27 @@ image.toolkit.fluxcd.io:
     filename: image.toolkit.fluxcd.io/imageupdateautomation_v1beta2.json
     kind: ImageUpdateAutomation
     name: imageupdateautomation_v1beta2
+  - apiVersion: image.toolkit.fluxcd.io/v1
+    filename: image.toolkit.fluxcd.io/imagerepository_v1.json
+    kind: ImageRepository
+    name: imagerepository_v1
+  - apiVersion: image.toolkit.fluxcd.io/v1
+    filename: image.toolkit.fluxcd.io/imageupdateautomation_v1.json
+    kind: ImageUpdateAutomation
+    name: imageupdateautomation_v1
+  - apiVersion: image.toolkit.fluxcd.io/v1
+    filename: image.toolkit.fluxcd.io/imagepolicy_v1.json
+    kind: ImagePolicy
+    name: imagepolicy_v1
+infra.contrib.fluxcd.io:
+  - apiVersion: infra.contrib.fluxcd.io/v1alpha2
+    filename: infra.contrib.fluxcd.io/terraform_v1alpha2.json
+    kind: Terraform
+    name: terraform_v1alpha2
+  - apiVersion: infra.contrib.fluxcd.io/v1alpha1
+    filename: infra.contrib.fluxcd.io/terraform_v1alpha1.json
+    kind: Terraform
+    name: terraform_v1alpha1
 infrastructure.cluster.x-k8s.io:
   - apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
     filename: infrastructure.cluster.x-k8s.io/awsclusterroleidentity_v1beta2.json
@@ -4637,11 +8601,246 @@ infrastructure.cluster.x-k8s.io:
     filename: infrastructure.cluster.x-k8s.io/devcluster_v1beta1.json
     kind: DevCluster
     name: devcluster_v1beta1
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    filename: infrastructure.cluster.x-k8s.io/hetznerbaremetalremediationtemplate_v1beta1.json
+    kind: HetznerBareMetalRemediationTemplate
+    name: hetznerbaremetalremediationtemplate_v1beta1
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    filename: infrastructure.cluster.x-k8s.io/openstackmachine_v1beta1.json
+    kind: OpenStackMachine
+    name: openstackmachine_v1beta1
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    filename: infrastructure.cluster.x-k8s.io/hetznerbaremetalhost_v1beta1.json
+    kind: HetznerBareMetalHost
+    name: hetznerbaremetalhost_v1beta1
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    filename: infrastructure.cluster.x-k8s.io/hcloudremediationtemplate_v1beta1.json
+    kind: HCloudRemediationTemplate
+    name: hcloudremediationtemplate_v1beta1
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    filename: infrastructure.cluster.x-k8s.io/openstackmachinetemplate_v1beta1.json
+    kind: OpenStackMachineTemplate
+    name: openstackmachinetemplate_v1beta1
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    filename: infrastructure.cluster.x-k8s.io/vspheredeploymentzone_v1beta1.json
+    kind: VSphereDeploymentZone
+    name: vspheredeploymentzone_v1beta1
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
+    filename: infrastructure.cluster.x-k8s.io/openstackclusteridentity_v1alpha1.json
+    kind: OpenStackClusterIdentity
+    name: openstackclusteridentity_v1alpha1
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    filename: infrastructure.cluster.x-k8s.io/hetznerclustertemplate_v1beta1.json
+    kind: HetznerClusterTemplate
+    name: hetznerclustertemplate_v1beta1
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    filename: infrastructure.cluster.x-k8s.io/hetznerbaremetalremediation_v1beta1.json
+    kind: HetznerBareMetalRemediation
+    name: hetznerbaremetalremediation_v1beta1
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    filename: infrastructure.cluster.x-k8s.io/azureasomanagedcluster_v1beta1.json
+    kind: AzureASOManagedCluster
+    name: azureasomanagedcluster_v1beta1
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    filename: infrastructure.cluster.x-k8s.io/hetznerbaremetalmachine_v1beta1.json
+    kind: HetznerBareMetalMachine
+    name: hetznerbaremetalmachine_v1beta1
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    filename: infrastructure.cluster.x-k8s.io/vsphereclusteridentity_v1beta1.json
+    kind: VSphereClusterIdentity
+    name: vsphereclusteridentity_v1beta1
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    filename: infrastructure.cluster.x-k8s.io/hetznerbaremetalmachinetemplate_v1beta1.json
+    kind: HetznerBareMetalMachineTemplate
+    name: hetznerbaremetalmachinetemplate_v1beta1
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    filename: infrastructure.cluster.x-k8s.io/vspheremachine_v1beta1.json
+    kind: VSphereMachine
+    name: vspheremachine_v1beta1
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    filename: infrastructure.cluster.x-k8s.io/osccluster_v1beta1.json
+    kind: OscCluster
+    name: osccluster_v1beta1
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    filename: infrastructure.cluster.x-k8s.io/vspherevm_v1beta1.json
+    kind: VSphereVM
+    name: vspherevm_v1beta1
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    filename: infrastructure.cluster.x-k8s.io/vsphereclustertemplate_v1beta1.json
+    kind: VSphereClusterTemplate
+    name: vsphereclustertemplate_v1beta1
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    filename: infrastructure.cluster.x-k8s.io/vspheremachinetemplate_v1beta1.json
+    kind: VSphereMachineTemplate
+    name: vspheremachinetemplate_v1beta1
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    filename: infrastructure.cluster.x-k8s.io/oscmachine_v1beta1.json
+    kind: OscMachine
+    name: oscmachine_v1beta1
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    filename: infrastructure.cluster.x-k8s.io/hcloudmachinetemplate_v1beta1.json
+    kind: HCloudMachineTemplate
+    name: hcloudmachinetemplate_v1beta1
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    filename: infrastructure.cluster.x-k8s.io/openstackclustertemplate_v1beta1.json
+    kind: OpenStackClusterTemplate
+    name: openstackclustertemplate_v1beta1
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
+    filename: infrastructure.cluster.x-k8s.io/openstackserver_v1alpha1.json
+    kind: OpenStackServer
+    name: openstackserver_v1alpha1
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    filename: infrastructure.cluster.x-k8s.io/azureasomanagedcontrolplane_v1beta1.json
+    kind: AzureASOManagedControlPlane
+    name: azureasomanagedcontrolplane_v1beta1
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    filename: infrastructure.cluster.x-k8s.io/vspherefailuredomain_v1beta1.json
+    kind: VSphereFailureDomain
+    name: vspherefailuredomain_v1beta1
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    filename: infrastructure.cluster.x-k8s.io/oscmachinetemplate_v1beta1.json
+    kind: OscMachineTemplate
+    name: oscmachinetemplate_v1beta1
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
+    filename: infrastructure.cluster.x-k8s.io/openstackfloatingippool_v1alpha1.json
+    kind: OpenStackFloatingIPPool
+    name: openstackfloatingippool_v1alpha1
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    filename: infrastructure.cluster.x-k8s.io/hcloudmachine_v1beta1.json
+    kind: HCloudMachine
+    name: hcloudmachine_v1beta1
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    filename: infrastructure.cluster.x-k8s.io/openstackcluster_v1beta1.json
+    kind: OpenStackCluster
+    name: openstackcluster_v1beta1
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    filename: infrastructure.cluster.x-k8s.io/hcloudremediation_v1beta1.json
+    kind: HCloudRemediation
+    name: hcloudremediation_v1beta1
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    filename: infrastructure.cluster.x-k8s.io/hetznercluster_v1beta1.json
+    kind: HetznerCluster
+    name: hetznercluster_v1beta1
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    filename: infrastructure.cluster.x-k8s.io/azureasomanagedmachinepool_v1beta1.json
+    kind: AzureASOManagedMachinePool
+    name: azureasomanagedmachinepool_v1beta1
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    filename: infrastructure.cluster.x-k8s.io/oscclustertemplate_v1beta1.json
+    kind: OscClusterTemplate
+    name: oscclustertemplate_v1beta1
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    filename: infrastructure.cluster.x-k8s.io/vspherecluster_v1beta1.json
+    kind: VSphereCluster
+    name: vspherecluster_v1beta1
 ingress.oraclecloud.com:
   - apiVersion: ingress.oraclecloud.com/v1beta1
     filename: ingress.oraclecloud.com/ingressclassparameters_v1beta1.json
     kind: IngressClassParameters
     name: ingressclassparameters_v1beta1
+ingress.v1.haproxy.org:
+  - apiVersion: ingress.v1.haproxy.org/v1
+    filename: ingress.v1.haproxy.org/tcp_v1.json
+    kind: TCP
+    name: tcp_v1
+  - apiVersion: ingress.v1.haproxy.org/v1
+    filename: ingress.v1.haproxy.org/global_v1.json
+    kind: Global
+    name: global_v1
+  - apiVersion: ingress.v1.haproxy.org/v1
+    filename: ingress.v1.haproxy.org/defaults_v1.json
+    kind: Defaults
+    name: defaults_v1
+  - apiVersion: ingress.v1.haproxy.org/v1
+    filename: ingress.v1.haproxy.org/backend_v1.json
+    kind: Backend
+    name: backend_v1
+insights.azure.com:
+  - apiVersion: insights.azure.com/v1api20220615
+    filename: insights.azure.com/webtest_v1api20220615.json
+    kind: webTest
+    name: webtest_v1api20220615
+  - apiVersion: insights.azure.com/v1api20180301
+    filename: insights.azure.com/metricalert_v1api20180301.json
+    kind: metricAlert
+    name: metricalert_v1api20180301
+  - apiVersion: insights.azure.com/v1api20200202
+    filename: insights.azure.com/component_v1api20200202.json
+    kind: component
+    name: component_v1api20200202
+  - apiVersion: insights.azure.com/v1api20240101preview
+    filename: insights.azure.com/scheduledqueryrule_v1api20240101preview.json
+    kind: scheduledQueryRule
+    name: scheduledqueryrule_v1api20240101preview
+  - apiVersion: insights.azure.com/v1api20210501preview
+    filename: insights.azure.com/diagnosticsetting_v1api20210501preview.json
+    kind: diagnosticSetting
+    name: diagnosticsetting_v1api20210501preview
+  - apiVersion: insights.azure.com/v1api20180501preview
+    filename: insights.azure.com/webtest_v1api20180501preview.json
+    kind: webTest
+    name: webtest_v1api20180501preview
+  - apiVersion: insights.azure.com/v1api20221001
+    filename: insights.azure.com/autoscalesetting_v1api20221001.json
+    kind: autoscalesetting
+    name: autoscalesetting_v1api20221001
+  - apiVersion: insights.azure.com/v1api20230101
+    filename: insights.azure.com/actiongroup_v1api20230101.json
+    kind: actionGroup
+    name: actiongroup_v1api20230101
+  - apiVersion: insights.azure.com/v1api20220615
+    filename: insights.azure.com/scheduledqueryrule_v1api20220615.json
+    kind: scheduledQueryRule
+    name: scheduledqueryrule_v1api20220615
+instancetype.kubevirt.io:
+  - apiVersion: instancetype.kubevirt.io/v1beta1
+    filename: instancetype.kubevirt.io/virtualmachineinstancetype_v1beta1.json
+    kind: VirtualMachineInstancetype
+    name: virtualmachineinstancetype_v1beta1
+  - apiVersion: instancetype.kubevirt.io/v1alpha2
+    filename: instancetype.kubevirt.io/virtualmachineclusterpreference_v1alpha2.json
+    kind: VirtualMachineClusterPreference
+    name: virtualmachineclusterpreference_v1alpha2
+  - apiVersion: instancetype.kubevirt.io/v1alpha2
+    filename: instancetype.kubevirt.io/virtualmachineclusterinstancetype_v1alpha2.json
+    kind: VirtualMachineClusterInstancetype
+    name: virtualmachineclusterinstancetype_v1alpha2
+  - apiVersion: instancetype.kubevirt.io/v1beta1
+    filename: instancetype.kubevirt.io/virtualmachinepreference_v1beta1.json
+    kind: VirtualMachinePreference
+    name: virtualmachinepreference_v1beta1
+  - apiVersion: instancetype.kubevirt.io/v1alpha1
+    filename: instancetype.kubevirt.io/virtualmachineinstancetype_v1alpha1.json
+    kind: VirtualMachineInstancetype
+    name: virtualmachineinstancetype_v1alpha1
+  - apiVersion: instancetype.kubevirt.io/v1beta1
+    filename: instancetype.kubevirt.io/virtualmachineclusterinstancetype_v1beta1.json
+    kind: VirtualMachineClusterInstancetype
+    name: virtualmachineclusterinstancetype_v1beta1
+  - apiVersion: instancetype.kubevirt.io/v1alpha2
+    filename: instancetype.kubevirt.io/virtualmachinepreference_v1alpha2.json
+    kind: VirtualMachinePreference
+    name: virtualmachinepreference_v1alpha2
+  - apiVersion: instancetype.kubevirt.io/v1alpha1
+    filename: instancetype.kubevirt.io/virtualmachineclusterpreference_v1alpha1.json
+    kind: VirtualMachineClusterPreference
+    name: virtualmachineclusterpreference_v1alpha1
+  - apiVersion: instancetype.kubevirt.io/v1alpha1
+    filename: instancetype.kubevirt.io/virtualmachineclusterinstancetype_v1alpha1.json
+    kind: VirtualMachineClusterInstancetype
+    name: virtualmachineclusterinstancetype_v1alpha1
+  - apiVersion: instancetype.kubevirt.io/v1alpha2
+    filename: instancetype.kubevirt.io/virtualmachineinstancetype_v1alpha2.json
+    kind: VirtualMachineInstancetype
+    name: virtualmachineinstancetype_v1alpha2
+  - apiVersion: instancetype.kubevirt.io/v1beta1
+    filename: instancetype.kubevirt.io/virtualmachineclusterpreference_v1beta1.json
+    kind: VirtualMachineClusterPreference
+    name: virtualmachineclusterpreference_v1beta1
+  - apiVersion: instancetype.kubevirt.io/v1alpha1
+    filename: instancetype.kubevirt.io/virtualmachinepreference_v1alpha1.json
+    kind: VirtualMachinePreference
+    name: virtualmachinepreference_v1alpha1
 ipam.cluster.x-k8s.io:
   - apiVersion: ipam.cluster.x-k8s.io/v1alpha1
     filename: ipam.cluster.x-k8s.io/ipaddressclaim_v1alpha1.json
@@ -4659,6 +8858,30 @@ ipam.cluster.x-k8s.io:
     filename: ipam.cluster.x-k8s.io/ipaddressclaim_v1beta1.json
     kind: IPAddressClaim
     name: ipaddressclaim_v1beta1
+  - apiVersion: ipam.cluster.x-k8s.io/v1alpha2
+    filename: ipam.cluster.x-k8s.io/inclusterippool_v1alpha2.json
+    kind: InClusterIPPool
+    name: inclusterippool_v1alpha2
+  - apiVersion: ipam.cluster.x-k8s.io/v1alpha1
+    filename: ipam.cluster.x-k8s.io/globalinclusterippool_v1alpha1.json
+    kind: GlobalInClusterIPPool
+    name: globalinclusterippool_v1alpha1
+  - apiVersion: ipam.cluster.x-k8s.io/v1beta2
+    filename: ipam.cluster.x-k8s.io/ipaddressclaim_v1beta2.json
+    kind: IPAddressClaim
+    name: ipaddressclaim_v1beta2
+  - apiVersion: ipam.cluster.x-k8s.io/v1beta2
+    filename: ipam.cluster.x-k8s.io/ipaddress_v1beta2.json
+    kind: IPAddress
+    name: ipaddress_v1beta2
+  - apiVersion: ipam.cluster.x-k8s.io/v1alpha1
+    filename: ipam.cluster.x-k8s.io/inclusterippool_v1alpha1.json
+    kind: InClusterIPPool
+    name: inclusterippool_v1alpha1
+  - apiVersion: ipam.cluster.x-k8s.io/v1alpha2
+    filename: ipam.cluster.x-k8s.io/globalinclusterippool_v1alpha2.json
+    kind: GlobalInClusterIPPool
+    name: globalinclusterippool_v1alpha2
 isindir.github.com:
   - apiVersion: isindir.github.com/v1alpha3
     filename: isindir.github.com/sopssecret_v1alpha3.json
@@ -4702,11 +8925,111 @@ jetstream.nats.io:
     filename: jetstream.nats.io/consumer_v1beta1.json
     kind: consumer
     name: consumer_v1beta1
+  - apiVersion: jetstream.nats.io/v1beta2
+    filename: jetstream.nats.io/keyvalue_v1beta2.json
+    kind: keyvalue
+    name: keyvalue_v1beta2
+  - apiVersion: jetstream.nats.io/v1beta2
+    filename: jetstream.nats.io/objectstore_v1beta2.json
+    kind: objectstore
+    name: objectstore_v1beta2
 job.min.io:
   - apiVersion: job.min.io/v1alpha1
     filename: job.min.io/miniojob_v1alpha1.json
     kind: miniojob
     name: miniojob_v1alpha1
+k0smotron.io:
+  - apiVersion: k0smotron.io/v1beta1
+    filename: k0smotron.io/jointokenrequest_v1beta1.json
+    kind: JoinTokenRequest
+    name: jointokenrequest_v1beta1
+  - apiVersion: k0smotron.io/v1beta1
+    filename: k0smotron.io/cluster_v1beta1.json
+    kind: Cluster
+    name: cluster_v1beta1
+k6.grafana.crossplane.io:
+  - apiVersion: k6.grafana.crossplane.io/v1alpha1
+    filename: k6.grafana.crossplane.io/loadtest_v1alpha1.json
+    kind: LoadTest
+    name: loadtest_v1alpha1
+  - apiVersion: k6.grafana.crossplane.io/v1alpha1
+    filename: k6.grafana.crossplane.io/project_v1alpha1.json
+    kind: Project
+    name: project_v1alpha1
+  - apiVersion: k6.grafana.crossplane.io/v1alpha1
+    filename: k6.grafana.crossplane.io/installation_v1alpha1.json
+    kind: Installation
+    name: installation_v1alpha1
+  - apiVersion: k6.grafana.crossplane.io/v1alpha1
+    filename: k6.grafana.crossplane.io/schedule_v1alpha1.json
+    kind: Schedule
+    name: schedule_v1alpha1
+  - apiVersion: k6.grafana.crossplane.io/v1alpha1
+    filename: k6.grafana.crossplane.io/projectallowedloadzones_v1alpha1.json
+    kind: ProjectAllowedLoadZones
+    name: projectallowedloadzones_v1alpha1
+  - apiVersion: k6.grafana.crossplane.io/v1alpha1
+    filename: k6.grafana.crossplane.io/projectlimits_v1alpha1.json
+    kind: ProjectLimits
+    name: projectlimits_v1alpha1
+k6.grafana.m.crossplane.io:
+  - apiVersion: k6.grafana.m.crossplane.io/v1alpha1
+    filename: k6.grafana.m.crossplane.io/loadtest_v1alpha1.json
+    kind: LoadTest
+    name: loadtest_v1alpha1
+  - apiVersion: k6.grafana.m.crossplane.io/v1alpha1
+    filename: k6.grafana.m.crossplane.io/project_v1alpha1.json
+    kind: Project
+    name: project_v1alpha1
+  - apiVersion: k6.grafana.m.crossplane.io/v1alpha1
+    filename: k6.grafana.m.crossplane.io/installation_v1alpha1.json
+    kind: Installation
+    name: installation_v1alpha1
+  - apiVersion: k6.grafana.m.crossplane.io/v1alpha1
+    filename: k6.grafana.m.crossplane.io/schedule_v1alpha1.json
+    kind: Schedule
+    name: schedule_v1alpha1
+  - apiVersion: k6.grafana.m.crossplane.io/v1alpha1
+    filename: k6.grafana.m.crossplane.io/projectallowedloadzones_v1alpha1.json
+    kind: ProjectAllowedLoadZones
+    name: projectallowedloadzones_v1alpha1
+  - apiVersion: k6.grafana.m.crossplane.io/v1alpha1
+    filename: k6.grafana.m.crossplane.io/projectlimits_v1alpha1.json
+    kind: ProjectLimits
+    name: projectlimits_v1alpha1
+k6.grafana.o.crossplane.io:
+  - apiVersion: k6.grafana.o.crossplane.io/v1alpha1
+    filename: k6.grafana.o.crossplane.io/loadtest_v1alpha1.json
+    kind: LoadTest
+    name: loadtest_v1alpha1
+  - apiVersion: k6.grafana.o.crossplane.io/v1alpha1
+    filename: k6.grafana.o.crossplane.io/projectset_v1alpha1.json
+    kind: ProjectSet
+    name: projectset_v1alpha1
+  - apiVersion: k6.grafana.o.crossplane.io/v1alpha1
+    filename: k6.grafana.o.crossplane.io/project_v1alpha1.json
+    kind: Project
+    name: project_v1alpha1
+  - apiVersion: k6.grafana.o.crossplane.io/v1alpha1
+    filename: k6.grafana.o.crossplane.io/loadtestset_v1alpha1.json
+    kind: LoadTestSet
+    name: loadtestset_v1alpha1
+  - apiVersion: k6.grafana.o.crossplane.io/v1alpha1
+    filename: k6.grafana.o.crossplane.io/scheduleset_v1alpha1.json
+    kind: ScheduleSet
+    name: scheduleset_v1alpha1
+  - apiVersion: k6.grafana.o.crossplane.io/v1alpha1
+    filename: k6.grafana.o.crossplane.io/schedule_v1alpha1.json
+    kind: Schedule
+    name: schedule_v1alpha1
+  - apiVersion: k6.grafana.o.crossplane.io/v1alpha1
+    filename: k6.grafana.o.crossplane.io/projectallowedloadzones_v1alpha1.json
+    kind: ProjectAllowedLoadZones
+    name: projectallowedloadzones_v1alpha1
+  - apiVersion: k6.grafana.o.crossplane.io/v1alpha1
+    filename: k6.grafana.o.crossplane.io/projectlimits_v1alpha1.json
+    kind: ProjectLimits
+    name: projectlimits_v1alpha1
 k6.io:
   - apiVersion: k6.io/v1alpha1
     filename: k6.io/k6_v1alpha1.json
@@ -4716,6 +9039,10 @@ k6.io:
     filename: k6.io/testrun_v1alpha1.json
     kind: testrun
     name: testrun_v1alpha1
+  - apiVersion: k6.io/v1alpha1
+    filename: k6.io/privateloadzone_v1alpha1.json
+    kind: privateloadzone
+    name: privateloadzone_v1alpha1
 k8s.cni.cncf.io:
   - apiVersion: k8s.cni.cncf.io/v1
     filename: k8s.cni.cncf.io/networkattachmentdefinition_v1.json
@@ -4730,6 +9057,14 @@ k8s.keycloak.org:
     filename: k8s.keycloak.org/keycloakrealmimport_v2alpha1.json
     kind: keycloakrealmimport
     name: keycloakrealmimport_v2alpha1
+  - apiVersion: k8s.keycloak.org/v2beta1
+    filename: k8s.keycloak.org/keycloak_v2beta1.json
+    kind: keycloak
+    name: keycloak_v2beta1
+  - apiVersion: k8s.keycloak.org/v2beta1
+    filename: k8s.keycloak.org/keycloakrealmimport_v2beta1.json
+    kind: keycloakrealmimport
+    name: keycloakrealmimport_v2beta1
 k8s.mariadb.com:
   - apiVersion: k8s.mariadb.com/v1alpha1
     filename: k8s.mariadb.com/grant_v1alpha1.json
@@ -4767,6 +9102,14 @@ k8s.mariadb.com:
     filename: k8s.mariadb.com/connection_v1alpha1.json
     kind: Connection
     name: connection_v1alpha1
+  - apiVersion: k8s.mariadb.com/v1alpha1
+    filename: k8s.mariadb.com/physicalbackup_v1alpha1.json
+    kind: PhysicalBackup
+    name: physicalbackup_v1alpha1
+  - apiVersion: k8s.mariadb.com/v1alpha1
+    filename: k8s.mariadb.com/externalmariadb_v1alpha1.json
+    kind: ExternalMariaDB
+    name: externalmariadb_v1alpha1
 k8s.nginx.org:
   - apiVersion: k8s.nginx.org/v1alpha1
     filename: k8s.nginx.org/globalconfiguration_v1alpha1.json
@@ -4911,6 +9254,42 @@ kafka.strimzi.io:
     filename: kafka.strimzi.io/kafkanodepool_v1beta2.json
     kind: kafkanodepool
     name: kafkanodepool_v1beta2
+  - apiVersion: kafka.strimzi.io/v1
+    filename: kafka.strimzi.io/kafkanodepool_v1.json
+    kind: kafkanodepool
+    name: kafkanodepool_v1
+  - apiVersion: kafka.strimzi.io/v1
+    filename: kafka.strimzi.io/kafkaconnector_v1.json
+    kind: kafkaconnector
+    name: kafkaconnector_v1
+  - apiVersion: kafka.strimzi.io/v1
+    filename: kafka.strimzi.io/kafkauser_v1.json
+    kind: kafkauser
+    name: kafkauser_v1
+  - apiVersion: kafka.strimzi.io/v1
+    filename: kafka.strimzi.io/kafka_v1.json
+    kind: kafka
+    name: kafka_v1
+  - apiVersion: kafka.strimzi.io/v1
+    filename: kafka.strimzi.io/kafkabridge_v1.json
+    kind: kafkabridge
+    name: kafkabridge_v1
+  - apiVersion: kafka.strimzi.io/v1
+    filename: kafka.strimzi.io/kafkarebalance_v1.json
+    kind: kafkarebalance
+    name: kafkarebalance_v1
+  - apiVersion: kafka.strimzi.io/v1
+    filename: kafka.strimzi.io/kafkaconnect_v1.json
+    kind: kafkaconnect
+    name: kafkaconnect_v1
+  - apiVersion: kafka.strimzi.io/v1
+    filename: kafka.strimzi.io/kafkatopic_v1.json
+    kind: kafkatopic
+    name: kafkatopic_v1
+  - apiVersion: kafka.strimzi.io/v1
+    filename: kafka.strimzi.io/kafkamirrormaker2_v1.json
+    kind: kafkamirrormaker2
+    name: kafkamirrormaker2_v1
 kargo.akuity.io:
   - apiVersion: kargo.akuity.io/v1alpha1
     filename: kargo.akuity.io/project_v1alpha1.json
@@ -4944,6 +9323,19 @@ kargo.akuity.io:
     filename: kargo.akuity.io/clusterpromotiontask_v1alpha1.json
     kind: clusterpromotiontask
     name: clusterpromotiontask_v1alpha1
+  - apiVersion: kargo.akuity.io/v1alpha1
+    filename: kargo.akuity.io/clusterconfig_v1alpha1.json
+    kind: ClusterConfig
+    name: clusterconfig_v1alpha1
+karpenter.azure.com:
+  - apiVersion: karpenter.azure.com/v1alpha2
+    filename: karpenter.azure.com/aksnodeclass_v1alpha2.json
+    kind: AKSNodeClass
+    name: aksnodeclass_v1alpha2
+  - apiVersion: karpenter.azure.com/v1beta1
+    filename: karpenter.azure.com/aksnodeclass_v1beta1.json
+    kind: AKSNodeClass
+    name: aksnodeclass_v1beta1
 karpenter.k8s.aws:
   - apiVersion: karpenter.k8s.aws/v1alpha1
     filename: karpenter.k8s.aws/awsnodetemplate_v1alpha1.json
@@ -4982,6 +9374,10 @@ karpenter.sh:
     filename: karpenter.sh/machine_v1alpha5.json
     kind: Machine
     name: machine_v1alpha5
+  - apiVersion: karpenter.sh/v1alpha1
+    filename: karpenter.sh/nodeoverlay_v1alpha1.json
+    kind: nodeoverlay
+    name: nodeoverlay_v1alpha1
 keda.sh:
   - apiVersion: keda.sh/v1alpha1
     filename: keda.sh/clustertriggerauthentication_v1alpha1.json
@@ -5003,6 +9399,15 @@ keda.sh:
     filename: keda.sh/cloudeventsource_v1alpha1.json
     kind: CloudEventSource
     name: cloudeventsource_v1alpha1
+keyvault.azure.com:
+  - apiVersion: keyvault.azure.com/v1api20230701
+    filename: keyvault.azure.com/vault_v1api20230701.json
+    kind: vault
+    name: vault_v1api20230701
+  - apiVersion: keyvault.azure.com/v1api20210401preview
+    filename: keyvault.azure.com/vault_v1api20210401preview.json
+    kind: vault
+    name: vault_v1api20210401preview
 kibana.k8s.elastic.co:
   - apiVersion: kibana.k8s.elastic.co/v1alpha1
     filename: kibana.k8s.elastic.co/kibana_v1alpha1.json
@@ -5016,6 +9421,27 @@ kibana.k8s.elastic.co:
     filename: kibana.k8s.elastic.co/kibana_v1.json
     kind: Kibana
     name: kibana_v1
+kinda.rocks:
+  - apiVersion: kinda.rocks/v1beta1
+    filename: kinda.rocks/dbuser_v1beta1.json
+    kind: DbUser
+    name: dbuser_v1beta1
+  - apiVersion: kinda.rocks/v1beta1
+    filename: kinda.rocks/database_v1beta1.json
+    kind: Database
+    name: database_v1beta1
+  - apiVersion: kinda.rocks/v1alpha1
+    filename: kinda.rocks/database_v1alpha1.json
+    kind: Database
+    name: database_v1alpha1
+  - apiVersion: kinda.rocks/v1alpha1
+    filename: kinda.rocks/dbinstance_v1alpha1.json
+    kind: DbInstance
+    name: dbinstance_v1alpha1
+  - apiVersion: kinda.rocks/v1beta1
+    filename: kinda.rocks/dbinstance_v1beta1.json
+    kind: DbInstance
+    name: dbinstance_v1beta1
 kinesis.services.k8s.aws:
   - apiVersion: kinesis.services.k8s.aws/v1alpha1
     filename: kinesis.services.k8s.aws/stream_v1alpha1.json
@@ -5050,6 +9476,22 @@ kms.cnrm.cloud.google.com:
     filename: kms.cnrm.cloud.google.com/kmsautokeyconfig_v1alpha1.json
     kind: KMSAutokeyConfig
     name: kmsautokeyconfig_v1alpha1
+  - apiVersion: kms.cnrm.cloud.google.com/v1beta1
+    filename: kms.cnrm.cloud.google.com/kmsimportjob_v1beta1.json
+    kind: KMSImportJob
+    name: kmsimportjob_v1beta1
+  - apiVersion: kms.cnrm.cloud.google.com/v1alpha1
+    filename: kms.cnrm.cloud.google.com/kmsimportjob_v1alpha1.json
+    kind: KMSImportJob
+    name: kmsimportjob_v1alpha1
+  - apiVersion: kms.cnrm.cloud.google.com/v1beta1
+    filename: kms.cnrm.cloud.google.com/kmskeyhandle_v1beta1.json
+    kind: KMSKeyHandle
+    name: kmskeyhandle_v1beta1
+  - apiVersion: kms.cnrm.cloud.google.com/v1beta1
+    filename: kms.cnrm.cloud.google.com/kmsautokeyconfig_v1beta1.json
+    kind: KMSAutokeyConfig
+    name: kmsautokeyconfig_v1beta1
 kms.services.k8s.aws:
   - apiVersion: kms.services.k8s.aws/v1alpha1
     filename: kms.services.k8s.aws/grant_v1alpha1.json
@@ -5063,6 +9505,16 @@ kms.services.k8s.aws:
     filename: kms.services.k8s.aws/alias_v1alpha1.json
     kind: Alias
     name: alias_v1alpha1
+kro.run:
+  - apiVersion: kro.run/v1alpha1
+    filename: kro.run/resourcegraphdefinition_v1alpha1.json
+    kind: ResourceGraphDefinition
+    name: resourcegraphdefinition_v1alpha1
+kubefledged.io:
+  - apiVersion: kubefledged.io/v1alpha2
+    filename: kubefledged.io/imagecache_v1alpha2.json
+    kind: ImageCache
+    name: imagecache_v1alpha2
 kubeflow.org:
   - apiVersion: kubeflow.org/v1
     filename: kubeflow.org/profile_v1.json
@@ -5088,6 +9540,97 @@ kubeflow.org:
     filename: kubeflow.org/poddefault_v1alpha1.json
     kind: PodDefault
     name: poddefault_v1alpha1
+  - apiVersion: kubeflow.org/v2beta1
+    filename: kubeflow.org/mpijob_v2beta1.json
+    kind: mpijob
+    name: mpijob_v2beta1
+kubernetesconfiguration.azure.com:
+  - apiVersion: kubernetesconfiguration.azure.com/v1api20241101
+    filename: kubernetesconfiguration.azure.com/extension_v1api20241101.json
+    kind: extension
+    name: extension_v1api20241101
+  - apiVersion: kubernetesconfiguration.azure.com/v1api20241101
+    filename: kubernetesconfiguration.azure.com/fluxconfiguration_v1api20241101.json
+    kind: fluxConfiguration
+    name: fluxconfiguration_v1api20241101
+  - apiVersion: kubernetesconfiguration.azure.com/v1api20230501
+    filename: kubernetesconfiguration.azure.com/fluxconfiguration_v1api20230501.json
+    kind: fluxconfiguration
+    name: fluxconfiguration_v1api20230501
+  - apiVersion: kubernetesconfiguration.azure.com/v1api20230501
+    filename: kubernetesconfiguration.azure.com/extension_v1api20230501.json
+    kind: extension
+    name: extension_v1api20230501
+kubescape.io:
+  - apiVersion: kubescape.io/v1
+    filename: kubescape.io/servicescanresult_v1.json
+    kind: servicescanresult
+    name: servicescanresult_v1
+  - apiVersion: kubescape.io/v1
+    filename: kubescape.io/runtimerulealertbinding_v1.json
+    kind: runtimerulealertbinding
+    name: runtimerulealertbinding_v1
+  - apiVersion: kubescape.io/v1alpha1
+    filename: kubescape.io/operatorcommand_v1alpha1.json
+    kind: operatorcommand
+    name: operatorcommand_v1alpha1
+  - apiVersion: kubescape.io/v1
+    filename: kubescape.io/rules_v1.json
+    kind: rules
+    name: rules_v1
+  - apiVersion: kubescape.io/v1
+    filename: kubescape.io/seccompprofile_v1.json
+    kind: seccompprofile
+    name: seccompprofile_v1
+kubevirt.io:
+  - apiVersion: kubevirt.io/v1
+    filename: kubevirt.io/virtualmachineinstancemigration_v1.json
+    kind: VirtualMachineInstanceMigration
+    name: virtualmachineinstancemigration_v1
+  - apiVersion: kubevirt.io/v1
+    filename: kubevirt.io/virtualmachineinstancereplicaset_v1.json
+    kind: virtualmachineinstancereplicaset
+    name: virtualmachineinstancereplicaset_v1
+  - apiVersion: kubevirt.io/v1alpha3
+    filename: kubevirt.io/virtualmachine_v1alpha3.json
+    kind: VirtualMachine
+    name: virtualmachine_v1alpha3
+  - apiVersion: kubevirt.io/v1
+    filename: kubevirt.io/virtualmachine_v1.json
+    kind: VirtualMachine
+    name: virtualmachine_v1
+  - apiVersion: kubevirt.io/v1alpha3
+    filename: kubevirt.io/virtualmachineinstancereplicaset_v1alpha3.json
+    kind: virtualmachineinstancereplicaset
+    name: virtualmachineinstancereplicaset_v1alpha3
+  - apiVersion: kubevirt.io/v1
+    filename: kubevirt.io/kubevirt_v1.json
+    kind: KubeVirt
+    name: kubevirt_v1
+  - apiVersion: kubevirt.io/v1
+    filename: kubevirt.io/virtualmachineinstance_v1.json
+    kind: VirtualMachineInstance
+    name: virtualmachineinstance_v1
+  - apiVersion: kubevirt.io/v1
+    filename: kubevirt.io/virtualmachineinstancepreset_v1.json
+    kind: VirtualMachineInstancePreset
+    name: virtualmachineinstancepreset_v1
+  - apiVersion: kubevirt.io/v1alpha3
+    filename: kubevirt.io/virtualmachineinstancepreset_v1alpha3.json
+    kind: VirtualMachineInstancePreset
+    name: virtualmachineinstancepreset_v1alpha3
+  - apiVersion: kubevirt.io/v1alpha3
+    filename: kubevirt.io/virtualmachineinstancemigration_v1alpha3.json
+    kind: VirtualMachineInstanceMigration
+    name: virtualmachineinstancemigration_v1alpha3
+  - apiVersion: kubevirt.io/v1alpha3
+    filename: kubevirt.io/virtualmachineinstance_v1alpha3.json
+    kind: VirtualMachineInstance
+    name: virtualmachineinstance_v1alpha3
+  - apiVersion: kubevirt.io/v1alpha3
+    filename: kubevirt.io/kubevirt_v1alpha3.json
+    kind: KubeVirt
+    name: kubevirt_v1alpha3
 kueue.x-k8s.io:
   - apiVersion: kueue.x-k8s.io/v1beta1
     filename: kueue.x-k8s.io/resourceflavor_v1beta1.json
@@ -5133,6 +9676,71 @@ kueue.x-k8s.io:
     filename: kueue.x-k8s.io/workloadpriorityclass_v1beta1.json
     kind: WorkloadPriorityClass
     name: workloadpriorityclass_v1beta1
+  - apiVersion: kueue.x-k8s.io/v1beta2
+    filename: kueue.x-k8s.io/cohort_v1beta2.json
+    kind: Cohort
+    name: cohort_v1beta2
+  - apiVersion: kueue.x-k8s.io/v1beta2
+    filename: kueue.x-k8s.io/admissioncheck_v1beta2.json
+    kind: AdmissionCheck
+    name: admissioncheck_v1beta2
+  - apiVersion: kueue.x-k8s.io/v1beta2
+    filename: kueue.x-k8s.io/multikueuecluster_v1beta2.json
+    kind: MultiKueueCluster
+    name: multikueuecluster_v1beta2
+  - apiVersion: kueue.x-k8s.io/v1beta2
+    filename: kueue.x-k8s.io/localqueue_v1beta2.json
+    kind: LocalQueue
+    name: localqueue_v1beta2
+  - apiVersion: kueue.x-k8s.io/v1beta2
+    filename: kueue.x-k8s.io/workload_v1beta2.json
+    kind: Workload
+    name: workload_v1beta2
+  - apiVersion: kueue.x-k8s.io/v1beta2
+    filename: kueue.x-k8s.io/resourceflavor_v1beta2.json
+    kind: ResourceFlavor
+    name: resourceflavor_v1beta2
+  - apiVersion: kueue.x-k8s.io/v1beta2
+    filename: kueue.x-k8s.io/workloadpriorityclass_v1beta2.json
+    kind: WorkloadPriorityClass
+    name: workloadpriorityclass_v1beta2
+  - apiVersion: kueue.x-k8s.io/v1beta2
+    filename: kueue.x-k8s.io/multikueueconfig_v1beta2.json
+    kind: MultiKueueConfig
+    name: multikueueconfig_v1beta2
+  - apiVersion: kueue.x-k8s.io/v1beta2
+    filename: kueue.x-k8s.io/topology_v1beta2.json
+    kind: Topology
+    name: topology_v1beta2
+  - apiVersion: kueue.x-k8s.io/v1beta1
+    filename: kueue.x-k8s.io/topology_v1beta1.json
+    kind: Topology
+    name: topology_v1beta1
+  - apiVersion: kueue.x-k8s.io/v1beta2
+    filename: kueue.x-k8s.io/provisioningrequestconfig_v1beta2.json
+    kind: ProvisioningRequestConfig
+    name: provisioningrequestconfig_v1beta2
+  - apiVersion: kueue.x-k8s.io/v1beta2
+    filename: kueue.x-k8s.io/clusterqueue_v1beta2.json
+    kind: ClusterQueue
+    name: clusterqueue_v1beta2
+  - apiVersion: kueue.x-k8s.io/v1beta1
+    filename: kueue.x-k8s.io/cohort_v1beta1.json
+    kind: Cohort
+    name: cohort_v1beta1
+kusto.azure.com:
+  - apiVersion: kusto.azure.com/v1api20230815
+    filename: kusto.azure.com/dataconnection_v1api20230815.json
+    kind: dataConnection
+    name: dataconnection_v1api20230815
+  - apiVersion: kusto.azure.com/v1api20230815
+    filename: kusto.azure.com/database_v1api20230815.json
+    kind: database
+    name: database_v1api20230815
+  - apiVersion: kusto.azure.com/v1api20230815
+    filename: kusto.azure.com/cluster_v1api20230815.json
+    kind: cluster
+    name: cluster_v1api20230815
 kustomize.toolkit.fluxcd.io:
   - apiVersion: kustomize.toolkit.fluxcd.io/v1beta1
     filename: kustomize.toolkit.fluxcd.io/kustomization_v1beta1.json
@@ -5271,6 +9879,14 @@ kyverno.io:
     filename: kyverno.io/clusteradmissionreport_v2.json
     kind: ClusterAdmissionReport
     name: clusteradmissionreport_v2
+  - apiVersion: kyverno.io/v2beta1
+    filename: kyverno.io/globalcontextentry_v2beta1.json
+    kind: GlobalContextEntry
+    name: globalcontextentry_v2beta1
+  - apiVersion: kyverno.io/v2
+    filename: kyverno.io/globalcontextentry_v2.json
+    kind: GlobalContextEntry
+    name: globalcontextentry_v2
 lambda.services.k8s.aws:
   - apiVersion: lambda.services.k8s.aws/v1alpha1
     filename: lambda.services.k8s.aws/function_v1alpha1.json
@@ -5300,6 +9916,79 @@ lambda.services.k8s.aws:
     filename: lambda.services.k8s.aws/version_v1alpha1.json
     kind: Version
     name: version_v1alpha1
+lib.projectsveltos.io:
+  - apiVersion: lib.projectsveltos.io/v1beta1
+    filename: lib.projectsveltos.io/eventreport_v1beta1.json
+    kind: EventReport
+    name: eventreport_v1beta1
+  - apiVersion: lib.projectsveltos.io/v1beta1
+    filename: lib.projectsveltos.io/resourcesummary_v1beta1.json
+    kind: ResourceSummary
+    name: resourcesummary_v1beta1
+  - apiVersion: lib.projectsveltos.io/v1beta1
+    filename: lib.projectsveltos.io/accessrequest_v1beta1.json
+    kind: AccessRequest
+    name: accessrequest_v1beta1
+  - apiVersion: lib.projectsveltos.io/v1beta1
+    filename: lib.projectsveltos.io/techsupport_v1beta1.json
+    kind: Techsupport
+    name: techsupport_v1beta1
+  - apiVersion: lib.projectsveltos.io/v1beta1
+    filename: lib.projectsveltos.io/eventsource_v1beta1.json
+    kind: EventSource
+    name: eventsource_v1beta1
+  - apiVersion: lib.projectsveltos.io/v1beta1
+    filename: lib.projectsveltos.io/eventtrigger_v1beta1.json
+    kind: EventTrigger
+    name: eventtrigger_v1beta1
+  - apiVersion: lib.projectsveltos.io/v1beta1
+    filename: lib.projectsveltos.io/classifier_v1beta1.json
+    kind: Classifier
+    name: classifier_v1beta1
+  - apiVersion: lib.projectsveltos.io/v1beta1
+    filename: lib.projectsveltos.io/configurationgroup_v1beta1.json
+    kind: ConfigurationGroup
+    name: configurationgroup_v1beta1
+  - apiVersion: lib.projectsveltos.io/v1beta1
+    filename: lib.projectsveltos.io/classifierreport_v1beta1.json
+    kind: ClassifierReport
+    name: classifierreport_v1beta1
+  - apiVersion: lib.projectsveltos.io/v1beta1
+    filename: lib.projectsveltos.io/reloaderreport_v1beta1.json
+    kind: ReloaderReport
+    name: reloaderreport_v1beta1
+  - apiVersion: lib.projectsveltos.io/v1beta1
+    filename: lib.projectsveltos.io/debuggingconfiguration_v1beta1.json
+    kind: DebuggingConfiguration
+    name: debuggingconfiguration_v1beta1
+  - apiVersion: lib.projectsveltos.io/v1beta1
+    filename: lib.projectsveltos.io/sveltoscluster_v1beta1.json
+    kind: SveltosCluster
+    name: sveltoscluster_v1beta1
+  - apiVersion: lib.projectsveltos.io/v1beta1
+    filename: lib.projectsveltos.io/healthcheck_v1beta1.json
+    kind: HealthCheck
+    name: healthcheck_v1beta1
+  - apiVersion: lib.projectsveltos.io/v1beta1
+    filename: lib.projectsveltos.io/reloader_v1beta1.json
+    kind: Reloader
+    name: reloader_v1beta1
+  - apiVersion: lib.projectsveltos.io/v1beta1
+    filename: lib.projectsveltos.io/clusterset_v1beta1.json
+    kind: ClusterSet
+    name: clusterset_v1beta1
+  - apiVersion: lib.projectsveltos.io/v1beta1
+    filename: lib.projectsveltos.io/healthcheckreport_v1beta1.json
+    kind: HealthCheckReport
+    name: healthcheckreport_v1beta1
+  - apiVersion: lib.projectsveltos.io/v1beta1
+    filename: lib.projectsveltos.io/clusterhealthcheck_v1beta1.json
+    kind: ClusterHealthCheck
+    name: clusterhealthcheck_v1beta1
+  - apiVersion: lib.projectsveltos.io/v1beta1
+    filename: lib.projectsveltos.io/configurationbundle_v1beta1.json
+    kind: ConfigurationBundle
+    name: configurationbundle_v1beta1
 linkerd.io:
   - apiVersion: linkerd.io/v1alpha1
     filename: linkerd.io/serviceprofile_v1alpha1.json
@@ -5416,6 +10105,14 @@ logging.cnrm.cloud.google.com:
     filename: logging.cnrm.cloud.google.com/logginglogsink_v1beta1.json
     kind: logginglogsink
     name: logginglogsink_v1beta1
+  - apiVersion: logging.cnrm.cloud.google.com/v1beta1
+    filename: logging.cnrm.cloud.google.com/logginglink_v1beta1.json
+    kind: LoggingLink
+    name: logginglink_v1beta1
+  - apiVersion: logging.cnrm.cloud.google.com/v1alpha1
+    filename: logging.cnrm.cloud.google.com/logginglink_v1alpha1.json
+    kind: LoggingLink
+    name: logginglink_v1alpha1
 logging.openshift.io:
   - apiVersion: logging.openshift.io/v1
     filename: logging.openshift.io/clusterlogging_v1.json
@@ -5571,6 +10268,110 @@ longhorn.io:
     filename: longhorn.io/node_v1beta1.json
     kind: Node
     name: node_v1beta1
+machinelearningservices.azure.com:
+  - apiVersion: machinelearningservices.azure.com/v1api20210701
+    filename: machinelearningservices.azure.com/workspace_v1api20210701.json
+    kind: workspace
+    name: workspace_v1api20210701
+  - apiVersion: machinelearningservices.azure.com/v1api20240401
+    filename: machinelearningservices.azure.com/workspacescompute_v1api20240401.json
+    kind: workspacescompute
+    name: workspacescompute_v1api20240401
+  - apiVersion: machinelearningservices.azure.com/v1api20240401
+    filename: machinelearningservices.azure.com/workspace_v1api20240401.json
+    kind: workspace
+    name: workspace_v1api20240401
+  - apiVersion: machinelearningservices.azure.com/v1api20210701
+    filename: machinelearningservices.azure.com/workspacescompute_v1api20210701.json
+    kind: workspacescompute
+    name: workspacescompute_v1api20210701
+  - apiVersion: machinelearningservices.azure.com/v1api20210701
+    filename: machinelearningservices.azure.com/workspacesconnection_v1api20210701.json
+    kind: workspacesconnection
+    name: workspacesconnection_v1api20210701
+  - apiVersion: machinelearningservices.azure.com/v1api20240401
+    filename: machinelearningservices.azure.com/workspacesconnection_v1api20240401.json
+    kind: workspacesconnection
+    name: workspacesconnection_v1api20240401
+  - apiVersion: machinelearningservices.azure.com/v1api20240401
+    filename: machinelearningservices.azure.com/registry_v1api20240401.json
+    kind: registry
+    name: registry_v1api20240401
+managedidentity.azure.com:
+  - apiVersion: managedidentity.azure.com/v1api20230131
+    filename: managedidentity.azure.com/federatedidentitycredential_v1api20230131.json
+    kind: federatedIdentityCredential
+    name: federatedidentitycredential_v1api20230131
+  - apiVersion: managedidentity.azure.com/v1api20181130
+    filename: managedidentity.azure.com/userassignedidentity_v1api20181130.json
+    kind: userassignedidentity
+    name: userassignedidentity_v1api20181130
+  - apiVersion: managedidentity.azure.com/v1api20220131preview
+    filename: managedidentity.azure.com/federatedidentitycredential_v1api20220131preview.json
+    kind: federatedIdentityCredential
+    name: federatedidentitycredential_v1api20220131preview
+  - apiVersion: managedidentity.azure.com/v1api20230131
+    filename: managedidentity.azure.com/userassignedidentity_v1api20230131.json
+    kind: userassignedidentity
+    name: userassignedidentity_v1api20230131
+managedkafka.cnrm.cloud.google.com:
+  - apiVersion: managedkafka.cnrm.cloud.google.com/v1alpha1
+    filename: managedkafka.cnrm.cloud.google.com/managedkafkatopic_v1alpha1.json
+    kind: ManagedKafkaTopic
+    name: managedkafkatopic_v1alpha1
+  - apiVersion: managedkafka.cnrm.cloud.google.com/v1alpha1
+    filename: managedkafka.cnrm.cloud.google.com/managedkafkacluster_v1alpha1.json
+    kind: ManagedKafkaCluster
+    name: managedkafkacluster_v1alpha1
+  - apiVersion: managedkafka.cnrm.cloud.google.com/v1beta1
+    filename: managedkafka.cnrm.cloud.google.com/managedkafkacluster_v1beta1.json
+    kind: ManagedKafkaCluster
+    name: managedkafkacluster_v1beta1
+  - apiVersion: managedkafka.cnrm.cloud.google.com/v1beta1
+    filename: managedkafka.cnrm.cloud.google.com/managedkafkatopic_v1beta1.json
+    kind: ManagedKafkaTopic
+    name: managedkafkatopic_v1beta1
+management.cattle.io:
+  - apiVersion: management.cattle.io/v3
+    filename: management.cattle.io/roletemplate_v3.json
+    kind: RoleTemplate
+    name: roletemplate_v3
+  - apiVersion: management.cattle.io/v3
+    filename: management.cattle.io/managedchart_v3.json
+    kind: managedchart
+    name: managedchart_v3
+  - apiVersion: management.cattle.io/v3
+    filename: management.cattle.io/podsecurityadmissionconfigurationtemplate_v3.json
+    kind: podsecurityadmissionconfigurationtemplate
+    name: podsecurityadmissionconfigurationtemplate_v3
+  - apiVersion: management.cattle.io/v3
+    filename: management.cattle.io/projectroletemplatebinding_v3.json
+    kind: ProjectRoleTemplateBinding
+    name: projectroletemplatebinding_v3
+  - apiVersion: management.cattle.io/v3
+    filename: management.cattle.io/clusterroletemplatebinding_v3.json
+    kind: ClusterRoleTemplateBinding
+    name: clusterroletemplatebinding_v3
+  - apiVersion: management.cattle.io/v3
+    filename: management.cattle.io/authconfig_v3.json
+    kind: authconfig
+    name: authconfig_v3
+  - apiVersion: management.cattle.io/v3
+    filename: management.cattle.io/globalrolebinding_v3.json
+    kind: GlobalRoleBinding
+    name: globalrolebinding_v3
+  - apiVersion: management.cattle.io/v3
+    filename: management.cattle.io/project_v3.json
+    kind: Project
+    name: project_v3
+  - apiVersion: management.cattle.io/v3
+    filename: management.cattle.io/clusterregistrationtoken_v3.json
+    kind: clusterregistrationtoken
+    name: clusterregistrationtoken_v3
+  - apiVersion: management.cattle.io/v3
+    filename: management.cattle.io/globalrole_v3.json
+    kind: GlobalRole
+    name: globalrole_v3
 maps.k8s.elastic.co:
   - apiVersion: maps.k8s.elastic.co/v1alpha1
     filename: maps.k8s.elastic.co/elasticmapsserver_v1alpha1.json
@@ -5606,6 +10407,15 @@ memorydb.services.k8s.aws:
     filename: memorydb.services.k8s.aws/user_v1alpha1.json
     kind: User
     name: user_v1alpha1
+messaging.knative.dev:
+  - apiVersion: messaging.knative.dev/v1
+    filename: messaging.knative.dev/subscription_v1.json
+    kind: Subscription
+    name: subscription_v1
+  - apiVersion: messaging.knative.dev/v1
+    filename: messaging.knative.dev/channel_v1.json
+    kind: Channel
+    name: channel_v1
 metal3.io:
   - apiVersion: metal3.io/v1alpha1
     filename: metal3.io/firmwareschema_v1alpha1.json
@@ -5680,6 +10490,20 @@ metallb.io:
     filename: metallb.io/bgppeer_v1beta2.json
     kind: BGPPeer
     name: bgppeer_v1beta2
+metastore.cnrm.cloud.google.com:
+  - apiVersion: metastore.cnrm.cloud.google.com/v1alpha1
+    filename: metastore.cnrm.cloud.google.com/metastorebackup_v1alpha1.json
+    kind: MetastoreBackup
+    name: metastorebackup_v1alpha1
+  - apiVersion: metastore.cnrm.cloud.google.com/v1beta1
+    filename: metastore.cnrm.cloud.google.com/metastorebackup_v1beta1.json
+    kind: MetastoreBackup
+    name: metastorebackup_v1beta1
+migrations.kubevirt.io:
+  - apiVersion: migrations.kubevirt.io/v1alpha1
+    filename: migrations.kubevirt.io/migrationpolicy_v1alpha1.json
+    kind: MigrationPolicy
+    name: migrationpolicy_v1alpha1
 minio.min.io:
   - apiVersion: minio.min.io/v2
     filename: minio.min.io/tenant_v2.json
@@ -5698,6 +10522,27 @@ ml.grafana.crossplane.io:
     filename: ml.grafana.crossplane.io/holiday_v1alpha1.json
     kind: Holiday
     name: holiday_v1alpha1
+  - apiVersion: ml.grafana.crossplane.io/v1alpha1
+    filename: ml.grafana.crossplane.io/alert_v1alpha1.json
+    kind: Alert
+    name: alert_v1alpha1
+ml.grafana.m.crossplane.io:
+  - apiVersion: ml.grafana.m.crossplane.io/v1alpha1
+    filename: ml.grafana.m.crossplane.io/alert_v1alpha1.json
+    kind: Alert
+    name: alert_v1alpha1
+  - apiVersion: ml.grafana.m.crossplane.io/v1alpha1
+    filename: ml.grafana.m.crossplane.io/holiday_v1alpha1.json
+    kind: Holiday
+    name: holiday_v1alpha1
+  - apiVersion: ml.grafana.m.crossplane.io/v1alpha1
+    filename: ml.grafana.m.crossplane.io/job_v1alpha1.json
+    kind: Job
+    name: job_v1alpha1
+  - apiVersion: ml.grafana.m.crossplane.io/v1alpha1
+    filename: ml.grafana.m.crossplane.io/outlierdetector_v1alpha1.json
+    kind: OutlierDetector
+    name: outlierdetector_v1alpha1
 mlengine.cnrm.cloud.google.com:
   - apiVersion: mlengine.cnrm.cloud.google.com/v1alpha1
     filename: mlengine.cnrm.cloud.google.com/mlenginemodel_v1alpha1.json
@@ -5708,6 +10553,11 @@ mongodbcommunity.mongodb.com:
     filename: mongodbcommunity.mongodb.com/mongodbcommunity_v1.json
     kind: MongoDBCommunity
     name: mongodbcommunity_v1
+monitor.azure.com:
+  - apiVersion: monitor.azure.com/v1api20230403
+    filename: monitor.azure.com/account_v1api20230403.json
+    kind: Account
+    name: account_v1api20230403
 monitoring.cnrm.cloud.google.com:
   - apiVersion: monitoring.cnrm.cloud.google.com/v1beta1
     filename: monitoring.cnrm.cloud.google.com/monitoringuptimecheckconfig_v1beta1.json
@@ -5936,11 +10786,355 @@ mysql.presslabs.org:
     filename: mysql.presslabs.org/mysqlbackup_v2.json
     kind: mysqlbackup
     name: mysqlbackup_v2
+nauth.io:
+  - apiVersion: nauth.io/v1alpha1
+    filename: nauth.io/natscluster_v1alpha1.json
+    kind: NatsCluster
+    name: natscluster_v1alpha1
+  - apiVersion: nauth.io/v1alpha1
+    filename: nauth.io/user_v1alpha1.json
+    kind: User
+    name: user_v1alpha1
+  - apiVersion: nauth.io/v1alpha1
+    filename: nauth.io/accountexport_v1alpha1.json
+    kind: AccountExport
+    name: accountexport_v1alpha1
+  - apiVersion: nauth.io/v1alpha1
+    filename: nauth.io/accountsigningkey_v1alpha1.json
+    kind: AccountSigningKey
+    name: accountsigningkey_v1alpha1
+  - apiVersion: nauth.io/v1alpha1
+    filename: nauth.io/accountimport_v1alpha1.json
+    kind: AccountImport
+    name: accountimport_v1alpha1
+  - apiVersion: nauth.io/v1alpha1
+    filename: nauth.io/account_v1alpha1.json
+    kind: Account
+    name: account_v1alpha1
+network.azure.com:
+  - apiVersion: network.azure.com/v1api20220701
+    filename: network.azure.com/privateendpoint_v1api20220701.json
+    kind: privateEndpoint
+    name: privateendpoint_v1api20220701
+  - apiVersion: network.azure.com/v1api20200601
+    filename: network.azure.com/privatednszonestxtrecord_v1api20200601.json
+    kind: privatednszonestxtrecord
+    name: privatednszonestxtrecord_v1api20200601
+  - apiVersion: network.azure.com/v1api20180501
+    filename: network.azure.com/dnszonestxtrecord_v1api20180501.json
+    kind: dnszonestxtrecord
+    name: dnszonestxtrecord_v1api20180501
+  - apiVersion: network.azure.com/v1api20220701
+    filename: network.azure.com/privateendpointsprivatednszonegroup_v1api20220701.json
+    kind: privateendpointsprivatednszonegroup
+    name: privateendpointsprivatednszonegroup_v1api20220701
+  - apiVersion: network.azure.com/v1api20220701
+    filename: network.azure.com/natgateway_v1api20220701.json
+    kind: natGateway
+    name: natgateway_v1api20220701
+  - apiVersion: network.azure.com/v1api20240601
+    filename: network.azure.com/privatednszonesarecord_v1api20240601.json
+    kind: privatednszonesarecord
+    name: privatednszonesarecord_v1api20240601
+  - apiVersion: network.azure.com/v1api20240301
+    filename: network.azure.com/privatelinkservice_v1api20240301.json
+    kind: privateLinkService
+    name: privatelinkservice_v1api20240301
+  - apiVersion: network.azure.com/v1api20220401
+    filename: network.azure.com/trafficmanagerprofile_v1api20220401.json
+    kind: trafficmanagerprofile
+    name: trafficmanagerprofile_v1api20220401
+  - apiVersion: network.azure.com/v1api20200601
+    filename: network.azure.com/privatednszonesarecord_v1api20200601.json
+    kind: privatednszonesarecord
+    name: privatednszonesarecord_v1api20200601
+  - apiVersion: network.azure.com/v1api20240601
+    filename: network.azure.com/privatednszonescnamerecord_v1api20240601.json
+    kind: privatednszonescnamerecord
+    name: privatednszonescnamerecord_v1api20240601
+  - apiVersion: network.azure.com/v1api20180501
+    filename: network.azure.com/dnszonesmxrecord_v1api20180501.json
+    kind: dnszonesmxrecord
+    name: dnszonesmxrecord_v1api20180501
+  - apiVersion: network.azure.com/v1api20201101
+    filename: network.azure.com/routetable_v1api20201101.json
+    kind: routeTable
+    name: routetable_v1api20201101
+  - apiVersion: network.azure.com/v1api20180501
+    filename: network.azure.com/dnszonesnsrecord_v1api20180501.json
+    kind: dnszonesnsrecord
+    name: dnszonesnsrecord_v1api20180501
+  - apiVersion: network.azure.com/v1api20240301
+    filename: network.azure.com/publicipprefix_v1api20240301.json
+    kind: publicIpPrefix
+    name: publicipprefix_v1api20240301
+  - apiVersion: network.azure.com/v1api20220701
+    filename: network.azure.com/dnsresolver_v1api20220701.json
+    kind: dnsresolver
+    name: dnsresolver_v1api20220701
+  - apiVersion: network.azure.com/v1api20240101
+    filename: network.azure.com/webapplicationfirewallpolicy_v1api20240101.json
+    kind: webapplicationfirewallpolicy
+    name: webapplicationfirewallpolicy_v1api20240101
+  - apiVersion: network.azure.com/v1api20220701
+    filename: network.azure.com/publicipprefix_v1api20220701.json
+    kind: publicIpPrefix
+    name: publicipprefix_v1api20220701
+  - apiVersion: network.azure.com/v1api20180501
+    filename: network.azure.com/dnszonesarecord_v1api20180501.json
+    kind: dnszonesarecord
+    name: dnszonesarecord_v1api20180501
+  - apiVersion: network.azure.com/v1api20200601
+    filename: network.azure.com/privatednszonescnamerecord_v1api20200601.json
+    kind: privatednszonescnamerecord
+    name: privatednszonescnamerecord_v1api20200601
+  - apiVersion: network.azure.com/v1api20240301
+    filename: network.azure.com/privateendpointsprivatednszonegroup_v1api20240301.json
+    kind: privateendpointsprivatednszonegroup
+    name: privateendpointsprivatednszonegroup_v1api20240301
+  - apiVersion: network.azure.com/v1api20201101
+    filename: network.azure.com/networksecuritygroup_v1api20201101.json
+    kind: networkSecurityGroup
+    name: networksecuritygroup_v1api20201101
+  - apiVersion: network.azure.com/v1api20201101
+    filename: network.azure.com/virtualnetworksvirtualnetworkpeering_v1api20201101.json
+    kind: virtualnetworksvirtualnetworkpeering
+    name: virtualnetworksvirtualnetworkpeering_v1api20201101
+  - apiVersion: network.azure.com/v1api20240601
+    filename: network.azure.com/privatednszonessrvrecord_v1api20240601.json
+    kind: privatednszonessrvrecord
+    name: privatednszonessrvrecord_v1api20240601
+  - apiVersion: network.azure.com/v1api20200601
+    filename: network.azure.com/privatednszonessrvrecord_v1api20200601.json
+    kind: privatednszonessrvrecord
+    name: privatednszonessrvrecord_v1api20200601
+  - apiVersion: network.azure.com/v1api20220701
+    filename: network.azure.com/applicationgateway_v1api20220701.json
+    kind: applicationGateway
+    name: applicationgateway_v1api20220701
+  - apiVersion: network.azure.com/v1api20180501
+    filename: network.azure.com/dnszonesptrrecord_v1api20180501.json
+    kind: dnszonesptrrecord
+    name: dnszonesptrrecord_v1api20180501
+  - apiVersion: network.azure.com/v1api20200601
+    filename: network.azure.com/privatednszonesmxrecord_v1api20200601.json
+    kind: privatednszonesmxrecord
+    name: privatednszonesmxrecord_v1api20200601
+  - apiVersion: network.azure.com/v1api20240301
+    filename: network.azure.com/virtualnetwork_v1api20240301.json
+    kind: virtualNetwork
+    name: virtualnetwork_v1api20240301
+  - apiVersion: network.azure.com/v1api20201101
+    filename: network.azure.com/loadbalancer_v1api20201101.json
+    kind: loadBalancer
+    name: loadbalancer_v1api20201101
+  - apiVersion: network.azure.com/v1api20240301
+    filename: network.azure.com/networkinterface_v1api20240301.json
+    kind: networkInterface
+    name: networkinterface_v1api20240301
+  - apiVersion: network.azure.com/v1api20201101
+    filename: network.azure.com/networksecuritygroupssecurityrule_v1api20201101.json
+    kind: networksecuritygroupssecurityrule
+    name: networksecuritygroupssecurityrule_v1api20201101
+  - apiVersion: network.azure.com/v1api20240301
+    filename: network.azure.com/routetablesroute_v1api20240301.json
+    kind: routetablesroute
+    name: routetablesroute_v1api20240301
+  - apiVersion: network.azure.com/v1api20220701
+    filename: network.azure.com/bastionhost_v1api20220701.json
+    kind: bastionHost
+    name: bastionhost_v1api20220701
+  - apiVersion: network.azure.com/v1api20200601
+    filename: network.azure.com/privatednszonesptrrecord_v1api20200601.json
+    kind: privatednszonesptrrecord
+    name: privatednszonesptrrecord_v1api20200601
+  - apiVersion: network.azure.com/v1api20180501
+    filename: network.azure.com/dnszonescnamerecord_v1api20180501.json
+    kind: dnszonescnamerecord
+    name: dnszonescnamerecord_v1api20180501
+  - apiVersion: network.azure.com/v1api20180501
+    filename: network.azure.com/dnszonessrvrecord_v1api20180501.json
+    kind: dnszonessrvrecord
+    name: dnszonessrvrecord_v1api20180501
+  - apiVersion: network.azure.com/v1api20201101
+    filename: network.azure.com/routetablesroute_v1api20201101.json
+    kind: routetablesroute
+    name: routetablesroute_v1api20201101
+  - apiVersion: network.azure.com/v1api20240301
+    filename: network.azure.com/privateendpoint_v1api20240301.json
+    kind: privateEndpoint
+    name: privateendpoint_v1api20240301
+  - apiVersion: network.azure.com/v1api20240301
+    filename: network.azure.com/routetable_v1api20240301.json
+    kind: routeTable
+    name: routetable_v1api20240301
+  - apiVersion: network.azure.com/v1api20220401
+    filename: network.azure.com/trafficmanagerprofilesnestedendpoint_v1api20220401.json
+    kind: trafficmanagerprofilesnestedendpoint
+    name: trafficmanagerprofilesnestedendpoint_v1api20220401
+  - apiVersion: network.azure.com/v1api20240301
+    filename: network.azure.com/networksecuritygroupssecurityrule_v1api20240301.json
+    kind: networksecuritygroupssecurityrule
+    name: networksecuritygroupssecurityrule_v1api20240301
+  - apiVersion: network.azure.com/v1api20240301
+    filename: network.azure.com/bastionhost_v1api20240301.json
+    kind: bastionHost
+    name: bastionhost_v1api20240301
+  - apiVersion: network.azure.com/v1api20220401
+    filename: network.azure.com/trafficmanagerprofilesazureendpoint_v1api20220401.json
+    kind: trafficmanagerprofilesazureendpoint
+    name: trafficmanagerprofilesazureendpoint_v1api20220401
+  - apiVersion: network.azure.com/v1api20220701
+    filename: network.azure.com/privatelinkservice_v1api20220701.json
+    kind: privateLinkService
+    name: privatelinkservice_v1api20220701
+  - apiVersion: network.azure.com/v1api20180501
+    filename: network.azure.com/dnszonescaarecord_v1api20180501.json
+    kind: dnszonescaarecord
+    name: dnszonescaarecord_v1api20180501
+  - apiVersion: network.azure.com/v1api20201101
+    filename: network.azure.com/loadbalancersinboundnatrule_v1api20201101.json
+    kind: loadbalancersinboundnatrule
+    name: loadbalancersinboundnatrule_v1api20201101
+  - apiVersion: network.azure.com/v1api20240601
+    filename: network.azure.com/privatednszonesvirtualnetworklink_v1api20240601.json
+    kind: privatednszonesvirtualnetworklink
+    name: privatednszonesvirtualnetworklink_v1api20240601
+  - apiVersion: network.azure.com/v1api20240601
+    filename: network.azure.com/privatednszone_v1api20240601.json
+    kind: privateDnsZone
+    name: privatednszone_v1api20240601
+  - apiVersion: network.azure.com/v1api20240601
+    filename: network.azure.com/privatednszonesaaaarecord_v1api20240601.json
+    kind: privatednszonesaaaarecord
+    name: privatednszonesaaaarecord_v1api20240601
+  - apiVersion: network.azure.com/v1api20201101
+    filename: network.azure.com/networkinterface_v1api20201101.json
+    kind: networkInterface
+    name: networkinterface_v1api20201101
+  - apiVersion: network.azure.com/v1api20200601
+    filename: network.azure.com/privatednszonesaaaarecord_v1api20200601.json
+    kind: privatednszonesaaaarecord
+    name: privatednszonesaaaarecord_v1api20200601
+  - apiVersion: network.azure.com/v1api20240301
+    filename: network.azure.com/publicipaddress_v1api20240301.json
+    kind: publicIpAddress
+    name: publicipaddress_v1api20240301
+  - apiVersion: network.azure.com/v1api20180501
+    filename: network.azure.com/dnszone_v1api20180501.json
+    kind: dnsZone
+    name: dnszone_v1api20180501
+  - apiVersion: network.azure.com/v1api20240601
+    filename: network.azure.com/privatednszonesptrrecord_v1api20240601.json
+    kind: privatednszonesptrrecord
+    name: privatednszonesptrrecord_v1api20240601
+  - apiVersion: network.azure.com/v1api20240301
+    filename: network.azure.com/natgateway_v1api20240301.json
+    kind: natGateway
+    name: natgateway_v1api20240301
+  - apiVersion: network.azure.com/v1api20201101
+    filename: network.azure.com/virtualnetwork_v1api20201101.json
+    kind: virtualNetwork
+    name: virtualnetwork_v1api20201101
+  - apiVersion: network.azure.com/v1api20240601
+    filename: network.azure.com/privatednszonestxtrecord_v1api20240601.json
+    kind: privatednszonestxtrecord
+    name: privatednszonestxtrecord_v1api20240601
+  - apiVersion: network.azure.com/v1api20240301
+    filename: network.azure.com/loadbalancer_v1api20240301.json
+    kind: loadBalancer
+    name: loadbalancer_v1api20240301
+  - apiVersion: network.azure.com/v1api20240301
+    filename: network.azure.com/loadbalancersinboundnatrule_v1api20240301.json
+    kind: loadbalancersinboundnatrule
+    name: loadbalancersinboundnatrule_v1api20240301
+  - apiVersion: network.azure.com/v1api20240601
+    filename: network.azure.com/privatednszonesmxrecord_v1api20240601.json
+    kind: privatednszonesmxrecord
+    name: privatednszonesmxrecord_v1api20240601
+  - apiVersion: network.azure.com/v1api20220701
+    filename: network.azure.com/dnsforwardingruleset_v1api20220701.json
+    kind: dnsForwardingRuleset
+    name: dnsforwardingruleset_v1api20220701
+  - apiVersion: network.azure.com/v1api20220701
+    filename: network.azure.com/dnsforwardingrulesetsvirtualnetworklink_v1api20220701.json
+    kind: dnsforwardingrulesetsvirtualnetworklink
+    name: dnsforwardingrulesetsvirtualnetworklink_v1api20220701
+  - apiVersion: network.azure.com/v1api20200601
+    filename: network.azure.com/privatednszonesvirtualnetworklink_v1api20200601.json
+    kind: privatednszonesvirtualnetworklink
+    name: privatednszonesvirtualnetworklink_v1api20200601
+  - apiVersion: network.azure.com/v1api20240301
+    filename: network.azure.com/virtualnetworkgateway_v1api20240301.json
+    kind: virtualNetworkGateway
+    name: virtualnetworkgateway_v1api20240301
+  - apiVersion: network.azure.com/v1api20220701
+    filename: network.azure.com/dnsresolversinboundendpoint_v1api20220701.json
+    kind: dnsresolversinboundendpoint
+    name: dnsresolversinboundendpoint_v1api20220701
+  - apiVersion: network.azure.com/v1api20201101
+    filename: network.azure.com/virtualnetworkssubnet_v1api20201101.json
+    kind: virtualnetworkssubnet
+    name: virtualnetworkssubnet_v1api20201101
+  - apiVersion: network.azure.com/v1api20201101
+    filename: network.azure.com/publicipaddress_v1api20201101.json
+    kind: publicIpAddress
+    name: publicipaddress_v1api20201101
+  - apiVersion: network.azure.com/v1api20240301
+    filename: network.azure.com/virtualnetworksvirtualnetworkpeering_v1api20240301.json
+    kind: virtualnetworksvirtualnetworkpeering
+    name: virtualnetworksvirtualnetworkpeering_v1api20240301
+  - apiVersion: network.azure.com/v1api20201101
+    filename: network.azure.com/virtualnetworkgateway_v1api20201101.json
+    kind: virtualNetworkGateway
+    name: virtualnetworkgateway_v1api20201101
+  - apiVersion: network.azure.com/v1api20240301
+    filename: network.azure.com/virtualnetworkssubnet_v1api20240301.json
+    kind: virtualnetworkssubnet
+    name: virtualnetworkssubnet_v1api20240301
+  - apiVersion: network.azure.com/v1api20220701
+    filename: network.azure.com/dnsresolversoutboundendpoint_v1api20220701.json
+    kind: dnsresolversoutboundendpoint
+    name: dnsresolversoutboundendpoint_v1api20220701
+  - apiVersion: network.azure.com/v1api20180901
+    filename: network.azure.com/privatednszone_v1api20180901.json
+    kind: privateDnsZone
+    name: privatednszone_v1api20180901
+  - apiVersion: network.azure.com/v1api20240301
+    filename: network.azure.com/networksecuritygroup_v1api20240301.json
+    kind: networkSecurityGroup
+    name: networksecuritygroup_v1api20240301
+  - apiVersion: network.azure.com/v1api20220701
+    filename: network.azure.com/dnsforwardingrulesetsforwardingrule_v1api20220701.json
+    kind: dnsforwardingrulesetsforwardingrule
+    name: dnsforwardingrulesetsforwardingrule_v1api20220701
+  - apiVersion: network.azure.com/v1api20180501
+    filename: network.azure.com/dnszonesaaaarecord_v1api20180501.json
+    kind: dnszonesaaaarecord
+    name: dnszonesaaaarecord_v1api20180501
+  - apiVersion: network.azure.com/v1api20240101
+    filename: network.azure.com/applicationsecuritygroup_v1api20240101.json
+    kind: applicationSecurityGroup
+    name: applicationsecuritygroup_v1api20240101
+  - apiVersion: network.azure.com/v1api20220401
+    filename: network.azure.com/trafficmanagerprofilesexternalendpoint_v1api20220401.json
+    kind: trafficmanagerprofilesexternalendpoint
+    name: trafficmanagerprofilesexternalendpoint_v1api20220401
+network.azure.m.upbound.io:
+  - apiVersion: network.azure.m.upbound.io/v1beta1
+    filename: network.azure.m.upbound.io/firewallpolicyrulecollectiongroup_v1beta1.json
+    kind: FirewallPolicyRuleCollectionGroup
+    name: firewallpolicyrulecollectiongroup_v1beta1
 network.azure.upbound.io:
   - apiVersion: network.azure.upbound.io/v1beta1
     filename: network.azure.upbound.io/firewallpolicyrulecollectiongroup_v1beta1.json
     kind: FirewallPolicyRuleCollectionGroup
     name: firewallpolicyrulecollectiongroup_v1beta1
+network.frontdoor.azure.com:
+  - apiVersion: network.frontdoor.azure.com/v1api20220501
+    filename: network.frontdoor.azure.com/webapplicationfirewallpolicy_v1api20220501.json
+    kind: webapplicationfirewallpolicy
+    name: webapplicationfirewallpolicy_v1api20220501
 networkconnectivity.cnrm.cloud.google.com:
   - apiVersion: networkconnectivity.cnrm.cloud.google.com/v1alpha1
     filename: networkconnectivity.cnrm.cloud.google.com/networkconnectivityserviceconnectionpolicy_v1alpha1.json
@@ -6024,6 +11218,59 @@ networking.gke.io:
     filename: networking.gke.io/networklogging_v1alpha1.json
     kind: NetworkLogging
     name: networklogging_v1alpha1
+  - apiVersion: networking.gke.io/v1
+    filename: networking.gke.io/servicefunctionchain_v1.json
+    kind: ServiceFunctionChain
+    name: servicefunctionchain_v1
+  - apiVersion: networking.gke.io/v1
+    filename: networking.gke.io/trafficselector_v1.json
+    kind: TrafficSelector
+    name: trafficselector_v1
+  - apiVersion: networking.gke.io/v1alpha1
+    filename: networking.gke.io/fqdnnetworkpolicy_v1alpha1.json
+    kind: FQDNNetworkPolicy
+    name: fqdnnetworkpolicy_v1alpha1
+  - apiVersion: networking.gke.io/v1
+    filename: networking.gke.io/gcproutingextension_v1.json
+    kind: GCPRoutingExtension
+    name: gcproutingextension_v1
+  - apiVersion: networking.gke.io/v1
+    filename: networking.gke.io/nodetopology_v1.json
+    kind: NodeTopology
+    name: nodetopology_v1
+  - apiVersion: networking.gke.io/v1
+    filename: networking.gke.io/gcpwasmplugin_v1.json
+    kind: GCPWasmPlugin
+    name: gcpwasmplugin_v1
+  - apiVersion: networking.gke.io/v1
+    filename: networking.gke.io/gcptrafficextension_v1.json
+    kind: GCPTrafficExtension
+    name: gcptrafficextension_v1
+  - apiVersion: networking.gke.io/v1
+    filename: networking.gke.io/gkeiproute_v1.json
+    kind: GKEIPRoute
+    name: gkeiproute_v1
+  - apiVersion: networking.gke.io/v1
+    filename: networking.gke.io/gcptrafficdistributionpolicy_v1.json
+    kind: GCPTrafficDistributionPolicy
+    name: gcptrafficdistributionpolicy_v1
+networking.internal.knative.dev:
+  - apiVersion: networking.internal.knative.dev/v1alpha1
+    filename: networking.internal.knative.dev/certificate_v1alpha1.json
+    kind: Certificate
+    name: certificate_v1alpha1
+  - apiVersion: networking.internal.knative.dev/v1alpha1
+    filename: networking.internal.knative.dev/serverlessservice_v1alpha1.json
+    kind: ServerlessService
+    name: serverlessservice_v1alpha1
+  - apiVersion: networking.internal.knative.dev/v1alpha1
+    filename: networking.internal.knative.dev/ingress_v1alpha1.json
+    kind: Ingress
+    name: ingress_v1alpha1
+  - apiVersion: networking.internal.knative.dev/v1alpha1
+    filename: networking.internal.knative.dev/clusterdomainclaim_v1alpha1.json
+    kind: ClusterDomainClaim
+    name: clusterdomainclaim_v1alpha1
 networking.istio.io:
   - apiVersion: networking.istio.io/v1
     filename: networking.istio.io/workloadgroup_v1.json
@@ -6122,6 +11369,18 @@ networking.k8s.aws:
     filename: networking.k8s.aws/policyendpoint_v1alpha1.json
     kind: PolicyEndpoint
     name: policyendpoint_v1alpha1
+  - apiVersion: networking.k8s.aws/v1alpha1
+    filename: networking.k8s.aws/clusternetworkpolicy_v1alpha1.json
+    kind: ClusterNetworkPolicy
+    name: clusternetworkpolicy_v1alpha1
+  - apiVersion: networking.k8s.aws/v1alpha1
+    filename: networking.k8s.aws/clusterpolicyendpoint_v1alpha1.json
+    kind: ClusterPolicyEndpoint
+    name: clusterpolicyendpoint_v1alpha1
+  - apiVersion: networking.k8s.aws/v1alpha1
+    filename: networking.k8s.aws/applicationnetworkpolicy_v1alpha1.json
+    kind: ApplicationNetworkPolicy
+    name: applicationnetworkpolicy_v1alpha1
 networkmanagement.cnrm.cloud.google.com:
   - apiVersion: networkmanagement.cnrm.cloud.google.com/v1alpha1
     filename: networkmanagement.cnrm.cloud.google.com/networkmanagementconnectivitytest_v1alpha1.json
@@ -6181,11 +11440,32 @@ networkservices.cnrm.cloud.google.com:
     filename: networkservices.cnrm.cloud.google.com/networkserviceshttproute_v1beta1.json
     kind: networkserviceshttproute
     name: networkserviceshttproute_v1beta1
+nfd.k8s-sigs.io:
+  - apiVersion: nfd.k8s-sigs.io/v1alpha1
+    filename: nfd.k8s-sigs.io/nodefeaturerule_v1alpha1.json
+    kind: NodeFeatureRule
+    name: nodefeaturerule_v1alpha1
+  - apiVersion: nfd.k8s-sigs.io/v1alpha1
+    filename: nfd.k8s-sigs.io/nodefeature_v1alpha1.json
+    kind: NodeFeature
+    name: nodefeature_v1alpha1
+  - apiVersion: nfd.k8s-sigs.io/v1alpha1
+    filename: nfd.k8s-sigs.io/nodefeaturegroup_v1alpha1.json
+    kind: NodeFeatureGroup
+    name: nodefeaturegroup_v1alpha1
 notebooks.cnrm.cloud.google.com:
   - apiVersion: notebooks.cnrm.cloud.google.com/v1alpha1
     filename: notebooks.cnrm.cloud.google.com/notebooksenvironment_v1alpha1.json
     kind: notebooksenvironment
     name: notebooksenvironment_v1alpha1
+  - apiVersion: notebooks.cnrm.cloud.google.com/v1beta1
+    filename: notebooks.cnrm.cloud.google.com/notebookinstance_v1beta1.json
+    kind: NotebookInstance
+    name: notebookinstance_v1beta1
+  - apiVersion: notebooks.cnrm.cloud.google.com/v1alpha1
+    filename: notebooks.cnrm.cloud.google.com/notebookinstance_v1alpha1.json
+    kind: NotebookInstance
+    name: notebookinstance_v1alpha1
 notification.toolkit.fluxcd.io:
   - apiVersion: notification.toolkit.fluxcd.io/v1beta1
     filename: notification.toolkit.fluxcd.io/alert_v1beta1.json
@@ -6223,6 +11503,32 @@ notification.toolkit.fluxcd.io:
     filename: notification.toolkit.fluxcd.io/alert_v1beta2.json
     kind: Alert
     name: alert_v1beta2
+notificationhubs.azure.com:
+  - apiVersion: notificationhubs.azure.com/v1api20230901
+    filename: notificationhubs.azure.com/notificationhub_v1api20230901.json
+    kind: notificationhub
+    name: notificationhub_v1api20230901
+  - apiVersion: notificationhubs.azure.com/v1api20230901
+    filename: notificationhubs.azure.com/namespacesauthorizationrule_v1api20230901.json
+    kind: namespacesauthorizationrule
+    name: namespacesauthorizationrule_v1api20230901
+  - apiVersion: notificationhubs.azure.com/v1api20230901
+    filename: notificationhubs.azure.com/notificationhubsauthorizationrule_v1api20230901.json
+    kind: notificationhubsauthorizationrule
+    name: notificationhubsauthorizationrule_v1api20230901
+  - apiVersion: notificationhubs.azure.com/v1api20230901
+    filename: notificationhubs.azure.com/namespace_v1api20230901.json
+    kind: namespace
+    name: namespace_v1api20230901
+nvidia.com:
+  - apiVersion: nvidia.com/v1alpha1
+    filename: nvidia.com/nvidiadriver_v1alpha1.json
+    kind: NVIDIADriver
+    name: nvidiadriver_v1alpha1
+  - apiVersion: nvidia.com/v1
+    filename: nvidia.com/clusterpolicy_v1.json
+    kind: ClusterPolicy
+    name: clusterpolicy_v1
 objectbucket.io:
   - apiVersion: objectbucket.io/v1alpha1
     filename: objectbucket.io/objectbucketclaim_v1alpha1.json
@@ -6261,6 +11567,84 @@ oncall.grafana.crossplane.io:
     filename: oncall.grafana.crossplane.io/integration_v1alpha1.json
     kind: Integration
     name: integration_v1alpha1
+  - apiVersion: oncall.grafana.crossplane.io/v1alpha1
+    filename: oncall.grafana.crossplane.io/usernotificationrule_v1alpha1.json
+    kind: UserNotificationRule
+    name: usernotificationrule_v1alpha1
+oncall.grafana.m.crossplane.io:
+  - apiVersion: oncall.grafana.m.crossplane.io/v1alpha1
+    filename: oncall.grafana.m.crossplane.io/oncallshift_v1alpha1.json
+    kind: OnCallShift
+    name: oncallshift_v1alpha1
+  - apiVersion: oncall.grafana.m.crossplane.io/v1alpha1
+    filename: oncall.grafana.m.crossplane.io/usernotificationrule_v1alpha1.json
+    kind: UserNotificationRule
+    name: usernotificationrule_v1alpha1
+  - apiVersion: oncall.grafana.m.crossplane.io/v1alpha1
+    filename: oncall.grafana.m.crossplane.io/escalation_v1alpha1.json
+    kind: Escalation
+    name: escalation_v1alpha1
+  - apiVersion: oncall.grafana.m.crossplane.io/v1alpha1
+    filename: oncall.grafana.m.crossplane.io/escalationchain_v1alpha1.json
+    kind: EscalationChain
+    name: escalationchain_v1alpha1
+  - apiVersion: oncall.grafana.m.crossplane.io/v1alpha1
+    filename: oncall.grafana.m.crossplane.io/schedule_v1alpha1.json
+    kind: Schedule
+    name: schedule_v1alpha1
+  - apiVersion: oncall.grafana.m.crossplane.io/v1alpha1
+    filename: oncall.grafana.m.crossplane.io/integration_v1alpha1.json
+    kind: Integration
+    name: integration_v1alpha1
+  - apiVersion: oncall.grafana.m.crossplane.io/v1alpha1
+    filename: oncall.grafana.m.crossplane.io/outgoingwebhook_v1alpha1.json
+    kind: OutgoingWebhook
+    name: outgoingwebhook_v1alpha1
+  - apiVersion: oncall.grafana.m.crossplane.io/v1alpha1
+    filename: oncall.grafana.m.crossplane.io/route_v1alpha1.json
+    kind: Route
+    name: route_v1alpha1
+oncall.grafana.o.crossplane.io:
+  - apiVersion: oncall.grafana.o.crossplane.io/v1alpha1
+    filename: oncall.grafana.o.crossplane.io/slackchannel_v1alpha1.json
+    kind: SlackChannel
+    name: slackchannel_v1alpha1
+  - apiVersion: oncall.grafana.o.crossplane.io/v1alpha1
+    filename: oncall.grafana.o.crossplane.io/user_v1alpha1.json
+    kind: User
+    name: user_v1alpha1
+  - apiVersion: oncall.grafana.o.crossplane.io/v1alpha1
+    filename: oncall.grafana.o.crossplane.io/escalationchain_v1alpha1.json
+    kind: EscalationChain
+    name: escalationchain_v1alpha1
+  - apiVersion: oncall.grafana.o.crossplane.io/v1alpha1
+    filename: oncall.grafana.o.crossplane.io/team_v1alpha1.json
+    kind: Team
+    name: team_v1alpha1
+  - apiVersion: oncall.grafana.o.crossplane.io/v1alpha1
+    filename: oncall.grafana.o.crossplane.io/schedule_v1alpha1.json
+    kind: Schedule
+    name: schedule_v1alpha1
+  - apiVersion: oncall.grafana.o.crossplane.io/v1alpha1
+    filename: oncall.grafana.o.crossplane.io/integration_v1alpha1.json
+    kind: Integration
+    name: integration_v1alpha1
+  - apiVersion: oncall.grafana.o.crossplane.io/v1alpha1
+    filename: oncall.grafana.o.crossplane.io/userset_v1alpha1.json
+    kind: UserSet
+    name: userset_v1alpha1
+  - apiVersion: oncall.grafana.o.crossplane.io/v1alpha1
+    filename: oncall.grafana.o.crossplane.io/label_v1alpha1.json
+    kind: Label
+    name: label_v1alpha1
+  - apiVersion: oncall.grafana.o.crossplane.io/v1alpha1
+    filename: oncall.grafana.o.crossplane.io/usergroup_v1alpha1.json
+    kind: UserGroup
+    name: usergroup_v1alpha1
+  - apiVersion: oncall.grafana.o.crossplane.io/v1alpha1
+    filename: oncall.grafana.o.crossplane.io/outgoingwebhook_v1alpha1.json
+    kind: OutgoingWebhook
+    name: outgoingwebhook_v1alpha1
 onepassword.com:
   - apiVersion: onepassword.com/v1
     filename: onepassword.com/onepassworditem_v1.json
@@ -6283,6 +11667,15 @@ openebs.io:
     filename: openebs.io/diskpool_v1beta2.json
     kind: DiskPool
     name: diskpool_v1beta2
+openreports.io:
+  - apiVersion: openreports.io/v1alpha1
+    filename: openreports.io/clusterreport_v1alpha1.json
+    kind: ClusterReport
+    name: clusterreport_v1alpha1
+  - apiVersion: openreports.io/v1alpha1
+    filename: openreports.io/report_v1alpha1.json
+    kind: Report
+    name: report_v1alpha1
 opensearchservice.services.k8s.aws:
   - apiVersion: opensearchservice.services.k8s.aws/v1alpha1
     filename: opensearchservice.services.k8s.aws/domain_v1alpha1.json
@@ -6309,6 +11702,11 @@ opentelemetry.io:
     filename: opentelemetry.io/targetallocator_v1alpha1.json
     kind: targetallocator
     name: targetallocator_v1alpha1
+operationalinsights.azure.com:
+  - apiVersion: operationalinsights.azure.com/v1api20210601
+    filename: operationalinsights.azure.com/workspace_v1api20210601.json
+    kind: Workspace
+    name: workspace_v1api20210601
 operator.cluster.x-k8s.io:
   - apiVersion: operator.cluster.x-k8s.io/v1alpha2
     filename: operator.cluster.x-k8s.io/addonprovider_v1alpha2.json
@@ -6354,6 +11752,29 @@ operator.cluster.x-k8s.io:
     filename: operator.cluster.x-k8s.io/runtimeextensionprovider_v1alpha2.json
     kind: RuntimeExtensionProvider
     name: runtimeextensionprovider_v1alpha2
+operator.h3poteto.dev:
+  - apiVersion: operator.h3poteto.dev/v1alpha1
+    filename: operator.h3poteto.dev/endpointgroupbinding_v1alpha1.json
+    kind: EndpointGroupBinding
+    name: endpointgroupbinding_v1alpha1
+operator.knative.dev:
+  - apiVersion: operator.knative.dev/v1beta1
+    filename: operator.knative.dev/knativeeventing_v1beta1.json
+    kind: KnativeEventing
+    name: knativeeventing_v1beta1
+  - apiVersion: operator.knative.dev/v1beta1
+    filename: operator.knative.dev/knativeserving_v1beta1.json
+    kind: KnativeServing
+    name: knativeserving_v1beta1
+operator.open-cluster-management.io:
+  - apiVersion: operator.open-cluster-management.io/v1
+    filename: operator.open-cluster-management.io/klusterlet_v1.json
+    kind: Klusterlet
+    name: klusterlet_v1
+  - apiVersion: operator.open-cluster-management.io/v1
+    filename: operator.open-cluster-management.io/clustermanager_v1.json
+    kind: ClusterManager
+    name: clustermanager_v1
 operator.tigera.io:
   - apiVersion: operator.tigera.io/v1
     filename: operator.tigera.io/tigerastatus_v1.json
@@ -6436,6 +11857,30 @@ operator.victoriametrics.com:
     filename: operator.victoriametrics.com/vmstaticscrape_v1beta1.json
     kind: VMStaticScrape
     name: vmstaticscrape_v1beta1
+  - apiVersion: operator.victoriametrics.com/v1
+    filename: operator.victoriametrics.com/vmanomaly_v1.json
+    kind: VMAnomaly
+    name: vmanomaly_v1
+  - apiVersion: operator.victoriametrics.com/v1
+    filename: operator.victoriametrics.com/vlsingle_v1.json
+    kind: vlsingle
+    name: vlsingle_v1
+  - apiVersion: operator.victoriametrics.com/v1
+    filename: operator.victoriametrics.com/vtsingle_v1.json
+    kind: vtsingle
+    name: vtsingle_v1
+  - apiVersion: operator.victoriametrics.com/v1
+    filename: operator.victoriametrics.com/vtcluster_v1.json
+    kind: VTCluster
+    name: vtcluster_v1
+  - apiVersion: operator.victoriametrics.com/v1
+    filename: operator.victoriametrics.com/vlagent_v1.json
+    kind: VLAgent
+    name: vlagent_v1
+  - apiVersion: operator.victoriametrics.com/v1
+    filename: operator.victoriametrics.com/vlcluster_v1.json
+    kind: vlcluster
+    name: vlcluster_v1
 operators.coreos.com:
   - apiVersion: operators.coreos.com/v2
     filename: operators.coreos.com/operatorcondition_v2.json
@@ -6477,6 +11922,19 @@ operators.coreos.com:
     filename: operators.coreos.com/operator_v1.json
     kind: Operator
     name: operator_v1
+ops.crossplane.io:
+  - apiVersion: ops.crossplane.io/v1alpha1
+    filename: ops.crossplane.io/operation_v1alpha1.json
+    kind: Operation
+    name: operation_v1alpha1
+  - apiVersion: ops.crossplane.io/v1alpha1
+    filename: ops.crossplane.io/cronoperation_v1alpha1.json
+    kind: CronOperation
+    name: cronoperation_v1alpha1
+  - apiVersion: ops.crossplane.io/v1alpha1
+    filename: ops.crossplane.io/watchoperation_v1alpha1.json
+    kind: WatchOperation
+    name: watchoperation_v1alpha1
 organizations.services.k8s.aws:
   - apiVersion: organizations.services.k8s.aws/v1alpha1
     filename: organizations.services.k8s.aws/organizationalunit_v1alpha1.json
@@ -6487,6 +11945,10 @@ orgpolicy.cnrm.cloud.google.com:
     filename: orgpolicy.cnrm.cloud.google.com/orgpolicycustomconstraint_v1alpha1.json
     kind: orgpolicycustomconstraint
     name: orgpolicycustomconstraint_v1alpha1
+  - apiVersion: orgpolicy.cnrm.cloud.google.com/v1beta1
+    filename: orgpolicy.cnrm.cloud.google.com/orgpolicycustomconstraint_v1beta1.json
+    kind: OrgPolicyCustomConstraint
+    name: orgpolicycustomconstraint_v1beta1
 osconfig.cnrm.cloud.google.com:
   - apiVersion: osconfig.cnrm.cloud.google.com/v1alpha1
     filename: osconfig.cnrm.cloud.google.com/osconfigpatchdeployment_v1alpha1.json
@@ -6578,6 +12040,236 @@ oss.grafana.crossplane.io:
     filename: oss.grafana.crossplane.io/serviceaccounttoken_v1alpha1.json
     kind: ServiceAccountToken
     name: serviceaccounttoken_v1alpha1
+  - apiVersion: oss.grafana.crossplane.io/v1alpha1
+    filename: oss.grafana.crossplane.io/serviceaccountrotatingtoken_v1alpha1.json
+    kind: ServiceAccountRotatingToken
+    name: serviceaccountrotatingtoken_v1alpha1
+  - apiVersion: oss.grafana.crossplane.io/v1alpha1
+    filename: oss.grafana.crossplane.io/dashboardv1beta1_v1alpha1.json
+    kind: DashboardV1Beta1
+    name: dashboardv1beta1_v1alpha1
+  - apiVersion: oss.grafana.crossplane.io/v1alpha1
+    filename: oss.grafana.crossplane.io/datasourceconfig_v1alpha1.json
+    kind: DataSourceConfig
+    name: datasourceconfig_v1alpha1
+  - apiVersion: oss.grafana.crossplane.io/v1alpha1
+    filename: oss.grafana.crossplane.io/folderpermissionitem_v1alpha1.json
+    kind: FolderPermissionItem
+    name: folderpermissionitem_v1alpha1
+  - apiVersion: oss.grafana.crossplane.io/v1alpha1
+    filename: oss.grafana.crossplane.io/repositoryv0alpha1_v1alpha1.json
+    kind: RepositoryV0Alpha1
+    name: repositoryv0alpha1_v1alpha1
+  - apiVersion: oss.grafana.crossplane.io/v1alpha1
+    filename: oss.grafana.crossplane.io/serviceaccountpermissionitem_v1alpha1.json
+    kind: ServiceAccountPermissionItem
+    name: serviceaccountpermissionitem_v1alpha1
+  - apiVersion: oss.grafana.crossplane.io/v1alpha1
+    filename: oss.grafana.crossplane.io/dashboardv2_v1alpha1.json
+    kind: DashboardV2
+    name: dashboardv2_v1alpha1
+  - apiVersion: oss.grafana.crossplane.io/v1alpha1
+    filename: oss.grafana.crossplane.io/resource_v1alpha1.json
+    kind: Resource
+    name: resource_v1alpha1
+  - apiVersion: oss.grafana.crossplane.io/v1alpha1
+    filename: oss.grafana.crossplane.io/playlistv1_v1alpha1.json
+    kind: PlaylistV1
+    name: playlistv1_v1alpha1
+  - apiVersion: oss.grafana.crossplane.io/v1alpha1
+    filename: oss.grafana.crossplane.io/connectionv0alpha1_v1alpha1.json
+    kind: ConnectionV0Alpha1
+    name: connectionv0alpha1_v1alpha1
+  - apiVersion: oss.grafana.crossplane.io/v1alpha1
+    filename: oss.grafana.crossplane.io/dashboardv2beta1_v1alpha1.json
+    kind: DashboardV2Beta1
+    name: dashboardv2beta1_v1alpha1
+  - apiVersion: oss.grafana.crossplane.io/v1alpha1
+    filename: oss.grafana.crossplane.io/dashboardpermissionitem_v1alpha1.json
+    kind: DashboardPermissionItem
+    name: dashboardpermissionitem_v1alpha1
+  - apiVersion: oss.grafana.crossplane.io/v1alpha1
+    filename: oss.grafana.crossplane.io/playlistv0alpha1_v1alpha1.json
+    kind: PlaylistV0Alpha1
+    name: playlistv0alpha1_v1alpha1
+oss.grafana.m.crossplane.io:
+  - apiVersion: oss.grafana.m.crossplane.io/v1alpha1
+    filename: oss.grafana.m.crossplane.io/playlist_v1alpha1.json
+    kind: Playlist
+    name: playlist_v1alpha1
+  - apiVersion: oss.grafana.m.crossplane.io/v1alpha1
+    filename: oss.grafana.m.crossplane.io/organizationpreferences_v1alpha1.json
+    kind: OrganizationPreferences
+    name: organizationpreferences_v1alpha1
+  - apiVersion: oss.grafana.m.crossplane.io/v1alpha1
+    filename: oss.grafana.m.crossplane.io/serviceaccountrotatingtoken_v1alpha1.json
+    kind: ServiceAccountRotatingToken
+    name: serviceaccountrotatingtoken_v1alpha1
+  - apiVersion: oss.grafana.m.crossplane.io/v1alpha1
+    filename: oss.grafana.m.crossplane.io/organization_v1alpha1.json
+    kind: Organization
+    name: organization_v1alpha1
+  - apiVersion: oss.grafana.m.crossplane.io/v1alpha1
+    filename: oss.grafana.m.crossplane.io/dashboardv1beta1_v1alpha1.json
+    kind: DashboardV1Beta1
+    name: dashboardv1beta1_v1alpha1
+  - apiVersion: oss.grafana.m.crossplane.io/v1alpha1
+    filename: oss.grafana.m.crossplane.io/datasourceconfig_v1alpha1.json
+    kind: DataSourceConfig
+    name: datasourceconfig_v1alpha1
+  - apiVersion: oss.grafana.m.crossplane.io/v1alpha1
+    filename: oss.grafana.m.crossplane.io/folderpermissionitem_v1alpha1.json
+    kind: FolderPermissionItem
+    name: folderpermissionitem_v1alpha1
+  - apiVersion: oss.grafana.m.crossplane.io/v1alpha1
+    filename: oss.grafana.m.crossplane.io/user_v1alpha1.json
+    kind: User
+    name: user_v1alpha1
+  - apiVersion: oss.grafana.m.crossplane.io/v1alpha1
+    filename: oss.grafana.m.crossplane.io/serviceaccounttoken_v1alpha1.json
+    kind: ServiceAccountToken
+    name: serviceaccounttoken_v1alpha1
+  - apiVersion: oss.grafana.m.crossplane.io/v1alpha1
+    filename: oss.grafana.m.crossplane.io/repositoryv0alpha1_v1alpha1.json
+    kind: RepositoryV0Alpha1
+    name: repositoryv0alpha1_v1alpha1
+  - apiVersion: oss.grafana.m.crossplane.io/v1alpha1
+    filename: oss.grafana.m.crossplane.io/serviceaccountpermissionitem_v1alpha1.json
+    kind: ServiceAccountPermissionItem
+    name: serviceaccountpermissionitem_v1alpha1
+  - apiVersion: oss.grafana.m.crossplane.io/v1alpha1
+    filename: oss.grafana.m.crossplane.io/dashboardv2_v1alpha1.json
+    kind: DashboardV2
+    name: dashboardv2_v1alpha1
+  - apiVersion: oss.grafana.m.crossplane.io/v1alpha1
+    filename: oss.grafana.m.crossplane.io/dashboardpermission_v1alpha1.json
+    kind: DashboardPermission
+    name: dashboardpermission_v1alpha1
+  - apiVersion: oss.grafana.m.crossplane.io/v1alpha1
+    filename: oss.grafana.m.crossplane.io/resource_v1alpha1.json
+    kind: Resource
+    name: resource_v1alpha1
+  - apiVersion: oss.grafana.m.crossplane.io/v1alpha1
+    filename: oss.grafana.m.crossplane.io/datasource_v1alpha1.json
+    kind: DataSource
+    name: datasource_v1alpha1
+  - apiVersion: oss.grafana.m.crossplane.io/v1alpha1
+    filename: oss.grafana.m.crossplane.io/folder_v1alpha1.json
+    kind: Folder
+    name: folder_v1alpha1
+  - apiVersion: oss.grafana.m.crossplane.io/v1alpha1
+    filename: oss.grafana.m.crossplane.io/librarypanel_v1alpha1.json
+    kind: LibraryPanel
+    name: librarypanel_v1alpha1
+  - apiVersion: oss.grafana.m.crossplane.io/v1alpha1
+    filename: oss.grafana.m.crossplane.io/playlistv1_v1alpha1.json
+    kind: PlaylistV1
+    name: playlistv1_v1alpha1
+  - apiVersion: oss.grafana.m.crossplane.io/v1alpha1
+    filename: oss.grafana.m.crossplane.io/team_v1alpha1.json
+    kind: Team
+    name: team_v1alpha1
+  - apiVersion: oss.grafana.m.crossplane.io/v1alpha1
+    filename: oss.grafana.m.crossplane.io/connectionv0alpha1_v1alpha1.json
+    kind: ConnectionV0Alpha1
+    name: connectionv0alpha1_v1alpha1
+  - apiVersion: oss.grafana.m.crossplane.io/v1alpha1
+    filename: oss.grafana.m.crossplane.io/dashboardv2beta1_v1alpha1.json
+    kind: DashboardV2Beta1
+    name: dashboardv2beta1_v1alpha1
+  - apiVersion: oss.grafana.m.crossplane.io/v1alpha1
+    filename: oss.grafana.m.crossplane.io/serviceaccount_v1alpha1.json
+    kind: ServiceAccount
+    name: serviceaccount_v1alpha1
+  - apiVersion: oss.grafana.m.crossplane.io/v1alpha1
+    filename: oss.grafana.m.crossplane.io/serviceaccountpermission_v1alpha1.json
+    kind: ServiceAccountPermission
+    name: serviceaccountpermission_v1alpha1
+  - apiVersion: oss.grafana.m.crossplane.io/v1alpha1
+    filename: oss.grafana.m.crossplane.io/dashboard_v1alpha1.json
+    kind: Dashboard
+    name: dashboard_v1alpha1
+  - apiVersion: oss.grafana.m.crossplane.io/v1alpha1
+    filename: oss.grafana.m.crossplane.io/annotation_v1alpha1.json
+    kind: Annotation
+    name: annotation_v1alpha1
+  - apiVersion: oss.grafana.m.crossplane.io/v1alpha1
+    filename: oss.grafana.m.crossplane.io/dashboardpublic_v1alpha1.json
+    kind: DashboardPublic
+    name: dashboardpublic_v1alpha1
+  - apiVersion: oss.grafana.m.crossplane.io/v1alpha1
+    filename: oss.grafana.m.crossplane.io/dashboardpermissionitem_v1alpha1.json
+    kind: DashboardPermissionItem
+    name: dashboardpermissionitem_v1alpha1
+  - apiVersion: oss.grafana.m.crossplane.io/v1alpha1
+    filename: oss.grafana.m.crossplane.io/ssosettings_v1alpha1.json
+    kind: SsoSettings
+    name: ssosettings_v1alpha1
+  - apiVersion: oss.grafana.m.crossplane.io/v1alpha1
+    filename: oss.grafana.m.crossplane.io/folderpermission_v1alpha1.json
+    kind: FolderPermission
+    name: folderpermission_v1alpha1
+  - apiVersion: oss.grafana.m.crossplane.io/v1alpha1
+    filename: oss.grafana.m.crossplane.io/playlistv0alpha1_v1alpha1.json
+    kind: PlaylistV0Alpha1
+    name: playlistv0alpha1_v1alpha1
+oss.grafana.o.crossplane.io:
+  - apiVersion: oss.grafana.o.crossplane.io/v1alpha1
+    filename: oss.grafana.o.crossplane.io/organizationpreferences_v1alpha1.json
+    kind: OrganizationPreferences
+    name: organizationpreferences_v1alpha1
+  - apiVersion: oss.grafana.o.crossplane.io/v1alpha1
+    filename: oss.grafana.o.crossplane.io/organization_v1alpha1.json
+    kind: Organization
+    name: organization_v1alpha1
+  - apiVersion: oss.grafana.o.crossplane.io/v1alpha1
+    filename: oss.grafana.o.crossplane.io/user_v1alpha1.json
+    kind: User
+    name: user_v1alpha1
+  - apiVersion: oss.grafana.o.crossplane.io/v1alpha1
+    filename: oss.grafana.o.crossplane.io/datasource_v1alpha1.json
+    kind: DataSource
+    name: datasource_v1alpha1
+  - apiVersion: oss.grafana.o.crossplane.io/v1alpha1
+    filename: oss.grafana.o.crossplane.io/folder_v1alpha1.json
+    kind: Folder
+    name: folder_v1alpha1
+  - apiVersion: oss.grafana.o.crossplane.io/v1alpha1
+    filename: oss.grafana.o.crossplane.io/librarypanel_v1alpha1.json
+    kind: LibraryPanel
+    name: librarypanel_v1alpha1
+  - apiVersion: oss.grafana.o.crossplane.io/v1alpha1
+    filename: oss.grafana.o.crossplane.io/team_v1alpha1.json
+    kind: Team
+    name: team_v1alpha1
+  - apiVersion: oss.grafana.o.crossplane.io/v1alpha1
+    filename: oss.grafana.o.crossplane.io/organizationuser_v1alpha1.json
+    kind: OrganizationUser
+    name: organizationuser_v1alpha1
+  - apiVersion: oss.grafana.o.crossplane.io/v1alpha1
+    filename: oss.grafana.o.crossplane.io/serviceaccount_v1alpha1.json
+    kind: ServiceAccount
+    name: serviceaccount_v1alpha1
+  - apiVersion: oss.grafana.o.crossplane.io/v1alpha1
+    filename: oss.grafana.o.crossplane.io/userset_v1alpha1.json
+    kind: UserSet
+    name: userset_v1alpha1
+  - apiVersion: oss.grafana.o.crossplane.io/v1alpha1
+    filename: oss.grafana.o.crossplane.io/folderset_v1alpha1.json
+    kind: FolderSet
+    name: folderset_v1alpha1
+  - apiVersion: oss.grafana.o.crossplane.io/v1alpha1
+    filename: oss.grafana.o.crossplane.io/dashboard_v1alpha1.json
+    kind: Dashboard
+    name: dashboard_v1alpha1
+  - apiVersion: oss.grafana.o.crossplane.io/v1alpha1
+    filename: oss.grafana.o.crossplane.io/librarypanelset_v1alpha1.json
+    kind: LibraryPanelSet
+    name: librarypanelset_v1alpha1
+  - apiVersion: oss.grafana.o.crossplane.io/v1alpha1
+    filename: oss.grafana.o.crossplane.io/dashboardset_v1alpha1.json
+    kind: DashboardSet
+    name: dashboardset_v1alpha1
 packages.eks.amazonaws.com:
   - apiVersion: packages.eks.amazonaws.com/v1alpha1
     filename: packages.eks.amazonaws.com/packagebundlecontroller_v1alpha1.json
@@ -6658,6 +12350,23 @@ pipes.services.k8s.aws:
     filename: pipes.services.k8s.aws/pipe_v1alpha1.json
     kind: Pipe
     name: pipe_v1alpha1
+piraeus.io:
+  - apiVersion: piraeus.io/v1
+    filename: piraeus.io/linstorsatellite_v1.json
+    kind: LinstorSatellite
+    name: linstorsatellite_v1
+  - apiVersion: piraeus.io/v1
+    filename: piraeus.io/linstorsatelliteconfiguration_v1.json
+    kind: LinstorSatelliteConfiguration
+    name: linstorsatelliteconfiguration_v1
+  - apiVersion: piraeus.io/v1
+    filename: piraeus.io/linstornodeconnection_v1.json
+    kind: LinstorNodeConnection
+    name: linstornodeconnection_v1
+  - apiVersion: piraeus.io/v1
+    filename: piraeus.io/linstorcluster_v1.json
+    kind: LinstorCluster
+    name: linstorcluster_v1
 pkg.crossplane.io:
   - apiVersion: pkg.crossplane.io/v1
     filename: pkg.crossplane.io/configuration_v1.json
@@ -6772,6 +12481,159 @@ platform.confluent.io:
     filename: platform.confluent.io/controlcenter_v1beta1.json
     kind: ControlCenter
     name: controlcenter_v1beta1
+  - apiVersion: platform.confluent.io/v1beta1
+    filename: platform.confluent.io/kraftmigrationjob_v1beta1.json
+    kind: kraftmigrationjob
+    name: kraftmigrationjob_v1beta1
+  - apiVersion: platform.confluent.io/v1beta1
+    filename: platform.confluent.io/cmfrestclass_v1beta1.json
+    kind: cmfrestclass
+    name: cmfrestclass_v1beta1
+  - apiVersion: platform.confluent.io/v1beta1
+    filename: platform.confluent.io/flinkenvironment_v1beta1.json
+    kind: flinkenvironment
+    name: flinkenvironment_v1beta1
+  - apiVersion: platform.confluent.io/v1beta1
+    filename: platform.confluent.io/usmagent_v1beta1.json
+    kind: usmagent
+    name: usmagent_v1beta1
+  - apiVersion: platform.confluent.io/v1beta1
+    filename: platform.confluent.io/schemaimporter_v1beta1.json
+    kind: schemaimporter
+    name: schemaimporter_v1beta1
+  - apiVersion: platform.confluent.io/v1beta1
+    filename: platform.confluent.io/referencegrant_v1beta1.json
+    kind: ReferenceGrant
+    name: referencegrant_v1beta1
+  - apiVersion: platform.confluent.io/v1beta1
+    filename: platform.confluent.io/gateway_v1beta1.json
+    kind: gateway
+    name: gateway_v1beta1
+  - apiVersion: platform.confluent.io/v1beta1
+    filename: platform.confluent.io/flinkapplication_v1beta1.json
+    kind: flinkapplication
+    name: flinkapplication_v1beta1
+policies.kyverno.io:
+  - apiVersion: policies.kyverno.io/v1alpha1
+    filename: policies.kyverno.io/generatingpolicy_v1alpha1.json
+    kind: generatingpolicy
+    name: generatingpolicy_v1alpha1
+  - apiVersion: policies.kyverno.io/v1
+    filename: policies.kyverno.io/generatingpolicy_v1.json
+    kind: generatingpolicy
+    name: generatingpolicy_v1
+  - apiVersion: policies.kyverno.io/v1
+    filename: policies.kyverno.io/deletingpolicy_v1.json
+    kind: deletingpolicy
+    name: deletingpolicy_v1
+  - apiVersion: policies.kyverno.io/v1beta1
+    filename: policies.kyverno.io/namespacedmutatingpolicy_v1beta1.json
+    kind: namespacedmutatingpolicy
+    name: namespacedmutatingpolicy_v1beta1
+  - apiVersion: policies.kyverno.io/v1beta1
+    filename: policies.kyverno.io/mutatingpolicy_v1beta1.json
+    kind: mutatingpolicy
+    name: mutatingpolicy_v1beta1
+  - apiVersion: policies.kyverno.io/v1
+    filename: policies.kyverno.io/namespacedvalidatingpolicy_v1.json
+    kind: namespacedvalidatingpolicy
+    name: namespacedvalidatingpolicy_v1
+  - apiVersion: policies.kyverno.io/v1beta1
+    filename: policies.kyverno.io/namespacedvalidatingpolicy_v1beta1.json
+    kind: namespacedvalidatingpolicy
+    name: namespacedvalidatingpolicy_v1beta1
+  - apiVersion: policies.kyverno.io/v2
+    filename: policies.kyverno.io/policyexception_v2.json
+    kind: PolicyException
+    name: policyexception_v2
+  - apiVersion: policies.kyverno.io/v1
+    filename: policies.kyverno.io/namespacedmutatingpolicy_v1.json
+    kind: namespacedmutatingpolicy
+    name: namespacedmutatingpolicy_v1
+  - apiVersion: policies.kyverno.io/v1alpha1
+    filename: policies.kyverno.io/policyexception_v1alpha1.json
+    kind: PolicyException
+    name: policyexception_v1alpha1
+  - apiVersion: policies.kyverno.io/v1
+    filename: policies.kyverno.io/validatingpolicy_v1.json
+    kind: validatingpolicy
+    name: validatingpolicy_v1
+  - apiVersion: policies.kyverno.io/v2beta1
+    filename: policies.kyverno.io/policyexception_v2beta1.json
+    kind: PolicyException
+    name: policyexception_v2beta1
+  - apiVersion: policies.kyverno.io/v1alpha1
+    filename: policies.kyverno.io/validatingpolicy_v1alpha1.json
+    kind: validatingpolicy
+    name: validatingpolicy_v1alpha1
+  - apiVersion: policies.kyverno.io/v1beta1
+    filename: policies.kyverno.io/validatingpolicy_v1beta1.json
+    kind: validatingpolicy
+    name: validatingpolicy_v1beta1
+  - apiVersion: policies.kyverno.io/v1
+    filename: policies.kyverno.io/policyexception_v1.json
+    kind: PolicyException
+    name: policyexception_v1
+  - apiVersion: policies.kyverno.io/v1beta1
+    filename: policies.kyverno.io/imagevalidatingpolicy_v1beta1.json
+    kind: imagevalidatingpolicy
+    name: imagevalidatingpolicy_v1beta1
+  - apiVersion: policies.kyverno.io/v1alpha1
+    filename: policies.kyverno.io/imagevalidatingpolicy_v1alpha1.json
+    kind: imagevalidatingpolicy
+    name: imagevalidatingpolicy_v1alpha1
+  - apiVersion: policies.kyverno.io/v1beta1
+    filename: policies.kyverno.io/namespacedgeneratingpolicy_v1beta1.json
+    kind: NamespacedGeneratingPolicy
+    name: namespacedgeneratingpolicy_v1beta1
+  - apiVersion: policies.kyverno.io/v1alpha1
+    filename: policies.kyverno.io/deletingpolicy_v1alpha1.json
+    kind: deletingpolicy
+    name: deletingpolicy_v1alpha1
+  - apiVersion: policies.kyverno.io/v1beta1
+    filename: policies.kyverno.io/deletingpolicy_v1beta1.json
+    kind: deletingpolicy
+    name: deletingpolicy_v1beta1
+  - apiVersion: policies.kyverno.io/v1alpha1
+    filename: policies.kyverno.io/mutatingpolicy_v1alpha1.json
+    kind: mutatingpolicy
+    name: mutatingpolicy_v1alpha1
+  - apiVersion: policies.kyverno.io/v1
+    filename: policies.kyverno.io/namespacedgeneratingpolicy_v1.json
+    kind: NamespacedGeneratingPolicy
+    name: namespacedgeneratingpolicy_v1
+  - apiVersion: policies.kyverno.io/v1
+    filename: policies.kyverno.io/namespaceddeletingpolicy_v1.json
+    kind: namespaceddeletingpolicy
+    name: namespaceddeletingpolicy_v1
+  - apiVersion: policies.kyverno.io/v1
+    filename: policies.kyverno.io/mutatingpolicy_v1.json
+    kind: mutatingpolicy
+    name: mutatingpolicy_v1
+  - apiVersion: policies.kyverno.io/v1beta1
+    filename: policies.kyverno.io/generatingpolicy_v1beta1.json
+    kind: generatingpolicy
+    name: generatingpolicy_v1beta1
+  - apiVersion: policies.kyverno.io/v1beta1
+    filename: policies.kyverno.io/policyexception_v1beta1.json
+    kind: PolicyException
+    name: policyexception_v1beta1
+  - apiVersion: policies.kyverno.io/v1
+    filename: policies.kyverno.io/imagevalidatingpolicy_v1.json
+    kind: imagevalidatingpolicy
+    name: imagevalidatingpolicy_v1
+  - apiVersion: policies.kyverno.io/v1beta1
+    filename: policies.kyverno.io/namespacedimagevalidatingpolicy_v1beta1.json
+    kind: namespacedimagevalidatingpolicy
+    name: namespacedimagevalidatingpolicy_v1beta1
+  - apiVersion: policies.kyverno.io/v1beta1
+    filename: policies.kyverno.io/namespaceddeletingpolicy_v1beta1.json
+    kind: namespaceddeletingpolicy
+    name: namespaceddeletingpolicy_v1beta1
+  - apiVersion: policies.kyverno.io/v1
+    filename: policies.kyverno.io/namespacedimagevalidatingpolicy_v1.json
+    kind: namespacedimagevalidatingpolicy
+    name: namespacedimagevalidatingpolicy_v1
 policy.cert-manager.io:
   - apiVersion: policy.cert-manager.io/v1alpha1
     filename: policy.cert-manager.io/certificaterequestpolicy_v1alpha1.json
@@ -6826,6 +12688,22 @@ policy.linkerd.io:
     filename: policy.linkerd.io/authorizationpolicy_v1alpha1.json
     kind: authorizationpolicy
     name: authorizationpolicy_v1alpha1
+  - apiVersion: policy.linkerd.io/v1beta3
+    filename: policy.linkerd.io/server_v1beta3.json
+    kind: server
+    name: server_v1beta3
+  - apiVersion: policy.linkerd.io/v1alpha1
+    filename: policy.linkerd.io/egressnetwork_v1alpha1.json
+    kind: EgressNetwork
+    name: egressnetwork_v1alpha1
+  - apiVersion: policy.linkerd.io/v1alpha1
+    filename: policy.linkerd.io/httplocalratelimitpolicy_v1alpha1.json
+    kind: httplocalratelimitpolicy
+    name: httplocalratelimitpolicy_v1alpha1
+  - apiVersion: policy.linkerd.io/v1beta2
+    filename: policy.linkerd.io/server_v1beta2.json
+    kind: server
+    name: server_v1beta2
 policy.sigstore.dev:
   - apiVersion: policy.sigstore.dev/v1alpha1
     filename: policy.sigstore.dev/clusterimagepolicy_v1alpha1.json
@@ -6839,6 +12717,11 @@ policy.sigstore.dev:
     filename: policy.sigstore.dev/trustroot_v1alpha1.json
     kind: trustroot
     name: trustroot_v1alpha1
+pool.kubevirt.io:
+  - apiVersion: pool.kubevirt.io/v1alpha1
+    filename: pool.kubevirt.io/virtualmachinepool_v1alpha1.json
+    kind: VirtualMachinePool
+    name: virtualmachinepool_v1alpha1
 postgres-operator.crunchydata.com:
   - apiVersion: postgres-operator.crunchydata.com/v1beta1
     filename: postgres-operator.crunchydata.com/postgrescluster_v1beta1.json
@@ -6856,6 +12739,10 @@ postgres-operator.crunchydata.com:
     filename: postgres-operator.crunchydata.com/crunchybridgecluster_v1beta1.json
     kind: CrunchyBridgeCluster
     name: crunchybridgecluster_v1beta1
+  - apiVersion: postgres-operator.crunchydata.com/v1
+    filename: postgres-operator.crunchydata.com/postgrescluster_v1.json
+    kind: PostgresCluster
+    name: postgrescluster_v1
 postgresql.cnpg.io:
   - apiVersion: postgresql.cnpg.io/v1
     filename: postgresql.cnpg.io/backup_v1.json
@@ -6897,6 +12784,10 @@ postgresql.cnpg.io:
     filename: postgresql.cnpg.io/cluster_v1.json
     kind: Cluster
     name: cluster_v1
+  - apiVersion: postgresql.cnpg.io/v1
+    filename: postgresql.cnpg.io/failoverquorum_v1.json
+    kind: FailoverQuorum
+    name: failoverquorum_v1
 privateca.cnrm.cloud.google.com:
   - apiVersion: privateca.cnrm.cloud.google.com/v1beta1
     filename: privateca.cnrm.cloud.google.com/privatecacertificate_v1beta1.json
@@ -6923,6 +12814,99 @@ privilegedaccessmanager.cnrm.cloud.google.com:
     filename: privilegedaccessmanager.cnrm.cloud.google.com/privilegedaccessmanagerentitlement_v1beta1.json
     kind: PrivilegedAccessManagerEntitlement
     name: privilegedaccessmanagerentitlement_v1beta1
+projectcalico.org:
+  - apiVersion: projectcalico.org/v3
+    filename: projectcalico.org/ipamhandle_v3.json
+    kind: ipamhandle
+    name: ipamhandle_v3
+  - apiVersion: projectcalico.org/v3
+    filename: projectcalico.org/stagedkubernetesnetworkpolicy_v3.json
+    kind: stagedkubernetesnetworkpolicy
+    name: stagedkubernetesnetworkpolicy_v3
+  - apiVersion: projectcalico.org/v3
+    filename: projectcalico.org/networkpolicy_v3.json
+    kind: networkpolicy
+    name: networkpolicy_v3
+  - apiVersion: projectcalico.org/v3
+    filename: projectcalico.org/globalnetworkset_v3.json
+    kind: globalnetworkset
+    name: globalnetworkset_v3
+  - apiVersion: projectcalico.org/v3
+    filename: projectcalico.org/caliconodestatus_v3.json
+    kind: caliconodestatus
+    name: caliconodestatus_v3
+  - apiVersion: projectcalico.org/v3
+    filename: projectcalico.org/ipamconfiguration_v3.json
+    kind: ipamconfiguration
+    name: ipamconfiguration_v3
+  - apiVersion: projectcalico.org/v3
+    filename: projectcalico.org/hostendpoint_v3.json
+    kind: hostendpoint
+    name: hostendpoint_v3
+  - apiVersion: projectcalico.org/v3
+    filename: projectcalico.org/stagednetworkpolicy_v3.json
+    kind: stagednetworkpolicy
+    name: stagednetworkpolicy_v3
+  - apiVersion: projectcalico.org/v3
+    filename: projectcalico.org/tier_v3.json
+    kind: tier
+    name: tier_v3
+  - apiVersion: projectcalico.org/v3
+    filename: projectcalico.org/ipreservation_v3.json
+    kind: ipreservation
+    name: ipreservation_v3
+  - apiVersion: projectcalico.org/v3
+    filename: projectcalico.org/bgppeer_v3.json
+    kind: bgppeer
+    name: bgppeer_v3
+  - apiVersion: projectcalico.org/v3
+    filename: projectcalico.org/ippool_v3.json
+    kind: ippool
+    name: ippool_v3
+  - apiVersion: projectcalico.org/v3
+    filename: projectcalico.org/bgpfilter_v3.json
+    kind: bgpfilter
+    name: bgpfilter_v3
+  - apiVersion: projectcalico.org/v3
+    filename: projectcalico.org/ipamblock_v3.json
+    kind: ipamblock
+    name: ipamblock_v3
+  - apiVersion: projectcalico.org/v3
+    filename: projectcalico.org/networkset_v3.json
+    kind: networkset
+    name: networkset_v3
+  - apiVersion: projectcalico.org/v3
+    filename: projectcalico.org/felixconfiguration_v3.json
+    kind: felixconfiguration
+    name: felixconfiguration_v3
+  - apiVersion: projectcalico.org/v3
+    filename: projectcalico.org/clusterinformation_v3.json
+    kind: clusterinformation
+    name: clusterinformation_v3
+  - apiVersion: projectcalico.org/v3
+    filename: projectcalico.org/blockaffinity_v3.json
+    kind: blockaffinity
+    name: blockaffinity_v3
+  - apiVersion: projectcalico.org/v3
+    filename: projectcalico.org/bgpconfiguration_v3.json
+    kind: bgpconfiguration
+    name: bgpconfiguration_v3
+  - apiVersion: projectcalico.org/v3
+    filename: projectcalico.org/stagedglobalnetworkpolicy_v3.json
+    kind: stagedglobalnetworkpolicy
+    name: stagedglobalnetworkpolicy_v3
+  - apiVersion: projectcalico.org/v3
+    filename: projectcalico.org/profile_v3.json
+    kind: profile
+    name: profile_v3
+  - apiVersion: projectcalico.org/v3
+    filename: projectcalico.org/kubecontrollersconfiguration_v3.json
+    kind: kubecontrollersconfiguration
+    name: kubecontrollersconfiguration_v3
+  - apiVersion: projectcalico.org/v3
+    filename: projectcalico.org/globalnetworkpolicy_v3.json
+    kind: globalnetworkpolicy
+    name: globalnetworkpolicy_v3
 projectcontour.io:
   - apiVersion: projectcontour.io/v1alpha1
     filename: projectcontour.io/extensionservice_v1alpha1.json
@@ -6961,6 +12945,20 @@ prometheusservice.services.k8s.aws:
     filename: prometheusservice.services.k8s.aws/rulegroupsnamespace_v1alpha1.json
     kind: RuleGroupsNamespace
     name: rulegroupsnamespace_v1alpha1
+protection.crossplane.io:
+  - apiVersion: protection.crossplane.io/v1beta1
+    filename: protection.crossplane.io/clusterusage_v1beta1.json
+    kind: ClusterUsage
+    name: clusterusage_v1beta1
+  - apiVersion: protection.crossplane.io/v1beta1
+    filename: protection.crossplane.io/usage_v1beta1.json
+    kind: Usage
+    name: usage_v1beta1
+provisioning.cattle.io:
+  - apiVersion: provisioning.cattle.io/v1
+    filename: provisioning.cattle.io/cluster_v1.json
+    kind: Cluster
+    name: cluster_v1
 ps.percona.com:
   - apiVersion: ps.percona.com/v1alpha1
     filename: ps.percona.com/perconaservermysqlbackup_v1alpha1.json
@@ -7000,6 +12998,14 @@ pubsub.cnrm.cloud.google.com:
     filename: pubsub.cnrm.cloud.google.com/pubsubtopic_v1beta1.json
     kind: pubsubtopic
     name: pubsubtopic_v1beta1
+  - apiVersion: pubsub.cnrm.cloud.google.com/v1alpha1
+    filename: pubsub.cnrm.cloud.google.com/pubsubsnapshot_v1alpha1.json
+    kind: PubSubSnapshot
+    name: pubsubsnapshot_v1alpha1
+  - apiVersion: pubsub.cnrm.cloud.google.com/v1beta1
+    filename: pubsub.cnrm.cloud.google.com/pubsubsnapshot_v1beta1.json
+    kind: PubSubSnapshot
+    name: pubsubsnapshot_v1beta1
 pubsublite.cnrm.cloud.google.com:
   - apiVersion: pubsublite.cnrm.cloud.google.com/v1alpha1
     filename: pubsublite.cnrm.cloud.google.com/pubsublitetopic_v1alpha1.json
@@ -7084,6 +13090,19 @@ rabbitmq.com:
     filename: rabbitmq.com/user_v1beta1.json
     kind: User
     name: user_v1beta1
+  - apiVersion: rabbitmq.com/v1beta1
+    filename: rabbitmq.com/operatorpolicy_v1beta1.json
+    kind: OperatorPolicy
+    name: operatorpolicy_v1beta1
+ram.services.k8s.aws:
+  - apiVersion: ram.services.k8s.aws/v1alpha1
+    filename: ram.services.k8s.aws/resourceshare_v1alpha1.json
+    kind: ResourceShare
+    name: resourceshare_v1alpha1
+  - apiVersion: ram.services.k8s.aws/v1alpha1
+    filename: ram.services.k8s.aws/permission_v1alpha1.json
+    kind: Permission
+    name: permission_v1alpha1
 ratelimit.solo.io:
   - apiVersion: ratelimit.solo.io/v1alpha1
     filename: ratelimit.solo.io/ratelimitconfig_v1alpha1.json
@@ -7098,6 +13117,200 @@ rbacmanager.reactiveops.io:
     filename: rbacmanager.reactiveops.io/rbacdefinitions_v1alpha1.json
     kind: rbacdefinitions
     name: rbacdefinitions_v1alpha1
+rds.aws.m.upbound.io:
+  - apiVersion: rds.aws.m.upbound.io/v1beta1
+    filename: rds.aws.m.upbound.io/clusteractivitystream_v1beta1.json
+    kind: ClusterActivityStream
+    name: clusteractivitystream_v1beta1
+  - apiVersion: rds.aws.m.upbound.io/v1beta1
+    filename: rds.aws.m.upbound.io/globalcluster_v1beta1.json
+    kind: GlobalCluster
+    name: globalcluster_v1beta1
+  - apiVersion: rds.aws.m.upbound.io/v1beta1
+    filename: rds.aws.m.upbound.io/proxydefaulttargetgroup_v1beta1.json
+    kind: ProxyDefaultTargetGroup
+    name: proxydefaulttargetgroup_v1beta1
+  - apiVersion: rds.aws.m.upbound.io/v1beta1
+    filename: rds.aws.m.upbound.io/instanceroleassociation_v1beta1.json
+    kind: InstanceRoleAssociation
+    name: instanceroleassociation_v1beta1
+  - apiVersion: rds.aws.m.upbound.io/v1beta1
+    filename: rds.aws.m.upbound.io/subnetgroup_v1beta1.json
+    kind: SubnetGroup
+    name: subnetgroup_v1beta1
+  - apiVersion: rds.aws.m.upbound.io/v1beta1
+    filename: rds.aws.m.upbound.io/dbsnapshotcopy_v1beta1.json
+    kind: DBSnapshotCopy
+    name: dbsnapshotcopy_v1beta1
+  - apiVersion: rds.aws.m.upbound.io/v1beta1
+    filename: rds.aws.m.upbound.io/proxy_v1beta1.json
+    kind: Proxy
+    name: proxy_v1beta1
+  - apiVersion: rds.aws.m.upbound.io/v1beta1
+    filename: rds.aws.m.upbound.io/clusterparametergroup_v1beta1.json
+    kind: ClusterParameterGroup
+    name: clusterparametergroup_v1beta1
+  - apiVersion: rds.aws.m.upbound.io/v1beta1
+    filename: rds.aws.m.upbound.io/clustersnapshot_v1beta1.json
+    kind: ClusterSnapshot
+    name: clustersnapshot_v1beta1
+  - apiVersion: rds.aws.m.upbound.io/v1beta1
+    filename: rds.aws.m.upbound.io/parametergroup_v1beta1.json
+    kind: ParameterGroup
+    name: parametergroup_v1beta1
+  - apiVersion: rds.aws.m.upbound.io/v1beta1
+    filename: rds.aws.m.upbound.io/instancestate_v1beta1.json
+    kind: InstanceState
+    name: instancestate_v1beta1
+  - apiVersion: rds.aws.m.upbound.io/v1beta1
+    filename: rds.aws.m.upbound.io/clusterendpoint_v1beta1.json
+    kind: ClusterEndpoint
+    name: clusterendpoint_v1beta1
+  - apiVersion: rds.aws.m.upbound.io/v1beta1
+    filename: rds.aws.m.upbound.io/clusterinstance_v1beta1.json
+    kind: ClusterInstance
+    name: clusterinstance_v1beta1
+  - apiVersion: rds.aws.m.upbound.io/v1beta1
+    filename: rds.aws.m.upbound.io/clusterroleassociation_v1beta1.json
+    kind: ClusterRoleAssociation
+    name: clusterroleassociation_v1beta1
+  - apiVersion: rds.aws.m.upbound.io/v1beta1
+    filename: rds.aws.m.upbound.io/eventsubscription_v1beta1.json
+    kind: EventSubscription
+    name: eventsubscription_v1beta1
+  - apiVersion: rds.aws.m.upbound.io/v1beta1
+    filename: rds.aws.m.upbound.io/optiongroup_v1beta1.json
+    kind: OptionGroup
+    name: optiongroup_v1beta1
+  - apiVersion: rds.aws.m.upbound.io/v1beta1
+    filename: rds.aws.m.upbound.io/proxytarget_v1beta1.json
+    kind: ProxyTarget
+    name: proxytarget_v1beta1
+  - apiVersion: rds.aws.m.upbound.io/v1beta1
+    filename: rds.aws.m.upbound.io/dbinstanceautomatedbackupsreplication_v1beta1.json
+    kind: DBInstanceAutomatedBackupsReplication
+    name: dbinstanceautomatedbackupsreplication_v1beta1
+  - apiVersion: rds.aws.m.upbound.io/v1beta1
+    filename: rds.aws.m.upbound.io/cluster_v1beta1.json
+    kind: Cluster
+    name: cluster_v1beta1
+  - apiVersion: rds.aws.m.upbound.io/v1beta1
+    filename: rds.aws.m.upbound.io/proxyendpoint_v1beta1.json
+    kind: ProxyEndpoint
+    name: proxyendpoint_v1beta1
+  - apiVersion: rds.aws.m.upbound.io/v1beta1
+    filename: rds.aws.m.upbound.io/instance_v1beta1.json
+    kind: Instance
+    name: instance_v1beta1
+  - apiVersion: rds.aws.m.upbound.io/v1beta1
+    filename: rds.aws.m.upbound.io/snapshot_v1beta1.json
+    kind: Snapshot
+    name: snapshot_v1beta1
+rds.aws.upbound.io:
+  - apiVersion: rds.aws.upbound.io/v1beta1
+    filename: rds.aws.upbound.io/clusteractivitystream_v1beta1.json
+    kind: ClusterActivityStream
+    name: clusteractivitystream_v1beta1
+  - apiVersion: rds.aws.upbound.io/v1beta1
+    filename: rds.aws.upbound.io/globalcluster_v1beta1.json
+    kind: GlobalCluster
+    name: globalcluster_v1beta1
+  - apiVersion: rds.aws.upbound.io/v1beta3
+    filename: rds.aws.upbound.io/instance_v1beta3.json
+    kind: Instance
+    name: instance_v1beta3
+  - apiVersion: rds.aws.upbound.io/v1beta1
+    filename: rds.aws.upbound.io/proxydefaulttargetgroup_v1beta1.json
+    kind: ProxyDefaultTargetGroup
+    name: proxydefaulttargetgroup_v1beta1
+  - apiVersion: rds.aws.upbound.io/v1beta1
+    filename: rds.aws.upbound.io/instanceroleassociation_v1beta1.json
+    kind: InstanceRoleAssociation
+    name: instanceroleassociation_v1beta1
+  - apiVersion: rds.aws.upbound.io/v1beta1
+    filename: rds.aws.upbound.io/subnetgroup_v1beta1.json
+    kind: SubnetGroup
+    name: subnetgroup_v1beta1
+  - apiVersion: rds.aws.upbound.io/v1beta1
+    filename: rds.aws.upbound.io/dbsnapshotcopy_v1beta1.json
+    kind: DBSnapshotCopy
+    name: dbsnapshotcopy_v1beta1
+  - apiVersion: rds.aws.upbound.io/v1beta1
+    filename: rds.aws.upbound.io/proxy_v1beta1.json
+    kind: Proxy
+    name: proxy_v1beta1
+  - apiVersion: rds.aws.upbound.io/v1beta1
+    filename: rds.aws.upbound.io/clusterparametergroup_v1beta1.json
+    kind: ClusterParameterGroup
+    name: clusterparametergroup_v1beta1
+  - apiVersion: rds.aws.upbound.io/v1beta1
+    filename: rds.aws.upbound.io/clustersnapshot_v1beta1.json
+    kind: ClusterSnapshot
+    name: clustersnapshot_v1beta1
+  - apiVersion: rds.aws.upbound.io/v1beta1
+    filename: rds.aws.upbound.io/parametergroup_v1beta1.json
+    kind: ParameterGroup
+    name: parametergroup_v1beta1
+  - apiVersion: rds.aws.upbound.io/v1beta1
+    filename: rds.aws.upbound.io/instancestate_v1beta1.json
+    kind: InstanceState
+    name: instancestate_v1beta1
+  - apiVersion: rds.aws.upbound.io/v1beta2
+    filename: rds.aws.upbound.io/instance_v1beta2.json
+    kind: Instance
+    name: instance_v1beta2
+  - apiVersion: rds.aws.upbound.io/v1beta1
+    filename: rds.aws.upbound.io/clusterendpoint_v1beta1.json
+    kind: ClusterEndpoint
+    name: clusterendpoint_v1beta1
+  - apiVersion: rds.aws.upbound.io/v1beta1
+    filename: rds.aws.upbound.io/clusterinstance_v1beta1.json
+    kind: ClusterInstance
+    name: clusterinstance_v1beta1
+  - apiVersion: rds.aws.upbound.io/v1beta1
+    filename: rds.aws.upbound.io/clusterroleassociation_v1beta1.json
+    kind: ClusterRoleAssociation
+    name: clusterroleassociation_v1beta1
+  - apiVersion: rds.aws.upbound.io/v1beta1
+    filename: rds.aws.upbound.io/eventsubscription_v1beta1.json
+    kind: EventSubscription
+    name: eventsubscription_v1beta1
+  - apiVersion: rds.aws.upbound.io/v1beta1
+    filename: rds.aws.upbound.io/optiongroup_v1beta1.json
+    kind: OptionGroup
+    name: optiongroup_v1beta1
+  - apiVersion: rds.aws.upbound.io/v1beta1
+    filename: rds.aws.upbound.io/proxytarget_v1beta1.json
+    kind: ProxyTarget
+    name: proxytarget_v1beta1
+  - apiVersion: rds.aws.upbound.io/v1beta1
+    filename: rds.aws.upbound.io/dbinstanceautomatedbackupsreplication_v1beta1.json
+    kind: DBInstanceAutomatedBackupsReplication
+    name: dbinstanceautomatedbackupsreplication_v1beta1
+  - apiVersion: rds.aws.upbound.io/v1beta1
+    filename: rds.aws.upbound.io/cluster_v1beta1.json
+    kind: Cluster
+    name: cluster_v1beta1
+  - apiVersion: rds.aws.upbound.io/v1beta1
+    filename: rds.aws.upbound.io/proxyendpoint_v1beta1.json
+    kind: ProxyEndpoint
+    name: proxyendpoint_v1beta1
+  - apiVersion: rds.aws.upbound.io/v1beta1
+    filename: rds.aws.upbound.io/instance_v1beta1.json
+    kind: Instance
+    name: instance_v1beta1
+  - apiVersion: rds.aws.upbound.io/v1beta2
+    filename: rds.aws.upbound.io/proxydefaulttargetgroup_v1beta2.json
+    kind: ProxyDefaultTargetGroup
+    name: proxydefaulttargetgroup_v1beta2
+  - apiVersion: rds.aws.upbound.io/v1beta1
+    filename: rds.aws.upbound.io/snapshot_v1beta1.json
+    kind: Snapshot
+    name: snapshot_v1beta1
+  - apiVersion: rds.aws.upbound.io/v1beta2
+    filename: rds.aws.upbound.io/cluster_v1beta2.json
+    kind: Cluster
+    name: cluster_v1beta2
 rds.services.k8s.aws:
   - apiVersion: rds.services.k8s.aws/v1alpha1
     filename: rds.services.k8s.aws/dbparametergroup_v1alpha1.json
@@ -7135,11 +13348,21 @@ rds.services.k8s.aws:
     filename: rds.services.k8s.aws/dbclustersnapshot_v1alpha1.json
     kind: DBClusterSnapshot
     name: dbclustersnapshot_v1alpha1
+readiness.node.x-k8s.io:
+  - apiVersion: readiness.node.x-k8s.io/v1alpha1
+    filename: readiness.node.x-k8s.io/nodereadinessrule_v1alpha1.json
+    kind: NodeReadinessRule
+    name: nodereadinessrule_v1alpha1
 recaptchaenterprise.cnrm.cloud.google.com:
   - apiVersion: recaptchaenterprise.cnrm.cloud.google.com/v1beta1
     filename: recaptchaenterprise.cnrm.cloud.google.com/recaptchaenterprisekey_v1beta1.json
     kind: recaptchaenterprisekey
     name: recaptchaenterprisekey_v1beta1
+redhatopenshift.azure.com:
+  - apiVersion: redhatopenshift.azure.com/v1api20231122
+    filename: redhatopenshift.azure.com/openshiftcluster_v1api20231122.json
+    kind: openshiftcluster
+    name: openshiftcluster_v1api20231122
 redis.cnrm.cloud.google.com:
   - apiVersion: redis.cnrm.cloud.google.com/v1beta1
     filename: redis.cnrm.cloud.google.com/redisinstance_v1beta1.json
@@ -7170,6 +13393,94 @@ redis.redis.opstreelabs.in:
     filename: redis.redis.opstreelabs.in/rediscluster_v1beta2.json
     kind: RedisCluster
     name: rediscluster_v1beta2
+renovate-operator.mogenius.com:
+  - apiVersion: renovate-operator.mogenius.com/v1alpha1
+    filename: renovate-operator.mogenius.com/renovatejob_v1alpha1.json
+    kind: renovatejob
+    name: renovatejob_v1alpha1
+repo-manager.pulpproject.org:
+  - apiVersion: repo-manager.pulpproject.org/v1
+    filename: repo-manager.pulpproject.org/pulprestore_v1.json
+    kind: PulpRestore
+    name: pulprestore_v1
+  - apiVersion: repo-manager.pulpproject.org/v1
+    filename: repo-manager.pulpproject.org/pulpbackup_v1.json
+    kind: PulpBackup
+    name: pulpbackup_v1
+  - apiVersion: repo-manager.pulpproject.org/v1
+    filename: repo-manager.pulpproject.org/pulp_v1.json
+    kind: Pulp
+    name: pulp_v1
+reports.kyverno.io:
+  - apiVersion: reports.kyverno.io/v1
+    filename: reports.kyverno.io/clusterephemeralreport_v1.json
+    kind: ClusterEphemeralReport
+    name: clusterephemeralreport_v1
+  - apiVersion: reports.kyverno.io/v1
+    filename: reports.kyverno.io/ephemeralreport_v1.json
+    kind: EphemeralReport
+    name: ephemeralreport_v1
+resource.streamnative.io:
+  - apiVersion: resource.streamnative.io/v1alpha1
+    filename: resource.streamnative.io/pulsartopic_v1alpha1.json
+    kind: PulsarTopic
+    name: pulsartopic_v1alpha1
+  - apiVersion: resource.streamnative.io/v1alpha1
+    filename: resource.streamnative.io/secret_v1alpha1.json
+    kind: Secret
+    name: secret_v1alpha1
+  - apiVersion: resource.streamnative.io/v1alpha1
+    filename: resource.streamnative.io/streamnativecloudconnection_v1alpha1.json
+    kind: StreamNativeCloudConnection
+    name: streamnativecloudconnection_v1alpha1
+  - apiVersion: resource.streamnative.io/v1alpha1
+    filename: resource.streamnative.io/pulsarconnection_v1alpha1.json
+    kind: PulsarConnection
+    name: pulsarconnection_v1alpha1
+  - apiVersion: resource.streamnative.io/v1alpha1
+    filename: resource.streamnative.io/pulsarpackage_v1alpha1.json
+    kind: PulsarPackage
+    name: pulsarpackage_v1alpha1
+  - apiVersion: resource.streamnative.io/v1alpha1
+    filename: resource.streamnative.io/pulsarsource_v1alpha1.json
+    kind: PulsarSource
+    name: pulsarsource_v1alpha1
+  - apiVersion: resource.streamnative.io/v1alpha1
+    filename: resource.streamnative.io/computeflinkdeployment_v1alpha1.json
+    kind: ComputeFlinkDeployment
+    name: computeflinkdeployment_v1alpha1
+  - apiVersion: resource.streamnative.io/v1alpha1
+    filename: resource.streamnative.io/pulsartenant_v1alpha1.json
+    kind: PulsarTenant
+    name: pulsartenant_v1alpha1
+  - apiVersion: resource.streamnative.io/v1alpha1
+    filename: resource.streamnative.io/pulsarpermission_v1alpha1.json
+    kind: PulsarPermission
+    name: pulsarpermission_v1alpha1
+  - apiVersion: resource.streamnative.io/v1alpha1
+    filename: resource.streamnative.io/pulsarfunction_v1alpha1.json
+    kind: PulsarFunction
+    name: pulsarfunction_v1alpha1
+  - apiVersion: resource.streamnative.io/v1alpha1
+    filename: resource.streamnative.io/pulsarsink_v1alpha1.json
+    kind: PulsarSink
+    name: pulsarsink_v1alpha1
+  - apiVersion: resource.streamnative.io/v1alpha1
+    filename: resource.streamnative.io/pulsargeoreplication_v1alpha1.json
+    kind: PulsarGeoReplication
+    name: pulsargeoreplication_v1alpha1
+  - apiVersion: resource.streamnative.io/v1alpha1
+    filename: resource.streamnative.io/pulsarnsisolationpolicy_v1alpha1.json
+    kind: PulsarNSIsolationPolicy
+    name: pulsarnsisolationpolicy_v1alpha1
+  - apiVersion: resource.streamnative.io/v1alpha1
+    filename: resource.streamnative.io/pulsarnamespace_v1alpha1.json
+    kind: PulsarNamespace
+    name: pulsarnamespace_v1alpha1
+  - apiVersion: resource.streamnative.io/v1alpha1
+    filename: resource.streamnative.io/computeworkspace_v1alpha1.json
+    kind: ComputeWorkspace
+    name: computeworkspace_v1alpha1
 resourcemanager.cnrm.cloud.google.com:
   - apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
     filename: resourcemanager.cnrm.cloud.google.com/resourcemanagerlien_v1beta1.json
@@ -7187,6 +13498,11 @@ resourcemanager.cnrm.cloud.google.com:
     filename: resourcemanager.cnrm.cloud.google.com/resourcemanagerpolicy_v1beta1.json
     kind: resourcemanagerpolicy
     name: resourcemanagerpolicy_v1beta1
+resources.azure.com:
+  - apiVersion: resources.azure.com/v1api20200601
+    filename: resources.azure.com/resourcegroup_v1api20200601.json
+    kind: resourcegroup
+    name: resourcegroup_v1api20200601
 resources.teleport.dev:
   - apiVersion: resources.teleport.dev/v1
     filename: resources.teleport.dev/teleportloginrule_v1.json
@@ -7244,6 +13560,101 @@ resources.teleport.dev:
     filename: resources.teleport.dev/teleportopensshserverv2_v1.json
     kind: teleportopensshserverv2
     name: teleportopensshserverv2_v1
+  - apiVersion: resources.teleport.dev/v1
+    filename: resources.teleport.dev/teleportautoupdateconfigv1_v1.json
+    kind: teleportautoupdateconfigv1
+    name: teleportautoupdateconfigv1_v1
+  - apiVersion: resources.teleport.dev/v1
+    filename: resources.teleport.dev/teleportscopedroleassignmentv1_v1.json
+    kind: teleportscopedroleassignmentv1
+    name: teleportscopedroleassignmentv1_v1
+  - apiVersion: resources.teleport.dev/v1
+    filename: resources.teleport.dev/teleportlockv2_v1.json
+    kind: teleportlockv2
+    name: teleportlockv2_v1
+  - apiVersion: resources.teleport.dev/v1
+    filename: resources.teleport.dev/teleportretrievalmodelv1_v1.json
+    kind: teleportretrievalmodelv1
+    name: teleportretrievalmodelv1_v1
+  - apiVersion: resources.teleport.dev/v1
+    filename: resources.teleport.dev/teleportsamlidpserviceproviderv1_v1.json
+    kind: teleportsamlidpserviceproviderv1
+    name: teleportsamlidpserviceproviderv1_v1
+  - apiVersion: resources.teleport.dev/v1
+    filename: resources.teleport.dev/teleportinferencemodel_v1.json
+    kind: teleportinferencemodel
+    name: teleportinferencemodel_v1
+  - apiVersion: resources.teleport.dev/v1
+    filename: resources.teleport.dev/teleportscopedtokenv1_v1.json
+    kind: teleportscopedtokenv1
+    name: teleportscopedtokenv1_v1
+  - apiVersion: resources.teleport.dev/v1
+    filename: resources.teleport.dev/teleportaccessmonitoringrulev1_v1.json
+    kind: teleportaccessmonitoringrulev1
+    name: teleportaccessmonitoringrulev1_v1
+  - apiVersion: resources.teleport.dev/v1
+    filename: resources.teleport.dev/teleportbotv1_v1.json
+    kind: teleportbotv1
+    name: teleportbotv1_v1
+  - apiVersion: resources.teleport.dev/v1
+    filename: resources.teleport.dev/teleporttrustedclusterv2_v1.json
+    kind: teleporttrustedclusterv2
+    name: teleporttrustedclusterv2_v1
+  - apiVersion: resources.teleport.dev/v1
+    filename: resources.teleport.dev/teleportdatabasev3_v1.json
+    kind: teleportdatabasev3
+    name: teleportdatabasev3_v1
+  - apiVersion: resources.teleport.dev/v1
+    filename: resources.teleport.dev/teleportappv3_v1.json
+    kind: teleportappv3
+    name: teleportappv3_v1
+  - apiVersion: resources.teleport.dev/v1
+    filename: resources.teleport.dev/teleportrolev8_v1.json
+    kind: teleportrolev8
+    name: teleportrolev8_v1
+  - apiVersion: resources.teleport.dev/v1
+    filename: resources.teleport.dev/teleportscopedrolev1_v1.json
+    kind: teleportscopedrolev1
+    name: teleportscopedrolev1_v1
+  - apiVersion: resources.teleport.dev/v1
+    filename: resources.teleport.dev/teleportinferencepolicy_v1.json
+    kind: teleportinferencepolicy
+    name: teleportinferencepolicy_v1
+  - apiVersion: resources.teleport.dev/v1
+    filename: resources.teleport.dev/teleportinferencesecret_v1.json
+    kind: teleportinferencesecret
+    name: teleportinferencesecret_v1
+  - apiVersion: resources.teleport.dev/v1
+    filename: resources.teleport.dev/teleportautoupdateversionv1_v1.json
+    kind: teleportautoupdateversionv1
+    name: teleportautoupdateversionv1_v1
+  - apiVersion: resources.teleport.dev/v1
+    filename: resources.teleport.dev/teleportworkloadidentityv1_v1.json
+    kind: teleportworkloadidentityv1
+    name: teleportworkloadidentityv1_v1
+restate.dev:
+  - apiVersion: restate.dev/v1
+    filename: restate.dev/restatecluster_v1.json
+    kind: RestateCluster
+    name: restatecluster_v1
+  - apiVersion: restate.dev/v1beta1
+    filename: restate.dev/restatedeployment_v1beta1.json
+    kind: RestateDeployment
+    name: restatedeployment_v1beta1
+rke-machine-config.cattle.io:
+  - apiVersion: rke-machine-config.cattle.io/v1
+    filename: rke-machine-config.cattle.io/hetznerconfig_v1.json
+    kind: HetznerConfig
+    name: hetznerconfig_v1
+rke.cattle.io:
+  - apiVersion: rke.cattle.io/v1
+    filename: rke.cattle.io/etcdsnapshot_v1.json
+    kind: ETCDSnapshot
+    name: etcdsnapshot_v1
+  - apiVersion: rke.cattle.io/v1
+    filename: rke.cattle.io/custommachine_v1.json
+    kind: CustomMachine
+    name: custommachine_v1
 route53.services.k8s.aws:
   - apiVersion: route53.services.k8s.aws/v1alpha1
     filename: route53.services.k8s.aws/hostedzone_v1alpha1.json
@@ -7271,11 +13682,355 @@ runtime.cluster.x-k8s.io:
     filename: runtime.cluster.x-k8s.io/extensionconfig_v1alpha1.json
     kind: ExtensionConfig
     name: extensionconfig_v1alpha1
+  - apiVersion: runtime.cluster.x-k8s.io/v1beta2
+    filename: runtime.cluster.x-k8s.io/extensionconfig_v1beta2.json
+    kind: ExtensionConfig
+    name: extensionconfig_v1beta2
+s3.aws.m.upbound.io:
+  - apiVersion: s3.aws.m.upbound.io/v1beta1
+    filename: s3.aws.m.upbound.io/bucket_v1beta1.json
+    kind: Bucket
+    name: bucket_v1beta1
+  - apiVersion: s3.aws.m.upbound.io/v1beta1
+    filename: s3.aws.m.upbound.io/bucketcorsconfiguration_v1beta1.json
+    kind: BucketCorsConfiguration
+    name: bucketcorsconfiguration_v1beta1
+  - apiVersion: s3.aws.m.upbound.io/v1beta1
+    filename: s3.aws.m.upbound.io/bucketrequestpaymentconfiguration_v1beta1.json
+    kind: BucketRequestPaymentConfiguration
+    name: bucketrequestpaymentconfiguration_v1beta1
+  - apiVersion: s3.aws.m.upbound.io/v1beta1
+    filename: s3.aws.m.upbound.io/bucketintelligenttieringconfiguration_v1beta1.json
+    kind: BucketIntelligentTieringConfiguration
+    name: bucketintelligenttieringconfiguration_v1beta1
+  - apiVersion: s3.aws.m.upbound.io/v1beta1
+    filename: s3.aws.m.upbound.io/bucketlogging_v1beta1.json
+    kind: BucketLogging
+    name: bucketlogging_v1beta1
+  - apiVersion: s3.aws.m.upbound.io/v1beta1
+    filename: s3.aws.m.upbound.io/object_v1beta1.json
+    kind: Object
+    name: object_v1beta1
+  - apiVersion: s3.aws.m.upbound.io/v1beta1
+    filename: s3.aws.m.upbound.io/bucketacl_v1beta1.json
+    kind: BucketACL
+    name: bucketacl_v1beta1
+  - apiVersion: s3.aws.m.upbound.io/v1beta1
+    filename: s3.aws.m.upbound.io/bucketnotification_v1beta1.json
+    kind: BucketNotification
+    name: bucketnotification_v1beta1
+  - apiVersion: s3.aws.m.upbound.io/v1beta1
+    filename: s3.aws.m.upbound.io/bucketinventory_v1beta1.json
+    kind: BucketInventory
+    name: bucketinventory_v1beta1
+  - apiVersion: s3.aws.m.upbound.io/v1beta1
+    filename: s3.aws.m.upbound.io/bucketobject_v1beta1.json
+    kind: BucketObject
+    name: bucketobject_v1beta1
+  - apiVersion: s3.aws.m.upbound.io/v1beta1
+    filename: s3.aws.m.upbound.io/bucketmetric_v1beta1.json
+    kind: BucketMetric
+    name: bucketmetric_v1beta1
+  - apiVersion: s3.aws.m.upbound.io/v1beta1
+    filename: s3.aws.m.upbound.io/bucketwebsiteconfiguration_v1beta1.json
+    kind: BucketWebsiteConfiguration
+    name: bucketwebsiteconfiguration_v1beta1
+  - apiVersion: s3.aws.m.upbound.io/v1beta1
+    filename: s3.aws.m.upbound.io/bucketreplicationconfiguration_v1beta1.json
+    kind: BucketReplicationConfiguration
+    name: bucketreplicationconfiguration_v1beta1
+  - apiVersion: s3.aws.m.upbound.io/v1beta1
+    filename: s3.aws.m.upbound.io/bucketpublicaccessblock_v1beta1.json
+    kind: BucketPublicAccessBlock
+    name: bucketpublicaccessblock_v1beta1
+  - apiVersion: s3.aws.m.upbound.io/v1beta1
+    filename: s3.aws.m.upbound.io/directorybucket_v1beta1.json
+    kind: DirectoryBucket
+    name: directorybucket_v1beta1
+  - apiVersion: s3.aws.m.upbound.io/v1beta1
+    filename: s3.aws.m.upbound.io/bucketobjectlockconfiguration_v1beta1.json
+    kind: BucketObjectLockConfiguration
+    name: bucketobjectlockconfiguration_v1beta1
+  - apiVersion: s3.aws.m.upbound.io/v1beta1
+    filename: s3.aws.m.upbound.io/bucketaccelerateconfiguration_v1beta1.json
+    kind: BucketAccelerateConfiguration
+    name: bucketaccelerateconfiguration_v1beta1
+  - apiVersion: s3.aws.m.upbound.io/v1beta1
+    filename: s3.aws.m.upbound.io/objectcopy_v1beta1.json
+    kind: ObjectCopy
+    name: objectcopy_v1beta1
+  - apiVersion: s3.aws.m.upbound.io/v1beta1
+    filename: s3.aws.m.upbound.io/bucketserversideencryptionconfiguration_v1beta1.json
+    kind: BucketServerSideEncryptionConfiguration
+    name: bucketserversideencryptionconfiguration_v1beta1
+  - apiVersion: s3.aws.m.upbound.io/v1beta1
+    filename: s3.aws.m.upbound.io/bucketpolicy_v1beta1.json
+    kind: BucketPolicy
+    name: bucketpolicy_v1beta1
+  - apiVersion: s3.aws.m.upbound.io/v1beta1
+    filename: s3.aws.m.upbound.io/bucketownershipcontrols_v1beta1.json
+    kind: BucketOwnershipControls
+    name: bucketownershipcontrols_v1beta1
+  - apiVersion: s3.aws.m.upbound.io/v1beta1
+    filename: s3.aws.m.upbound.io/bucketversioning_v1beta1.json
+    kind: BucketVersioning
+    name: bucketversioning_v1beta1
+  - apiVersion: s3.aws.m.upbound.io/v1beta1
+    filename: s3.aws.m.upbound.io/bucketanalyticsconfiguration_v1beta1.json
+    kind: BucketAnalyticsConfiguration
+    name: bucketanalyticsconfiguration_v1beta1
+  - apiVersion: s3.aws.m.upbound.io/v1beta1
+    filename: s3.aws.m.upbound.io/bucketlifecycleconfiguration_v1beta1.json
+    kind: BucketLifecycleConfiguration
+    name: bucketlifecycleconfiguration_v1beta1
+s3.aws.upbound.io:
+  - apiVersion: s3.aws.upbound.io/v1beta1
+    filename: s3.aws.upbound.io/bucket_v1beta1.json
+    kind: Bucket
+    name: bucket_v1beta1
+  - apiVersion: s3.aws.upbound.io/v1beta1
+    filename: s3.aws.upbound.io/bucketcorsconfiguration_v1beta1.json
+    kind: BucketCorsConfiguration
+    name: bucketcorsconfiguration_v1beta1
+  - apiVersion: s3.aws.upbound.io/v1beta1
+    filename: s3.aws.upbound.io/bucketrequestpaymentconfiguration_v1beta1.json
+    kind: BucketRequestPaymentConfiguration
+    name: bucketrequestpaymentconfiguration_v1beta1
+  - apiVersion: s3.aws.upbound.io/v1beta2
+    filename: s3.aws.upbound.io/bucketreplicationconfiguration_v1beta2.json
+    kind: BucketReplicationConfiguration
+    name: bucketreplicationconfiguration_v1beta2
+  - apiVersion: s3.aws.upbound.io/v1beta1
+    filename: s3.aws.upbound.io/bucketintelligenttieringconfiguration_v1beta1.json
+    kind: BucketIntelligentTieringConfiguration
+    name: bucketintelligenttieringconfiguration_v1beta1
+  - apiVersion: s3.aws.upbound.io/v1beta1
+    filename: s3.aws.upbound.io/bucketlogging_v1beta1.json
+    kind: BucketLogging
+    name: bucketlogging_v1beta1
+  - apiVersion: s3.aws.upbound.io/v1beta1
+    filename: s3.aws.upbound.io/object_v1beta1.json
+    kind: Object
+    name: object_v1beta1
+  - apiVersion: s3.aws.upbound.io/v1beta1
+    filename: s3.aws.upbound.io/bucketacl_v1beta1.json
+    kind: BucketACL
+    name: bucketacl_v1beta1
+  - apiVersion: s3.aws.upbound.io/v1beta1
+    filename: s3.aws.upbound.io/bucketnotification_v1beta1.json
+    kind: BucketNotification
+    name: bucketnotification_v1beta1
+  - apiVersion: s3.aws.upbound.io/v1beta2
+    filename: s3.aws.upbound.io/bucketlogging_v1beta2.json
+    kind: BucketLogging
+    name: bucketlogging_v1beta2
+  - apiVersion: s3.aws.upbound.io/v1beta1
+    filename: s3.aws.upbound.io/bucketinventory_v1beta1.json
+    kind: BucketInventory
+    name: bucketinventory_v1beta1
+  - apiVersion: s3.aws.upbound.io/v1beta2
+    filename: s3.aws.upbound.io/bucketanalyticsconfiguration_v1beta2.json
+    kind: BucketAnalyticsConfiguration
+    name: bucketanalyticsconfiguration_v1beta2
+  - apiVersion: s3.aws.upbound.io/v1beta2
+    filename: s3.aws.upbound.io/object_v1beta2.json
+    kind: Object
+    name: object_v1beta2
+  - apiVersion: s3.aws.upbound.io/v1beta1
+    filename: s3.aws.upbound.io/bucketobject_v1beta1.json
+    kind: BucketObject
+    name: bucketobject_v1beta1
+  - apiVersion: s3.aws.upbound.io/v1beta2
+    filename: s3.aws.upbound.io/bucketacl_v1beta2.json
+    kind: BucketACL
+    name: bucketacl_v1beta2
+  - apiVersion: s3.aws.upbound.io/v1beta2
+    filename: s3.aws.upbound.io/bucketownershipcontrols_v1beta2.json
+    kind: BucketOwnershipControls
+    name: bucketownershipcontrols_v1beta2
+  - apiVersion: s3.aws.upbound.io/v1beta2
+    filename: s3.aws.upbound.io/bucketwebsiteconfiguration_v1beta2.json
+    kind: BucketWebsiteConfiguration
+    name: bucketwebsiteconfiguration_v1beta2
+  - apiVersion: s3.aws.upbound.io/v1beta1
+    filename: s3.aws.upbound.io/bucketmetric_v1beta1.json
+    kind: BucketMetric
+    name: bucketmetric_v1beta1
+  - apiVersion: s3.aws.upbound.io/v1beta1
+    filename: s3.aws.upbound.io/bucketwebsiteconfiguration_v1beta1.json
+    kind: BucketWebsiteConfiguration
+    name: bucketwebsiteconfiguration_v1beta1
+  - apiVersion: s3.aws.upbound.io/v1beta1
+    filename: s3.aws.upbound.io/bucketreplicationconfiguration_v1beta1.json
+    kind: BucketReplicationConfiguration
+    name: bucketreplicationconfiguration_v1beta1
+  - apiVersion: s3.aws.upbound.io/v1beta2
+    filename: s3.aws.upbound.io/bucket_v1beta2.json
+    kind: Bucket
+    name: bucket_v1beta2
+  - apiVersion: s3.aws.upbound.io/v1beta1
+    filename: s3.aws.upbound.io/bucketpublicaccessblock_v1beta1.json
+    kind: BucketPublicAccessBlock
+    name: bucketpublicaccessblock_v1beta1
+  - apiVersion: s3.aws.upbound.io/v1beta2
+    filename: s3.aws.upbound.io/bucketobjectlockconfiguration_v1beta2.json
+    kind: BucketObjectLockConfiguration
+    name: bucketobjectlockconfiguration_v1beta2
+  - apiVersion: s3.aws.upbound.io/v1beta1
+    filename: s3.aws.upbound.io/directorybucket_v1beta1.json
+    kind: DirectoryBucket
+    name: directorybucket_v1beta1
+  - apiVersion: s3.aws.upbound.io/v1beta1
+    filename: s3.aws.upbound.io/bucketobjectlockconfiguration_v1beta1.json
+    kind: BucketObjectLockConfiguration
+    name: bucketobjectlockconfiguration_v1beta1
+  - apiVersion: s3.aws.upbound.io/v1beta1
+    filename: s3.aws.upbound.io/bucketaccelerateconfiguration_v1beta1.json
+    kind: BucketAccelerateConfiguration
+    name: bucketaccelerateconfiguration_v1beta1
+  - apiVersion: s3.aws.upbound.io/v1beta2
+    filename: s3.aws.upbound.io/bucketintelligenttieringconfiguration_v1beta2.json
+    kind: BucketIntelligentTieringConfiguration
+    name: bucketintelligenttieringconfiguration_v1beta2
+  - apiVersion: s3.aws.upbound.io/v1beta1
+    filename: s3.aws.upbound.io/objectcopy_v1beta1.json
+    kind: ObjectCopy
+    name: objectcopy_v1beta1
+  - apiVersion: s3.aws.upbound.io/v1beta2
+    filename: s3.aws.upbound.io/bucketmetric_v1beta2.json
+    kind: BucketMetric
+    name: bucketmetric_v1beta2
+  - apiVersion: s3.aws.upbound.io/v1beta2
+    filename: s3.aws.upbound.io/bucketversioning_v1beta2.json
+    kind: BucketVersioning
+    name: bucketversioning_v1beta2
+  - apiVersion: s3.aws.upbound.io/v1beta2
+    filename: s3.aws.upbound.io/bucketinventory_v1beta2.json
+    kind: BucketInventory
+    name: bucketinventory_v1beta2
+  - apiVersion: s3.aws.upbound.io/v1beta1
+    filename: s3.aws.upbound.io/bucketserversideencryptionconfiguration_v1beta1.json
+    kind: BucketServerSideEncryptionConfiguration
+    name: bucketserversideencryptionconfiguration_v1beta1
+  - apiVersion: s3.aws.upbound.io/v1beta1
+    filename: s3.aws.upbound.io/bucketpolicy_v1beta1.json
+    kind: BucketPolicy
+    name: bucketpolicy_v1beta1
+  - apiVersion: s3.aws.upbound.io/v1beta1
+    filename: s3.aws.upbound.io/bucketownershipcontrols_v1beta1.json
+    kind: BucketOwnershipControls
+    name: bucketownershipcontrols_v1beta1
+  - apiVersion: s3.aws.upbound.io/v1beta2
+    filename: s3.aws.upbound.io/bucketserversideencryptionconfiguration_v1beta2.json
+    kind: BucketServerSideEncryptionConfiguration
+    name: bucketserversideencryptionconfiguration_v1beta2
+  - apiVersion: s3.aws.upbound.io/v1beta1
+    filename: s3.aws.upbound.io/bucketversioning_v1beta1.json
+    kind: BucketVersioning
+    name: bucketversioning_v1beta1
+  - apiVersion: s3.aws.upbound.io/v1beta1
+    filename: s3.aws.upbound.io/bucketanalyticsconfiguration_v1beta1.json
+    kind: BucketAnalyticsConfiguration
+    name: bucketanalyticsconfiguration_v1beta1
+  - apiVersion: s3.aws.upbound.io/v1beta1
+    filename: s3.aws.upbound.io/bucketlifecycleconfiguration_v1beta1.json
+    kind: BucketLifecycleConfiguration
+    name: bucketlifecycleconfiguration_v1beta1
+  - apiVersion: s3.aws.upbound.io/v1beta2
+    filename: s3.aws.upbound.io/bucketlifecycleconfiguration_v1beta2.json
+    kind: BucketLifecycleConfiguration
+    name: bucketlifecycleconfiguration_v1beta2
 s3.services.k8s.aws:
   - apiVersion: s3.services.k8s.aws/v1alpha1
     filename: s3.services.k8s.aws/bucket_v1alpha1.json
     kind: Bucket
     name: bucket_v1alpha1
+s3control.aws.m.upbound.io:
+  - apiVersion: s3control.aws.m.upbound.io/v1beta1
+    filename: s3control.aws.m.upbound.io/accesspoint_v1beta1.json
+    kind: AccessPoint
+    name: accesspoint_v1beta1
+  - apiVersion: s3control.aws.m.upbound.io/v1beta1
+    filename: s3control.aws.m.upbound.io/storagelensconfiguration_v1beta1.json
+    kind: StorageLensConfiguration
+    name: storagelensconfiguration_v1beta1
+  - apiVersion: s3control.aws.m.upbound.io/v1beta1
+    filename: s3control.aws.m.upbound.io/multiregionaccesspointpolicy_v1beta1.json
+    kind: MultiRegionAccessPointPolicy
+    name: multiregionaccesspointpolicy_v1beta1
+  - apiVersion: s3control.aws.m.upbound.io/v1beta1
+    filename: s3control.aws.m.upbound.io/objectlambdaaccesspointpolicy_v1beta1.json
+    kind: ObjectLambdaAccessPointPolicy
+    name: objectlambdaaccesspointpolicy_v1beta1
+  - apiVersion: s3control.aws.m.upbound.io/v1beta1
+    filename: s3control.aws.m.upbound.io/multiregionaccesspoint_v1beta1.json
+    kind: MultiRegionAccessPoint
+    name: multiregionaccesspoint_v1beta1
+  - apiVersion: s3control.aws.m.upbound.io/v1beta1
+    filename: s3control.aws.m.upbound.io/objectlambdaaccesspoint_v1beta1.json
+    kind: ObjectLambdaAccessPoint
+    name: objectlambdaaccesspoint_v1beta1
+  - apiVersion: s3control.aws.m.upbound.io/v1beta1
+    filename: s3control.aws.m.upbound.io/accountpublicaccessblock_v1beta1.json
+    kind: AccountPublicAccessBlock
+    name: accountpublicaccessblock_v1beta1
+  - apiVersion: s3control.aws.m.upbound.io/v1beta1
+    filename: s3control.aws.m.upbound.io/accesspointpolicy_v1beta1.json
+    kind: AccessPointPolicy
+    name: accesspointpolicy_v1beta1
+s3control.aws.upbound.io:
+  - apiVersion: s3control.aws.upbound.io/v1beta2
+    filename: s3control.aws.upbound.io/accesspoint_v1beta2.json
+    kind: AccessPoint
+    name: accesspoint_v1beta2
+  - apiVersion: s3control.aws.upbound.io/v1beta1
+    filename: s3control.aws.upbound.io/accesspoint_v1beta1.json
+    kind: AccessPoint
+    name: accesspoint_v1beta1
+  - apiVersion: s3control.aws.upbound.io/v1beta2
+    filename: s3control.aws.upbound.io/multiregionaccesspoint_v1beta2.json
+    kind: MultiRegionAccessPoint
+    name: multiregionaccesspoint_v1beta2
+  - apiVersion: s3control.aws.upbound.io/v1beta1
+    filename: s3control.aws.upbound.io/storagelensconfiguration_v1beta1.json
+    kind: StorageLensConfiguration
+    name: storagelensconfiguration_v1beta1
+  - apiVersion: s3control.aws.upbound.io/v1beta1
+    filename: s3control.aws.upbound.io/multiregionaccesspointpolicy_v1beta1.json
+    kind: MultiRegionAccessPointPolicy
+    name: multiregionaccesspointpolicy_v1beta1
+  - apiVersion: s3control.aws.upbound.io/v1beta2
+    filename: s3control.aws.upbound.io/multiregionaccesspointpolicy_v1beta2.json
+    kind: MultiRegionAccessPointPolicy
+    name: multiregionaccesspointpolicy_v1beta2
+  - apiVersion: s3control.aws.upbound.io/v1beta1
+    filename: s3control.aws.upbound.io/objectlambdaaccesspointpolicy_v1beta1.json
+    kind: ObjectLambdaAccessPointPolicy
+    name: objectlambdaaccesspointpolicy_v1beta1
+  - apiVersion: s3control.aws.upbound.io/v1beta1
+    filename: s3control.aws.upbound.io/multiregionaccesspoint_v1beta1.json
+    kind: MultiRegionAccessPoint
+    name: multiregionaccesspoint_v1beta1
+  - apiVersion: s3control.aws.upbound.io/v1beta1
+    filename: s3control.aws.upbound.io/objectlambdaaccesspoint_v1beta1.json
+    kind: ObjectLambdaAccessPoint
+    name: objectlambdaaccesspoint_v1beta1
+  - apiVersion: s3control.aws.upbound.io/v1beta1
+    filename: s3control.aws.upbound.io/accountpublicaccessblock_v1beta1.json
+    kind: AccountPublicAccessBlock
+    name: accountpublicaccessblock_v1beta1
+  - apiVersion: s3control.aws.upbound.io/v1beta2
+    filename: s3control.aws.upbound.io/storagelensconfiguration_v1beta2.json
+    kind: StorageLensConfiguration
+    name: storagelensconfiguration_v1beta2
+  - apiVersion: s3control.aws.upbound.io/v1beta1
+    filename: s3control.aws.upbound.io/accesspointpolicy_v1beta1.json
+    kind: AccessPointPolicy
+    name: accesspointpolicy_v1beta1
+  - apiVersion: s3control.aws.upbound.io/v1beta2
+    filename: s3control.aws.upbound.io/objectlambdaaccesspoint_v1beta2.json
+    kind: ObjectLambdaAccessPoint
+    name: objectlambdaaccesspoint_v1beta2
 sagemaker.services.k8s.aws:
   - apiVersion: sagemaker.services.k8s.aws/v1alpha1
     filename: sagemaker.services.k8s.aws/userprofile_v1alpha1.json
@@ -7365,6 +14120,22 @@ sagemaker.services.k8s.aws:
     filename: sagemaker.services.k8s.aws/endpoint_v1alpha1.json
     kind: Endpoint
     name: endpoint_v1alpha1
+  - apiVersion: sagemaker.services.k8s.aws/v1alpha1
+    filename: sagemaker.services.k8s.aws/project_v1alpha1.json
+    kind: Project
+    name: project_v1alpha1
+  - apiVersion: sagemaker.services.k8s.aws/v1alpha1
+    filename: sagemaker.services.k8s.aws/space_v1alpha1.json
+    kind: Space
+    name: space_v1alpha1
+  - apiVersion: sagemaker.services.k8s.aws/v1alpha1
+    filename: sagemaker.services.k8s.aws/inferencecomponent_v1alpha1.json
+    kind: InferenceComponent
+    name: inferencecomponent_v1alpha1
+  - apiVersion: sagemaker.services.k8s.aws/v1alpha1
+    filename: sagemaker.services.k8s.aws/labelingjob_v1alpha1.json
+    kind: LabelingJob
+    name: labelingjob_v1alpha1
 scylla.scylladb.com:
   - apiVersion: scylla.scylladb.com/v1alpha1
     filename: scylla.scylladb.com/scyllaoperatorconfig_v1alpha1.json
@@ -7382,6 +14153,34 @@ scylla.scylladb.com:
     filename: scylla.scylladb.com/scyllacluster_v1.json
     kind: ScyllaCluster
     name: scyllacluster_v1
+search.azure.com:
+  - apiVersion: search.azure.com/v1api20220901
+    filename: search.azure.com/searchservice_v1api20220901.json
+    kind: searchService
+    name: searchservice_v1api20220901
+seaweed.seaweedfs.com:
+  - apiVersion: seaweed.seaweedfs.com/v1
+    filename: seaweed.seaweedfs.com/seaweed_v1.json
+    kind: seaweed
+    name: seaweed_v1
+secret-sync.gke.io:
+  - apiVersion: secret-sync.gke.io/v1
+    filename: secret-sync.gke.io/secretsync_v1.json
+    kind: SecretSync
+    name: secretsync_v1
+secretgenerator.mittwald.de:
+  - apiVersion: secretgenerator.mittwald.de/v1alpha1
+    filename: secretgenerator.mittwald.de/sshkeypair_v1alpha1.json
+    kind: SSHKeyPair
+    name: sshkeypair_v1alpha1
+  - apiVersion: secretgenerator.mittwald.de/v1alpha1
+    filename: secretgenerator.mittwald.de/stringsecret_v1alpha1.json
+    kind: StringSecret
+    name: stringsecret_v1alpha1
+  - apiVersion: secretgenerator.mittwald.de/v1alpha1
+    filename: secretgenerator.mittwald.de/basicauth_v1alpha1.json
+    kind: BasicAuth
+    name: basicauth_v1alpha1
 secretmanager.cnrm.cloud.google.com:
   - apiVersion: secretmanager.cnrm.cloud.google.com/v1beta1
     filename: secretmanager.cnrm.cloud.google.com/secretmanagersecret_v1beta1.json
@@ -7455,6 +14254,28 @@ secrets.hashicorp.com:
     filename: secrets.hashicorp.com/vaultauthglobal_v1beta1.json
     kind: VaultAuthGlobal
     name: vaultauthglobal_v1beta1
+secrets.infisical.com:
+  - apiVersion: secrets.infisical.com/v1alpha1
+    filename: secrets.infisical.com/infisicalsecret_v1alpha1.json
+    kind: InfisicalSecret
+    name: infisicalsecret_v1alpha1
+  - apiVersion: secrets.infisical.com/v1alpha1
+    filename: secrets.infisical.com/infisicaldynamicsecret_v1alpha1.json
+    kind: InfisicalDynamicSecret
+    name: infisicaldynamicsecret_v1alpha1
+  - apiVersion: secrets.infisical.com/v1alpha1
+    filename: secrets.infisical.com/clustergenerator_v1alpha1.json
+    kind: ClusterGenerator
+    name: clustergenerator_v1alpha1
+  - apiVersion: secrets.infisical.com/v1alpha1
+    filename: secrets.infisical.com/infisicalpushsecret_v1alpha1.json
+    kind: InfisicalPushSecret
+    name: infisicalpushsecret_v1alpha1
+secretsmanager.services.k8s.aws:
+  - apiVersion: secretsmanager.services.k8s.aws/v1alpha1
+    filename: secretsmanager.services.k8s.aws/secret_v1alpha1.json
+    kind: Secret
+    name: secret_v1alpha1
 securesourcemanager.cnrm.cloud.google.com:
   - apiVersion: securesourcemanager.cnrm.cloud.google.com/v1alpha1
     filename: securesourcemanager.cnrm.cloud.google.com/securesourcemanagerinstance_v1alpha1.json
@@ -7464,6 +14285,14 @@ securesourcemanager.cnrm.cloud.google.com:
     filename: securesourcemanager.cnrm.cloud.google.com/securesourcemanagerrepository_v1alpha1.json
     kind: SecureSourceManagerRepository
     name: securesourcemanagerrepository_v1alpha1
+  - apiVersion: securesourcemanager.cnrm.cloud.google.com/v1beta1
+    filename: securesourcemanager.cnrm.cloud.google.com/securesourcemanagerrepository_v1beta1.json
+    kind: SecureSourceManagerRepository
+    name: securesourcemanagerrepository_v1beta1
+  - apiVersion: securesourcemanager.cnrm.cloud.google.com/v1beta1
+    filename: securesourcemanager.cnrm.cloud.google.com/securesourcemanagerinstance_v1beta1.json
+    kind: SecureSourceManagerInstance
+    name: securesourcemanagerinstance_v1beta1
 security.istio.io:
   - apiVersion: security.istio.io/v1beta1
     filename: security.istio.io/peerauthentication_v1beta1.json
@@ -7498,6 +14327,107 @@ securitycenter.cnrm.cloud.google.com:
     filename: securitycenter.cnrm.cloud.google.com/securitycentersource_v1alpha1.json
     kind: securitycentersource
     name: securitycentersource_v1alpha1
+servicebus.azure.com:
+  - apiVersion: servicebus.azure.com/v1api20221001preview
+    filename: servicebus.azure.com/namespacestopicssubscription_v1api20221001preview.json
+    kind: namespacestopicssubscription
+    name: namespacestopicssubscription_v1api20221001preview
+  - apiVersion: servicebus.azure.com/v1api20221001preview
+    filename: servicebus.azure.com/namespacestopicssubscriptionsrule_v1api20221001preview.json
+    kind: namespacestopicssubscriptionsrule
+    name: namespacestopicssubscriptionsrule_v1api20221001preview
+  - apiVersion: servicebus.azure.com/v1api20211101
+    filename: servicebus.azure.com/namespacestopicssubscription_v1api20211101.json
+    kind: namespacestopicssubscription
+    name: namespacestopicssubscription_v1api20211101
+  - apiVersion: servicebus.azure.com/v1api20240101
+    filename: servicebus.azure.com/namespacestopicssubscription_v1api20240101.json
+    kind: namespacestopicssubscription
+    name: namespacestopicssubscription_v1api20240101
+  - apiVersion: servicebus.azure.com/v1api20240101
+    filename: servicebus.azure.com/topicauthorizationrule_v1api20240101.json
+    kind: topicauthorizationrule
+    name: topicauthorizationrule_v1api20240101
+  - apiVersion: servicebus.azure.com/v1api20210101preview
+    filename: servicebus.azure.com/namespacestopicssubscriptionsrule_v1api20210101preview.json
+    kind: namespacestopicssubscriptionsrule
+    name: namespacestopicssubscriptionsrule_v1api20210101preview
+  - apiVersion: servicebus.azure.com/v1api20221001preview
+    filename: servicebus.azure.com/namespace_v1api20221001preview.json
+    kind: namespace
+    name: namespace_v1api20221001preview
+  - apiVersion: servicebus.azure.com/v1api20211101
+    filename: servicebus.azure.com/namespacesqueue_v1api20211101.json
+    kind: namespacesqueue
+    name: namespacesqueue_v1api20211101
+  - apiVersion: servicebus.azure.com/v1api20221001preview
+    filename: servicebus.azure.com/namespacesauthorizationrule_v1api20221001preview.json
+    kind: namespacesauthorizationrule
+    name: namespacesauthorizationrule_v1api20221001preview
+  - apiVersion: servicebus.azure.com/v1api20210101preview
+    filename: servicebus.azure.com/namespacesauthorizationrule_v1api20210101preview.json
+    kind: namespacesauthorizationrule
+    name: namespacesauthorizationrule_v1api20210101preview
+  - apiVersion: servicebus.azure.com/v1api20221001preview
+    filename: servicebus.azure.com/namespacestopic_v1api20221001preview.json
+    kind: namespacestopic
+    name: namespacestopic_v1api20221001preview
+  - apiVersion: servicebus.azure.com/v1api20210101preview
+    filename: servicebus.azure.com/namespacestopicssubscription_v1api20210101preview.json
+    kind: namespacestopicssubscription
+    name: namespacestopicssubscription_v1api20210101preview
+  - apiVersion: servicebus.azure.com/v1api20240101
+    filename: servicebus.azure.com/namespacestopicssubscriptionsrule_v1api20240101.json
+    kind: namespacestopicssubscriptionsrule
+    name: namespacestopicssubscriptionsrule_v1api20240101
+  - apiVersion: servicebus.azure.com/v1api20210101preview
+    filename: servicebus.azure.com/namespace_v1api20210101preview.json
+    kind: namespace
+    name: namespace_v1api20210101preview
+  - apiVersion: servicebus.azure.com/v1api20211101
+    filename: servicebus.azure.com/namespace_v1api20211101.json
+    kind: namespace
+    name: namespace_v1api20211101
+  - apiVersion: servicebus.azure.com/v1api20240101
+    filename: servicebus.azure.com/namespacesqueue_v1api20240101.json
+    kind: namespacesqueue
+    name: namespacesqueue_v1api20240101
+  - apiVersion: servicebus.azure.com/v1api20221001preview
+    filename: servicebus.azure.com/namespacesqueue_v1api20221001preview.json
+    kind: namespacesqueue
+    name: namespacesqueue_v1api20221001preview
+  - apiVersion: servicebus.azure.com/v1api20211101
+    filename: servicebus.azure.com/namespacesauthorizationrule_v1api20211101.json
+    kind: namespacesauthorizationrule
+    name: namespacesauthorizationrule_v1api20211101
+  - apiVersion: servicebus.azure.com/v1api20211101
+    filename: servicebus.azure.com/namespacestopic_v1api20211101.json
+    kind: namespacestopic
+    name: namespacestopic_v1api20211101
+  - apiVersion: servicebus.azure.com/v1api20240101
+    filename: servicebus.azure.com/namespacesauthorizationrule_v1api20240101.json
+    kind: namespacesauthorizationrule
+    name: namespacesauthorizationrule_v1api20240101
+  - apiVersion: servicebus.azure.com/v1api20240101
+    filename: servicebus.azure.com/namespace_v1api20240101.json
+    kind: namespace
+    name: namespace_v1api20240101
+  - apiVersion: servicebus.azure.com/v1api20210101preview
+    filename: servicebus.azure.com/namespacesqueue_v1api20210101preview.json
+    kind: namespacesqueue
+    name: namespacesqueue_v1api20210101preview
+  - apiVersion: servicebus.azure.com/v1api20240101
+    filename: servicebus.azure.com/namespacestopic_v1api20240101.json
+    kind: namespacestopic
+    name: namespacestopic_v1api20240101
+  - apiVersion: servicebus.azure.com/v1api20211101
+    filename: servicebus.azure.com/namespacestopicssubscriptionsrule_v1api20211101.json
+    kind: namespacestopicssubscriptionsrule
+    name: namespacestopicssubscriptionsrule_v1api20211101
+  - apiVersion: servicebus.azure.com/v1api20210101preview
+    filename: servicebus.azure.com/namespacestopic_v1api20210101preview.json
+    kind: namespacestopic
+    name: namespacestopic_v1api20210101preview
 servicedirectory.cnrm.cloud.google.com:
   - apiVersion: servicedirectory.cnrm.cloud.google.com/v1beta1
     filename: servicedirectory.cnrm.cloud.google.com/servicedirectoryservice_v1beta1.json
@@ -7525,6 +14455,10 @@ services.k8s.aws:
     filename: services.k8s.aws/adoptedresource_v1alpha1.json
     kind: AdoptedResource
     name: adoptedresource_v1alpha1
+  - apiVersion: services.k8s.aws/v1alpha1
+    filename: services.k8s.aws/iamroleselector_v1alpha1.json
+    kind: IAMRoleSelector
+    name: iamroleselector_v1alpha1
 serviceusage.cnrm.cloud.google.com:
   - apiVersion: serviceusage.cnrm.cloud.google.com/v1beta1
     filename: serviceusage.cnrm.cloud.google.com/service_v1beta1.json
@@ -7538,6 +14472,27 @@ serviceusage.cnrm.cloud.google.com:
     filename: serviceusage.cnrm.cloud.google.com/serviceidentity_v1beta1.json
     kind: serviceidentity
     name: serviceidentity_v1beta1
+serving.knative.dev:
+  - apiVersion: serving.knative.dev/v1
+    filename: serving.knative.dev/configuration_v1.json
+    kind: Configuration
+    name: configuration_v1
+  - apiVersion: serving.knative.dev/v1
+    filename: serving.knative.dev/revision_v1.json
+    kind: Revision
+    name: revision_v1
+  - apiVersion: serving.knative.dev/v1
+    filename: serving.knative.dev/route_v1.json
+    kind: Route
+    name: route_v1
+  - apiVersion: serving.knative.dev/v1beta1
+    filename: serving.knative.dev/domainmapping_v1beta1.json
+    kind: DomainMapping
+    name: domainmapping_v1beta1
+  - apiVersion: serving.knative.dev/v1
+    filename: serving.knative.dev/service_v1.json
+    kind: Service
+    name: service_v1
 serving.kserve.io:
   - apiVersion: serving.kserve.io/v1alpha1
     filename: serving.kserve.io/inferencegraph_v1alpha1.json
@@ -7559,6 +14514,22 @@ serving.kserve.io:
     filename: serving.kserve.io/clusterservingruntime_v1alpha1.json
     kind: clusterservingruntime
     name: clusterservingruntime_v1alpha1
+  - apiVersion: serving.kserve.io/v1alpha1
+    filename: serving.kserve.io/clusterstoragecontainer_v1alpha1.json
+    kind: clusterstoragecontainer
+    name: clusterstoragecontainer_v1alpha1
+  - apiVersion: serving.kserve.io/v1alpha1
+    filename: serving.kserve.io/localmodelnodegroup_v1alpha1.json
+    kind: localmodelnodegroup
+    name: localmodelnodegroup_v1alpha1
+  - apiVersion: serving.kserve.io/v1alpha1
+    filename: serving.kserve.io/localmodelcache_v1alpha1.json
+    kind: localmodelcache
+    name: localmodelcache_v1alpha1
+  - apiVersion: serving.kserve.io/v1alpha1
+    filename: serving.kserve.io/localmodelnode_v1alpha1.json
+    kind: localmodelnode
+    name: localmodelnode_v1alpha1
 sfn.services.k8s.aws:
   - apiVersion: sfn.services.k8s.aws/v1alpha1
     filename: sfn.services.k8s.aws/activity_v1alpha1.json
@@ -7568,11 +14539,51 @@ sfn.services.k8s.aws:
     filename: sfn.services.k8s.aws/statemachine_v1alpha1.json
     kind: StateMachine
     name: statemachine_v1alpha1
+signalrservice.azure.com:
+  - apiVersion: signalrservice.azure.com/v1api20240301
+    filename: signalrservice.azure.com/customcertificate_v1api20240301.json
+    kind: customCertificate
+    name: customcertificate_v1api20240301
+  - apiVersion: signalrservice.azure.com/v1api20211001
+    filename: signalrservice.azure.com/signalr_v1api20211001.json
+    kind: signalr
+    name: signalr_v1api20211001
+  - apiVersion: signalrservice.azure.com/v1api20240301
+    filename: signalrservice.azure.com/replica_v1api20240301.json
+    kind: replica
+    name: replica_v1api20240301
+  - apiVersion: signalrservice.azure.com/v1api20240301
+    filename: signalrservice.azure.com/customdomain_v1api20240301.json
+    kind: customDomain
+    name: customdomain_v1api20240301
+  - apiVersion: signalrservice.azure.com/v1api20240301
+    filename: signalrservice.azure.com/signalr_v1api20240301.json
+    kind: signalr
+    name: signalr_v1api20240301
+sinks.knative.dev:
+  - apiVersion: sinks.knative.dev/v1alpha1
+    filename: sinks.knative.dev/jobsink_v1alpha1.json
+    kind: JobSink
+    name: jobsink_v1alpha1
+  - apiVersion: sinks.knative.dev/v1alpha1
+    filename: sinks.knative.dev/integrationsink_v1alpha1.json
+    kind: IntegrationSink
+    name: integrationsink_v1alpha1
 slo.grafana.crossplane.io:
   - apiVersion: slo.grafana.crossplane.io/v1alpha1
     filename: slo.grafana.crossplane.io/slo_v1alpha1.json
     kind: SLO
     name: slo_v1alpha1
+slo.grafana.m.crossplane.io:
+  - apiVersion: slo.grafana.m.crossplane.io/v1alpha1
+    filename: slo.grafana.m.crossplane.io/slo_v1alpha1.json
+    kind: SLO
+    name: slo_v1alpha1
+slo.grafana.o.crossplane.io:
+  - apiVersion: slo.grafana.o.crossplane.io/v1alpha1
+    filename: slo.grafana.o.crossplane.io/slos_v1alpha1.json
+    kind: SLOs
+    name: slos_v1alpha1
 sloth.slok.dev:
   - apiVersion: sloth.slok.dev/v1
     filename: sloth.slok.dev/prometheusservicelevel_v1.json
@@ -7591,11 +14602,66 @@ sm.grafana.crossplane.io:
     filename: sm.grafana.crossplane.io/installation_v1alpha1.json
     kind: Installation
     name: installation_v1alpha1
+  - apiVersion: sm.grafana.crossplane.io/v1alpha1
+    filename: sm.grafana.crossplane.io/checkalerts_v1alpha1.json
+    kind: CheckAlerts
+    name: checkalerts_v1alpha1
+sm.grafana.m.crossplane.io:
+  - apiVersion: sm.grafana.m.crossplane.io/v1alpha1
+    filename: sm.grafana.m.crossplane.io/checkalerts_v1alpha1.json
+    kind: CheckAlerts
+    name: checkalerts_v1alpha1
+  - apiVersion: sm.grafana.m.crossplane.io/v1alpha1
+    filename: sm.grafana.m.crossplane.io/check_v1alpha1.json
+    kind: Check
+    name: check_v1alpha1
+  - apiVersion: sm.grafana.m.crossplane.io/v1alpha1
+    filename: sm.grafana.m.crossplane.io/probe_v1alpha1.json
+    kind: Probe
+    name: probe_v1alpha1
+  - apiVersion: sm.grafana.m.crossplane.io/v1alpha1
+    filename: sm.grafana.m.crossplane.io/installation_v1alpha1.json
+    kind: Installation
+    name: installation_v1alpha1
+sm.grafana.o.crossplane.io:
+  - apiVersion: sm.grafana.o.crossplane.io/v1alpha1
+    filename: sm.grafana.o.crossplane.io/probe_v1alpha1.json
+    kind: Probe
+    name: probe_v1alpha1
+  - apiVersion: sm.grafana.o.crossplane.io/v1alpha1
+    filename: sm.grafana.o.crossplane.io/probeset_v1alpha1.json
+    kind: ProbeSet
+    name: probeset_v1alpha1
 snapscheduler.backube:
   - apiVersion: snapscheduler.backube/v1
     filename: snapscheduler.backube/snapshotschedule_v1.json
     kind: SnapshotSchedule
     name: snapshotschedule_v1
+snapshot.kubevirt.io:
+  - apiVersion: snapshot.kubevirt.io/v1beta1
+    filename: snapshot.kubevirt.io/virtualmachinesnapshot_v1beta1.json
+    kind: VirtualMachineSnapshot
+    name: virtualmachinesnapshot_v1beta1
+  - apiVersion: snapshot.kubevirt.io/v1beta1
+    filename: snapshot.kubevirt.io/virtualmachinesnapshotcontent_v1beta1.json
+    kind: VirtualMachineSnapshotContent
+    name: virtualmachinesnapshotcontent_v1beta1
+  - apiVersion: snapshot.kubevirt.io/v1alpha1
+    filename: snapshot.kubevirt.io/virtualmachinerestore_v1alpha1.json
+    kind: VirtualMachineRestore
+    name: virtualmachinerestore_v1alpha1
+  - apiVersion: snapshot.kubevirt.io/v1alpha1
+    filename: snapshot.kubevirt.io/virtualmachinesnapshotcontent_v1alpha1.json
+    kind: VirtualMachineSnapshotContent
+    name: virtualmachinesnapshotcontent_v1alpha1
+  - apiVersion: snapshot.kubevirt.io/v1alpha1
+    filename: snapshot.kubevirt.io/virtualmachinesnapshot_v1alpha1.json
+    kind: VirtualMachineSnapshot
+    name: virtualmachinesnapshot_v1alpha1
+  - apiVersion: snapshot.kubevirt.io/v1beta1
+    filename: snapshot.kubevirt.io/virtualmachinerestore_v1beta1.json
+    kind: VirtualMachineRestore
+    name: virtualmachinerestore_v1beta1
 snapshot.storage.k8s.io:
   - apiVersion: snapshot.storage.k8s.io/v1
     filename: snapshot.storage.k8s.io/volumesnapshotcontent_v1.json
@@ -7621,6 +14687,48 @@ snapshot.storage.k8s.io:
     filename: snapshot.storage.k8s.io/volumesnapshotclass_v1beta1.json
     kind: VolumeSnapshotClass
     name: volumesnapshotclass_v1beta1
+sns.aws.m.upbound.io:
+  - apiVersion: sns.aws.m.upbound.io/v1beta1
+    filename: sns.aws.m.upbound.io/platformapplication_v1beta1.json
+    kind: PlatformApplication
+    name: platformapplication_v1beta1
+  - apiVersion: sns.aws.m.upbound.io/v1beta1
+    filename: sns.aws.m.upbound.io/topic_v1beta1.json
+    kind: Topic
+    name: topic_v1beta1
+  - apiVersion: sns.aws.m.upbound.io/v1beta1
+    filename: sns.aws.m.upbound.io/topicpolicy_v1beta1.json
+    kind: TopicPolicy
+    name: topicpolicy_v1beta1
+  - apiVersion: sns.aws.m.upbound.io/v1beta1
+    filename: sns.aws.m.upbound.io/topicsubscription_v1beta1.json
+    kind: TopicSubscription
+    name: topicsubscription_v1beta1
+  - apiVersion: sns.aws.m.upbound.io/v1beta1
+    filename: sns.aws.m.upbound.io/smspreferences_v1beta1.json
+    kind: SMSPreferences
+    name: smspreferences_v1beta1
+sns.aws.upbound.io:
+  - apiVersion: sns.aws.upbound.io/v1beta1
+    filename: sns.aws.upbound.io/platformapplication_v1beta1.json
+    kind: PlatformApplication
+    name: platformapplication_v1beta1
+  - apiVersion: sns.aws.upbound.io/v1beta1
+    filename: sns.aws.upbound.io/topic_v1beta1.json
+    kind: Topic
+    name: topic_v1beta1
+  - apiVersion: sns.aws.upbound.io/v1beta1
+    filename: sns.aws.upbound.io/topicpolicy_v1beta1.json
+    kind: TopicPolicy
+    name: topicpolicy_v1beta1
+  - apiVersion: sns.aws.upbound.io/v1beta1
+    filename: sns.aws.upbound.io/topicsubscription_v1beta1.json
+    kind: TopicSubscription
+    name: topicsubscription_v1beta1
+  - apiVersion: sns.aws.upbound.io/v1beta1
+    filename: sns.aws.upbound.io/smspreferences_v1beta1.json
+    kind: SMSPreferences
+    name: smspreferences_v1beta1
 sns.services.k8s.aws:
   - apiVersion: sns.services.k8s.aws/v1alpha1
     filename: sns.services.k8s.aws/platformapplication_v1alpha1.json
@@ -7638,6 +14746,11 @@ sns.services.k8s.aws:
     filename: sns.services.k8s.aws/subscription_v1alpha1.json
     kind: Subscription
     name: subscription_v1alpha1
+source.extensions.fluxcd.io:
+  - apiVersion: source.extensions.fluxcd.io/v1beta1
+    filename: source.extensions.fluxcd.io/artifactgenerator_v1beta1.json
+    kind: ArtifactGenerator
+    name: artifactgenerator_v1beta1
 source.toolkit.fluxcd.io:
   - apiVersion: source.toolkit.fluxcd.io/v1beta1
     filename: source.toolkit.fluxcd.io/bucket_v1beta1.json
@@ -7691,11 +14804,44 @@ source.toolkit.fluxcd.io:
     filename: source.toolkit.fluxcd.io/bucket_v1.json
     kind: Bucket
     name: bucket_v1
+  - apiVersion: source.toolkit.fluxcd.io/v1
+    filename: source.toolkit.fluxcd.io/externalartifact_v1.json
+    kind: ExternalArtifact
+    name: externalartifact_v1
+  - apiVersion: source.toolkit.fluxcd.io/v1
+    filename: source.toolkit.fluxcd.io/ocirepository_v1.json
+    kind: OCIRepository
+    name: ocirepository_v1
 sourcerepo.cnrm.cloud.google.com:
   - apiVersion: sourcerepo.cnrm.cloud.google.com/v1beta1
     filename: sourcerepo.cnrm.cloud.google.com/sourcereporepository_v1beta1.json
     kind: sourcereporepository
     name: sourcereporepository_v1beta1
+sources.knative.dev:
+  - apiVersion: sources.knative.dev/v1
+    filename: sources.knative.dev/apiserversource_v1.json
+    kind: ApiServerSource
+    name: apiserversource_v1
+  - apiVersion: sources.knative.dev/v1
+    filename: sources.knative.dev/pingsource_v1.json
+    kind: PingSource
+    name: pingsource_v1
+  - apiVersion: sources.knative.dev/v1
+    filename: sources.knative.dev/sinkbinding_v1.json
+    kind: SinkBinding
+    name: sinkbinding_v1
+  - apiVersion: sources.knative.dev/v1alpha1
+    filename: sources.knative.dev/integrationsource_v1alpha1.json
+    kind: IntegrationSource
+    name: integrationsource_v1alpha1
+  - apiVersion: sources.knative.dev/v1beta2
+    filename: sources.knative.dev/pingsource_v1beta2.json
+    kind: PingSource
+    name: pingsource_v1beta2
+  - apiVersion: sources.knative.dev/v1
+    filename: sources.knative.dev/containersource_v1.json
+    kind: ContainerSource
+    name: containersource_v1
 spanner.cnrm.cloud.google.com:
   - apiVersion: spanner.cnrm.cloud.google.com/v1beta1
     filename: spanner.cnrm.cloud.google.com/spannerdatabase_v1beta1.json
@@ -7705,6 +14851,14 @@ spanner.cnrm.cloud.google.com:
     filename: spanner.cnrm.cloud.google.com/spannerinstance_v1beta1.json
     kind: SpannerInstance
     name: spannerinstance_v1beta1
+  - apiVersion: spanner.cnrm.cloud.google.com/v1alpha1
+    filename: spanner.cnrm.cloud.google.com/spannerbackupschedule_v1alpha1.json
+    kind: SpannerBackupSchedule
+    name: spannerbackupschedule_v1alpha1
+  - apiVersion: spanner.cnrm.cloud.google.com/v1beta1
+    filename: spanner.cnrm.cloud.google.com/spannerbackupschedule_v1beta1.json
+    kind: SpannerBackupSchedule
+    name: spannerbackupschedule_v1beta1
 sparkoperator.k8s.io:
   - apiVersion: sparkoperator.k8s.io/v1beta2
     filename: sparkoperator.k8s.io/sparkapplication_v1beta2.json
@@ -7714,6 +14868,31 @@ sparkoperator.k8s.io:
     filename: sparkoperator.k8s.io/scheduledsparkapplication_v1beta2.json
     kind: scheduledsparkapplication
     name: scheduledsparkapplication_v1beta2
+speech.cnrm.cloud.google.com:
+  - apiVersion: speech.cnrm.cloud.google.com/v1alpha1
+    filename: speech.cnrm.cloud.google.com/speechcustomclass_v1alpha1.json
+    kind: SpeechCustomClass
+    name: speechcustomclass_v1alpha1
+  - apiVersion: speech.cnrm.cloud.google.com/v1alpha1
+    filename: speech.cnrm.cloud.google.com/speechrecognizer_v1alpha1.json
+    kind: SpeechRecognizer
+    name: speechrecognizer_v1alpha1
+  - apiVersion: speech.cnrm.cloud.google.com/v1beta1
+    filename: speech.cnrm.cloud.google.com/speechphraseset_v1beta1.json
+    kind: SpeechPhraseSet
+    name: speechphraseset_v1beta1
+  - apiVersion: speech.cnrm.cloud.google.com/v1alpha1
+    filename: speech.cnrm.cloud.google.com/speechphraseset_v1alpha1.json
+    kind: SpeechPhraseSet
+    name: speechphraseset_v1alpha1
+  - apiVersion: speech.cnrm.cloud.google.com/v1beta1
+    filename: speech.cnrm.cloud.google.com/speechrecognizer_v1beta1.json
+    kind: SpeechRecognizer
+    name: speechrecognizer_v1beta1
+  - apiVersion: speech.cnrm.cloud.google.com/v1beta1
+    filename: speech.cnrm.cloud.google.com/speechcustomclass_v1beta1.json
+    kind: SpeechCustomClass
+    name: speechcustomclass_v1beta1
 spv.no:
   - apiVersion: spv.no/v2beta1
     filename: spv.no/azurekeyvaultsecret_v2beta1.json
@@ -7731,6 +14910,99 @@ spv.no:
     filename: spv.no/azurekeyvaultsecret_v1.json
     kind: AzureKeyVaultSecret
     name: azurekeyvaultsecret_v1
+sql.azure.com:
+  - apiVersion: sql.azure.com/v1api20211101
+    filename: sql.azure.com/server_v1api20211101.json
+    kind: Server
+    name: server_v1api20211101
+  - apiVersion: sql.azure.com/v1api20211101
+    filename: sql.azure.com/serversadvancedthreatprotectionsetting_v1api20211101.json
+    kind: serversadvancedthreatprotectionsetting
+    name: serversadvancedthreatprotectionsetting_v1api20211101
+  - apiVersion: sql.azure.com/v1api20211101
+    filename: sql.azure.com/serversauditingsetting_v1api20211101.json
+    kind: serversauditingsetting
+    name: serversauditingsetting_v1api20211101
+  - apiVersion: sql.azure.com/v1api20211101
+    filename: sql.azure.com/serversdatabasesauditingsetting_v1api20211101.json
+    kind: serversdatabasesauditingsetting
+    name: serversdatabasesauditingsetting_v1api20211101
+  - apiVersion: sql.azure.com/v1api20211101
+    filename: sql.azure.com/serversfailovergroup_v1api20211101.json
+    kind: serversfailovergroup
+    name: serversfailovergroup_v1api20211101
+  - apiVersion: sql.azure.com/v1api20211101
+    filename: sql.azure.com/serversoutboundfirewallrule_v1api20211101.json
+    kind: serversoutboundfirewallrule
+    name: serversoutboundfirewallrule_v1api20211101
+  - apiVersion: sql.azure.com/v1api20211101
+    filename: sql.azure.com/serversdatabase_v1api20211101.json
+    kind: serversdatabase
+    name: serversdatabase_v1api20211101
+  - apiVersion: sql.azure.com/v1api20211101
+    filename: sql.azure.com/serversfirewallrule_v1api20211101.json
+    kind: serversfirewallrule
+    name: serversfirewallrule_v1api20211101
+  - apiVersion: sql.azure.com/v1
+    filename: sql.azure.com/user_v1.json
+    kind: User
+    name: user_v1
+  - apiVersion: sql.azure.com/v1api20211101
+    filename: sql.azure.com/serversdatabasessecurityalertpolicy_v1api20211101.json
+    kind: serversdatabasessecurityalertpolicy
+    name: serversdatabasessecurityalertpolicy_v1api20211101
+  - apiVersion: sql.azure.com/v1api20211101
+    filename: sql.azure.com/serversdatabasesadvancedthreatprotectionsetting_v1api20211101.json
+    kind: serversdatabasesadvancedthreatprotectionsetting
+    name: serversdatabasesadvancedthreatprotectionsetting_v1api20211101
+  - apiVersion: sql.azure.com/v1api20211101
+    filename: sql.azure.com/serversvirtualnetworkrule_v1api20211101.json
+    kind: serversvirtualnetworkrule
+    name: serversvirtualnetworkrule_v1api20211101
+  - apiVersion: sql.azure.com/v1api20211101
+    filename: sql.azure.com/serversazureadonlyauthentication_v1api20211101.json
+    kind: serversazureadonlyauthentication
+    name: serversazureadonlyauthentication_v1api20211101
+  - apiVersion: sql.azure.com/v1api20211101
+    filename: sql.azure.com/serversipv6firewallrule_v1api20211101.json
+    kind: serversipv6firewallrule
+    name: serversipv6firewallrule_v1api20211101
+  - apiVersion: sql.azure.com/v1api20211101
+    filename: sql.azure.com/serversdatabasesbackupshorttermretentionpolicy_v1api20211101.json
+    kind: serversdatabasesbackupshorttermretentionpolicy
+    name: serversdatabasesbackupshorttermretentionpolicy_v1api20211101
+  - apiVersion: sql.azure.com/v1api20211101
+    filename: sql.azure.com/serversdatabasestransparentdataencryption_v1api20211101.json
+    kind: serversdatabasestransparentdataencryption
+    name: serversdatabasestransparentdataencryption_v1api20211101
+  - apiVersion: sql.azure.com/v1api20211101
+    filename: sql.azure.com/serverssecurityalertpolicy_v1api20211101.json
+    kind: serverssecurityalertpolicy
+    name: serverssecurityalertpolicy_v1api20211101
+  - apiVersion: sql.azure.com/v1api20211101
+    filename: sql.azure.com/serversdatabasesbackuplongtermretentionpolicy_v1api20211101.json
+    kind: serversdatabasesbackuplongtermretentionpolicy
+    name: serversdatabasesbackuplongtermretentionpolicy_v1api20211101
+  - apiVersion: sql.azure.com/v1api20211101
+    filename: sql.azure.com/serversadministrator_v1api20211101.json
+    kind: serversadministrator
+    name: serversadministrator_v1api20211101
+  - apiVersion: sql.azure.com/v1api20211101
+    filename: sql.azure.com/serversdatabasesvulnerabilityassessment_v1api20211101.json
+    kind: serversdatabasesvulnerabilityassessment
+    name: serversdatabasesvulnerabilityassessment_v1api20211101
+  - apiVersion: sql.azure.com/v1api20211101
+    filename: sql.azure.com/serversconnectionpolicy_v1api20211101.json
+    kind: serversconnectionpolicy
+    name: serversconnectionpolicy_v1api20211101
+  - apiVersion: sql.azure.com/v1api20211101
+    filename: sql.azure.com/serverselasticpool_v1api20211101.json
+    kind: serverselasticpool
+    name: serverselasticpool_v1api20211101
+  - apiVersion: sql.azure.com/v1api20211101
+    filename: sql.azure.com/serversvulnerabilityassessment_v1api20211101.json
+    kind: serversvulnerabilityassessment
+    name: serversvulnerabilityassessment_v1api20211101
 sql.cnrm.cloud.google.com:
   - apiVersion: sql.cnrm.cloud.google.com/v1beta1
     filename: sql.cnrm.cloud.google.com/sqlsslcert_v1beta1.json
@@ -7748,6 +15020,40 @@ sql.cnrm.cloud.google.com:
     filename: sql.cnrm.cloud.google.com/sqluser_v1beta1.json
     kind: sqluser
     name: sqluser_v1beta1
+sqs.aws.m.upbound.io:
+  - apiVersion: sqs.aws.m.upbound.io/v1beta1
+    filename: sqs.aws.m.upbound.io/queue_v1beta1.json
+    kind: Queue
+    name: queue_v1beta1
+  - apiVersion: sqs.aws.m.upbound.io/v1beta1
+    filename: sqs.aws.m.upbound.io/queueredrivepolicy_v1beta1.json
+    kind: QueueRedrivePolicy
+    name: queueredrivepolicy_v1beta1
+  - apiVersion: sqs.aws.m.upbound.io/v1beta1
+    filename: sqs.aws.m.upbound.io/queueredriveallowpolicy_v1beta1.json
+    kind: QueueRedriveAllowPolicy
+    name: queueredriveallowpolicy_v1beta1
+  - apiVersion: sqs.aws.m.upbound.io/v1beta1
+    filename: sqs.aws.m.upbound.io/queuepolicy_v1beta1.json
+    kind: QueuePolicy
+    name: queuepolicy_v1beta1
+sqs.aws.upbound.io:
+  - apiVersion: sqs.aws.upbound.io/v1beta1
+    filename: sqs.aws.upbound.io/queue_v1beta1.json
+    kind: Queue
+    name: queue_v1beta1
+  - apiVersion: sqs.aws.upbound.io/v1beta1
+    filename: sqs.aws.upbound.io/queueredrivepolicy_v1beta1.json
+    kind: QueueRedrivePolicy
+    name: queueredrivepolicy_v1beta1
+  - apiVersion: sqs.aws.upbound.io/v1beta1
+    filename: sqs.aws.upbound.io/queueredriveallowpolicy_v1beta1.json
+    kind: QueueRedriveAllowPolicy
+    name: queueredriveallowpolicy_v1beta1
+  - apiVersion: sqs.aws.upbound.io/v1beta1
+    filename: sqs.aws.upbound.io/queuepolicy_v1beta1.json
+    kind: QueuePolicy
+    name: queuepolicy_v1beta1
 sqs.services.k8s.aws:
   - apiVersion: sqs.services.k8s.aws/v1alpha1
     filename: sqs.services.k8s.aws/queue_v1alpha1.json
@@ -7775,6 +15081,111 @@ status.gatekeeper.sh:
     filename: status.gatekeeper.sh/mutatorpodstatus_v1beta1.json
     kind: MutatorPodStatus
     name: mutatorpodstatus_v1beta1
+storage.azure.com:
+  - apiVersion: storage.azure.com/v1api20220901
+    filename: storage.azure.com/storageaccountsmanagementpolicy_v1api20220901.json
+    kind: storageaccountsmanagementpolicy
+    name: storageaccountsmanagementpolicy_v1api20220901
+  - apiVersion: storage.azure.com/v1api20230101
+    filename: storage.azure.com/storageaccountsblobservicescontainer_v1api20230101.json
+    kind: storageaccountsblobservicescontainer
+    name: storageaccountsblobservicescontainer_v1api20230101
+  - apiVersion: storage.azure.com/v1api20230101
+    filename: storage.azure.com/storageaccountsblobservice_v1api20230101.json
+    kind: storageaccountsblobservice
+    name: storageaccountsblobservice_v1api20230101
+  - apiVersion: storage.azure.com/v1api20230101
+    filename: storage.azure.com/storageaccountsmanagementpolicy_v1api20230101.json
+    kind: storageaccountsmanagementpolicy
+    name: storageaccountsmanagementpolicy_v1api20230101
+  - apiVersion: storage.azure.com/v1api20230101
+    filename: storage.azure.com/storageaccountstableservicestable_v1api20230101.json
+    kind: storageaccountstableservicestable
+    name: storageaccountstableservicestable_v1api20230101
+  - apiVersion: storage.azure.com/v1api20220901
+    filename: storage.azure.com/storageaccountsqueueservicesqueue_v1api20220901.json
+    kind: storageaccountsqueueservicesqueue
+    name: storageaccountsqueueservicesqueue_v1api20220901
+  - apiVersion: storage.azure.com/v1api20230101
+    filename: storage.azure.com/storageaccountstableservice_v1api20230101.json
+    kind: storageaccountstableservice
+    name: storageaccountstableservice_v1api20230101
+  - apiVersion: storage.azure.com/v1api20230101
+    filename: storage.azure.com/storageaccountsqueueservicesqueue_v1api20230101.json
+    kind: storageaccountsqueueservicesqueue
+    name: storageaccountsqueueservicesqueue_v1api20230101
+  - apiVersion: storage.azure.com/v1api20220901
+    filename: storage.azure.com/storageaccountsblobservicescontainer_v1api20220901.json
+    kind: storageaccountsblobservicescontainer
+    name: storageaccountsblobservicescontainer_v1api20220901
+  - apiVersion: storage.azure.com/v1api20210401
+    filename: storage.azure.com/storageaccountsqueueservice_v1api20210401.json
+    kind: storageaccountsqueueservice
+    name: storageaccountsqueueservice_v1api20210401
+  - apiVersion: storage.azure.com/v1api20220901
+    filename: storage.azure.com/storageaccountsfileservicesshare_v1api20220901.json
+    kind: storageaccountsfileservicesshare
+    name: storageaccountsfileservicesshare_v1api20220901
+  - apiVersion: storage.azure.com/v1api20230101
+    filename: storage.azure.com/storageaccountsfileservicesshare_v1api20230101.json
+    kind: storageaccountsfileservicesshare
+    name: storageaccountsfileservicesshare_v1api20230101
+  - apiVersion: storage.azure.com/v1api20210401
+    filename: storage.azure.com/storageaccountsmanagementpolicy_v1api20210401.json
+    kind: storageaccountsmanagementpolicy
+    name: storageaccountsmanagementpolicy_v1api20210401
+  - apiVersion: storage.azure.com/v1api20220901
+    filename: storage.azure.com/storageaccountstableservicestable_v1api20220901.json
+    kind: storageaccountstableservicestable
+    name: storageaccountstableservicestable_v1api20220901
+  - apiVersion: storage.azure.com/v1api20220901
+    filename: storage.azure.com/storageaccountstableservice_v1api20220901.json
+    kind: storageaccountstableservice
+    name: storageaccountstableservice_v1api20220901
+  - apiVersion: storage.azure.com/v1api20210401
+    filename: storage.azure.com/storageaccount_v1api20210401.json
+    kind: storageAccount
+    name: storageaccount_v1api20210401
+  - apiVersion: storage.azure.com/v1api20220901
+    filename: storage.azure.com/storageaccount_v1api20220901.json
+    kind: storageAccount
+    name: storageaccount_v1api20220901
+  - apiVersion: storage.azure.com/v1api20230101
+    filename: storage.azure.com/storageaccountsqueueservice_v1api20230101.json
+    kind: storageaccountsqueueservice
+    name: storageaccountsqueueservice_v1api20230101
+  - apiVersion: storage.azure.com/v1api20210401
+    filename: storage.azure.com/storageaccountsblobservicescontainer_v1api20210401.json
+    kind: storageaccountsblobservicescontainer
+    name: storageaccountsblobservicescontainer_v1api20210401
+  - apiVersion: storage.azure.com/v1api20210401
+    filename: storage.azure.com/storageaccountsqueueservicesqueue_v1api20210401.json
+    kind: storageaccountsqueueservicesqueue
+    name: storageaccountsqueueservicesqueue_v1api20210401
+  - apiVersion: storage.azure.com/v1api20230101
+    filename: storage.azure.com/storageaccount_v1api20230101.json
+    kind: storageAccount
+    name: storageaccount_v1api20230101
+  - apiVersion: storage.azure.com/v1api20220901
+    filename: storage.azure.com/storageaccountsblobservice_v1api20220901.json
+    kind: storageaccountsblobservice
+    name: storageaccountsblobservice_v1api20220901
+  - apiVersion: storage.azure.com/v1api20220901
+    filename: storage.azure.com/storageaccountsfileservice_v1api20220901.json
+    kind: storageaccountsfileservice
+    name: storageaccountsfileservice_v1api20220901
+  - apiVersion: storage.azure.com/v1api20210401
+    filename: storage.azure.com/storageaccountsblobservice_v1api20210401.json
+    kind: storageaccountsblobservice
+    name: storageaccountsblobservice_v1api20210401
+  - apiVersion: storage.azure.com/v1api20220901
+    filename: storage.azure.com/storageaccountsqueueservice_v1api20220901.json
+    kind: storageaccountsqueueservice
+    name: storageaccountsqueueservice_v1api20220901
+  - apiVersion: storage.azure.com/v1api20230101
+    filename: storage.azure.com/storageaccountsfileservice_v1api20230101.json
+    kind: storageaccountsfileservice
+    name: storageaccountsfileservice_v1api20230101
 storage.cnrm.cloud.google.com:
   - apiVersion: storage.cnrm.cloud.google.com/v1beta1
     filename: storage.cnrm.cloud.google.com/storagebucket_v1beta1.json
@@ -7796,6 +15207,14 @@ storage.cnrm.cloud.google.com:
     filename: storage.cnrm.cloud.google.com/storagebucketaccesscontrol_v1beta1.json
     kind: storagebucketaccesscontrol
     name: storagebucketaccesscontrol_v1beta1
+  - apiVersion: storage.cnrm.cloud.google.com/v1beta1
+    filename: storage.cnrm.cloud.google.com/storageanywherecache_v1beta1.json
+    kind: StorageAnywhereCache
+    name: storageanywherecache_v1beta1
+  - apiVersion: storage.cnrm.cloud.google.com/v1alpha1
+    filename: storage.cnrm.cloud.google.com/storageanywherecache_v1alpha1.json
+    kind: StorageAnywhereCache
+    name: storageanywherecache_v1alpha1
 storagetransfer.cnrm.cloud.google.com:
   - apiVersion: storagetransfer.cnrm.cloud.google.com/v1beta1
     filename: storagetransfer.cnrm.cloud.google.com/storagetransferjob_v1beta1.json
@@ -7814,6 +15233,49 @@ sts.min.io:
     filename: sts.min.io/policybinding_v1alpha1.json
     kind: policybinding
     name: policybinding_v1alpha1
+stunner.l7mp.io:
+  - apiVersion: stunner.l7mp.io/v1alpha1
+    filename: stunner.l7mp.io/dataplane_v1alpha1.json
+    kind: Dataplane
+    name: dataplane_v1alpha1
+  - apiVersion: stunner.l7mp.io/v1
+    filename: stunner.l7mp.io/udproute_v1.json
+    kind: UDPRoute
+    name: udproute_v1
+  - apiVersion: stunner.l7mp.io/v1
+    filename: stunner.l7mp.io/gatewayconfig_v1.json
+    kind: GatewayConfig
+    name: gatewayconfig_v1
+  - apiVersion: stunner.l7mp.io/v1
+    filename: stunner.l7mp.io/dataplane_v1.json
+    kind: Dataplane
+    name: dataplane_v1
+  - apiVersion: stunner.l7mp.io/v1
+    filename: stunner.l7mp.io/staticservice_v1.json
+    kind: StaticService
+    name: staticservice_v1
+  - apiVersion: stunner.l7mp.io/v1alpha1
+    filename: stunner.l7mp.io/gatewayconfig_v1alpha1.json
+    kind: GatewayConfig
+    name: gatewayconfig_v1alpha1
+  - apiVersion: stunner.l7mp.io/v1alpha1
+    filename: stunner.l7mp.io/staticservice_v1alpha1.json
+    kind: StaticService
+    name: staticservice_v1alpha1
+subscription.azure.com:
+  - apiVersion: subscription.azure.com/v1api20211001
+    filename: subscription.azure.com/alias_v1api20211001.json
+    kind: alias
+    name: alias_v1api20211001
+synapse.azure.com:
+  - apiVersion: synapse.azure.com/v1api20210601
+    filename: synapse.azure.com/workspacesbigdatapool_v1api20210601.json
+    kind: workspacesbigdatapool
+    name: workspacesbigdatapool_v1api20210601
+  - apiVersion: synapse.azure.com/v1api20210601
+    filename: synapse.azure.com/workspace_v1api20210601.json
+    kind: workspace
+    name: workspace_v1api20210601
 syncset.gatekeeper.sh:
   - apiVersion: syncset.gatekeeper.sh/v1alpha1
     filename: syncset.gatekeeper.sh/syncset_v1alpha1.json
@@ -7857,6 +15319,19 @@ tailscale.com:
     filename: tailscale.com/dnsconfig_v1alpha1.json
     kind: DNSConfig
     name: dnsconfig_v1alpha1
+  - apiVersion: tailscale.com/v1alpha1
+    filename: tailscale.com/proxygrouppolicy_v1alpha1.json
+    kind: proxygrouppolicy
+    name: proxygrouppolicy_v1alpha1
+  - apiVersion: tailscale.com/v1alpha1
+    filename: tailscale.com/tailnet_v1alpha1.json
+    kind: tailnet
+    name: tailnet_v1alpha1
+talos.dev:
+  - apiVersion: talos.dev/v1alpha1
+    filename: talos.dev/serviceaccount_v1alpha1.json
+    kind: serviceaccount
+    name: serviceaccount_v1alpha1
 telemetry.istio.io:
   - apiVersion: telemetry.istio.io/v1
     filename: telemetry.istio.io/telemetry_v1.json
@@ -7912,6 +15387,15 @@ templates.kluctl.io:
     filename: templates.kluctl.io/githubcomment_v1alpha1.json
     kind: GithubComment
     name: githubcomment_v1alpha1
+tempo.grafana.com:
+  - apiVersion: tempo.grafana.com/v1alpha1
+    filename: tempo.grafana.com/tempomonolithic_v1alpha1.json
+    kind: TempoMonolithic
+    name: tempomonolithic_v1alpha1
+  - apiVersion: tempo.grafana.com/v1alpha1
+    filename: tempo.grafana.com/tempostack_v1alpha1.json
+    kind: TempoStack
+    name: tempostack_v1alpha1
 temporal.io:
   - apiVersion: temporal.io/v1beta1
     filename: temporal.io/temporalclusterclient_v1beta1.json
@@ -7933,6 +15417,26 @@ temporal.io:
     filename: temporal.io/temporalnamespace_v1beta1.json
     kind: TemporalNamespace
     name: temporalnamespace_v1beta1
+  - apiVersion: temporal.io/v1alpha1
+    filename: temporal.io/workerdeployment_v1alpha1.json
+    kind: workerdeployment
+    name: workerdeployment_v1alpha1
+  - apiVersion: temporal.io/v1alpha1
+    filename: temporal.io/temporalworkerdeployment_v1alpha1.json
+    kind: temporalworkerdeployment
+    name: temporalworkerdeployment_v1alpha1
+  - apiVersion: temporal.io/v1alpha1
+    filename: temporal.io/temporalconnection_v1alpha1.json
+    kind: temporalconnection
+    name: temporalconnection_v1alpha1
+  - apiVersion: temporal.io/v1alpha1
+    filename: temporal.io/connection_v1alpha1.json
+    kind: connection
+    name: connection_v1alpha1
+  - apiVersion: temporal.io/v1alpha1
+    filename: temporal.io/workerresourcetemplate_v1alpha1.json
+    kind: workerresourcetemplate
+    name: workerresourcetemplate_v1alpha1
 tests.testkube.io:
   - apiVersion: tests.testkube.io/v2
     filename: tests.testkube.io/script_v2.json
@@ -8012,6 +15516,10 @@ tinkerbell.org:
     filename: tinkerbell.org/template_v1alpha1.json
     kind: Template
     name: template_v1alpha1
+  - apiVersion: tinkerbell.org/v1alpha1
+    filename: tinkerbell.org/workflowruleset_v1alpha1.json
+    kind: workflowruleset
+    name: workflowruleset_v1alpha1
 tpu.cnrm.cloud.google.com:
   - apiVersion: tpu.cnrm.cloud.google.com/v1alpha1
     filename: tpu.cnrm.cloud.google.com/tpunode_v1alpha1.json
@@ -8095,11 +15603,114 @@ traefik.io:
     filename: traefik.io/middleware_v1alpha1.json
     kind: Middleware
     name: middleware_v1alpha1
+trident.netapp.io:
+  - apiVersion: trident.netapp.io/v1
+    filename: trident.netapp.io/tridentvolumepublication_v1.json
+    kind: tridentvolumepublication
+    name: tridentvolumepublication_v1
+  - apiVersion: trident.netapp.io/v1
+    filename: trident.netapp.io/tridentactionmirrorupdate_v1.json
+    kind: tridentactionmirrorupdate
+    name: tridentactionmirrorupdate_v1
+  - apiVersion: trident.netapp.io/v1
+    filename: trident.netapp.io/tridentconfigurator_v1.json
+    kind: tridentconfigurator
+    name: tridentconfigurator_v1
+  - apiVersion: trident.netapp.io/v1
+    filename: trident.netapp.io/tridentmirrorrelationship_v1.json
+    kind: tridentmirrorrelationship
+    name: tridentmirrorrelationship_v1
+  - apiVersion: trident.netapp.io/v1
+    filename: trident.netapp.io/tridentsnapshot_v1.json
+    kind: tridentsnapshot
+    name: tridentsnapshot_v1
+  - apiVersion: trident.netapp.io/v1
+    filename: trident.netapp.io/tridentvolume_v1.json
+    kind: tridentvolume
+    name: tridentvolume_v1
+  - apiVersion: trident.netapp.io/v1
+    filename: trident.netapp.io/tridentorchestrator_v1.json
+    kind: tridentorchestrator
+    name: tridentorchestrator_v1
+  - apiVersion: trident.netapp.io/v1
+    filename: trident.netapp.io/tridentversion_v1.json
+    kind: tridentversion
+    name: tridentversion_v1
+  - apiVersion: trident.netapp.io/v1
+    filename: trident.netapp.io/tridentgroupsnapshot_v1.json
+    kind: tridentgroupsnapshot
+    name: tridentgroupsnapshot_v1
+  - apiVersion: trident.netapp.io/v1
+    filename: trident.netapp.io/tridenttransaction_v1.json
+    kind: tridenttransaction
+    name: tridenttransaction_v1
+  - apiVersion: trident.netapp.io/v1
+    filename: trident.netapp.io/tridentnode_v1.json
+    kind: tridentnode
+    name: tridentnode_v1
+  - apiVersion: trident.netapp.io/v1
+    filename: trident.netapp.io/tridentbackendconfig_v1.json
+    kind: tridentbackendconfig
+    name: tridentbackendconfig_v1
+  - apiVersion: trident.netapp.io/v1
+    filename: trident.netapp.io/tridentvolumereference_v1.json
+    kind: tridentvolumereference
+    name: tridentvolumereference_v1
+  - apiVersion: trident.netapp.io/v1
+    filename: trident.netapp.io/tridentnoderemediationtemplate_v1.json
+    kind: tridentnoderemediationtemplate
+    name: tridentnoderemediationtemplate_v1
+  - apiVersion: trident.netapp.io/v1
+    filename: trident.netapp.io/tridentsnapshotinfo_v1.json
+    kind: tridentsnapshotinfo
+    name: tridentsnapshotinfo_v1
+  - apiVersion: trident.netapp.io/v1
+    filename: trident.netapp.io/tridentstorageclass_v1.json
+    kind: tridentstorageclass
+    name: tridentstorageclass_v1
+  - apiVersion: trident.netapp.io/v1
+    filename: trident.netapp.io/tridentbackend_v1.json
+    kind: tridentbackend
+    name: tridentbackend_v1
+  - apiVersion: trident.netapp.io/v1
+    filename: trident.netapp.io/tridentnoderemediation_v1.json
+    kind: tridentnoderemediation
+    name: tridentnoderemediation_v1
+  - apiVersion: trident.netapp.io/v1
+    filename: trident.netapp.io/tridentactionsnapshotrestore_v1.json
+    kind: tridentactionsnapshotrestore
+    name: tridentactionsnapshotrestore_v1
 trust.cert-manager.io:
   - apiVersion: trust.cert-manager.io/v1alpha1
     filename: trust.cert-manager.io/bundle_v1alpha1.json
     kind: bundle
     name: bundle_v1alpha1
+tuppr.home-operations.com:
+  - apiVersion: tuppr.home-operations.com/v1alpha1
+    filename: tuppr.home-operations.com/talosupgrade_v1alpha1.json
+    kind: TalosUpgrade
+    name: talosupgrade_v1alpha1
+  - apiVersion: tuppr.home-operations.com/v1alpha1
+    filename: tuppr.home-operations.com/kubernetesupgrade_v1alpha1.json
+    kind: KubernetesUpgrade
+    name: kubernetesupgrade_v1alpha1
+twingate.com:
+  - apiVersion: twingate.com/v1beta
+    filename: twingate.com/twingateresource_v1beta.json
+    kind: TwingateResource
+    name: twingateresource_v1beta
+  - apiVersion: twingate.com/v1beta
+    filename: twingate.com/twingateresourceaccess_v1beta.json
+    kind: TwingateResourceAccess
+    name: twingateresourceaccess_v1beta
+  - apiVersion: twingate.com/v1beta
+    filename: twingate.com/twingateconnector_v1beta.json
+    kind: TwingateConnector
+    name: twingateconnector_v1beta
+  - apiVersion: twingate.com/v1beta
+    filename: twingate.com/twingategroup_v1beta.json
+    kind: TwingateGroup
+    name: twingategroup_v1beta
 uds.dev:
   - apiVersion: uds.dev/v1alpha1
     filename: uds.dev/exemption_v1alpha1.json
@@ -8274,6 +15885,19 @@ vertexai.cnrm.cloud.google.com:
     filename: vertexai.cnrm.cloud.google.com/vertexaidataset_v1alpha1.json
     kind: vertexaidataset
     name: vertexaidataset_v1alpha1
+  - apiVersion: vertexai.cnrm.cloud.google.com/v1beta1
+    filename: vertexai.cnrm.cloud.google.com/vertexaimetadatastore_v1beta1.json
+    kind: VertexAIMetadataStore
+    name: vertexaimetadatastore_v1beta1
+vmwareengine.cnrm.cloud.google.com:
+  - apiVersion: vmwareengine.cnrm.cloud.google.com/v1beta1
+    filename: vmwareengine.cnrm.cloud.google.com/vmwareengineexternaladdress_v1beta1.json
+    kind: VMwareEngineExternalAddress
+    name: vmwareengineexternaladdress_v1beta1
+  - apiVersion: vmwareengine.cnrm.cloud.google.com/v1alpha1
+    filename: vmwareengine.cnrm.cloud.google.com/vmwareengineexternaladdress_v1alpha1.json
+    kind: VMwareEngineExternalAddress
+    name: vmwareengineexternaladdress_v1alpha1
 volsync.backube:
   - apiVersion: volsync.backube/v1alpha1
     filename: volsync.backube/replicationsource_v1alpha1.json
@@ -8354,6 +15978,19 @@ vshn.appcat.vshn.io:
     filename: vshn.appcat.vshn.io/xvshnminio_v1.json
     kind: XVSHNMinio
     name: xvshnminio_v1
+web.azure.com:
+  - apiVersion: web.azure.com/v1api20220301
+    filename: web.azure.com/serverfarm_v1api20220301.json
+    kind: serverfarm
+    name: serverfarm_v1api20220301
+  - apiVersion: web.azure.com/v1api20220301
+    filename: web.azure.com/site_v1api20220301.json
+    kind: site
+    name: site_v1api20220301
+  - apiVersion: web.azure.com/v1api20220301
+    filename: web.azure.com/sitessourcecontrol_v1api20220301.json
+    kind: sitessourcecontrol
+    name: sitessourcecontrol_v1api20220301
 wgpolicyk8s.io:
   - apiVersion: wgpolicyk8s.io/v1alpha2
     filename: wgpolicyk8s.io/clusterpolicyreport_v1alpha2.json
@@ -8363,6 +16000,19 @@ wgpolicyk8s.io:
     filename: wgpolicyk8s.io/policyreport_v1alpha2.json
     kind: PolicyReport
     name: policyreport_v1alpha2
+work.open-cluster-management.io:
+  - apiVersion: work.open-cluster-management.io/v1alpha1
+    filename: work.open-cluster-management.io/manifestworkreplicaset_v1alpha1.json
+    kind: ManifestWorkReplicaSet
+    name: manifestworkreplicaset_v1alpha1
+  - apiVersion: work.open-cluster-management.io/v1
+    filename: work.open-cluster-management.io/appliedmanifestwork_v1.json
+    kind: AppliedManifestWork
+    name: appliedmanifestwork_v1
+  - apiVersion: work.open-cluster-management.io/v1
+    filename: work.open-cluster-management.io/manifestwork_v1.json
+    kind: ManifestWork
+    name: manifestwork_v1
 workflows.cnrm.cloud.google.com:
   - apiVersion: workflows.cnrm.cloud.google.com/v1alpha1
     filename: workflows.cnrm.cloud.google.com/workflowsworkflow_v1alpha1.json
@@ -8381,3 +16031,48 @@ workstations.cnrm.cloud.google.com:
     filename: workstations.cnrm.cloud.google.com/workstationcluster_v1beta1.json
     kind: WorkstationCluster
     name: workstationcluster_v1beta1
+  - apiVersion: workstations.cnrm.cloud.google.com/v1alpha1
+    filename: workstations.cnrm.cloud.google.com/workstation_v1alpha1.json
+    kind: Workstation
+    name: workstation_v1alpha1
+  - apiVersion: workstations.cnrm.cloud.google.com/v1alpha1
+    filename: workstations.cnrm.cloud.google.com/workstationconfig_v1alpha1.json
+    kind: WorkstationConfig
+    name: workstationconfig_v1alpha1
+  - apiVersion: workstations.cnrm.cloud.google.com/v1beta1
+    filename: workstations.cnrm.cloud.google.com/workstation_v1beta1.json
+    kind: Workstation
+    name: workstation_v1beta1
+  - apiVersion: workstations.cnrm.cloud.google.com/v1beta1
+    filename: workstations.cnrm.cloud.google.com/workstationconfig_v1beta1.json
+    kind: WorkstationConfig
+    name: workstationconfig_v1beta1
+zfs.openebs.io:
+  - apiVersion: zfs.openebs.io/v1
+    filename: zfs.openebs.io/zfsvolume_v1.json
+    kind: ZFSVolume
+    name: zfsvolume_v1
+  - apiVersion: zfs.openebs.io/v1
+    filename: zfs.openebs.io/zfsrestore_v1.json
+    kind: ZFSRestore
+    name: zfsrestore_v1
+  - apiVersion: zfs.openebs.io/v1
+    filename: zfs.openebs.io/zfssnapshot_v1.json
+    kind: ZFSSnapshot
+    name: zfssnapshot_v1
+  - apiVersion: zfs.openebs.io/v1alpha1
+    filename: zfs.openebs.io/zfssnapshot_v1alpha1.json
+    kind: ZFSSnapshot
+    name: zfssnapshot_v1alpha1
+  - apiVersion: zfs.openebs.io/v1alpha1
+    filename: zfs.openebs.io/zfsvolume_v1alpha1.json
+    kind: ZFSVolume
+    name: zfsvolume_v1alpha1
+  - apiVersion: zfs.openebs.io/v1
+    filename: zfs.openebs.io/zfsnode_v1.json
+    kind: ZFSNode
+    name: zfsnode_v1
+  - apiVersion: zfs.openebs.io/v1
+    filename: zfs.openebs.io/zfsbackup_v1.json
+    kind: ZFSBackup
+    name: zfsbackup_v1

--- a/infrastructure.cluster.x-k8s.io/osccluster_v1beta1.json
+++ b/infrastructure.cluster.x-k8s.io/osccluster_v1beta1.json
@@ -232,7 +232,7 @@
                   "type": "string"
                 },
                 "vmType": {
-                  "description": "The type of VM (tinav6.c1r1p2 by default)",
+                  "description": "The type of VM (tinav7.c1r1p2 by default)",
                   "type": "string"
                 }
               },

--- a/infrastructure.cluster.x-k8s.io/oscclustertemplate_v1beta1.json
+++ b/infrastructure.cluster.x-k8s.io/oscclustertemplate_v1beta1.json
@@ -258,7 +258,7 @@
                           "type": "string"
                         },
                         "vmType": {
-                          "description": "The type of VM (tinav6.c1r1p2 by default)",
+                          "description": "The type of VM (tinav7.c1r1p2 by default)",
                           "type": "string"
                         }
                       },

--- a/infrastructure.cluster.x-k8s.io/oscmachine_v1beta1.json
+++ b/infrastructure.cluster.x-k8s.io/oscmachine_v1beta1.json
@@ -122,6 +122,17 @@
                   "description": "unused",
                   "type": "string"
                 },
+                "fGPU": {
+                  "description": "The fGPU configuration for this VM.",
+                  "properties": {
+                    "model": {
+                      "description": "The fGPU model to add to the VM (e.g. nvidia-h100).\nThe fGPU will be released when the node VM is deleted.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
                 "imageId": {
                   "type": "string"
                 },
@@ -244,12 +255,20 @@
                   "description": "The subnet of the node (deprecated, use controlplane and/or worker roles on subnets)",
                   "type": "string"
                 },
+                "subregionMode": {
+                  "description": "The way nodes will be allocated in subregions (leastNodes or random; by default, leastNodes).",
+                  "enum": [
+                    "leastNodes",
+                    "random"
+                  ],
+                  "type": "string"
+                },
                 "subregionName": {
                   "description": "The subregion where the machine needs to be placed (deprecated, use subregionNames).",
                   "type": "string"
                 },
                 "subregionNames": {
-                  "description": "The subregions where the machines needs to be placed.",
+                  "description": "The subregions where the machines needs to be placed. If empty, the subregions defined at cluster level will be used.",
                   "items": {
                     "type": "string"
                   },
@@ -263,7 +282,7 @@
                   "type": "object"
                 },
                 "vmType": {
-                  "description": "The type of vm (tinav6.c4r8p1 by default)",
+                  "description": "The type of vm (tinav7.c4r8p1 by default)",
                   "type": "string"
                 },
                 "volumeDeviceName": {
@@ -518,6 +537,12 @@
         },
         "resources": {
           "properties": {
+            "fGPU": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            },
             "image": {
               "additionalProperties": {
                 "type": "string"

--- a/infrastructure.cluster.x-k8s.io/oscmachinetemplate_v1beta1.json
+++ b/infrastructure.cluster.x-k8s.io/oscmachinetemplate_v1beta1.json
@@ -149,6 +149,17 @@
                           "description": "unused",
                           "type": "string"
                         },
+                        "fGPU": {
+                          "description": "The fGPU configuration for this VM.",
+                          "properties": {
+                            "model": {
+                              "description": "The fGPU model to add to the VM (e.g. nvidia-h100).\nThe fGPU will be released when the node VM is deleted.",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
                         "imageId": {
                           "type": "string"
                         },
@@ -271,12 +282,20 @@
                           "description": "The subnet of the node (deprecated, use controlplane and/or worker roles on subnets)",
                           "type": "string"
                         },
+                        "subregionMode": {
+                          "description": "The way nodes will be allocated in subregions (leastNodes or random; by default, leastNodes).",
+                          "enum": [
+                            "leastNodes",
+                            "random"
+                          ],
+                          "type": "string"
+                        },
                         "subregionName": {
                           "description": "The subregion where the machine needs to be placed (deprecated, use subregionNames).",
                           "type": "string"
                         },
                         "subregionNames": {
-                          "description": "The subregions where the machines needs to be placed.",
+                          "description": "The subregions where the machines needs to be placed. If empty, the subregions defined at cluster level will be used.",
                           "items": {
                             "type": "string"
                           },
@@ -290,7 +309,7 @@
                           "type": "object"
                         },
                         "vmType": {
-                          "description": "The type of vm (tinav6.c4r8p1 by default)",
+                          "description": "The type of vm (tinav7.c4r8p1 by default)",
                           "type": "string"
                         },
                         "volumeDeviceName": {


### PR DESCRIPTION
Here the update [schemas](https://github.com/outscale/cluster-api-provider-outscale/tree/v1.5.0/config/crd/bases)

## PR Checklist

- [x] I generated these CRs using the [CRD Extractor tool](https://github.com/datreeio/CRDs-catalog?tab=readme-ov-file#crd-extractor). If I used a different method, I have described the method in this PR.
- [x] I am updating existing schemas and have specified the updated schema version.
- [x] I am adding new schemas and included a link to the GitHub repository that contains the source of these schemas.
