### PR TITLE
feat(kustomize.config.k8s.io): Add the client CRD

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -5134,6 +5134,10 @@ kueue.x-k8s.io:
     kind: WorkloadPriorityClass
     name: workloadpriorityclass_v1beta1
 kustomize.config.k8s.io:
+  - apiVersion: kustomize.config.k8s.io/v1alpha1
+    filename: kustomize.config.k8s.io/component_v1alpha1.json
+    kind: Component
+    name: component_v1alpha1
   - apiVersion: kustomize.config.k8s.io/v1beta1
     filename: kustomize.config.k8s.io/kustomization_v1beta1.json
     kind: Kustomization

--- a/index.yaml
+++ b/index.yaml
@@ -5133,6 +5133,15 @@ kueue.x-k8s.io:
     filename: kueue.x-k8s.io/workloadpriorityclass_v1beta1.json
     kind: WorkloadPriorityClass
     name: workloadpriorityclass_v1beta1
+kustomize.config.k8s.io:
+  - apiVersion: kustomize.config.k8s.io/v1beta1
+    filename: kustomize.config.k8s.io/kustomization_v1beta1.json
+    kind: Kustomization
+    name: kustomization_v1beta1
+  - apiVersion: kustomize.config.k8s.io/v1
+    filename: kustomize.config.k8s.io/kustomization_v1.json
+    kind: Kustomization
+    name: kustomization_v1
 kustomize.toolkit.fluxcd.io:
   - apiVersion: kustomize.toolkit.fluxcd.io/v1beta1
     filename: kustomize.toolkit.fluxcd.io/kustomization_v1beta1.json

--- a/kustomize.config.k8s.io/component_v1alpha1.json
+++ b/kustomize.config.k8s.io/component_v1alpha1.json
@@ -1,16 +1,13 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "description": "Kustomization is the Schema for a kustomize kustomization.yaml file",
+  "description": "Component is the Schema for a kustomize component.yaml file",
   "properties": {
     "apiVersion": {
-      "type": "string"
-    },
-    "bases": {
-      "description": "DEPRECATED. Bases are relative paths or git repository URLs specifying a directory containing a kustomization.yaml file.",
-      "items": {
-        "type": "string"
-      },
-      "type": "array"
+      "description": "APIVersion defines the versioned schema of this representation of an object.",
+      "type": "string",
+      "enum": [
+        "kustomize.config.k8s.io/v1alpha1"
+      ]
     },
     "commonAnnotations": {
       "description": "CommonAnnotations to add to all objects",
@@ -68,37 +65,12 @@
       },
       "type": "array"
     },
-    "helmCharts": {
-      "description": "HelmCharts is a list of helm chart configuration instances",
-      "items": {
-        "$ref": "#/definitions/HelmChart"
-      },
-      "type": "array"
-    },
-    "helmGlobals": {
-      "description": "HelmGlobals contains helm configuration that isn't chart specific",
-      "properties": {
-        "chartHome": {
-          "description": "ChartHome is a file path, relative to the kustomization root, to a directory containing a subdirectory for each chart to be included in the kustomization",
-          "type": "string"
-        },
-        "configHome": {
-          "description": "ConfigHome defines a value that kustomize should pass to helm via the HELM_CONFIG_HOME environment variable",
-          "type": "string"
-        }
-      },
-      "additionalProperties": false,
-      "type": "object"
-    },
     "images": {
       "description": "Images is a list of (image name, new name, new tag or digest) for changing image names, tags or digests. This can also be achieved with a patch, but this operator is simpler to specify.",
       "items": {
         "$ref": "#/definitions/Image"
       },
       "type": "array"
-    },
-    "inventory": {
-      "$ref": "#/definitions/Inventory"
     },
     "labels": {
       "description": "Labels to add to all objects but not selectors",
@@ -111,7 +83,7 @@
       "description": "Kind is a string value representing the resource this object represents.",
       "type": "string",
       "enum": [
-        "Kustomization"
+        "Component"
       ]
     },
     "metadata": {
@@ -259,13 +231,6 @@
       "description": "Validators is a list of files containing validators",
       "items": {
         "type": "string"
-      },
-      "type": "array"
-    },
-    "vars": {
-      "description": "Allows things modified by kustomize to be injected into a container specification. A var is a name (e.g. FOO) associated with a field in a specific resource instance.  The field must contain a value of type string, and defaults to the name field of the instance",
-      "items": {
-        "$ref": "#/definitions/Var"
       },
       "type": "array"
     }

--- a/kustomize.config.k8s.io/kustomization_v1.json
+++ b/kustomize.config.k8s.io/kustomization_v1.json
@@ -1,0 +1,1038 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$ref": "#/definitions/Kustomization",
+  "definitions": {
+    "ConfigMapArgs": {
+      "description": "ConfigMapArgs contains the metadata of how to generate a configmap",
+      "properties": {
+        "KVSources": {
+          "items": {
+            "$ref": "#/definitions/KVSource"
+          },
+          "type": "array"
+        },
+        "behavior": {
+          "enum": [
+            "create",
+            "replace",
+            "merge"
+          ]
+        },
+        "env": {
+          "description": "Deprecated.  Use envs instead.",
+          "type": "string"
+        },
+        "envs": {
+          "description": "A list of file paths. The contents of each file should be one key=value pair per line",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "files": {
+          "description": "A list of file sources to use in creating a list of key, value pairs",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "literals": {
+          "description": "A list of literal pair sources. Each literal source should be a key and literal value, e.g. `key=value`",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "name": {
+          "description": "Name - actually the partial name - of the generated resource",
+          "type": "string"
+        },
+        "namespace": {
+          "description": "Namespace for the configmap, optional",
+          "type": "string"
+        },
+        "options": {
+          "$ref": "#/definitions/GeneratorOptions"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "FieldSelector": {
+      "description": "Contains the fieldPath to an object field",
+      "properties": {
+        "fieldpath": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "FieldSpec": {
+      "properties": {
+        "create": {
+          "type": "boolean"
+        },
+        "group": {
+          "type": "string"
+        },
+        "kind": {
+          "type": "string"
+        },
+        "path": {
+          "type": "string"
+        },
+        "version": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "GeneratorOptions": {
+      "description": "GeneratorOptions modify behavior of all ConfigMap and Secret generators",
+      "properties": {
+        "annotations": {
+          "description": "Annotations to add to all generated resources",
+          "patternProperties": {
+            ".*": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "disableNameSuffixHash": {
+          "description": "DisableNameSuffixHash if true disables the default behavior of adding a suffix to the names of generated resources that is a hash of the resource contents",
+          "type": "boolean"
+        },
+        "immutable": {
+          "description": "Immutable if true add to all generated resources",
+          "type": "boolean"
+        },
+        "labels": {
+          "description": "Labels to add to all generated resources",
+          "patternProperties": {
+            ".*": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "HelmChart": {
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "version": {
+          "type": "string"
+        },
+        "repo": {
+          "type": "string"
+        },
+        "releaseName": {
+          "type": "string"
+        },
+        "namespace": {
+          "type": "string"
+        },
+        "valuesFile": {
+          "type": "string"
+        },
+        "valuesInline": {
+          "type": "object",
+          "patternProperties": {
+            ".*": {
+              "additionalProperties": true
+            }
+          }
+        },
+        "valuesMerge": {
+          "type": "string",
+          "enum": [
+            "merge",
+            "override",
+            "replace"
+          ]
+        },
+        "includeCRDs": {
+          "type": "boolean"
+        },
+        "skipHooks": {
+          "type": "boolean"
+        },
+        "additionalValuesFiles": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "skipTests": {
+          "type": "boolean"
+        },
+        "apiVersions": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "kubeVersion": {
+          "type": "string"
+        },
+        "nameTemplate": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "Image": {
+      "properties": {
+        "digest": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "newName": {
+          "type": "string"
+        },
+        "newTag": {
+          "type": "string"
+        },
+        "tagSuffix": {
+          "type": "string",
+          "description": "UNDOCUMENTED."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "Inventory": {
+      "description": "Inventory appends an object that contains the record of all other objects, which can be used in apply, prune and delete",
+      "properties": {
+        "configMap": {
+          "$ref": "#/definitions/NameArgs"
+        },
+        "type": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "KVSource": {
+      "properties": {
+        "args": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "name": {
+          "type": "string"
+        },
+        "pluginType": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "Kustomization": {
+      "properties": {
+        "apiVersion": {
+          "type": "string"
+        },
+        "bases": {
+          "description": "DEPRECATED. Bases are relative paths or git repository URLs specifying a directory containing a kustomization.yaml file.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "commonAnnotations": {
+          "description": "CommonAnnotations to add to all objects",
+          "patternProperties": {
+            ".*": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "buildMetadata": {
+          "description": "BuildMetadata is a list of strings used to toggle different build options",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "commonLabels": {
+          "description": " CommonLabels to add to all objects and selectors",
+          "patternProperties": {
+            ".*": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "configMapGenerator": {
+          "description": "ConfigMapGenerator is a list of configmaps to generate from local data (one configMap per list item)",
+          "items": {
+            "$ref": "#/definitions/ConfigMapArgs"
+          },
+          "type": "array"
+        },
+        "configurations": {
+          "description": "Configurations is a list of transformer configuration files",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "crds": {
+          "description": "Crds specifies relative paths to Custom Resource Definition files. This allows custom resources to be recognized as operands, making it possible to add them to the Resources list. CRDs themselves are not modified.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "generatorOptions": {
+          "$ref": "#/definitions/GeneratorOptions"
+        },
+        "generators": {
+          "description": "Generators is a list of files containing custom generators",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "helmCharts": {
+          "description": "HelmCharts is a list of helm chart configuration instances",
+          "items": {
+            "$ref": "#/definitions/HelmChart"
+          },
+          "type": "array"
+        },
+        "helmGlobals": {
+          "description": "HelmGlobals contains helm configuration that isn't chart specific",
+          "properties": {
+            "chartHome": {
+              "description": "ChartHome is a file path, relative to the kustomization root, to a directory containing a subdirectory for each chart to be included in the kustomization",
+              "type": "string"
+            },
+            "configHome": {
+              "description": "ConfigHome defines a value that kustomize should pass to helm via the HELM_CONFIG_HOME environment variable",
+              "type": "string"
+            }
+          },
+          "additionalProperties": false,
+          "type": "object"
+        },
+        "images": {
+          "description": "Images is a list of (image name, new name, new tag or digest) for changing image names, tags or digests. This can also be achieved with a patch, but this operator is simpler to specify.",
+          "items": {
+            "$ref": "#/definitions/Image"
+          },
+          "type": "array"
+        },
+        "inventory": {
+          "$ref": "#/definitions/Inventory"
+        },
+        "labels": {
+          "description": "Labels to add to all objects but not selectors",
+          "items": {
+            "$ref": "#/definitions/Labels"
+          },
+          "type": "array"
+        },
+        "kind": {
+          "type": "string"
+        },
+        "metadata": {
+          "$ref": "#/definitions/Metadata",
+          "description": "Contains metadata about a Resource"
+        },
+        "namePrefix": {
+          "description": "NamePrefix will prefix the names of all resources mentioned in the kustomization file including generated configmaps and secrets",
+          "type": "string"
+        },
+        "nameSuffix": {
+          "description": "NameSuffix will suffix the names of all resources mentioned in the kustomization file including generated configmaps and secrets",
+          "type": "string"
+        },
+        "namespace": {
+          "description": "Namespace to add to all objects",
+          "type": "string"
+        },
+        "replacements": {
+          "type": "array",
+          "description": "Substitute field(s) in N target(s) with a field from a source",
+          "items": {
+            "oneOf": [
+              {
+                "$ref": "#/definitions/ReplacementsPath"
+              },
+              {
+                "$ref": "#/definitions/ReplacementsInline"
+              }
+            ]
+          }
+        },
+        "openapi": {
+          "description": "OpenAPI contains information about what kubernetes schema to use",
+          "patternProperties": {
+            ".*": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "patches": {
+          "description": "Apply a patch to multiple resources",
+          "items": {
+            "oneOf": [
+              {
+                "$ref": "#/definitions/PatchesPatchPath"
+              },
+              {
+                "$ref": "#/definitions/PatchesInlinePatch"
+              }
+            ]
+          },
+          "type": "array"
+        },
+        "patchesJson6902": {
+          "description": "JSONPatches is a list of JSONPatch for applying JSON patch. See http://jsonpatch.com",
+          "items": {
+            "$ref": "#/definitions/PatchJson6902"
+          },
+          "type": "array"
+        },
+        "patchesStrategicMerge": {
+          "description": " PatchesStrategicMerge specifies the relative path to a file containing a strategic merge patch. URLs and globs are not supported",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "replicas": {
+          "description": "Replicas is a list of (resource name, count) for changing number of replicas for a resources. It will match any group and kind that has a matching name and that is one of: Deployment, ReplicationController, Replicaset, Statefulset.",
+          "items": {
+            "$ref": "#/definitions/Replicas"
+          },
+          "type": "array"
+        },
+        "resources": {
+          "description": "Resources specifies relative paths to files holding YAML representations of kubernetes API objects. URLs and globs not supported.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "components": {
+          "description": "Components are relative paths or git repository URLs specifying a directory containing a kustomization.yaml file of Kind Component.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "secretGenerator": {
+          "description": "SecretGenerator is a list of secrets to generate from local data (one secret per list item)",
+          "items": {
+            "$ref": "#/definitions/SecretArgs"
+          },
+          "type": "array"
+        },
+        "sortOptions": {
+          "description": "sortOptions is used to sort the resources kustomize outputs",
+          "oneOf": [
+            {
+              "properties": {
+                "order": {
+                  "enum": [
+                    "legacy"
+                  ]
+                },
+                "legacySortOptions": {
+                  "properties": {
+                    "orderFirst": {
+                      "type": "array"
+                    },
+                    "orderLast": {
+                      "type": "array"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "type": "object"
+                }
+              },
+              "additionalProperties": false,
+              "type": "object"
+            },
+            {
+              "properties": {
+                "order": {
+                  "enum": [
+                    "fifo"
+                  ]
+                }
+              },
+              "additionalProperties": false,
+              "type": "object"
+            }
+          ]
+        },
+        "transformers": {
+          "description": "Transformers is a list of files containing transformers",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "validators": {
+          "description": "Validators is a list of files containing validators",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "vars": {
+          "description": "Allows things modified by kustomize to be injected into a container specification. A var is a name (e.g. FOO) associated with a field in a specific resource instance.  The field must contain a value of type string, and defaults to the name field of the instance",
+          "items": {
+            "$ref": "#/definitions/Var"
+          },
+          "type": "array"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "Labels": {
+      "properties": {
+        "pairs": {
+          "description": "Pairs contains the key-value pairs for labels to add",
+          "patternProperties": {
+            ".*": {
+              "type": "string"
+            }
+          }
+        },
+        "includeSelectors": {
+          "description": "IncludeSelectors indicates should transformer include the fieldSpecs for selectors",
+          "type": "boolean"
+        },
+        "includeTemplates": {
+          "description": "IncludeTemplates indicates should transformer include the template labels",
+          "type": "boolean"
+        },
+        "fields": {
+          "description": "FieldSpec completely specifies a kustomizable field in a k8s API object. It helps define the operands of transformations",
+          "items": {
+            "$ref": "#/definitions/FieldSpec"
+          },
+          "type": "array"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "Metadata": {
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "namespace": {
+          "type": "string"
+        },
+        "labels": {
+          "patternProperties": {
+            ".*": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "annotations": {
+          "patternProperties": {
+            ".*": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "NameArgs": {
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "namespace": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "PatchJson6902": {
+      "oneOf": [
+        {
+          "required": [
+            "path",
+            "target"
+          ],
+          "properties": {
+            "path": {
+              "description": "relative file path for a json patch file inside a kustomization",
+              "type": "string"
+            },
+            "target": {
+              "$ref": "#/definitions/PatchTarget",
+              "description": "Refers to a Kubernetes object that the json patch will be applied to. It must refer to a Kubernetes resource under the purview of this kustomization"
+            }
+          },
+          "additionalProperties": false,
+          "type": "object"
+        },
+        {
+          "required": [
+            "patch",
+            "target"
+          ],
+          "properties": {
+            "patch": {
+              "description": "inline json patch",
+              "type": "string"
+            },
+            "target": {
+              "$ref": "#/definitions/PatchTarget",
+              "description": "Refers to a Kubernetes object that the json patch will be applied to. It must refer to a Kubernetes resource under the purview of this kustomization"
+            }
+          },
+          "additionalProperties": false,
+          "type": "object"
+        },
+        {
+          "required": [
+            "op",
+            "path"
+          ],
+          "properties": {
+            "op": {
+              "description": "The operation",
+              "type": "string",
+              "enum": [
+                "add",
+                "remove",
+                "replace",
+                "move",
+                "copy",
+                "test"
+              ]
+            },
+            "from": {
+              "description": "The source location.",
+              "type": "string"
+            },
+            "path": {
+              "description": "The target location.",
+              "type": "string"
+            },
+            "value": {
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "type": "object"
+        }
+      ]
+    },
+    "PatchTarget": {
+      "required": [
+        "kind",
+        "name",
+        "version"
+      ],
+      "properties": {
+        "group": {
+          "type": "string"
+        },
+        "kind": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "namespace": {
+          "type": "string"
+        },
+        "version": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "PatchesOptions": {
+      "properties": {
+        "allowNameChange": {
+          "type": "boolean"
+        },
+        "allowKindChange": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "PatchesPatchPath": {
+      "required": [
+        "path"
+      ],
+      "properties": {
+        "options": {
+          "$ref": "#/definitions/PatchesOptions"
+        },
+        "path": {
+          "type": "string"
+        },
+        "target": {
+          "$ref": "#/definitions/Selector",
+          "description": "Refers to a Kubernetes object that the patch will be applied to. It must refer to a Kubernetes resource under the purview of this kustomization"
+        }
+      },
+      "additionalProperties": false
+    },
+    "PatchesInlinePatch": {
+      "required": [
+        "patch"
+      ],
+      "properties": {
+        "options": {
+          "$ref": "#/definitions/PatchesOptions"
+        },
+        "patch": {
+          "type": "string"
+        },
+        "target": {
+          "$ref": "#/definitions/Selector",
+          "description": "Refers to a Kubernetes object that the patch will be applied to. It must refer to a Kubernetes resource under the purview of this kustomization"
+        }
+      },
+      "additionalProperties": false
+    },
+    "ReplacementsInline": {
+      "oneOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "source",
+            "targets"
+          ],
+          "properties": {
+            "source": {
+              "$ref": "#/definitions/ReplacementsSource"
+            },
+            "targets": {
+              "description": "The N fields to write the value to",
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/ReplacementsTarget"
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "sourceValue",
+            "targets"
+          ],
+          "properties": {
+            "sourceValue": {
+              "description": "A scalar value as source",
+              "type": "string"
+            },
+            "targets": {
+              "description": "The N fields to write the value to",
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/ReplacementsTarget"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "ReplacementsPath": {
+      "required": [
+        "path"
+      ],
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        }
+      }
+    },
+    "ReplacementsSource": {
+      "type": "object",
+      "description": "The source of the value",
+      "properties": {
+        "group": {
+          "type": "string",
+          "description": "The group of the referent"
+        },
+        "version": {
+          "type": "string",
+          "description": "The version of the referent"
+        },
+        "kind": {
+          "type": "string",
+          "description": "The kind of the referent"
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the referent"
+        },
+        "namespace": {
+          "type": "string",
+          "description": "The namespace of the referent"
+        },
+        "fieldPath": {
+          "type": "string",
+          "description": "The structured path to the source value"
+        },
+        "options": {
+          "type": "object",
+          "properties": {
+            "delimiter": {
+              "type": "string"
+            },
+            "index": {
+              "type": "number"
+            },
+            "create": {
+              "type": "boolean"
+            }
+          }
+        }
+      }
+    },
+    "ReplacementsTarget": {
+      "required": [
+        "select"
+      ],
+      "type": "object",
+      "properties": {
+        "select": {
+          "$ref": "#/definitions/Selector",
+          "description": "Include objects that match this"
+        },
+        "reject": {
+          "type": "array",
+          "description": "Exclude objects that match this",
+          "items": {
+            "$ref": "#/definitions/Selector"
+          }
+        },
+        "fieldPaths": {
+          "type": "array",
+          "description": "The structured path(s) to the target nodes",
+          "items": {
+            "type": "string",
+            "description": "The structured path to the source value"
+          }
+        },
+        "options": {
+          "type": "object",
+          "properties": {
+            "delimiter": {
+              "type": "string"
+            },
+            "index": {
+              "type": "number"
+            },
+            "create": {
+              "type": "boolean"
+            }
+          }
+        }
+      }
+    },
+    "Replicas": {
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "count": {
+          "type": "number"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "SecretArgs": {
+      "description": "SecretArgs contains the metadata of how to generate a secret",
+      "properties": {
+        "KVSources": {
+          "items": {
+            "$ref": "#/definitions/KVSource"
+          },
+          "type": "array"
+        },
+        "behavior": {
+          "enum": [
+            "create",
+            "replace",
+            "merge"
+          ]
+        },
+        "env": {
+          "type": "string"
+        },
+        "envs": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "files": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "literals": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "name": {
+          "description": "Name - actually the partial name - of the generated resource",
+          "type": "string"
+        },
+        "namespace": {
+          "description": "Namespace for the secret, optional",
+          "type": "string"
+        },
+        "options": {
+          "$ref": "#/definitions/GeneratorOptions"
+        },
+        "type": {
+          "description": "Type of the secret, optional",
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "Selector": {
+      "description": "Selector specifies a set of resources.\nAny resource that matches intersection of all conditions is included in this set.",
+      "properties": {
+        "group": {
+          "description": "The group of the referent",
+          "type": "string"
+        },
+        "kind": {
+          "description": "The kind of the referent",
+          "type": "string"
+        },
+        "name": {
+          "description": "The name of the referent",
+          "type": "string"
+        },
+        "namespace": {
+          "description": "The namespace of the referent",
+          "type": "string"
+        },
+        "version": {
+          "description": "The version of the referent",
+          "type": "string"
+        },
+        "annotationSelector": {
+          "description": "AnnotationSelector is a string that follows the label selection expression\nhttps://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api",
+          "type": "string"
+        },
+        "labelSelector": {
+          "description": "LabelSelector is a string that follows the label selection expression\nhttps://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api",
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "Target": {
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "apiVersion": {
+          "type": "string"
+        },
+        "group": {
+          "type": "string"
+        },
+        "kind": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "namespace": {
+          "type": "string",
+          "description": "UNDOCUMENTED."
+        },
+        "version": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "Var": {
+      "description": "Represents a variable whose value will be sourced from a field in a Kubernetes object.",
+      "required": [
+        "name",
+        "objref"
+      ],
+      "properties": {
+        "fieldref": {
+          "$ref": "#/definitions/FieldSelector",
+          "description": "Refers to the field of the object referred to by objref whose value will be extracted for use in replacing $(FOO)"
+        },
+        "name": {
+          "description": "Value of identifier name e.g. FOO used in container args, annotations, Appears in pod template as $(FOO)",
+          "type": "string"
+        },
+        "objref": {
+          "$ref": "#/definitions/Target",
+          "description": "Refers to a Kubernetes resource under the purview of this kustomization"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    }
+  },
+  "id": "https://json.schemastore.org/kustomization.json",
+  "description": "Kustomization is the Schema for a kustomize kustomization.yaml file"
+}

--- a/kustomize.config.k8s.io/kustomization_v1beta1.json
+++ b/kustomize.config.k8s.io/kustomization_v1beta1.json
@@ -1,0 +1,1038 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$ref": "#/definitions/Kustomization",
+  "definitions": {
+    "ConfigMapArgs": {
+      "description": "ConfigMapArgs contains the metadata of how to generate a configmap",
+      "properties": {
+        "KVSources": {
+          "items": {
+            "$ref": "#/definitions/KVSource"
+          },
+          "type": "array"
+        },
+        "behavior": {
+          "enum": [
+            "create",
+            "replace",
+            "merge"
+          ]
+        },
+        "env": {
+          "description": "Deprecated.  Use envs instead.",
+          "type": "string"
+        },
+        "envs": {
+          "description": "A list of file paths. The contents of each file should be one key=value pair per line",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "files": {
+          "description": "A list of file sources to use in creating a list of key, value pairs",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "literals": {
+          "description": "A list of literal pair sources. Each literal source should be a key and literal value, e.g. `key=value`",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "name": {
+          "description": "Name - actually the partial name - of the generated resource",
+          "type": "string"
+        },
+        "namespace": {
+          "description": "Namespace for the configmap, optional",
+          "type": "string"
+        },
+        "options": {
+          "$ref": "#/definitions/GeneratorOptions"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "FieldSelector": {
+      "description": "Contains the fieldPath to an object field",
+      "properties": {
+        "fieldpath": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "FieldSpec": {
+      "properties": {
+        "create": {
+          "type": "boolean"
+        },
+        "group": {
+          "type": "string"
+        },
+        "kind": {
+          "type": "string"
+        },
+        "path": {
+          "type": "string"
+        },
+        "version": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "GeneratorOptions": {
+      "description": "GeneratorOptions modify behavior of all ConfigMap and Secret generators",
+      "properties": {
+        "annotations": {
+          "description": "Annotations to add to all generated resources",
+          "patternProperties": {
+            ".*": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "disableNameSuffixHash": {
+          "description": "DisableNameSuffixHash if true disables the default behavior of adding a suffix to the names of generated resources that is a hash of the resource contents",
+          "type": "boolean"
+        },
+        "immutable": {
+          "description": "Immutable if true add to all generated resources",
+          "type": "boolean"
+        },
+        "labels": {
+          "description": "Labels to add to all generated resources",
+          "patternProperties": {
+            ".*": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "HelmChart": {
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "version": {
+          "type": "string"
+        },
+        "repo": {
+          "type": "string"
+        },
+        "releaseName": {
+          "type": "string"
+        },
+        "namespace": {
+          "type": "string"
+        },
+        "valuesFile": {
+          "type": "string"
+        },
+        "valuesInline": {
+          "type": "object",
+          "patternProperties": {
+            ".*": {
+              "additionalProperties": true
+            }
+          }
+        },
+        "valuesMerge": {
+          "type": "string",
+          "enum": [
+            "merge",
+            "override",
+            "replace"
+          ]
+        },
+        "includeCRDs": {
+          "type": "boolean"
+        },
+        "skipHooks": {
+          "type": "boolean"
+        },
+        "additionalValuesFiles": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "skipTests": {
+          "type": "boolean"
+        },
+        "apiVersions": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "kubeVersion": {
+          "type": "string"
+        },
+        "nameTemplate": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "Image": {
+      "properties": {
+        "digest": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "newName": {
+          "type": "string"
+        },
+        "newTag": {
+          "type": "string"
+        },
+        "tagSuffix": {
+          "type": "string",
+          "description": "UNDOCUMENTED."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "Inventory": {
+      "description": "Inventory appends an object that contains the record of all other objects, which can be used in apply, prune and delete",
+      "properties": {
+        "configMap": {
+          "$ref": "#/definitions/NameArgs"
+        },
+        "type": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "KVSource": {
+      "properties": {
+        "args": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "name": {
+          "type": "string"
+        },
+        "pluginType": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "Kustomization": {
+      "properties": {
+        "apiVersion": {
+          "type": "string"
+        },
+        "bases": {
+          "description": "DEPRECATED. Bases are relative paths or git repository URLs specifying a directory containing a kustomization.yaml file.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "commonAnnotations": {
+          "description": "CommonAnnotations to add to all objects",
+          "patternProperties": {
+            ".*": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "buildMetadata": {
+          "description": "BuildMetadata is a list of strings used to toggle different build options",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "commonLabels": {
+          "description": " CommonLabels to add to all objects and selectors",
+          "patternProperties": {
+            ".*": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "configMapGenerator": {
+          "description": "ConfigMapGenerator is a list of configmaps to generate from local data (one configMap per list item)",
+          "items": {
+            "$ref": "#/definitions/ConfigMapArgs"
+          },
+          "type": "array"
+        },
+        "configurations": {
+          "description": "Configurations is a list of transformer configuration files",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "crds": {
+          "description": "Crds specifies relative paths to Custom Resource Definition files. This allows custom resources to be recognized as operands, making it possible to add them to the Resources list. CRDs themselves are not modified.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "generatorOptions": {
+          "$ref": "#/definitions/GeneratorOptions"
+        },
+        "generators": {
+          "description": "Generators is a list of files containing custom generators",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "helmCharts": {
+          "description": "HelmCharts is a list of helm chart configuration instances",
+          "items": {
+            "$ref": "#/definitions/HelmChart"
+          },
+          "type": "array"
+        },
+        "helmGlobals": {
+          "description": "HelmGlobals contains helm configuration that isn't chart specific",
+          "properties": {
+            "chartHome": {
+              "description": "ChartHome is a file path, relative to the kustomization root, to a directory containing a subdirectory for each chart to be included in the kustomization",
+              "type": "string"
+            },
+            "configHome": {
+              "description": "ConfigHome defines a value that kustomize should pass to helm via the HELM_CONFIG_HOME environment variable",
+              "type": "string"
+            }
+          },
+          "additionalProperties": false,
+          "type": "object"
+        },
+        "images": {
+          "description": "Images is a list of (image name, new name, new tag or digest) for changing image names, tags or digests. This can also be achieved with a patch, but this operator is simpler to specify.",
+          "items": {
+            "$ref": "#/definitions/Image"
+          },
+          "type": "array"
+        },
+        "inventory": {
+          "$ref": "#/definitions/Inventory"
+        },
+        "labels": {
+          "description": "Labels to add to all objects but not selectors",
+          "items": {
+            "$ref": "#/definitions/Labels"
+          },
+          "type": "array"
+        },
+        "kind": {
+          "type": "string"
+        },
+        "metadata": {
+          "$ref": "#/definitions/Metadata",
+          "description": "Contains metadata about a Resource"
+        },
+        "namePrefix": {
+          "description": "NamePrefix will prefix the names of all resources mentioned in the kustomization file including generated configmaps and secrets",
+          "type": "string"
+        },
+        "nameSuffix": {
+          "description": "NameSuffix will suffix the names of all resources mentioned in the kustomization file including generated configmaps and secrets",
+          "type": "string"
+        },
+        "namespace": {
+          "description": "Namespace to add to all objects",
+          "type": "string"
+        },
+        "replacements": {
+          "type": "array",
+          "description": "Substitute field(s) in N target(s) with a field from a source",
+          "items": {
+            "oneOf": [
+              {
+                "$ref": "#/definitions/ReplacementsPath"
+              },
+              {
+                "$ref": "#/definitions/ReplacementsInline"
+              }
+            ]
+          }
+        },
+        "openapi": {
+          "description": "OpenAPI contains information about what kubernetes schema to use",
+          "patternProperties": {
+            ".*": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "patches": {
+          "description": "Apply a patch to multiple resources",
+          "items": {
+            "oneOf": [
+              {
+                "$ref": "#/definitions/PatchesPatchPath"
+              },
+              {
+                "$ref": "#/definitions/PatchesInlinePatch"
+              }
+            ]
+          },
+          "type": "array"
+        },
+        "patchesJson6902": {
+          "description": "JSONPatches is a list of JSONPatch for applying JSON patch. See http://jsonpatch.com",
+          "items": {
+            "$ref": "#/definitions/PatchJson6902"
+          },
+          "type": "array"
+        },
+        "patchesStrategicMerge": {
+          "description": " PatchesStrategicMerge specifies the relative path to a file containing a strategic merge patch. URLs and globs are not supported",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "replicas": {
+          "description": "Replicas is a list of (resource name, count) for changing number of replicas for a resources. It will match any group and kind that has a matching name and that is one of: Deployment, ReplicationController, Replicaset, Statefulset.",
+          "items": {
+            "$ref": "#/definitions/Replicas"
+          },
+          "type": "array"
+        },
+        "resources": {
+          "description": "Resources specifies relative paths to files holding YAML representations of kubernetes API objects. URLs and globs not supported.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "components": {
+          "description": "Components are relative paths or git repository URLs specifying a directory containing a kustomization.yaml file of Kind Component.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "secretGenerator": {
+          "description": "SecretGenerator is a list of secrets to generate from local data (one secret per list item)",
+          "items": {
+            "$ref": "#/definitions/SecretArgs"
+          },
+          "type": "array"
+        },
+        "sortOptions": {
+          "description": "sortOptions is used to sort the resources kustomize outputs",
+          "oneOf": [
+            {
+              "properties": {
+                "order": {
+                  "enum": [
+                    "legacy"
+                  ]
+                },
+                "legacySortOptions": {
+                  "properties": {
+                    "orderFirst": {
+                      "type": "array"
+                    },
+                    "orderLast": {
+                      "type": "array"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "type": "object"
+                }
+              },
+              "additionalProperties": false,
+              "type": "object"
+            },
+            {
+              "properties": {
+                "order": {
+                  "enum": [
+                    "fifo"
+                  ]
+                }
+              },
+              "additionalProperties": false,
+              "type": "object"
+            }
+          ]
+        },
+        "transformers": {
+          "description": "Transformers is a list of files containing transformers",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "validators": {
+          "description": "Validators is a list of files containing validators",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "vars": {
+          "description": "Allows things modified by kustomize to be injected into a container specification. A var is a name (e.g. FOO) associated with a field in a specific resource instance.  The field must contain a value of type string, and defaults to the name field of the instance",
+          "items": {
+            "$ref": "#/definitions/Var"
+          },
+          "type": "array"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "Labels": {
+      "properties": {
+        "pairs": {
+          "description": "Pairs contains the key-value pairs for labels to add",
+          "patternProperties": {
+            ".*": {
+              "type": "string"
+            }
+          }
+        },
+        "includeSelectors": {
+          "description": "IncludeSelectors indicates should transformer include the fieldSpecs for selectors",
+          "type": "boolean"
+        },
+        "includeTemplates": {
+          "description": "IncludeTemplates indicates should transformer include the template labels",
+          "type": "boolean"
+        },
+        "fields": {
+          "description": "FieldSpec completely specifies a kustomizable field in a k8s API object. It helps define the operands of transformations",
+          "items": {
+            "$ref": "#/definitions/FieldSpec"
+          },
+          "type": "array"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "Metadata": {
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "namespace": {
+          "type": "string"
+        },
+        "labels": {
+          "patternProperties": {
+            ".*": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "annotations": {
+          "patternProperties": {
+            ".*": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "NameArgs": {
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "namespace": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "PatchJson6902": {
+      "oneOf": [
+        {
+          "required": [
+            "path",
+            "target"
+          ],
+          "properties": {
+            "path": {
+              "description": "relative file path for a json patch file inside a kustomization",
+              "type": "string"
+            },
+            "target": {
+              "$ref": "#/definitions/PatchTarget",
+              "description": "Refers to a Kubernetes object that the json patch will be applied to. It must refer to a Kubernetes resource under the purview of this kustomization"
+            }
+          },
+          "additionalProperties": false,
+          "type": "object"
+        },
+        {
+          "required": [
+            "patch",
+            "target"
+          ],
+          "properties": {
+            "patch": {
+              "description": "inline json patch",
+              "type": "string"
+            },
+            "target": {
+              "$ref": "#/definitions/PatchTarget",
+              "description": "Refers to a Kubernetes object that the json patch will be applied to. It must refer to a Kubernetes resource under the purview of this kustomization"
+            }
+          },
+          "additionalProperties": false,
+          "type": "object"
+        },
+        {
+          "required": [
+            "op",
+            "path"
+          ],
+          "properties": {
+            "op": {
+              "description": "The operation",
+              "type": "string",
+              "enum": [
+                "add",
+                "remove",
+                "replace",
+                "move",
+                "copy",
+                "test"
+              ]
+            },
+            "from": {
+              "description": "The source location.",
+              "type": "string"
+            },
+            "path": {
+              "description": "The target location.",
+              "type": "string"
+            },
+            "value": {
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "type": "object"
+        }
+      ]
+    },
+    "PatchTarget": {
+      "required": [
+        "kind",
+        "name",
+        "version"
+      ],
+      "properties": {
+        "group": {
+          "type": "string"
+        },
+        "kind": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "namespace": {
+          "type": "string"
+        },
+        "version": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "PatchesOptions": {
+      "properties": {
+        "allowNameChange": {
+          "type": "boolean"
+        },
+        "allowKindChange": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "PatchesPatchPath": {
+      "required": [
+        "path"
+      ],
+      "properties": {
+        "options": {
+          "$ref": "#/definitions/PatchesOptions"
+        },
+        "path": {
+          "type": "string"
+        },
+        "target": {
+          "$ref": "#/definitions/Selector",
+          "description": "Refers to a Kubernetes object that the patch will be applied to. It must refer to a Kubernetes resource under the purview of this kustomization"
+        }
+      },
+      "additionalProperties": false
+    },
+    "PatchesInlinePatch": {
+      "required": [
+        "patch"
+      ],
+      "properties": {
+        "options": {
+          "$ref": "#/definitions/PatchesOptions"
+        },
+        "patch": {
+          "type": "string"
+        },
+        "target": {
+          "$ref": "#/definitions/Selector",
+          "description": "Refers to a Kubernetes object that the patch will be applied to. It must refer to a Kubernetes resource under the purview of this kustomization"
+        }
+      },
+      "additionalProperties": false
+    },
+    "ReplacementsInline": {
+      "oneOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "source",
+            "targets"
+          ],
+          "properties": {
+            "source": {
+              "$ref": "#/definitions/ReplacementsSource"
+            },
+            "targets": {
+              "description": "The N fields to write the value to",
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/ReplacementsTarget"
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "sourceValue",
+            "targets"
+          ],
+          "properties": {
+            "sourceValue": {
+              "description": "A scalar value as source",
+              "type": "string"
+            },
+            "targets": {
+              "description": "The N fields to write the value to",
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/ReplacementsTarget"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "ReplacementsPath": {
+      "required": [
+        "path"
+      ],
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        }
+      }
+    },
+    "ReplacementsSource": {
+      "type": "object",
+      "description": "The source of the value",
+      "properties": {
+        "group": {
+          "type": "string",
+          "description": "The group of the referent"
+        },
+        "version": {
+          "type": "string",
+          "description": "The version of the referent"
+        },
+        "kind": {
+          "type": "string",
+          "description": "The kind of the referent"
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the referent"
+        },
+        "namespace": {
+          "type": "string",
+          "description": "The namespace of the referent"
+        },
+        "fieldPath": {
+          "type": "string",
+          "description": "The structured path to the source value"
+        },
+        "options": {
+          "type": "object",
+          "properties": {
+            "delimiter": {
+              "type": "string"
+            },
+            "index": {
+              "type": "number"
+            },
+            "create": {
+              "type": "boolean"
+            }
+          }
+        }
+      }
+    },
+    "ReplacementsTarget": {
+      "required": [
+        "select"
+      ],
+      "type": "object",
+      "properties": {
+        "select": {
+          "$ref": "#/definitions/Selector",
+          "description": "Include objects that match this"
+        },
+        "reject": {
+          "type": "array",
+          "description": "Exclude objects that match this",
+          "items": {
+            "$ref": "#/definitions/Selector"
+          }
+        },
+        "fieldPaths": {
+          "type": "array",
+          "description": "The structured path(s) to the target nodes",
+          "items": {
+            "type": "string",
+            "description": "The structured path to the source value"
+          }
+        },
+        "options": {
+          "type": "object",
+          "properties": {
+            "delimiter": {
+              "type": "string"
+            },
+            "index": {
+              "type": "number"
+            },
+            "create": {
+              "type": "boolean"
+            }
+          }
+        }
+      }
+    },
+    "Replicas": {
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "count": {
+          "type": "number"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "SecretArgs": {
+      "description": "SecretArgs contains the metadata of how to generate a secret",
+      "properties": {
+        "KVSources": {
+          "items": {
+            "$ref": "#/definitions/KVSource"
+          },
+          "type": "array"
+        },
+        "behavior": {
+          "enum": [
+            "create",
+            "replace",
+            "merge"
+          ]
+        },
+        "env": {
+          "type": "string"
+        },
+        "envs": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "files": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "literals": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "name": {
+          "description": "Name - actually the partial name - of the generated resource",
+          "type": "string"
+        },
+        "namespace": {
+          "description": "Namespace for the secret, optional",
+          "type": "string"
+        },
+        "options": {
+          "$ref": "#/definitions/GeneratorOptions"
+        },
+        "type": {
+          "description": "Type of the secret, optional",
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "Selector": {
+      "description": "Selector specifies a set of resources.\nAny resource that matches intersection of all conditions is included in this set.",
+      "properties": {
+        "group": {
+          "description": "The group of the referent",
+          "type": "string"
+        },
+        "kind": {
+          "description": "The kind of the referent",
+          "type": "string"
+        },
+        "name": {
+          "description": "The name of the referent",
+          "type": "string"
+        },
+        "namespace": {
+          "description": "The namespace of the referent",
+          "type": "string"
+        },
+        "version": {
+          "description": "The version of the referent",
+          "type": "string"
+        },
+        "annotationSelector": {
+          "description": "AnnotationSelector is a string that follows the label selection expression\nhttps://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api",
+          "type": "string"
+        },
+        "labelSelector": {
+          "description": "LabelSelector is a string that follows the label selection expression\nhttps://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api",
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "Target": {
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "apiVersion": {
+          "type": "string"
+        },
+        "group": {
+          "type": "string"
+        },
+        "kind": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "namespace": {
+          "type": "string",
+          "description": "UNDOCUMENTED."
+        },
+        "version": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "Var": {
+      "description": "Represents a variable whose value will be sourced from a field in a Kubernetes object.",
+      "required": [
+        "name",
+        "objref"
+      ],
+      "properties": {
+        "fieldref": {
+          "$ref": "#/definitions/FieldSelector",
+          "description": "Refers to the field of the object referred to by objref whose value will be extracted for use in replacing $(FOO)"
+        },
+        "name": {
+          "description": "Value of identifier name e.g. FOO used in container args, annotations, Appears in pod template as $(FOO)",
+          "type": "string"
+        },
+        "objref": {
+          "$ref": "#/definitions/Target",
+          "description": "Refers to a Kubernetes resource under the purview of this kustomization"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    }
+  },
+  "id": "https://json.schemastore.org/kustomization.json",
+  "description": "Kustomization is the Schema for a kustomize kustomization.yaml file"
+}

--- a/kustomize.config.k8s.io/kustomization_v1beta1.json
+++ b/kustomize.config.k8s.io/kustomization_v1beta1.json
@@ -1,6 +1,277 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
-  "$ref": "#/definitions/Kustomization",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "description": "Kustomization is the Schema for a kustomize kustomization.yaml file",
+  "properties": {
+    "apiVersion": {
+      "type": "string"
+    },
+    "bases": {
+      "description": "DEPRECATED. Bases are relative paths or git repository URLs specifying a directory containing a kustomization.yaml file.",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "commonAnnotations": {
+      "description": "CommonAnnotations to add to all objects",
+      "patternProperties": {
+        ".*": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "buildMetadata": {
+      "description": "BuildMetadata is a list of strings used to toggle different build options",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "commonLabels": {
+      "description": " CommonLabels to add to all objects and selectors",
+      "patternProperties": {
+        ".*": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "configMapGenerator": {
+      "description": "ConfigMapGenerator is a list of configmaps to generate from local data (one configMap per list item)",
+      "items": {
+        "$ref": "#/definitions/ConfigMapArgs"
+      },
+      "type": "array"
+    },
+    "configurations": {
+      "description": "Configurations is a list of transformer configuration files",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "crds": {
+      "description": "Crds specifies relative paths to Custom Resource Definition files. This allows custom resources to be recognized as operands, making it possible to add them to the Resources list. CRDs themselves are not modified.",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "generatorOptions": {
+      "$ref": "#/definitions/GeneratorOptions"
+    },
+    "generators": {
+      "description": "Generators is a list of files containing custom generators",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "helmCharts": {
+      "description": "HelmCharts is a list of helm chart configuration instances",
+      "items": {
+        "$ref": "#/definitions/HelmChart"
+      },
+      "type": "array"
+    },
+    "helmGlobals": {
+      "description": "HelmGlobals contains helm configuration that isn't chart specific",
+      "properties": {
+        "chartHome": {
+          "description": "ChartHome is a file path, relative to the kustomization root, to a directory containing a subdirectory for each chart to be included in the kustomization",
+          "type": "string"
+        },
+        "configHome": {
+          "description": "ConfigHome defines a value that kustomize should pass to helm via the HELM_CONFIG_HOME environment variable",
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "images": {
+      "description": "Images is a list of (image name, new name, new tag or digest) for changing image names, tags or digests. This can also be achieved with a patch, but this operator is simpler to specify.",
+      "items": {
+        "$ref": "#/definitions/Image"
+      },
+      "type": "array"
+    },
+    "inventory": {
+      "$ref": "#/definitions/Inventory"
+    },
+    "labels": {
+      "description": "Labels to add to all objects but not selectors",
+      "items": {
+        "$ref": "#/definitions/Labels"
+      },
+      "type": "array"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the resource this object represents.",
+      "type": "string",
+      "enum": [
+        "Kustomization"
+      ]
+    },
+    "metadata": {
+      "$ref": "#/definitions/Metadata",
+      "description": "Contains metadata about a Resource"
+    },
+    "namePrefix": {
+      "description": "NamePrefix will prefix the names of all resources mentioned in the kustomization file including generated configmaps and secrets",
+      "type": "string"
+    },
+    "nameSuffix": {
+      "description": "NameSuffix will suffix the names of all resources mentioned in the kustomization file including generated configmaps and secrets",
+      "type": "string"
+    },
+    "namespace": {
+      "description": "Namespace to add to all objects",
+      "type": "string"
+    },
+    "replacements": {
+      "type": "array",
+      "description": "Substitute field(s) in N target(s) with a field from a source",
+      "items": {
+        "oneOf": [
+          {
+            "$ref": "#/definitions/ReplacementsPath"
+          },
+          {
+            "$ref": "#/definitions/ReplacementsInline"
+          }
+        ]
+      }
+    },
+    "openapi": {
+      "description": "OpenAPI contains information about what kubernetes schema to use",
+      "patternProperties": {
+        ".*": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "patches": {
+      "description": "Apply a patch to multiple resources",
+      "items": {
+        "oneOf": [
+          {
+            "$ref": "#/definitions/PatchesPatchPath"
+          },
+          {
+            "$ref": "#/definitions/PatchesInlinePatch"
+          }
+        ]
+      },
+      "type": "array"
+    },
+    "patchesJson6902": {
+      "description": "JSONPatches is a list of JSONPatch for applying JSON patch. See http://jsonpatch.com",
+      "items": {
+        "$ref": "#/definitions/PatchJson6902"
+      },
+      "type": "array"
+    },
+    "patchesStrategicMerge": {
+      "description": " PatchesStrategicMerge specifies the relative path to a file containing a strategic merge patch. URLs and globs are not supported",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "replicas": {
+      "description": "Replicas is a list of (resource name, count) for changing number of replicas for a resources. It will match any group and kind that has a matching name and that is one of: Deployment, ReplicationController, Replicaset, Statefulset.",
+      "items": {
+        "$ref": "#/definitions/Replicas"
+      },
+      "type": "array"
+    },
+    "resources": {
+      "description": "Resources specifies relative paths to files holding YAML representations of kubernetes API objects. URLs and globs not supported.",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "components": {
+      "description": "Components are relative paths or git repository URLs specifying a directory containing a kustomization.yaml file of Kind Component.",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "secretGenerator": {
+      "description": "SecretGenerator is a list of secrets to generate from local data (one secret per list item)",
+      "items": {
+        "$ref": "#/definitions/SecretArgs"
+      },
+      "type": "array"
+    },
+    "sortOptions": {
+      "description": "sortOptions is used to sort the resources kustomize outputs",
+      "oneOf": [
+        {
+          "properties": {
+            "order": {
+              "enum": [
+                "legacy"
+              ]
+            },
+            "legacySortOptions": {
+              "properties": {
+                "orderFirst": {
+                  "type": "array"
+                },
+                "orderLast": {
+                  "type": "array"
+                }
+              },
+              "additionalProperties": false,
+              "type": "object"
+            }
+          },
+          "additionalProperties": false,
+          "type": "object"
+        },
+        {
+          "properties": {
+            "order": {
+              "enum": [
+                "fifo"
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "type": "object"
+        }
+      ]
+    },
+    "transformers": {
+      "description": "Transformers is a list of files containing transformers",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "validators": {
+      "description": "Validators is a list of files containing validators",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "vars": {
+      "description": "Allows things modified by kustomize to be injected into a container specification. A var is a name (e.g. FOO) associated with a field in a specific resource instance.  The field must contain a value of type string, and defaults to the name field of the instance",
+      "items": {
+        "$ref": "#/definitions/Var"
+      },
+      "type": "array"
+    }
+  },
+  "additionalProperties": false,
+  "type": "object",
   "definitions": {
     "ConfigMapArgs": {
       "description": "ConfigMapArgs contains the metadata of how to generate a configmap",
@@ -236,275 +507,6 @@
         },
         "pluginType": {
           "type": "string"
-        }
-      },
-      "additionalProperties": false,
-      "type": "object"
-    },
-    "Kustomization": {
-      "properties": {
-        "apiVersion": {
-          "type": "string"
-        },
-        "bases": {
-          "description": "DEPRECATED. Bases are relative paths or git repository URLs specifying a directory containing a kustomization.yaml file.",
-          "items": {
-            "type": "string"
-          },
-          "type": "array"
-        },
-        "commonAnnotations": {
-          "description": "CommonAnnotations to add to all objects",
-          "patternProperties": {
-            ".*": {
-              "type": "string"
-            }
-          },
-          "type": "object"
-        },
-        "buildMetadata": {
-          "description": "BuildMetadata is a list of strings used to toggle different build options",
-          "items": {
-            "type": "string"
-          },
-          "type": "array"
-        },
-        "commonLabels": {
-          "description": " CommonLabels to add to all objects and selectors",
-          "patternProperties": {
-            ".*": {
-              "type": "string"
-            }
-          },
-          "type": "object"
-        },
-        "configMapGenerator": {
-          "description": "ConfigMapGenerator is a list of configmaps to generate from local data (one configMap per list item)",
-          "items": {
-            "$ref": "#/definitions/ConfigMapArgs"
-          },
-          "type": "array"
-        },
-        "configurations": {
-          "description": "Configurations is a list of transformer configuration files",
-          "items": {
-            "type": "string"
-          },
-          "type": "array"
-        },
-        "crds": {
-          "description": "Crds specifies relative paths to Custom Resource Definition files. This allows custom resources to be recognized as operands, making it possible to add them to the Resources list. CRDs themselves are not modified.",
-          "items": {
-            "type": "string"
-          },
-          "type": "array"
-        },
-        "generatorOptions": {
-          "$ref": "#/definitions/GeneratorOptions"
-        },
-        "generators": {
-          "description": "Generators is a list of files containing custom generators",
-          "items": {
-            "type": "string"
-          },
-          "type": "array"
-        },
-        "helmCharts": {
-          "description": "HelmCharts is a list of helm chart configuration instances",
-          "items": {
-            "$ref": "#/definitions/HelmChart"
-          },
-          "type": "array"
-        },
-        "helmGlobals": {
-          "description": "HelmGlobals contains helm configuration that isn't chart specific",
-          "properties": {
-            "chartHome": {
-              "description": "ChartHome is a file path, relative to the kustomization root, to a directory containing a subdirectory for each chart to be included in the kustomization",
-              "type": "string"
-            },
-            "configHome": {
-              "description": "ConfigHome defines a value that kustomize should pass to helm via the HELM_CONFIG_HOME environment variable",
-              "type": "string"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object"
-        },
-        "images": {
-          "description": "Images is a list of (image name, new name, new tag or digest) for changing image names, tags or digests. This can also be achieved with a patch, but this operator is simpler to specify.",
-          "items": {
-            "$ref": "#/definitions/Image"
-          },
-          "type": "array"
-        },
-        "inventory": {
-          "$ref": "#/definitions/Inventory"
-        },
-        "labels": {
-          "description": "Labels to add to all objects but not selectors",
-          "items": {
-            "$ref": "#/definitions/Labels"
-          },
-          "type": "array"
-        },
-        "kind": {
-          "type": "string"
-        },
-        "metadata": {
-          "$ref": "#/definitions/Metadata",
-          "description": "Contains metadata about a Resource"
-        },
-        "namePrefix": {
-          "description": "NamePrefix will prefix the names of all resources mentioned in the kustomization file including generated configmaps and secrets",
-          "type": "string"
-        },
-        "nameSuffix": {
-          "description": "NameSuffix will suffix the names of all resources mentioned in the kustomization file including generated configmaps and secrets",
-          "type": "string"
-        },
-        "namespace": {
-          "description": "Namespace to add to all objects",
-          "type": "string"
-        },
-        "replacements": {
-          "type": "array",
-          "description": "Substitute field(s) in N target(s) with a field from a source",
-          "items": {
-            "oneOf": [
-              {
-                "$ref": "#/definitions/ReplacementsPath"
-              },
-              {
-                "$ref": "#/definitions/ReplacementsInline"
-              }
-            ]
-          }
-        },
-        "openapi": {
-          "description": "OpenAPI contains information about what kubernetes schema to use",
-          "patternProperties": {
-            ".*": {
-              "type": "string"
-            }
-          },
-          "type": "object"
-        },
-        "patches": {
-          "description": "Apply a patch to multiple resources",
-          "items": {
-            "oneOf": [
-              {
-                "$ref": "#/definitions/PatchesPatchPath"
-              },
-              {
-                "$ref": "#/definitions/PatchesInlinePatch"
-              }
-            ]
-          },
-          "type": "array"
-        },
-        "patchesJson6902": {
-          "description": "JSONPatches is a list of JSONPatch for applying JSON patch. See http://jsonpatch.com",
-          "items": {
-            "$ref": "#/definitions/PatchJson6902"
-          },
-          "type": "array"
-        },
-        "patchesStrategicMerge": {
-          "description": " PatchesStrategicMerge specifies the relative path to a file containing a strategic merge patch. URLs and globs are not supported",
-          "items": {
-            "type": "string"
-          },
-          "type": "array"
-        },
-        "replicas": {
-          "description": "Replicas is a list of (resource name, count) for changing number of replicas for a resources. It will match any group and kind that has a matching name and that is one of: Deployment, ReplicationController, Replicaset, Statefulset.",
-          "items": {
-            "$ref": "#/definitions/Replicas"
-          },
-          "type": "array"
-        },
-        "resources": {
-          "description": "Resources specifies relative paths to files holding YAML representations of kubernetes API objects. URLs and globs not supported.",
-          "items": {
-            "type": "string"
-          },
-          "type": "array"
-        },
-        "components": {
-          "description": "Components are relative paths or git repository URLs specifying a directory containing a kustomization.yaml file of Kind Component.",
-          "items": {
-            "type": "string"
-          },
-          "type": "array"
-        },
-        "secretGenerator": {
-          "description": "SecretGenerator is a list of secrets to generate from local data (one secret per list item)",
-          "items": {
-            "$ref": "#/definitions/SecretArgs"
-          },
-          "type": "array"
-        },
-        "sortOptions": {
-          "description": "sortOptions is used to sort the resources kustomize outputs",
-          "oneOf": [
-            {
-              "properties": {
-                "order": {
-                  "enum": [
-                    "legacy"
-                  ]
-                },
-                "legacySortOptions": {
-                  "properties": {
-                    "orderFirst": {
-                      "type": "array"
-                    },
-                    "orderLast": {
-                      "type": "array"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "type": "object"
-                }
-              },
-              "additionalProperties": false,
-              "type": "object"
-            },
-            {
-              "properties": {
-                "order": {
-                  "enum": [
-                    "fifo"
-                  ]
-                }
-              },
-              "additionalProperties": false,
-              "type": "object"
-            }
-          ]
-        },
-        "transformers": {
-          "description": "Transformers is a list of files containing transformers",
-          "items": {
-            "type": "string"
-          },
-          "type": "array"
-        },
-        "validators": {
-          "description": "Validators is a list of files containing validators",
-          "items": {
-            "type": "string"
-          },
-          "type": "array"
-        },
-        "vars": {
-          "description": "Allows things modified by kustomize to be injected into a container specification. A var is a name (e.g. FOO) associated with a field in a specific resource instance.  The field must contain a value of type string, and defaults to the name field of the instance",
-          "items": {
-            "$ref": "#/definitions/Var"
-          },
-          "type": "array"
         }
       },
       "additionalProperties": false,
@@ -1032,7 +1034,5 @@
       "additionalProperties": false,
       "type": "object"
     }
-  },
-  "id": "https://json.schemastore.org/kustomization.json",
-  "description": "Kustomization is the Schema for a kustomize kustomization.yaml file"
+  }
 }


### PR DESCRIPTION
Hello,

I know that `kustomize.config.k8s.io` is supposed to a client side CRDs, I don't know if you think this `kind` belongs here, but in case you think this could be helpfull here it is.

## PR Checklist

- [ ] I generated these CRs using the [CRD Extractor tool](https://github.com/datreeio/CRDs-catalog?tab=readme-ov-file#crd-extractor). If I used a different method, I have described the method in this PR.
- [ ] I am updating existing schemas and have specified the updated schema version.
- [ ] I am adding new schemas and included a link to the GitHub repository that contains the source of these schemas.
