### PR TITLE
Add Cluster schema (dsql.services.k8s.aws/v1alpha1)

### DIFF
--- a/dsql.services.k8s.aws/cluster_v1alpha1.json
+++ b/dsql.services.k8s.aws/cluster_v1alpha1.json
@@ -1,0 +1,184 @@
+{
+  "description": "Cluster is the Schema for the Clusters API",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "ClusterSpec defines the desired state of Cluster.",
+      "properties": {
+        "deletionProtectionEnabled": {
+          "description": "If enabled, you can't delete your cluster. You must first disable this property\nbefore you can delete your cluster.",
+          "type": "boolean"
+        },
+        "kmsEncryptionKey": {
+          "description": "The KMS key that encrypts and protects the data on your cluster. You can\nspecify the ARN, ID, or alias of an existing key or have Amazon Web Services\ncreate a default key for you.\n\nRegex Pattern: `^[a-zA-Z0-9:/_-]+$`",
+          "type": "string"
+        },
+        "kmsEncryptionKeyRef": {
+          "description": "AWSResourceReferenceWrapper provides a wrapper around *AWSResourceReference\ntype to provide more user friendly syntax for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t  name: my-api",
+          "properties": {
+            "from": {
+              "description": "AWSResourceReference provides all the values necessary to reference another\nk8s resource for finding the identifier(Id/ARN/Name)",
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "namespace": {
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "multiRegionProperties": {
+          "description": "The configuration settings when creating a multi-Region cluster, including\nthe witness region and linked cluster properties.",
+          "properties": {
+            "clusters": {
+              "description": "A list of the Amazon Resource Names of the cluster.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "witnessRegion": {
+              "description": "Region name.",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "policy": {
+          "description": "An optional resource-based policy document in JSON format that defines access\npermissions for the cluster.",
+          "type": "string"
+        },
+        "tags": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "A map of key and value pairs to use to tag your cluster.",
+          "type": "object"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "ClusterStatus defines the observed state of Cluster",
+      "properties": {
+        "ackResourceMetadata": {
+          "description": "All CRs managed by ACK have a common `Status.ACKResourceMetadata` member\nthat is used to contain resource sync state, account ownership,\nconstructed ARN for the resource",
+          "properties": {
+            "arn": {
+              "description": "ARN is the Amazon Resource Name for the resource. This is a\nglobally-unique identifier and is set only by the ACK service controller\nonce the controller has orchestrated the creation of the resource OR\nwhen it has verified that an \"adopted\" resource (a resource where the\nARN annotation was set by the Kubernetes user on the CR) exists and\nmatches the supplied CR's Spec field values.\nhttps://github.com/aws/aws-controllers-k8s/issues/270",
+              "type": "string"
+            },
+            "ownerAccountID": {
+              "description": "OwnerAccountID is the AWS Account ID of the account that owns the\nbackend AWS service API resource.",
+              "type": "string"
+            },
+            "partition": {
+              "description": "Partition is the AWS partition in which the resource exists or will exist",
+              "type": "string"
+            },
+            "region": {
+              "description": "Region is the AWS region in which the resource exists or will exist.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "ownerAccountID",
+            "region"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "conditions": {
+          "description": "All CRs managed by ACK have a common `Status.Conditions` member that\ncontains a collection of `ackv1alpha1.Condition` objects that describe\nthe various terminal states of the CR and its backend AWS service API\nresource",
+          "items": {
+            "description": "Condition is the common struct used by all CRDs managed by ACK service\ncontrollers to indicate terminal states  of the CR and its backend AWS\nservice API resource",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "A human readable message indicating details about the transition.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type is the type of the Condition",
+                "type": "string"
+              }
+            },
+            "required": [
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "creationTime": {
+          "description": "The time of when created the cluster.",
+          "format": "date-time",
+          "type": "string"
+        },
+        "encryptionDetails": {
+          "description": "The encryption configuration for the cluster that was specified during the\ncreation process, including the KMS key identifier and encryption state.",
+          "properties": {
+            "encryptionStatus": {
+              "type": "string"
+            },
+            "encryptionType": {
+              "type": "string"
+            },
+            "kmsKeyARN": {
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "endpoint": {
+          "description": "The connection endpoint for the created cluster.\n\nRegex Pattern: `^[a-zA-Z0-9.-]+$`",
+          "type": "string"
+        },
+        "identifier": {
+          "description": "The ID of the created cluster.\n\nRegex Pattern: `^[a-z0-9]{26}$`",
+          "type": "string"
+        },
+        "status": {
+          "description": "The status of the created cluster.",
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}


### PR DESCRIPTION
Adds JSON schema for the `Cluster` CRD from [aws-controllers-k8s/dsql-controller](https://github.com/aws-controllers-k8s/dsql-controller) v1.0.1.

## Generated with

```bash
curl -sLO https://raw.githubusercontent.com/aws-controllers-k8s/dsql-controller/refs/tags/v1.0.1/config/crd/bases/dsql.services.k8s.aws_clusters.yaml
curl -sL https://raw.githubusercontent.com/yannh/kubeconform/6ae8c45bc156ceeb1d421e9b217cfc0c7ba5828d/scripts/openapi2jsonschema.py \
  | FILENAME_FORMAT='{kind}_{version}' uv run --with pyyaml - dsql.services.k8s.aws_clusters.yaml
```

## File added

- `dsql.services.k8s.aws/cluster_v1alpha1.json`
