### PR TITLE
Update Datadog CRD schemas to 2.22.0

### DIFF
--- a/datadoghq.com/datadoggenericresource_v1alpha1.json
+++ b/datadoghq.com/datadoggenericresource_v1alpha1.json
@@ -17,14 +17,17 @@
       "properties": {
         "jsonSpec": {
           "description": "JsonSpec is the specification of the API object",
+          "minLength": 1,
           "type": "string"
         },
         "type": {
           "description": "Type is the type of the API object",
           "enum": [
+            "dashboard",
             "downtime",
             "monitor",
             "notebook",
+            "slo",
             "synthetics_api_test",
             "synthetics_browser_test"
           ],
@@ -120,6 +123,20 @@
         },
         "lastForceSyncTime": {
           "description": "LastForceSyncTime is the last time the API object was last force synced with the custom resource",
+          "format": "date-time",
+          "type": "string"
+        },
+        "state": {
+          "description": "State is the live Datadog-side state of the underlying resource as last\nfetched from the Datadog API. Values are resource-type dependent \u2014 for\nMonitors: OK, Alert, Warn, No Data, Skipped, Ignored, Unknown. For SLOs:\nbreached, warning, ok, no_data. Only populated for resource types that\nexpose live state.",
+          "type": "string"
+        },
+        "stateLastTransitionTime": {
+          "description": "StateLastTransitionTime is the last time State changed value.",
+          "format": "date-time",
+          "type": "string"
+        },
+        "stateLastUpdateTime": {
+          "description": "StateLastUpdateTime is the last time State was successfully refreshed from Datadog.",
           "format": "date-time",
           "type": "string"
         },

--- a/datadoghq.com/datadogmonitor_v1alpha1.json
+++ b/datadoghq.com/datadogmonitor_v1alpha1.json
@@ -274,7 +274,8 @@
             "slo alert",
             "event-v2 alert",
             "audit alert",
-            "composite"
+            "composite",
+            "error-tracking alert"
           ],
           "type": "string"
         }

--- a/datadoghq.com/datadogslo_v1alpha1.json
+++ b/datadoghq.com/datadogslo_v1alpha1.json
@@ -90,6 +90,57 @@
           "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
           "x-kubernetes-int-or-string": true
         },
+        "timeSlice": {
+          "description": "TimeSlice defines the SLI specification for a time_slice SLO. Required if type is time_slice.\nIt specifies a metric query and a comparator/threshold that determines what counts as good uptime.",
+          "properties": {
+            "comparator": {
+              "allOf": [
+                {
+                  "enum": [
+                    ">",
+                    ">=",
+                    "<",
+                    "<="
+                  ]
+                },
+                {
+                  "enum": [
+                    ">",
+                    ">=",
+                    "<",
+                    "<="
+                  ]
+                }
+              ],
+              "description": "Comparator is the comparison operator used to compare the SLI value to the threshold.",
+              "type": "string"
+            },
+            "query": {
+              "description": "Query is a Datadog metric query string that produces the SLI value.",
+              "type": "string"
+            },
+            "threshold": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "string"
+                }
+              ],
+              "description": "Threshold is the value against which the SLI is compared using the comparator to determine\nif a time slice is good or bad.",
+              "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+              "x-kubernetes-int-or-string": true
+            }
+          },
+          "required": [
+            "comparator",
+            "query",
+            "threshold"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
         "timeframe": {
           "description": "The SLO time window options.",
           "type": "string"


### PR DESCRIPTION
## What

Updates existing Datadog CRD schemas from the public `datadog-crds` Helm chart version `2.22.0`, which is the CRD dependency used by `datadog-operator` chart `2.24.0` / app `1.28.0`.

This refreshes:

- `datadoghq.com/datadoggenericresource_v1alpha1.json`
- `datadoghq.com/datadogmonitor_v1alpha1.json`
- `datadoghq.com/datadogslo_v1alpha1.json`

Notable schema changes include:

- `DatadogGenericResource.spec.type` now allows `dashboard` and `slo`
- `DatadogMonitor.spec.type` now allows `error-tracking alert`
- `DatadogSLO.spec.timeSlice` is now included for time-slice SLOs

## How

Generated with this repository's bundled `Utilities/openapi2jsonschema.py` against CRDs rendered from the public Datadog Helm chart:

```sh
helm template datadog-crds datadog/datadog-crds \
  --version 2.22.0 \
  --set crds.datadogGenericResources=true \
  --set crds.datadogMonitors=true \
  --set crds.datadogSLOs=true
```

Source chart: https://github.com/DataDog/helm-charts/releases/tag/datadog-crds-2.22.0

## Validation

```sh
jq empty datadoghq.com/datadoggenericresource_v1alpha1.json
jq empty datadoghq.com/datadogmonitor_v1alpha1.json
jq empty datadoghq.com/datadogslo_v1alpha1.json
git diff --check
```

Also validated sample resources with `kubeconform` against the updated local schemas for:

- `DatadogGenericResource` with `spec.type: dashboard`
- `DatadogGenericResource` with `spec.type: slo`
- `DatadogMonitor` with `spec.type: error-tracking alert`
- `DatadogSLO` with `spec.timeSlice`

## PR Checklist

- [ ] I generated these CRs using the [CRD Extractor tool](https://github.com/datreeio/CRDs-catalog?tab=readme-ov-file#crd-extractor). If I used a different method, I have described the method in this PR.
- [x] I am updating existing schemas and have specified the updated schema version.
- [ ] I am adding new schemas and included a link to the GitHub repository that contains the source of these schemas.
