### PR TITLE
Add Cluster-API Provider for Proxmox (CAPMOX) CRDs

### DIFF
--- a/infrastructure.cluster.x-k8s.io/proxmoxcluster_v1alpha1.json
+++ b/infrastructure.cluster.x-k8s.io/proxmoxcluster_v1alpha1.json
@@ -1,0 +1,1045 @@
+{
+  "description": "ProxmoxCluster is the Schema for the proxmoxclusters API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "ProxmoxClusterSpec defines the desired state of a ProxmoxCluster.",
+      "properties": {
+        "allowedNodes": {
+          "description": "AllowedNodes specifies all Proxmox nodes which will be considered\nfor operations. This implies that VMs can be cloned on different nodes from\nthe node which holds the VM template.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "cloneSpec": {
+          "description": "NodeCloneSpec is the configuration pertaining to all items configurable\nin the configuration and cloning of a proxmox VM. Multiple types of nodes can be specified.",
+          "properties": {
+            "machineSpec": {
+              "additionalProperties": {
+                "description": "ProxmoxMachineSpec defines the desired state of a ProxmoxMachine.",
+                "properties": {
+                  "allowedNodes": {
+                    "description": "AllowedNodes specifies all Proxmox nodes which will be considered\nfor operations. This implies that VMs can be cloned on different nodes from\nthe node which holds the VM template.\n\nThis field is optional and should only be set if you want to restrict\nthe nodes where the VM can be cloned.\nIf not set, the ProxmoxCluster will be used to determine the nodes.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "checks": {
+                    "description": "Checks defines possibles checks to skip.",
+                    "properties": {
+                      "skipCloudInitStatus": {
+                        "description": "Skip checking CloudInit which can be very useful for specific Operating Systems like TalOS",
+                        "type": "boolean"
+                      },
+                      "skipQemuGuestAgent": {
+                        "description": "Skip checking QEMU Agent readiness which can be very useful for specific Operating Systems like TalOS",
+                        "type": "boolean"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "description": {
+                    "description": "Description for the new VM.",
+                    "type": "string"
+                  },
+                  "disks": {
+                    "description": "Disks contains a set of disk configuration options,\nwhich will be applied before the first startup.",
+                    "properties": {
+                      "bootVolume": {
+                        "description": "BootVolume defines the storage size for the boot volume.\nThis field is optional, and should only be set if you want\nto change the size of the boot volume.",
+                        "properties": {
+                          "disk": {
+                            "description": "Disk is the name of the disk device, that should be resized.\nExample values are: ide[0-3], scsi[0-30], sata[0-5].",
+                            "type": "string"
+                          },
+                          "sizeGb": {
+                            "description": "Size defines the size in gigabyte.\n\nAs Proxmox does not support shrinking, the size\nmust be bigger than the already configured size in the\ntemplate.",
+                            "format": "int32",
+                            "minimum": 5,
+                            "type": "integer"
+                          }
+                        },
+                        "required": [
+                          "disk",
+                          "sizeGb"
+                        ],
+                        "type": "object",
+                        "x-kubernetes-validations": [
+                          {
+                            "message": "Value is immutable",
+                            "rule": "self == oldSelf"
+                          }
+                        ],
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "format": {
+                    "description": "Format for file storage. Only valid for full clone.",
+                    "enum": [
+                      "raw",
+                      "qcow2",
+                      "vmdk"
+                    ],
+                    "type": "string"
+                  },
+                  "full": {
+                    "default": true,
+                    "description": "Full Create a full copy of all disks.\nThis is always done when you clone a normal VM.\nCreate a Full clone by default.",
+                    "type": "boolean"
+                  },
+                  "memoryMiB": {
+                    "description": "MemoryMiB is the size of a virtual machine's memory, in MiB.\nDefaults to the property value in the template from which the virtual machine is cloned.",
+                    "format": "int32",
+                    "multipleOf": 8,
+                    "type": "integer"
+                  },
+                  "metadataSettings": {
+                    "description": "MetadataSettings defines the metadata settings for this machine's VM.",
+                    "properties": {
+                      "providerIDInjection": {
+                        "description": "ProviderIDInjection enables the injection of the `providerID` into the cloudinit metadata.\nthis will basically set the `provider-id` field in the metadata to `proxmox://<instanceID>`.",
+                        "type": "boolean"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "network": {
+                    "description": "Network is the network configuration for this machine's VM.",
+                    "properties": {
+                      "additionalDevices": {
+                        "description": "AdditionalDevices defines additional network devices bound to the virtual machine.",
+                        "items": {
+                          "description": "AdditionalNetworkDevice the definition of a Proxmox network device.",
+                          "properties": {
+                            "bridge": {
+                              "description": "Bridge is the network bridge to attach to the machine.",
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "dnsServers": {
+                              "description": "DNSServers contains information about nameservers to be used for this interface.\nIf this field is not set, it will use the default dns servers from the ProxmoxCluster.",
+                              "items": {
+                                "type": "string"
+                              },
+                              "minItems": 1,
+                              "type": "array"
+                            },
+                            "ipv4PoolRef": {
+                              "description": "IPv4PoolRef is a reference to an IPAM Pool resource, which exposes IPv4 addresses.\nThe network device will use an available IP address from the referenced pool.\nThis can be combined with `IPv6PoolRef` in order to enable dual stack.",
+                              "properties": {
+                                "apiGroup": {
+                                  "description": "APIGroup is the group for the resource being referenced.\nIf APIGroup is not specified, the specified Kind must be in the core API group.\nFor any other third-party types, APIGroup is required.",
+                                  "type": "string"
+                                },
+                                "kind": {
+                                  "description": "Kind is the type of resource being referenced",
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "description": "Name is the name of resource being referenced",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "kind",
+                                "name"
+                              ],
+                              "type": "object",
+                              "x-kubernetes-map-type": "atomic",
+                              "x-kubernetes-validations": [
+                                {
+                                  "message": "ipv4PoolRef allows only IPAM apiGroup ipam.cluster.x-k8s.io",
+                                  "rule": "self.apiGroup == 'ipam.cluster.x-k8s.io'"
+                                },
+                                {
+                                  "message": "ipv4PoolRef allows either InClusterIPPool or GlobalInClusterIPPool",
+                                  "rule": "self.kind == 'InClusterIPPool' || self.kind == 'GlobalInClusterIPPool'"
+                                }
+                              ],
+                              "additionalProperties": false
+                            },
+                            "ipv6PoolRef": {
+                              "description": "IPv6PoolRef is a reference to an IPAM pool resource, which exposes IPv6 addresses.\nThe network device will use an available IP address from the referenced pool.\nthis can be combined with `IPv4PoolRef` in order to enable dual stack.",
+                              "properties": {
+                                "apiGroup": {
+                                  "description": "APIGroup is the group for the resource being referenced.\nIf APIGroup is not specified, the specified Kind must be in the core API group.\nFor any other third-party types, APIGroup is required.",
+                                  "type": "string"
+                                },
+                                "kind": {
+                                  "description": "Kind is the type of resource being referenced",
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "description": "Name is the name of resource being referenced",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "kind",
+                                "name"
+                              ],
+                              "type": "object",
+                              "x-kubernetes-map-type": "atomic",
+                              "x-kubernetes-validations": [
+                                {
+                                  "message": "ipv6PoolRef allows only IPAM apiGroup ipam.cluster.x-k8s.io",
+                                  "rule": "self.apiGroup == 'ipam.cluster.x-k8s.io'"
+                                },
+                                {
+                                  "message": "ipv6PoolRef allows either InClusterIPPool or GlobalInClusterIPPool",
+                                  "rule": "self.kind == 'InClusterIPPool' || self.kind == 'GlobalInClusterIPPool'"
+                                }
+                              ],
+                              "additionalProperties": false
+                            },
+                            "linkMtu": {
+                              "description": "LinkMTU is the network device Maximum Transmission Unit.",
+                              "type": "integer",
+                              "x-kubernetes-validations": [
+                                {
+                                  "message": "invalid MTU value",
+                                  "rule": "self == 1 || ( self >= 576 && self <= 65520)"
+                                }
+                              ]
+                            },
+                            "model": {
+                              "default": "virtio",
+                              "description": "Model is the network device model.",
+                              "enum": [
+                                "e1000",
+                                "virtio",
+                                "rtl8139",
+                                "vmxnet3"
+                              ],
+                              "type": "string"
+                            },
+                            "mtu": {
+                              "description": "MTU is the network device Maximum Transmission Unit.\nWhen set to 1, virtio devices inherit the MTU value from the underlying bridge.",
+                              "type": "integer",
+                              "x-kubernetes-validations": [
+                                {
+                                  "message": "invalid MTU value",
+                                  "rule": "self == 1 || ( self >= 576 && self <= 65520)"
+                                }
+                              ]
+                            },
+                            "name": {
+                              "description": "Name is the network device name.\nMust be unique within the virtual machine and different from the primary device 'net0'.",
+                              "minLength": 1,
+                              "type": "string",
+                              "x-kubernetes-validations": [
+                                {
+                                  "message": "additional network devices doesn't allow net0",
+                                  "rule": "self != 'net0'"
+                                }
+                              ]
+                            },
+                            "routes": {
+                              "description": "Routes are the routes associated with this interface.",
+                              "items": {
+                                "description": "RouteSpec describes an IPv4/IPv6 Route.",
+                                "properties": {
+                                  "metric": {
+                                    "description": "Metric is the priority of the route in the routing table.",
+                                    "format": "int32",
+                                    "type": "integer"
+                                  },
+                                  "table": {
+                                    "description": "Table is the routing table used for this route.",
+                                    "format": "int32",
+                                    "type": "integer"
+                                  },
+                                  "to": {
+                                    "description": "To is the subnet to be routed.",
+                                    "type": "string"
+                                  },
+                                  "via": {
+                                    "description": "Via is the gateway to the subnet.",
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "minItems": 1,
+                              "type": "array"
+                            },
+                            "routingPolicy": {
+                              "description": "RoutingPolicy is an interface-specific policy inserted into FIB (forwarding information base).",
+                              "items": {
+                                "description": "RoutingPolicySpec is a Linux FIB rule.",
+                                "properties": {
+                                  "from": {
+                                    "description": "From is the subnet of the source.",
+                                    "type": "string"
+                                  },
+                                  "priority": {
+                                    "description": "Priority is the position in the ip rule FIB table.",
+                                    "format": "int32",
+                                    "maximum": 4294967295,
+                                    "type": "integer",
+                                    "x-kubernetes-validations": [
+                                      {
+                                        "message": "Cowardly refusing to insert FIB rule matching kernel rules",
+                                        "rule": "(self > 0 && self < 32765) || (self > 32766)"
+                                      }
+                                    ]
+                                  },
+                                  "table": {
+                                    "description": "Table is the routing table ID.\nwhen used in the networks, the value should be the VRF Table.",
+                                    "format": "int32",
+                                    "type": "integer"
+                                  },
+                                  "to": {
+                                    "description": "To is the subnet of the target.",
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "minItems": 1,
+                              "type": "array"
+                            },
+                            "vlan": {
+                              "description": "VLAN is the network L2 VLAN.",
+                              "maximum": 4094,
+                              "minimum": 1,
+                              "type": "integer"
+                            }
+                          },
+                          "required": [
+                            "bridge",
+                            "name"
+                          ],
+                          "type": "object",
+                          "x-kubernetes-validations": [
+                            {
+                              "message": "at least one pool reference must be set, either ipv4PoolRef or ipv6PoolRef",
+                              "rule": "self.ipv4PoolRef != null || self.ipv6PoolRef != null"
+                            }
+                          ],
+                          "additionalProperties": false
+                        },
+                        "type": "array",
+                        "x-kubernetes-list-map-keys": [
+                          "name"
+                        ],
+                        "x-kubernetes-list-type": "map"
+                      },
+                      "default": {
+                        "description": "Default is the default network device,\nwhich will be used for the primary network interface.\nnet0 is always the default network device.",
+                        "properties": {
+                          "bridge": {
+                            "description": "Bridge is the network bridge to attach to the machine.",
+                            "minLength": 1,
+                            "type": "string"
+                          },
+                          "dnsServers": {
+                            "description": "DNSServers contains information about nameservers to be used for this interface.\nIf this field is not set, it will use the default dns servers from the ProxmoxCluster.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "minItems": 1,
+                            "type": "array"
+                          },
+                          "ipv4PoolRef": {
+                            "description": "IPv4PoolRef is a reference to an IPAM Pool resource, which exposes IPv4 addresses.\nThe network device will use an available IP address from the referenced pool.\nThis can be combined with `IPv6PoolRef` in order to enable dual stack.",
+                            "properties": {
+                              "apiGroup": {
+                                "description": "APIGroup is the group for the resource being referenced.\nIf APIGroup is not specified, the specified Kind must be in the core API group.\nFor any other third-party types, APIGroup is required.",
+                                "type": "string"
+                              },
+                              "kind": {
+                                "description": "Kind is the type of resource being referenced",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "Name is the name of resource being referenced",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "kind",
+                              "name"
+                            ],
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "x-kubernetes-validations": [
+                              {
+                                "message": "ipv4PoolRef allows only IPAM apiGroup ipam.cluster.x-k8s.io",
+                                "rule": "self.apiGroup == 'ipam.cluster.x-k8s.io'"
+                              },
+                              {
+                                "message": "ipv4PoolRef allows either InClusterIPPool or GlobalInClusterIPPool",
+                                "rule": "self.kind == 'InClusterIPPool' || self.kind == 'GlobalInClusterIPPool'"
+                              }
+                            ],
+                            "additionalProperties": false
+                          },
+                          "ipv6PoolRef": {
+                            "description": "IPv6PoolRef is a reference to an IPAM pool resource, which exposes IPv6 addresses.\nThe network device will use an available IP address from the referenced pool.\nthis can be combined with `IPv4PoolRef` in order to enable dual stack.",
+                            "properties": {
+                              "apiGroup": {
+                                "description": "APIGroup is the group for the resource being referenced.\nIf APIGroup is not specified, the specified Kind must be in the core API group.\nFor any other third-party types, APIGroup is required.",
+                                "type": "string"
+                              },
+                              "kind": {
+                                "description": "Kind is the type of resource being referenced",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "Name is the name of resource being referenced",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "kind",
+                              "name"
+                            ],
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "x-kubernetes-validations": [
+                              {
+                                "message": "ipv6PoolRef allows only IPAM apiGroup ipam.cluster.x-k8s.io",
+                                "rule": "self.apiGroup == 'ipam.cluster.x-k8s.io'"
+                              },
+                              {
+                                "message": "ipv6PoolRef allows either InClusterIPPool or GlobalInClusterIPPool",
+                                "rule": "self.kind == 'InClusterIPPool' || self.kind == 'GlobalInClusterIPPool'"
+                              }
+                            ],
+                            "additionalProperties": false
+                          },
+                          "model": {
+                            "default": "virtio",
+                            "description": "Model is the network device model.",
+                            "enum": [
+                              "e1000",
+                              "virtio",
+                              "rtl8139",
+                              "vmxnet3"
+                            ],
+                            "type": "string"
+                          },
+                          "mtu": {
+                            "description": "MTU is the network device Maximum Transmission Unit.\nWhen set to 1, virtio devices inherit the MTU value from the underlying bridge.",
+                            "type": "integer",
+                            "x-kubernetes-validations": [
+                              {
+                                "message": "invalid MTU value",
+                                "rule": "self == 1 || ( self >= 576 && self <= 65520)"
+                              }
+                            ]
+                          },
+                          "vlan": {
+                            "description": "VLAN is the network L2 VLAN.",
+                            "maximum": 4094,
+                            "minimum": 1,
+                            "type": "integer"
+                          }
+                        },
+                        "required": [
+                          "bridge"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "vrfs": {
+                        "description": "Definition of a VRF Device.",
+                        "items": {
+                          "description": "VRFDevice defines Virtual Routing Flow devices.",
+                          "properties": {
+                            "interfaces": {
+                              "description": "Interfaces is the list of proxmox network devices managed by this virtual device.",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "name": {
+                              "description": "Name is the virtual network device name.\nMust be unique within the virtual machine.",
+                              "minLength": 3,
+                              "type": "string"
+                            },
+                            "routes": {
+                              "description": "Routes are the routes associated with this interface.",
+                              "items": {
+                                "description": "RouteSpec describes an IPv4/IPv6 Route.",
+                                "properties": {
+                                  "metric": {
+                                    "description": "Metric is the priority of the route in the routing table.",
+                                    "format": "int32",
+                                    "type": "integer"
+                                  },
+                                  "table": {
+                                    "description": "Table is the routing table used for this route.",
+                                    "format": "int32",
+                                    "type": "integer"
+                                  },
+                                  "to": {
+                                    "description": "To is the subnet to be routed.",
+                                    "type": "string"
+                                  },
+                                  "via": {
+                                    "description": "Via is the gateway to the subnet.",
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "minItems": 1,
+                              "type": "array"
+                            },
+                            "routingPolicy": {
+                              "description": "RoutingPolicy is an interface-specific policy inserted into FIB (forwarding information base).",
+                              "items": {
+                                "description": "RoutingPolicySpec is a Linux FIB rule.",
+                                "properties": {
+                                  "from": {
+                                    "description": "From is the subnet of the source.",
+                                    "type": "string"
+                                  },
+                                  "priority": {
+                                    "description": "Priority is the position in the ip rule FIB table.",
+                                    "format": "int32",
+                                    "maximum": 4294967295,
+                                    "type": "integer",
+                                    "x-kubernetes-validations": [
+                                      {
+                                        "message": "Cowardly refusing to insert FIB rule matching kernel rules",
+                                        "rule": "(self > 0 && self < 32765) || (self > 32766)"
+                                      }
+                                    ]
+                                  },
+                                  "table": {
+                                    "description": "Table is the routing table ID.\nwhen used in the networks, the value should be the VRF Table.",
+                                    "format": "int32",
+                                    "type": "integer"
+                                  },
+                                  "to": {
+                                    "description": "To is the subnet of the target.",
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "minItems": 1,
+                              "type": "array"
+                            },
+                            "table": {
+                              "description": "Table is the ID of the routing table used for the l3mdev vrf device.",
+                              "format": "int32",
+                              "maximum": 4294967295,
+                              "type": "integer",
+                              "x-kubernetes-validations": [
+                                {
+                                  "message": "Cowardly refusing to insert l3mdev rules into kernel tables",
+                                  "rule": "(self > 0 && self < 254) || (self > 255)"
+                                }
+                              ]
+                            }
+                          },
+                          "required": [
+                            "name",
+                            "table"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array",
+                        "x-kubernetes-list-map-keys": [
+                          "name"
+                        ],
+                        "x-kubernetes-list-type": "map"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "numCores": {
+                    "description": "NumCores is the number of cores per CPU socket in a virtual machine.\nDefaults to the property value in the template from which the virtual machine is cloned.",
+                    "format": "int32",
+                    "minimum": 1,
+                    "type": "integer"
+                  },
+                  "numSockets": {
+                    "description": "NumSockets is the number of CPU sockets in a virtual machine.\nDefaults to the property value in the template from which the virtual machine is cloned.",
+                    "format": "int32",
+                    "minimum": 1,
+                    "type": "integer"
+                  },
+                  "pool": {
+                    "description": "Pool Add the new VM to the specified pool.",
+                    "type": "string"
+                  },
+                  "providerID": {
+                    "description": "ProviderID is the virtual machine BIOS UUID formatted as\nproxmox://6c3fa683-bef9-4425-b413-eaa45a9d6191",
+                    "type": "string"
+                  },
+                  "snapName": {
+                    "description": "SnapName The name of the snapshot.",
+                    "type": "string"
+                  },
+                  "sourceNode": {
+                    "description": "SourceNode is the initially selected proxmox node.\nThis node will be used to locate the template VM, which will\nbe used for cloning operations.\n\nCloning will be performed according to the configuration.\nSetting the `Target` field will tell Proxmox to clone the\nVM on that target node.\n\nWhen Target is not set and the ProxmoxCluster contains\na set of `AllowedNodes`, the algorithm will instead evenly\ndistribute the VMs across the nodes from that list.\n\nIf neither a `Target` nor `AllowedNodes` was set, the VM\nwill be cloned onto the same node as SourceNode.",
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "storage": {
+                    "description": "Storage for full clone.",
+                    "type": "string"
+                  },
+                  "tags": {
+                    "description": "Tags is a list of tags to be applied to the virtual machine.",
+                    "items": {
+                      "pattern": "^(?i)[a-z0-9_][a-z0-9_\\-\\+\\.]*$",
+                      "type": "string"
+                    },
+                    "minItems": 1,
+                    "type": "array",
+                    "x-kubernetes-list-type": "set"
+                  },
+                  "target": {
+                    "description": "Target node. Only allowed if the original VM is on shared storage.",
+                    "type": "string"
+                  },
+                  "templateID": {
+                    "description": "TemplateID the vm_template vmid used for cloning a new VM.",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "templateSelector": {
+                    "description": "TemplateSelector defines MatchTags for looking up VM templates.",
+                    "properties": {
+                      "matchPolicy": {
+                        "default": "exact",
+                        "description": "MatchPolicy controls how MatchTags are evaluated against template tags.\nWhen not set, or set to \"exact\", the behaviour is identical to the previous implementation\nand requires an exact 1:1 tag match. When set to \"subset\", the template's tags must contain\nall MatchTags, but may include additional tags.",
+                        "enum": [
+                          "exact",
+                          "uniqueSubset",
+                          "bestSubset"
+                        ],
+                        "type": "string"
+                      },
+                      "matchTags": {
+                        "description": "Specifies all tags to look for, when looking up the VM template.\nWhen MatchPolicy is \"exact\" (the default), the template's tags must be an exact 1:1 match\nwith MatchTags. If multiple VM templates with the same set of tags are found, provisioning will fail.\nWhen MatchPolicy is \"subset\", the template's tags must contain all of the MatchTags, but may\nhave additional tags.",
+                        "items": {
+                          "pattern": "^(?i)[a-z0-9_][a-z0-9_\\-\\+\\.]*$",
+                          "type": "string"
+                        },
+                        "minItems": 1,
+                        "type": "array",
+                        "x-kubernetes-list-type": "set"
+                      }
+                    },
+                    "required": [
+                      "matchTags"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "virtualMachineID": {
+                    "description": "VirtualMachineID is the Proxmox identifier for the ProxmoxMachine VM.",
+                    "format": "int64",
+                    "type": "integer"
+                  },
+                  "vmIDRange": {
+                    "description": "VMIDRange is the range of VMIDs to use for VMs.",
+                    "properties": {
+                      "end": {
+                        "description": "VMIDRangeEnd is the end of the VMID range to use for VMs.\nOnly used if VMIDRangeStart is set.",
+                        "format": "int64",
+                        "maximum": 999999999,
+                        "minimum": 100,
+                        "type": "integer"
+                      },
+                      "start": {
+                        "description": "VMIDRangeStart is the start of the VMID range to use for VMs.",
+                        "format": "int64",
+                        "maximum": 999999999,
+                        "minimum": 100,
+                        "type": "integer"
+                      }
+                    },
+                    "required": [
+                      "end",
+                      "start"
+                    ],
+                    "type": "object",
+                    "x-kubernetes-validations": [
+                      {
+                        "message": "end should be greater than or equal to start",
+                        "rule": "self.end >= self.start"
+                      }
+                    ],
+                    "additionalProperties": false
+                  }
+                },
+                "type": "object",
+                "x-kubernetes-validations": [
+                  {
+                    "message": "Must set full=true when specifying format",
+                    "rule": "self.full || !has(self.format)"
+                  },
+                  {
+                    "message": "Must set full=true when specifying storage",
+                    "rule": "self.full || !has(self.storage)"
+                  }
+                ],
+                "additionalProperties": false
+              },
+              "type": "object"
+            },
+            "sshAuthorizedKeys": {
+              "description": "SshAuthorizedKeys contains the authorized keys deployed to the PROXMOX VMs.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "virtualIPNetworkInterface": {
+              "description": "VirtualIPNetworkInterface is the interface the k8s control plane binds to.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "machineSpec"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "controlPlaneEndpoint": {
+          "description": "ControlPlaneEndpoint represents the endpoint used to communicate with the control plane.",
+          "properties": {
+            "host": {
+              "description": "host is the hostname on which the API server is serving.",
+              "maxLength": 512,
+              "type": "string"
+            },
+            "port": {
+              "description": "port is the port on which the API server is serving.",
+              "format": "int32",
+              "type": "integer"
+            }
+          },
+          "type": "object",
+          "x-kubernetes-validations": [
+            {
+              "message": "port must be within 1-65535",
+              "rule": "self.port > 0 && self.port < 65536"
+            }
+          ],
+          "additionalProperties": false
+        },
+        "credentialsRef": {
+          "description": "CredentialsRef is a reference to a Secret that contains the credentials to use for provisioning this cluster. If not\nsupplied then the credentials of the controller will be used.\nif no namespace is provided, the namespace of the ProxmoxCluster will be used.",
+          "properties": {
+            "name": {
+              "description": "name is unique within a namespace to reference a secret resource.",
+              "type": "string"
+            },
+            "namespace": {
+              "description": "namespace defines the space within which the secret name must be unique.",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "x-kubernetes-map-type": "atomic",
+          "additionalProperties": false
+        },
+        "dnsServers": {
+          "description": "DNSServers contains information about nameservers used by the machines.",
+          "items": {
+            "type": "string"
+          },
+          "minItems": 1,
+          "type": "array"
+        },
+        "externalManagedControlPlane": {
+          "description": "ExternalManagedControlPlane can be enabled to allow externally managed Control Planes to patch the\nProxmox cluster with the Load Balancer IP provided by Control Plane provider.",
+          "type": "boolean"
+        },
+        "ipv4Config": {
+          "description": "IPv4Config contains information about available IPV4 address pools and the gateway.\nThis can be combined with ipv6Config in order to enable dual stack.\nEither IPv4Config or IPv6Config must be provided.",
+          "properties": {
+            "addresses": {
+              "description": "Addresses is a list of IP addresses that can be assigned. This set of\naddresses can be non-contiguous.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "gateway": {
+              "description": "Gateway",
+              "type": "string"
+            },
+            "metric": {
+              "default": 100,
+              "description": "Metric is the route priority applied to the default gateway",
+              "format": "int32",
+              "type": "integer"
+            },
+            "prefix": {
+              "description": "Prefix is the network prefix to use.",
+              "maximum": 128,
+              "type": "integer"
+            }
+          },
+          "required": [
+            "addresses",
+            "metric",
+            "prefix"
+          ],
+          "type": "object",
+          "x-kubernetes-validations": [
+            {
+              "message": "IPv4Config addresses must be provided",
+              "rule": "self.addresses.size() > 0"
+            }
+          ],
+          "additionalProperties": false
+        },
+        "ipv6Config": {
+          "description": "IPv6Config contains information about available IPV6 address pools and the gateway.\nThis can be combined with ipv4Config in order to enable dual stack.\nEither IPv4Config or IPv6Config must be provided.",
+          "properties": {
+            "addresses": {
+              "description": "Addresses is a list of IP addresses that can be assigned. This set of\naddresses can be non-contiguous.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "gateway": {
+              "description": "Gateway",
+              "type": "string"
+            },
+            "metric": {
+              "default": 100,
+              "description": "Metric is the route priority applied to the default gateway",
+              "format": "int32",
+              "type": "integer"
+            },
+            "prefix": {
+              "description": "Prefix is the network prefix to use.",
+              "maximum": 128,
+              "type": "integer"
+            }
+          },
+          "required": [
+            "addresses",
+            "metric",
+            "prefix"
+          ],
+          "type": "object",
+          "x-kubernetes-validations": [
+            {
+              "message": "IPv6Config addresses must be provided",
+              "rule": "self.addresses.size() > 0"
+            }
+          ],
+          "additionalProperties": false
+        },
+        "schedulerHints": {
+          "description": "SchedulerHints allows to influence the decision on where a VM will be scheduled. For example by applying a multiplicator\nto a node's resources, to allow for overprovisioning or to ensure a node will always have a safety buffer.",
+          "properties": {
+            "memoryAdjustment": {
+              "description": "MemoryAdjustment allows to adjust a node's memory by a given percentage.\nFor example, setting it to 300 allows to allocate 300% of a host's memory for VMs,\nand setting it to 95 limits memory allocation to 95% of a host's memory.\nSetting it to 0 entirely disables scheduling memory constraints.\nBy default 100% of a node's memory will be used for allocation.",
+              "format": "int64",
+              "type": "integer"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "dnsServers"
+      ],
+      "type": "object",
+      "x-kubernetes-validations": [
+        {
+          "message": "at least one ip config must be set, either ipv4Config or ipv6Config",
+          "rule": "self.ipv4Config != null || self.ipv6Config != null"
+        }
+      ],
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "ProxmoxClusterStatus defines the observed state of a ProxmoxCluster.",
+      "properties": {
+        "conditions": {
+          "description": "Conditions defines current service state of the ProxmoxCluster.",
+          "items": {
+            "description": "Condition defines an observation of a Cluster API resource operational state.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "lastTransitionTime is the last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed. If that is not known, then using the time when\nthe API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "message is a human readable message indicating details about the transition.\nThis field may be empty.",
+                "maxLength": 10240,
+                "minLength": 1,
+                "type": "string"
+              },
+              "reason": {
+                "description": "reason is the reason for the condition's last transition in CamelCase.\nThe specific API may choose whether or not this field is considered a guaranteed API.\nThis field may be empty.",
+                "maxLength": 256,
+                "minLength": 1,
+                "type": "string"
+              },
+              "severity": {
+                "description": "severity provides an explicit classification of Reason code, so the users or machines can immediately\nunderstand the current situation and act accordingly.\nThe Severity field MUST be set only when Status=False.",
+                "maxLength": 32,
+                "type": "string"
+              },
+              "status": {
+                "description": "status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "type of condition in CamelCase or in foo.example.com/CamelCase.\nMany .condition.type values are consistent across resources like Available, but because arbitrary conditions\ncan be useful (see .node.status.conditions), the ability to deconflict is important.",
+                "maxLength": 256,
+                "minLength": 1,
+                "type": "string"
+              }
+            },
+            "required": [
+              "lastTransitionTime",
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "failureMessage": {
+          "description": "FailureMessage will be set in the event that there is a terminal problem\nreconciling the Machine and will contain a more verbose string suitable\nfor logging and human consumption.\n\nThis field should not be set for transitive errors that a controller\nfaces that are expected to be fixed automatically over\ntime (like service outages), but instead indicate that something is\nfundamentally wrong with the Machine's spec or the configuration of\nthe controller, and that manual intervention is required. Examples\nof terminal errors would be invalid combinations of settings in the\nspec, values that are unsupported by the controller, or the\nresponsible controller itself being critically misconfigured.\n\nAny transient errors that occur during the reconciliation of ProxmoxMachines\ncan be added as events to the ProxmoxCluster object and/or logged in the\ncontroller's output.",
+          "type": "string"
+        },
+        "failureReason": {
+          "description": "FailureReason will be set in the event that there is a terminal problem\nreconciling the Machine and will contain a succinct value suitable\nfor machine interpretation.\n\nThis field should not be set for transitive errors that a controller\nfaces that are expected to be fixed automatically over\ntime (like service outages), but instead indicate that something is\nfundamentally wrong with the Machine's spec or the configuration of\nthe controller, and that manual intervention is required. Examples\nof terminal errors would be invalid combinations of settings in the\nspec, values that are unsupported by the controller, or the\nresponsible controller itself being critically misconfigured.\n\nAny transient errors that occur during the reconciliation of ProxmoxCluster\ncan be added as events to the ProxmoxCluster object and/or logged in the\ncontroller's output.",
+          "type": "string"
+        },
+        "inClusterIpPoolRef": {
+          "description": "InClusterIPPoolRef is the reference to the created in-cluster IP pool.",
+          "items": {
+            "description": "LocalObjectReference contains enough information to let you locate the\nreferenced object inside the same namespace.",
+            "properties": {
+              "name": {
+                "default": "",
+                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                "type": "string"
+              }
+            },
+            "type": "object",
+            "x-kubernetes-map-type": "atomic",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "nodeLocations": {
+          "description": "NodeLocations keeps track of which nodes have been selected\nfor different machines.",
+          "properties": {
+            "controlPlane": {
+              "description": "ControlPlane contains all deployed control plane nodes.",
+              "items": {
+                "description": "NodeLocation holds information about a single VM\nin Proxmox.",
+                "properties": {
+                  "machine": {
+                    "description": "Machine is the reference to the ProxmoxMachine.",
+                    "properties": {
+                      "name": {
+                        "default": "",
+                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "x-kubernetes-map-type": "atomic",
+                    "additionalProperties": false
+                  },
+                  "node": {
+                    "description": "Node is the Proxmox node.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "machine",
+                  "node"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "workers": {
+              "description": "Workers contains all deployed worker nodes.",
+              "items": {
+                "description": "NodeLocation holds information about a single VM\nin Proxmox.",
+                "properties": {
+                  "machine": {
+                    "description": "Machine is the reference to the ProxmoxMachine.",
+                    "properties": {
+                      "name": {
+                        "default": "",
+                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "x-kubernetes-map-type": "atomic",
+                    "additionalProperties": false
+                  },
+                  "node": {
+                    "description": "Node is the Proxmox node.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "machine",
+                  "node"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "ready": {
+          "default": false,
+          "description": "Ready indicates that the cluster is ready.",
+          "type": "boolean"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/infrastructure.cluster.x-k8s.io/proxmoxcluster_v1alpha2.json
+++ b/infrastructure.cluster.x-k8s.io/proxmoxcluster_v1alpha2.json
@@ -1,0 +1,557 @@
+{
+  "description": "ProxmoxCluster is the Schema for the proxmoxclusters API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "spec is the Proxmox Cluster spec",
+      "properties": {
+        "allowedNodes": {
+          "description": "allowedNodes specifies all Proxmox nodes which will be considered\nfor operations. This implies that VMs can be cloned on different nodes from\nthe node which holds the VM template.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "set"
+        },
+        "controlPlaneEndpoint": {
+          "description": "controlPlaneEndpoint represents the endpoint used to communicate with the control plane.",
+          "minProperties": 1,
+          "properties": {
+            "host": {
+              "description": "host is the hostname on which the API server is serving.",
+              "maxLength": 512,
+              "minLength": 1,
+              "type": "string"
+            },
+            "port": {
+              "description": "port is the port on which the API server is serving.",
+              "format": "int32",
+              "maximum": 65535,
+              "minimum": 1,
+              "type": "integer"
+            }
+          },
+          "type": "object",
+          "x-kubernetes-validations": [
+            {
+              "message": "port must be within 1-65535",
+              "rule": "self.port > 0 && self.port < 65536"
+            }
+          ],
+          "additionalProperties": false
+        },
+        "credentialsRef": {
+          "description": "credentialsRef is a reference to a Secret that contains the credentials to use for provisioning this cluster. If not\nsupplied then the credentials of the controller will be used.\nif no namespace is provided, the namespace of the ProxmoxCluster will be used.",
+          "properties": {
+            "name": {
+              "description": "name is unique within a namespace to reference a secret resource.",
+              "type": "string"
+            },
+            "namespace": {
+              "description": "namespace defines the space within which the secret name must be unique.",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "x-kubernetes-map-type": "atomic",
+          "additionalProperties": false
+        },
+        "dnsServers": {
+          "description": "dnsServers contains information about nameservers used by the machines.",
+          "items": {
+            "type": "string"
+          },
+          "minItems": 1,
+          "type": "array",
+          "x-kubernetes-list-type": "set"
+        },
+        "externalManagedControlPlane": {
+          "default": false,
+          "description": "externalManagedControlPlane can be enabled to allow externally managed Control Planes to patch the\nProxmox cluster with the Load Balancer IP provided by Control Plane provider.",
+          "type": "boolean"
+        },
+        "ipv4Config": {
+          "description": "ipv4Config contains information about available IPv4 address pools and the gateway.\nThis can be combined with ipv6Config in order to enable dual stack.\nEither IPv4Config or IPv6Config must be provided.",
+          "properties": {
+            "addresses": {
+              "description": "addresses is a list of IP addresses that can be assigned. This set of addresses can be non-contiguous.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array",
+              "x-kubernetes-list-type": "set"
+            },
+            "gateway": {
+              "description": "gateway is the network gateway",
+              "minLength": 1,
+              "type": "string"
+            },
+            "metric": {
+              "default": 100,
+              "description": "metric is the route priority applied to the default gateway",
+              "format": "int32",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "prefix": {
+              "description": "prefix is the network prefix to use.",
+              "format": "int32",
+              "maximum": 128,
+              "minimum": 1,
+              "type": "integer"
+            }
+          },
+          "required": [
+            "addresses",
+            "gateway",
+            "prefix"
+          ],
+          "type": "object",
+          "x-kubernetes-validations": [
+            {
+              "message": "IPv4Config addresses must be provided",
+              "rule": "self.addresses.size() > 0"
+            }
+          ],
+          "additionalProperties": false
+        },
+        "ipv6Config": {
+          "description": "ipv6Config contains information about available IPv6 address pools and the gateway.\nThis can be combined with ipv4Config in order to enable dual stack.\nEither IPv4Config or IPv6Config must be provided.",
+          "properties": {
+            "addresses": {
+              "description": "addresses is a list of IP addresses that can be assigned. This set of addresses can be non-contiguous.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array",
+              "x-kubernetes-list-type": "set"
+            },
+            "gateway": {
+              "description": "gateway is the network gateway",
+              "minLength": 1,
+              "type": "string"
+            },
+            "metric": {
+              "default": 100,
+              "description": "metric is the route priority applied to the default gateway",
+              "format": "int32",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "prefix": {
+              "description": "prefix is the network prefix to use.",
+              "format": "int32",
+              "maximum": 128,
+              "minimum": 1,
+              "type": "integer"
+            }
+          },
+          "required": [
+            "addresses",
+            "gateway",
+            "prefix"
+          ],
+          "type": "object",
+          "x-kubernetes-validations": [
+            {
+              "message": "IPv6Config addresses must be provided",
+              "rule": "self.addresses.size() > 0"
+            }
+          ],
+          "additionalProperties": false
+        },
+        "schedulerHints": {
+          "description": "schedulerHints allows to influence the decision on where a VM will be scheduled. For example by applying a multiplicator\nto a node's resources, to allow for overprovisioning or to ensure a node will always have a safety buffer.",
+          "properties": {
+            "memoryAdjustment": {
+              "description": "memoryAdjustment allows to adjust a node's memory by a given percentage.\nFor example, setting it to 300 allows to allocate 300% of a host's memory for VMs,\nand setting it to 95 limits memory allocation to 95% of a host's memory.\nSetting it to 0 entirely disables scheduling memory constraints.\nBy default 100% of a node's memory will be used for allocation.",
+              "format": "int64",
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "zoneConfig": {
+          "description": "zoneConfig defines a IPAddress config per deployment zone.",
+          "items": {
+            "description": "ZoneConfigSpec is the Network Configuration for further deployment zones.",
+            "properties": {
+              "dnsServers": {
+                "description": "dnsServers contains information about nameservers used by the machines in this zone.",
+                "items": {
+                  "type": "string"
+                },
+                "minItems": 1,
+                "type": "array",
+                "x-kubernetes-list-type": "set"
+              },
+              "ipv4Config": {
+                "description": "ipv4Config contains information about available IPv4 address pools and the gateway.\nThis can be combined with ipv6Config in order to enable dual stack.\nEither IPv4Config or IPv6Config must be provided.",
+                "properties": {
+                  "addresses": {
+                    "description": "addresses is a list of IP addresses that can be assigned. This set of addresses can be non-contiguous.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-type": "set"
+                  },
+                  "gateway": {
+                    "description": "gateway is the network gateway",
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "metric": {
+                    "default": 100,
+                    "description": "metric is the route priority applied to the default gateway",
+                    "format": "int32",
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "prefix": {
+                    "description": "prefix is the network prefix to use.",
+                    "format": "int32",
+                    "maximum": 128,
+                    "minimum": 1,
+                    "type": "integer"
+                  }
+                },
+                "required": [
+                  "addresses",
+                  "gateway",
+                  "prefix"
+                ],
+                "type": "object",
+                "x-kubernetes-validations": [
+                  {
+                    "message": "IPv4Config addresses must be provided",
+                    "rule": "self.addresses.size() > 0"
+                  }
+                ],
+                "additionalProperties": false
+              },
+              "ipv6Config": {
+                "description": "ipv6Config contains information about available IPv6 address pools and the gateway.\nThis can be combined with ipv4Config in order to enable dual stack.\nEither IPv4Config or IPv6Config must be provided.",
+                "properties": {
+                  "addresses": {
+                    "description": "addresses is a list of IP addresses that can be assigned. This set of addresses can be non-contiguous.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-type": "set"
+                  },
+                  "gateway": {
+                    "description": "gateway is the network gateway",
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "metric": {
+                    "default": 100,
+                    "description": "metric is the route priority applied to the default gateway",
+                    "format": "int32",
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "prefix": {
+                    "description": "prefix is the network prefix to use.",
+                    "format": "int32",
+                    "maximum": 128,
+                    "minimum": 1,
+                    "type": "integer"
+                  }
+                },
+                "required": [
+                  "addresses",
+                  "gateway",
+                  "prefix"
+                ],
+                "type": "object",
+                "x-kubernetes-validations": [
+                  {
+                    "message": "IPv6Config addresses must be provided",
+                    "rule": "self.addresses.size() > 0"
+                  }
+                ],
+                "additionalProperties": false
+              },
+              "zone": {
+                "description": "zone is the name of your deployment zone.",
+                "pattern": "^[a-z0-9A-Z](?:[a-z0-9A-Z-_.]{0,61}[a-z0-9A-Z])?$",
+                "type": "string"
+              }
+            },
+            "required": [
+              "dnsServers",
+              "zone"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array",
+          "x-kubernetes-list-map-keys": [
+            "zone"
+          ],
+          "x-kubernetes-list-type": "map"
+        }
+      },
+      "required": [
+        "dnsServers"
+      ],
+      "type": "object",
+      "x-kubernetes-validations": [
+        {
+          "message": "at least one ip config must be set, either ipv4Config or ipv6Config",
+          "rule": "self.ipv4Config != null || self.ipv6Config != null"
+        }
+      ],
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "status is the Proxmox Cluster status",
+      "properties": {
+        "conditions": {
+          "description": "conditions represents the observations of a ProxmoxCluster's current state.\nKnown condition types are Ready, ProxmoxAvailable and Paused.",
+          "items": {
+            "description": "Condition contains details for one aspect of the current state of this API Resource.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "lastTransitionTime is the last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "message is a human readable message indicating details about the transition.\nThis may be an empty string.",
+                "maxLength": 32768,
+                "type": "string"
+              },
+              "observedGeneration": {
+                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon.\nFor instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date\nwith respect to the current state of the instance.",
+                "format": "int64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "reason": {
+                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition.\nProducers of specific condition types may define expected values and meanings for this field,\nand whether the values are considered a guaranteed API.\nThe value should be a CamelCase string.\nThis field may not be empty.",
+                "maxLength": 1024,
+                "minLength": 1,
+                "pattern": "^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$",
+                "type": "string"
+              },
+              "status": {
+                "description": "status of the condition, one of True, False, Unknown.",
+                "enum": [
+                  "True",
+                  "False",
+                  "Unknown"
+                ],
+                "type": "string"
+              },
+              "type": {
+                "description": "type of condition in CamelCase or in foo.example.com/CamelCase.",
+                "maxLength": 316,
+                "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$",
+                "type": "string"
+              }
+            },
+            "required": [
+              "lastTransitionTime",
+              "message",
+              "reason",
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "maxItems": 32,
+          "type": "array",
+          "x-kubernetes-list-map-keys": [
+            "type"
+          ],
+          "x-kubernetes-list-type": "map"
+        },
+        "inClusterIPPoolRef": {
+          "description": "inClusterIPPoolRef is the reference to the created in-cluster IP pool.",
+          "items": {
+            "description": "LocalObjectReference contains enough information to let you locate the\nreferenced object inside the same namespace.",
+            "properties": {
+              "name": {
+                "default": "",
+                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                "type": "string"
+              }
+            },
+            "type": "object",
+            "x-kubernetes-map-type": "atomic",
+            "additionalProperties": false
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        },
+        "inClusterZoneRef": {
+          "description": "inClusterZoneRef lists InClusterIPPools per proxmox-zone.",
+          "items": {
+            "description": "InClusterZoneRef holds the InClusterIPPools associated with a zone.",
+            "properties": {
+              "inClusterIPPoolRefV4": {
+                "description": "inClusterIPPoolRefV4 is the reference to the created in-cluster IP pool.",
+                "properties": {
+                  "name": {
+                    "default": "",
+                    "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "x-kubernetes-map-type": "atomic",
+                "additionalProperties": false
+              },
+              "inClusterIPPoolRefV6": {
+                "description": "inClusterIPPoolRefV6 is the reference to the created in-cluster IP pool.",
+                "properties": {
+                  "name": {
+                    "default": "",
+                    "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "x-kubernetes-map-type": "atomic",
+                "additionalProperties": false
+              },
+              "zone": {
+                "default": "default",
+                "description": "zone defines the deployment proxmox-zone.",
+                "pattern": "^[a-z0-9A-Z](?:[a-z0-9A-Z-_.]{0,61}[a-z0-9A-Z])?$",
+                "type": "string"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array",
+          "x-kubernetes-list-map-keys": [
+            "zone"
+          ],
+          "x-kubernetes-list-type": "map"
+        },
+        "initialization": {
+          "description": "initialization provides observations of the ProxmoxCluster initialization process.\nNOTE: Fields in this struct are part of the Cluster API contract and are used to orchestrate initial Cluster provisioning.",
+          "minProperties": 1,
+          "properties": {
+            "provisioned": {
+              "description": "provisioned is true when the infrastructure provider reports that the Cluster's infrastructure is fully provisioned.\nNOTE: this field is part of the Cluster API contract, and it is used to orchestrate initial Cluster provisioning.",
+              "type": "boolean"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "nodeLocations": {
+          "description": "nodeLocations keeps track of which nodes have been selected\nfor different machines.",
+          "properties": {
+            "controlPlane": {
+              "description": "controlPlane contains all deployed control plane nodes.",
+              "items": {
+                "description": "NodeLocation holds information about a single VM\nin Proxmox.",
+                "properties": {
+                  "machine": {
+                    "description": "machine is the reference to the ProxmoxMachine that the node is on.",
+                    "properties": {
+                      "name": {
+                        "default": "",
+                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "x-kubernetes-map-type": "atomic",
+                    "additionalProperties": false
+                  },
+                  "node": {
+                    "description": "node is the Proxmox node.",
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "zone": {
+                    "description": "zone is the zone the Machine is in.",
+                    "pattern": "^[a-z0-9A-Z](?:[a-z0-9A-Z-_.]{0,61}[a-z0-9A-Z])?$",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "machine",
+                  "node"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array",
+              "x-kubernetes-list-type": "atomic"
+            },
+            "workers": {
+              "description": "workers contains all deployed worker nodes.",
+              "items": {
+                "description": "NodeLocation holds information about a single VM\nin Proxmox.",
+                "properties": {
+                  "machine": {
+                    "description": "machine is the reference to the ProxmoxMachine that the node is on.",
+                    "properties": {
+                      "name": {
+                        "default": "",
+                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "x-kubernetes-map-type": "atomic",
+                    "additionalProperties": false
+                  },
+                  "node": {
+                    "description": "node is the Proxmox node.",
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "zone": {
+                    "description": "zone is the zone the Machine is in.",
+                    "pattern": "^[a-z0-9A-Z](?:[a-z0-9A-Z-_.]{0,61}[a-z0-9A-Z])?$",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "machine",
+                  "node"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array",
+              "x-kubernetes-list-type": "atomic"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "required": [
+    "spec"
+  ],
+  "type": "object"
+}

--- a/infrastructure.cluster.x-k8s.io/proxmoxclustertemplate_v1alpha1.json
+++ b/infrastructure.cluster.x-k8s.io/proxmoxclustertemplate_v1alpha1.json
@@ -1,0 +1,924 @@
+{
+  "description": "ProxmoxClusterTemplate is the Schema for the proxmoxclustertemplates API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "ProxmoxClusterTemplateSpec defines the desired state of ProxmoxClusterTemplate.",
+      "properties": {
+        "template": {
+          "description": "ProxmoxClusterTemplateResource defines the spec and metadata for ProxmoxClusterTemplate supported by capi.",
+          "properties": {
+            "metadata": {
+              "description": "Standard object's metadata.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+              "properties": {
+                "annotations": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "annotations is an unstructured key value map stored with a resource that may be\nset by external tools to store and retrieve arbitrary metadata. They are not\nqueryable and should be preserved when modifying objects.\nMore info: http://kubernetes.io/docs/user-guide/annotations",
+                  "type": "object"
+                },
+                "labels": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "labels is a map of string keys and values that can be used to organize and categorize\n(scope and select) objects. May match selectors of replication controllers\nand services.\nMore info: http://kubernetes.io/docs/user-guide/labels",
+                  "type": "object"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "spec": {
+              "description": "ProxmoxClusterSpec defines the desired state of a ProxmoxCluster.",
+              "properties": {
+                "allowedNodes": {
+                  "description": "AllowedNodes specifies all Proxmox nodes which will be considered\nfor operations. This implies that VMs can be cloned on different nodes from\nthe node which holds the VM template.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "cloneSpec": {
+                  "description": "NodeCloneSpec is the configuration pertaining to all items configurable\nin the configuration and cloning of a proxmox VM. Multiple types of nodes can be specified.",
+                  "properties": {
+                    "machineSpec": {
+                      "additionalProperties": {
+                        "description": "ProxmoxMachineSpec defines the desired state of a ProxmoxMachine.",
+                        "properties": {
+                          "allowedNodes": {
+                            "description": "AllowedNodes specifies all Proxmox nodes which will be considered\nfor operations. This implies that VMs can be cloned on different nodes from\nthe node which holds the VM template.\n\nThis field is optional and should only be set if you want to restrict\nthe nodes where the VM can be cloned.\nIf not set, the ProxmoxCluster will be used to determine the nodes.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "checks": {
+                            "description": "Checks defines possibles checks to skip.",
+                            "properties": {
+                              "skipCloudInitStatus": {
+                                "description": "Skip checking CloudInit which can be very useful for specific Operating Systems like TalOS",
+                                "type": "boolean"
+                              },
+                              "skipQemuGuestAgent": {
+                                "description": "Skip checking QEMU Agent readiness which can be very useful for specific Operating Systems like TalOS",
+                                "type": "boolean"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "description": {
+                            "description": "Description for the new VM.",
+                            "type": "string"
+                          },
+                          "disks": {
+                            "description": "Disks contains a set of disk configuration options,\nwhich will be applied before the first startup.",
+                            "properties": {
+                              "bootVolume": {
+                                "description": "BootVolume defines the storage size for the boot volume.\nThis field is optional, and should only be set if you want\nto change the size of the boot volume.",
+                                "properties": {
+                                  "disk": {
+                                    "description": "Disk is the name of the disk device, that should be resized.\nExample values are: ide[0-3], scsi[0-30], sata[0-5].",
+                                    "type": "string"
+                                  },
+                                  "sizeGb": {
+                                    "description": "Size defines the size in gigabyte.\n\nAs Proxmox does not support shrinking, the size\nmust be bigger than the already configured size in the\ntemplate.",
+                                    "format": "int32",
+                                    "minimum": 5,
+                                    "type": "integer"
+                                  }
+                                },
+                                "required": [
+                                  "disk",
+                                  "sizeGb"
+                                ],
+                                "type": "object",
+                                "x-kubernetes-validations": [
+                                  {
+                                    "message": "Value is immutable",
+                                    "rule": "self == oldSelf"
+                                  }
+                                ],
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "format": {
+                            "description": "Format for file storage. Only valid for full clone.",
+                            "enum": [
+                              "raw",
+                              "qcow2",
+                              "vmdk"
+                            ],
+                            "type": "string"
+                          },
+                          "full": {
+                            "default": true,
+                            "description": "Full Create a full copy of all disks.\nThis is always done when you clone a normal VM.\nCreate a Full clone by default.",
+                            "type": "boolean"
+                          },
+                          "memoryMiB": {
+                            "description": "MemoryMiB is the size of a virtual machine's memory, in MiB.\nDefaults to the property value in the template from which the virtual machine is cloned.",
+                            "format": "int32",
+                            "multipleOf": 8,
+                            "type": "integer"
+                          },
+                          "metadataSettings": {
+                            "description": "MetadataSettings defines the metadata settings for this machine's VM.",
+                            "properties": {
+                              "providerIDInjection": {
+                                "description": "ProviderIDInjection enables the injection of the `providerID` into the cloudinit metadata.\nthis will basically set the `provider-id` field in the metadata to `proxmox://<instanceID>`.",
+                                "type": "boolean"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "network": {
+                            "description": "Network is the network configuration for this machine's VM.",
+                            "properties": {
+                              "additionalDevices": {
+                                "description": "AdditionalDevices defines additional network devices bound to the virtual machine.",
+                                "items": {
+                                  "description": "AdditionalNetworkDevice the definition of a Proxmox network device.",
+                                  "properties": {
+                                    "bridge": {
+                                      "description": "Bridge is the network bridge to attach to the machine.",
+                                      "minLength": 1,
+                                      "type": "string"
+                                    },
+                                    "dnsServers": {
+                                      "description": "DNSServers contains information about nameservers to be used for this interface.\nIf this field is not set, it will use the default dns servers from the ProxmoxCluster.",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "minItems": 1,
+                                      "type": "array"
+                                    },
+                                    "ipv4PoolRef": {
+                                      "description": "IPv4PoolRef is a reference to an IPAM Pool resource, which exposes IPv4 addresses.\nThe network device will use an available IP address from the referenced pool.\nThis can be combined with `IPv6PoolRef` in order to enable dual stack.",
+                                      "properties": {
+                                        "apiGroup": {
+                                          "description": "APIGroup is the group for the resource being referenced.\nIf APIGroup is not specified, the specified Kind must be in the core API group.\nFor any other third-party types, APIGroup is required.",
+                                          "type": "string"
+                                        },
+                                        "kind": {
+                                          "description": "Kind is the type of resource being referenced",
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "description": "Name is the name of resource being referenced",
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "kind",
+                                        "name"
+                                      ],
+                                      "type": "object",
+                                      "x-kubernetes-map-type": "atomic",
+                                      "x-kubernetes-validations": [
+                                        {
+                                          "message": "ipv4PoolRef allows only IPAM apiGroup ipam.cluster.x-k8s.io",
+                                          "rule": "self.apiGroup == 'ipam.cluster.x-k8s.io'"
+                                        },
+                                        {
+                                          "message": "ipv4PoolRef allows either InClusterIPPool or GlobalInClusterIPPool",
+                                          "rule": "self.kind == 'InClusterIPPool' || self.kind == 'GlobalInClusterIPPool'"
+                                        }
+                                      ],
+                                      "additionalProperties": false
+                                    },
+                                    "ipv6PoolRef": {
+                                      "description": "IPv6PoolRef is a reference to an IPAM pool resource, which exposes IPv6 addresses.\nThe network device will use an available IP address from the referenced pool.\nthis can be combined with `IPv4PoolRef` in order to enable dual stack.",
+                                      "properties": {
+                                        "apiGroup": {
+                                          "description": "APIGroup is the group for the resource being referenced.\nIf APIGroup is not specified, the specified Kind must be in the core API group.\nFor any other third-party types, APIGroup is required.",
+                                          "type": "string"
+                                        },
+                                        "kind": {
+                                          "description": "Kind is the type of resource being referenced",
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "description": "Name is the name of resource being referenced",
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "kind",
+                                        "name"
+                                      ],
+                                      "type": "object",
+                                      "x-kubernetes-map-type": "atomic",
+                                      "x-kubernetes-validations": [
+                                        {
+                                          "message": "ipv6PoolRef allows only IPAM apiGroup ipam.cluster.x-k8s.io",
+                                          "rule": "self.apiGroup == 'ipam.cluster.x-k8s.io'"
+                                        },
+                                        {
+                                          "message": "ipv6PoolRef allows either InClusterIPPool or GlobalInClusterIPPool",
+                                          "rule": "self.kind == 'InClusterIPPool' || self.kind == 'GlobalInClusterIPPool'"
+                                        }
+                                      ],
+                                      "additionalProperties": false
+                                    },
+                                    "linkMtu": {
+                                      "description": "LinkMTU is the network device Maximum Transmission Unit.",
+                                      "type": "integer",
+                                      "x-kubernetes-validations": [
+                                        {
+                                          "message": "invalid MTU value",
+                                          "rule": "self == 1 || ( self >= 576 && self <= 65520)"
+                                        }
+                                      ]
+                                    },
+                                    "model": {
+                                      "default": "virtio",
+                                      "description": "Model is the network device model.",
+                                      "enum": [
+                                        "e1000",
+                                        "virtio",
+                                        "rtl8139",
+                                        "vmxnet3"
+                                      ],
+                                      "type": "string"
+                                    },
+                                    "mtu": {
+                                      "description": "MTU is the network device Maximum Transmission Unit.\nWhen set to 1, virtio devices inherit the MTU value from the underlying bridge.",
+                                      "type": "integer",
+                                      "x-kubernetes-validations": [
+                                        {
+                                          "message": "invalid MTU value",
+                                          "rule": "self == 1 || ( self >= 576 && self <= 65520)"
+                                        }
+                                      ]
+                                    },
+                                    "name": {
+                                      "description": "Name is the network device name.\nMust be unique within the virtual machine and different from the primary device 'net0'.",
+                                      "minLength": 1,
+                                      "type": "string",
+                                      "x-kubernetes-validations": [
+                                        {
+                                          "message": "additional network devices doesn't allow net0",
+                                          "rule": "self != 'net0'"
+                                        }
+                                      ]
+                                    },
+                                    "routes": {
+                                      "description": "Routes are the routes associated with this interface.",
+                                      "items": {
+                                        "description": "RouteSpec describes an IPv4/IPv6 Route.",
+                                        "properties": {
+                                          "metric": {
+                                            "description": "Metric is the priority of the route in the routing table.",
+                                            "format": "int32",
+                                            "type": "integer"
+                                          },
+                                          "table": {
+                                            "description": "Table is the routing table used for this route.",
+                                            "format": "int32",
+                                            "type": "integer"
+                                          },
+                                          "to": {
+                                            "description": "To is the subnet to be routed.",
+                                            "type": "string"
+                                          },
+                                          "via": {
+                                            "description": "Via is the gateway to the subnet.",
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "minItems": 1,
+                                      "type": "array"
+                                    },
+                                    "routingPolicy": {
+                                      "description": "RoutingPolicy is an interface-specific policy inserted into FIB (forwarding information base).",
+                                      "items": {
+                                        "description": "RoutingPolicySpec is a Linux FIB rule.",
+                                        "properties": {
+                                          "from": {
+                                            "description": "From is the subnet of the source.",
+                                            "type": "string"
+                                          },
+                                          "priority": {
+                                            "description": "Priority is the position in the ip rule FIB table.",
+                                            "format": "int32",
+                                            "maximum": 4294967295,
+                                            "type": "integer",
+                                            "x-kubernetes-validations": [
+                                              {
+                                                "message": "Cowardly refusing to insert FIB rule matching kernel rules",
+                                                "rule": "(self > 0 && self < 32765) || (self > 32766)"
+                                              }
+                                            ]
+                                          },
+                                          "table": {
+                                            "description": "Table is the routing table ID.\nwhen used in the networks, the value should be the VRF Table.",
+                                            "format": "int32",
+                                            "type": "integer"
+                                          },
+                                          "to": {
+                                            "description": "To is the subnet of the target.",
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "minItems": 1,
+                                      "type": "array"
+                                    },
+                                    "vlan": {
+                                      "description": "VLAN is the network L2 VLAN.",
+                                      "maximum": 4094,
+                                      "minimum": 1,
+                                      "type": "integer"
+                                    }
+                                  },
+                                  "required": [
+                                    "bridge",
+                                    "name"
+                                  ],
+                                  "type": "object",
+                                  "x-kubernetes-validations": [
+                                    {
+                                      "message": "at least one pool reference must be set, either ipv4PoolRef or ipv6PoolRef",
+                                      "rule": "self.ipv4PoolRef != null || self.ipv6PoolRef != null"
+                                    }
+                                  ],
+                                  "additionalProperties": false
+                                },
+                                "type": "array",
+                                "x-kubernetes-list-map-keys": [
+                                  "name"
+                                ],
+                                "x-kubernetes-list-type": "map"
+                              },
+                              "default": {
+                                "description": "Default is the default network device,\nwhich will be used for the primary network interface.\nnet0 is always the default network device.",
+                                "properties": {
+                                  "bridge": {
+                                    "description": "Bridge is the network bridge to attach to the machine.",
+                                    "minLength": 1,
+                                    "type": "string"
+                                  },
+                                  "dnsServers": {
+                                    "description": "DNSServers contains information about nameservers to be used for this interface.\nIf this field is not set, it will use the default dns servers from the ProxmoxCluster.",
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "minItems": 1,
+                                    "type": "array"
+                                  },
+                                  "ipv4PoolRef": {
+                                    "description": "IPv4PoolRef is a reference to an IPAM Pool resource, which exposes IPv4 addresses.\nThe network device will use an available IP address from the referenced pool.\nThis can be combined with `IPv6PoolRef` in order to enable dual stack.",
+                                    "properties": {
+                                      "apiGroup": {
+                                        "description": "APIGroup is the group for the resource being referenced.\nIf APIGroup is not specified, the specified Kind must be in the core API group.\nFor any other third-party types, APIGroup is required.",
+                                        "type": "string"
+                                      },
+                                      "kind": {
+                                        "description": "Kind is the type of resource being referenced",
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "description": "Name is the name of resource being referenced",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "kind",
+                                      "name"
+                                    ],
+                                    "type": "object",
+                                    "x-kubernetes-map-type": "atomic",
+                                    "x-kubernetes-validations": [
+                                      {
+                                        "message": "ipv4PoolRef allows only IPAM apiGroup ipam.cluster.x-k8s.io",
+                                        "rule": "self.apiGroup == 'ipam.cluster.x-k8s.io'"
+                                      },
+                                      {
+                                        "message": "ipv4PoolRef allows either InClusterIPPool or GlobalInClusterIPPool",
+                                        "rule": "self.kind == 'InClusterIPPool' || self.kind == 'GlobalInClusterIPPool'"
+                                      }
+                                    ],
+                                    "additionalProperties": false
+                                  },
+                                  "ipv6PoolRef": {
+                                    "description": "IPv6PoolRef is a reference to an IPAM pool resource, which exposes IPv6 addresses.\nThe network device will use an available IP address from the referenced pool.\nthis can be combined with `IPv4PoolRef` in order to enable dual stack.",
+                                    "properties": {
+                                      "apiGroup": {
+                                        "description": "APIGroup is the group for the resource being referenced.\nIf APIGroup is not specified, the specified Kind must be in the core API group.\nFor any other third-party types, APIGroup is required.",
+                                        "type": "string"
+                                      },
+                                      "kind": {
+                                        "description": "Kind is the type of resource being referenced",
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "description": "Name is the name of resource being referenced",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "kind",
+                                      "name"
+                                    ],
+                                    "type": "object",
+                                    "x-kubernetes-map-type": "atomic",
+                                    "x-kubernetes-validations": [
+                                      {
+                                        "message": "ipv6PoolRef allows only IPAM apiGroup ipam.cluster.x-k8s.io",
+                                        "rule": "self.apiGroup == 'ipam.cluster.x-k8s.io'"
+                                      },
+                                      {
+                                        "message": "ipv6PoolRef allows either InClusterIPPool or GlobalInClusterIPPool",
+                                        "rule": "self.kind == 'InClusterIPPool' || self.kind == 'GlobalInClusterIPPool'"
+                                      }
+                                    ],
+                                    "additionalProperties": false
+                                  },
+                                  "model": {
+                                    "default": "virtio",
+                                    "description": "Model is the network device model.",
+                                    "enum": [
+                                      "e1000",
+                                      "virtio",
+                                      "rtl8139",
+                                      "vmxnet3"
+                                    ],
+                                    "type": "string"
+                                  },
+                                  "mtu": {
+                                    "description": "MTU is the network device Maximum Transmission Unit.\nWhen set to 1, virtio devices inherit the MTU value from the underlying bridge.",
+                                    "type": "integer",
+                                    "x-kubernetes-validations": [
+                                      {
+                                        "message": "invalid MTU value",
+                                        "rule": "self == 1 || ( self >= 576 && self <= 65520)"
+                                      }
+                                    ]
+                                  },
+                                  "vlan": {
+                                    "description": "VLAN is the network L2 VLAN.",
+                                    "maximum": 4094,
+                                    "minimum": 1,
+                                    "type": "integer"
+                                  }
+                                },
+                                "required": [
+                                  "bridge"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "vrfs": {
+                                "description": "Definition of a VRF Device.",
+                                "items": {
+                                  "description": "VRFDevice defines Virtual Routing Flow devices.",
+                                  "properties": {
+                                    "interfaces": {
+                                      "description": "Interfaces is the list of proxmox network devices managed by this virtual device.",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "name": {
+                                      "description": "Name is the virtual network device name.\nMust be unique within the virtual machine.",
+                                      "minLength": 3,
+                                      "type": "string"
+                                    },
+                                    "routes": {
+                                      "description": "Routes are the routes associated with this interface.",
+                                      "items": {
+                                        "description": "RouteSpec describes an IPv4/IPv6 Route.",
+                                        "properties": {
+                                          "metric": {
+                                            "description": "Metric is the priority of the route in the routing table.",
+                                            "format": "int32",
+                                            "type": "integer"
+                                          },
+                                          "table": {
+                                            "description": "Table is the routing table used for this route.",
+                                            "format": "int32",
+                                            "type": "integer"
+                                          },
+                                          "to": {
+                                            "description": "To is the subnet to be routed.",
+                                            "type": "string"
+                                          },
+                                          "via": {
+                                            "description": "Via is the gateway to the subnet.",
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "minItems": 1,
+                                      "type": "array"
+                                    },
+                                    "routingPolicy": {
+                                      "description": "RoutingPolicy is an interface-specific policy inserted into FIB (forwarding information base).",
+                                      "items": {
+                                        "description": "RoutingPolicySpec is a Linux FIB rule.",
+                                        "properties": {
+                                          "from": {
+                                            "description": "From is the subnet of the source.",
+                                            "type": "string"
+                                          },
+                                          "priority": {
+                                            "description": "Priority is the position in the ip rule FIB table.",
+                                            "format": "int32",
+                                            "maximum": 4294967295,
+                                            "type": "integer",
+                                            "x-kubernetes-validations": [
+                                              {
+                                                "message": "Cowardly refusing to insert FIB rule matching kernel rules",
+                                                "rule": "(self > 0 && self < 32765) || (self > 32766)"
+                                              }
+                                            ]
+                                          },
+                                          "table": {
+                                            "description": "Table is the routing table ID.\nwhen used in the networks, the value should be the VRF Table.",
+                                            "format": "int32",
+                                            "type": "integer"
+                                          },
+                                          "to": {
+                                            "description": "To is the subnet of the target.",
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "minItems": 1,
+                                      "type": "array"
+                                    },
+                                    "table": {
+                                      "description": "Table is the ID of the routing table used for the l3mdev vrf device.",
+                                      "format": "int32",
+                                      "maximum": 4294967295,
+                                      "type": "integer",
+                                      "x-kubernetes-validations": [
+                                        {
+                                          "message": "Cowardly refusing to insert l3mdev rules into kernel tables",
+                                          "rule": "(self > 0 && self < 254) || (self > 255)"
+                                        }
+                                      ]
+                                    }
+                                  },
+                                  "required": [
+                                    "name",
+                                    "table"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array",
+                                "x-kubernetes-list-map-keys": [
+                                  "name"
+                                ],
+                                "x-kubernetes-list-type": "map"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "numCores": {
+                            "description": "NumCores is the number of cores per CPU socket in a virtual machine.\nDefaults to the property value in the template from which the virtual machine is cloned.",
+                            "format": "int32",
+                            "minimum": 1,
+                            "type": "integer"
+                          },
+                          "numSockets": {
+                            "description": "NumSockets is the number of CPU sockets in a virtual machine.\nDefaults to the property value in the template from which the virtual machine is cloned.",
+                            "format": "int32",
+                            "minimum": 1,
+                            "type": "integer"
+                          },
+                          "pool": {
+                            "description": "Pool Add the new VM to the specified pool.",
+                            "type": "string"
+                          },
+                          "providerID": {
+                            "description": "ProviderID is the virtual machine BIOS UUID formatted as\nproxmox://6c3fa683-bef9-4425-b413-eaa45a9d6191",
+                            "type": "string"
+                          },
+                          "snapName": {
+                            "description": "SnapName The name of the snapshot.",
+                            "type": "string"
+                          },
+                          "sourceNode": {
+                            "description": "SourceNode is the initially selected proxmox node.\nThis node will be used to locate the template VM, which will\nbe used for cloning operations.\n\nCloning will be performed according to the configuration.\nSetting the `Target` field will tell Proxmox to clone the\nVM on that target node.\n\nWhen Target is not set and the ProxmoxCluster contains\na set of `AllowedNodes`, the algorithm will instead evenly\ndistribute the VMs across the nodes from that list.\n\nIf neither a `Target` nor `AllowedNodes` was set, the VM\nwill be cloned onto the same node as SourceNode.",
+                            "minLength": 1,
+                            "type": "string"
+                          },
+                          "storage": {
+                            "description": "Storage for full clone.",
+                            "type": "string"
+                          },
+                          "tags": {
+                            "description": "Tags is a list of tags to be applied to the virtual machine.",
+                            "items": {
+                              "pattern": "^(?i)[a-z0-9_][a-z0-9_\\-\\+\\.]*$",
+                              "type": "string"
+                            },
+                            "minItems": 1,
+                            "type": "array",
+                            "x-kubernetes-list-type": "set"
+                          },
+                          "target": {
+                            "description": "Target node. Only allowed if the original VM is on shared storage.",
+                            "type": "string"
+                          },
+                          "templateID": {
+                            "description": "TemplateID the vm_template vmid used for cloning a new VM.",
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "templateSelector": {
+                            "description": "TemplateSelector defines MatchTags for looking up VM templates.",
+                            "properties": {
+                              "matchPolicy": {
+                                "default": "exact",
+                                "description": "MatchPolicy controls how MatchTags are evaluated against template tags.\nWhen not set, or set to \"exact\", the behaviour is identical to the previous implementation\nand requires an exact 1:1 tag match. When set to \"subset\", the template's tags must contain\nall MatchTags, but may include additional tags.",
+                                "enum": [
+                                  "exact",
+                                  "uniqueSubset",
+                                  "bestSubset"
+                                ],
+                                "type": "string"
+                              },
+                              "matchTags": {
+                                "description": "Specifies all tags to look for, when looking up the VM template.\nWhen MatchPolicy is \"exact\" (the default), the template's tags must be an exact 1:1 match\nwith MatchTags. If multiple VM templates with the same set of tags are found, provisioning will fail.\nWhen MatchPolicy is \"subset\", the template's tags must contain all of the MatchTags, but may\nhave additional tags.",
+                                "items": {
+                                  "pattern": "^(?i)[a-z0-9_][a-z0-9_\\-\\+\\.]*$",
+                                  "type": "string"
+                                },
+                                "minItems": 1,
+                                "type": "array",
+                                "x-kubernetes-list-type": "set"
+                              }
+                            },
+                            "required": [
+                              "matchTags"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "virtualMachineID": {
+                            "description": "VirtualMachineID is the Proxmox identifier for the ProxmoxMachine VM.",
+                            "format": "int64",
+                            "type": "integer"
+                          },
+                          "vmIDRange": {
+                            "description": "VMIDRange is the range of VMIDs to use for VMs.",
+                            "properties": {
+                              "end": {
+                                "description": "VMIDRangeEnd is the end of the VMID range to use for VMs.\nOnly used if VMIDRangeStart is set.",
+                                "format": "int64",
+                                "maximum": 999999999,
+                                "minimum": 100,
+                                "type": "integer"
+                              },
+                              "start": {
+                                "description": "VMIDRangeStart is the start of the VMID range to use for VMs.",
+                                "format": "int64",
+                                "maximum": 999999999,
+                                "minimum": 100,
+                                "type": "integer"
+                              }
+                            },
+                            "required": [
+                              "end",
+                              "start"
+                            ],
+                            "type": "object",
+                            "x-kubernetes-validations": [
+                              {
+                                "message": "end should be greater than or equal to start",
+                                "rule": "self.end >= self.start"
+                              }
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-validations": [
+                          {
+                            "message": "Must set full=true when specifying format",
+                            "rule": "self.full || !has(self.format)"
+                          },
+                          {
+                            "message": "Must set full=true when specifying storage",
+                            "rule": "self.full || !has(self.storage)"
+                          }
+                        ],
+                        "additionalProperties": false
+                      },
+                      "type": "object"
+                    },
+                    "sshAuthorizedKeys": {
+                      "description": "SshAuthorizedKeys contains the authorized keys deployed to the PROXMOX VMs.",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "virtualIPNetworkInterface": {
+                      "description": "VirtualIPNetworkInterface is the interface the k8s control plane binds to.",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "machineSpec"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "controlPlaneEndpoint": {
+                  "description": "ControlPlaneEndpoint represents the endpoint used to communicate with the control plane.",
+                  "properties": {
+                    "host": {
+                      "description": "host is the hostname on which the API server is serving.",
+                      "maxLength": 512,
+                      "type": "string"
+                    },
+                    "port": {
+                      "description": "port is the port on which the API server is serving.",
+                      "format": "int32",
+                      "type": "integer"
+                    }
+                  },
+                  "type": "object",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "port must be within 1-65535",
+                      "rule": "self.port > 0 && self.port < 65536"
+                    }
+                  ],
+                  "additionalProperties": false
+                },
+                "credentialsRef": {
+                  "description": "CredentialsRef is a reference to a Secret that contains the credentials to use for provisioning this cluster. If not\nsupplied then the credentials of the controller will be used.\nif no namespace is provided, the namespace of the ProxmoxCluster will be used.",
+                  "properties": {
+                    "name": {
+                      "description": "name is unique within a namespace to reference a secret resource.",
+                      "type": "string"
+                    },
+                    "namespace": {
+                      "description": "namespace defines the space within which the secret name must be unique.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "x-kubernetes-map-type": "atomic",
+                  "additionalProperties": false
+                },
+                "dnsServers": {
+                  "description": "DNSServers contains information about nameservers used by the machines.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "minItems": 1,
+                  "type": "array"
+                },
+                "externalManagedControlPlane": {
+                  "description": "ExternalManagedControlPlane can be enabled to allow externally managed Control Planes to patch the\nProxmox cluster with the Load Balancer IP provided by Control Plane provider.",
+                  "type": "boolean"
+                },
+                "ipv4Config": {
+                  "description": "IPv4Config contains information about available IPV4 address pools and the gateway.\nThis can be combined with ipv6Config in order to enable dual stack.\nEither IPv4Config or IPv6Config must be provided.",
+                  "properties": {
+                    "addresses": {
+                      "description": "Addresses is a list of IP addresses that can be assigned. This set of\naddresses can be non-contiguous.",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "gateway": {
+                      "description": "Gateway",
+                      "type": "string"
+                    },
+                    "metric": {
+                      "default": 100,
+                      "description": "Metric is the route priority applied to the default gateway",
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "prefix": {
+                      "description": "Prefix is the network prefix to use.",
+                      "maximum": 128,
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "addresses",
+                    "metric",
+                    "prefix"
+                  ],
+                  "type": "object",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "IPv4Config addresses must be provided",
+                      "rule": "self.addresses.size() > 0"
+                    }
+                  ],
+                  "additionalProperties": false
+                },
+                "ipv6Config": {
+                  "description": "IPv6Config contains information about available IPV6 address pools and the gateway.\nThis can be combined with ipv4Config in order to enable dual stack.\nEither IPv4Config or IPv6Config must be provided.",
+                  "properties": {
+                    "addresses": {
+                      "description": "Addresses is a list of IP addresses that can be assigned. This set of\naddresses can be non-contiguous.",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "gateway": {
+                      "description": "Gateway",
+                      "type": "string"
+                    },
+                    "metric": {
+                      "default": 100,
+                      "description": "Metric is the route priority applied to the default gateway",
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "prefix": {
+                      "description": "Prefix is the network prefix to use.",
+                      "maximum": 128,
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "addresses",
+                    "metric",
+                    "prefix"
+                  ],
+                  "type": "object",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "IPv6Config addresses must be provided",
+                      "rule": "self.addresses.size() > 0"
+                    }
+                  ],
+                  "additionalProperties": false
+                },
+                "schedulerHints": {
+                  "description": "SchedulerHints allows to influence the decision on where a VM will be scheduled. For example by applying a multiplicator\nto a node's resources, to allow for overprovisioning or to ensure a node will always have a safety buffer.",
+                  "properties": {
+                    "memoryAdjustment": {
+                      "description": "MemoryAdjustment allows to adjust a node's memory by a given percentage.\nFor example, setting it to 300 allows to allocate 300% of a host's memory for VMs,\nand setting it to 95 limits memory allocation to 95% of a host's memory.\nSetting it to 0 entirely disables scheduling memory constraints.\nBy default 100% of a node's memory will be used for allocation.",
+                      "format": "int64",
+                      "type": "integer"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "required": [
+                "dnsServers"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "required": [
+            "spec"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "template"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/infrastructure.cluster.x-k8s.io/proxmoxclustertemplate_v1alpha2.json
+++ b/infrastructure.cluster.x-k8s.io/proxmoxclustertemplate_v1alpha2.json
@@ -1,0 +1,363 @@
+{
+  "description": "ProxmoxClusterTemplate is the Schema for the proxmoxclustertemplates API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "spec is the Proxmox Cluster Template spec",
+      "properties": {
+        "template": {
+          "description": "template is the Proxmox Cluster template",
+          "properties": {
+            "metadata": {
+              "description": "metadata is the standard object metadata.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+              "minProperties": 1,
+              "properties": {
+                "annotations": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "annotations is an unstructured key value map stored with a resource that may be\nset by external tools to store and retrieve arbitrary metadata. They are not\nqueryable and should be preserved when modifying objects.\nMore info: http://kubernetes.io/docs/user-guide/annotations",
+                  "type": "object"
+                },
+                "labels": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "labels is a map of string keys and values that can be used to organize and categorize\n(scope and select) objects. May match selectors of replication controllers\nand services.\nMore info: http://kubernetes.io/docs/user-guide/labels",
+                  "type": "object"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "spec": {
+              "description": "spec is the Proxmox Cluster spec",
+              "properties": {
+                "allowedNodes": {
+                  "description": "allowedNodes specifies all Proxmox nodes which will be considered\nfor operations. This implies that VMs can be cloned on different nodes from\nthe node which holds the VM template.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array",
+                  "x-kubernetes-list-type": "set"
+                },
+                "controlPlaneEndpoint": {
+                  "description": "controlPlaneEndpoint represents the endpoint used to communicate with the control plane.",
+                  "minProperties": 1,
+                  "properties": {
+                    "host": {
+                      "description": "host is the hostname on which the API server is serving.",
+                      "maxLength": 512,
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "port": {
+                      "description": "port is the port on which the API server is serving.",
+                      "format": "int32",
+                      "maximum": 65535,
+                      "minimum": 1,
+                      "type": "integer"
+                    }
+                  },
+                  "type": "object",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "port must be within 1-65535",
+                      "rule": "self.port > 0 && self.port < 65536"
+                    }
+                  ],
+                  "additionalProperties": false
+                },
+                "credentialsRef": {
+                  "description": "credentialsRef is a reference to a Secret that contains the credentials to use for provisioning this cluster. If not\nsupplied then the credentials of the controller will be used.\nif no namespace is provided, the namespace of the ProxmoxCluster will be used.",
+                  "properties": {
+                    "name": {
+                      "description": "name is unique within a namespace to reference a secret resource.",
+                      "type": "string"
+                    },
+                    "namespace": {
+                      "description": "namespace defines the space within which the secret name must be unique.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "x-kubernetes-map-type": "atomic",
+                  "additionalProperties": false
+                },
+                "dnsServers": {
+                  "description": "dnsServers contains information about nameservers used by the machines.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "minItems": 1,
+                  "type": "array",
+                  "x-kubernetes-list-type": "set"
+                },
+                "externalManagedControlPlane": {
+                  "default": false,
+                  "description": "externalManagedControlPlane can be enabled to allow externally managed Control Planes to patch the\nProxmox cluster with the Load Balancer IP provided by Control Plane provider.",
+                  "type": "boolean"
+                },
+                "ipv4Config": {
+                  "description": "ipv4Config contains information about available IPv4 address pools and the gateway.\nThis can be combined with ipv6Config in order to enable dual stack.\nEither IPv4Config or IPv6Config must be provided.",
+                  "properties": {
+                    "addresses": {
+                      "description": "addresses is a list of IP addresses that can be assigned. This set of addresses can be non-contiguous.",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array",
+                      "x-kubernetes-list-type": "set"
+                    },
+                    "gateway": {
+                      "description": "gateway is the network gateway",
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "metric": {
+                      "default": 100,
+                      "description": "metric is the route priority applied to the default gateway",
+                      "format": "int32",
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "prefix": {
+                      "description": "prefix is the network prefix to use.",
+                      "format": "int32",
+                      "maximum": 128,
+                      "minimum": 1,
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "addresses",
+                    "gateway",
+                    "prefix"
+                  ],
+                  "type": "object",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "IPv4Config addresses must be provided",
+                      "rule": "self.addresses.size() > 0"
+                    }
+                  ],
+                  "additionalProperties": false
+                },
+                "ipv6Config": {
+                  "description": "ipv6Config contains information about available IPv6 address pools and the gateway.\nThis can be combined with ipv4Config in order to enable dual stack.\nEither IPv4Config or IPv6Config must be provided.",
+                  "properties": {
+                    "addresses": {
+                      "description": "addresses is a list of IP addresses that can be assigned. This set of addresses can be non-contiguous.",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array",
+                      "x-kubernetes-list-type": "set"
+                    },
+                    "gateway": {
+                      "description": "gateway is the network gateway",
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "metric": {
+                      "default": 100,
+                      "description": "metric is the route priority applied to the default gateway",
+                      "format": "int32",
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "prefix": {
+                      "description": "prefix is the network prefix to use.",
+                      "format": "int32",
+                      "maximum": 128,
+                      "minimum": 1,
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "addresses",
+                    "gateway",
+                    "prefix"
+                  ],
+                  "type": "object",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "IPv6Config addresses must be provided",
+                      "rule": "self.addresses.size() > 0"
+                    }
+                  ],
+                  "additionalProperties": false
+                },
+                "schedulerHints": {
+                  "description": "schedulerHints allows to influence the decision on where a VM will be scheduled. For example by applying a multiplicator\nto a node's resources, to allow for overprovisioning or to ensure a node will always have a safety buffer.",
+                  "properties": {
+                    "memoryAdjustment": {
+                      "description": "memoryAdjustment allows to adjust a node's memory by a given percentage.\nFor example, setting it to 300 allows to allocate 300% of a host's memory for VMs,\nand setting it to 95 limits memory allocation to 95% of a host's memory.\nSetting it to 0 entirely disables scheduling memory constraints.\nBy default 100% of a node's memory will be used for allocation.",
+                      "format": "int64",
+                      "minimum": 0,
+                      "type": "integer"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "zoneConfig": {
+                  "description": "zoneConfig defines a IPAddress config per deployment zone.",
+                  "items": {
+                    "description": "ZoneConfigSpec is the Network Configuration for further deployment zones.",
+                    "properties": {
+                      "dnsServers": {
+                        "description": "dnsServers contains information about nameservers used by the machines in this zone.",
+                        "items": {
+                          "type": "string"
+                        },
+                        "minItems": 1,
+                        "type": "array",
+                        "x-kubernetes-list-type": "set"
+                      },
+                      "ipv4Config": {
+                        "description": "ipv4Config contains information about available IPv4 address pools and the gateway.\nThis can be combined with ipv6Config in order to enable dual stack.\nEither IPv4Config or IPv6Config must be provided.",
+                        "properties": {
+                          "addresses": {
+                            "description": "addresses is a list of IP addresses that can be assigned. This set of addresses can be non-contiguous.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "set"
+                          },
+                          "gateway": {
+                            "description": "gateway is the network gateway",
+                            "minLength": 1,
+                            "type": "string"
+                          },
+                          "metric": {
+                            "default": 100,
+                            "description": "metric is the route priority applied to the default gateway",
+                            "format": "int32",
+                            "minimum": 0,
+                            "type": "integer"
+                          },
+                          "prefix": {
+                            "description": "prefix is the network prefix to use.",
+                            "format": "int32",
+                            "maximum": 128,
+                            "minimum": 1,
+                            "type": "integer"
+                          }
+                        },
+                        "required": [
+                          "addresses",
+                          "gateway",
+                          "prefix"
+                        ],
+                        "type": "object",
+                        "x-kubernetes-validations": [
+                          {
+                            "message": "IPv4Config addresses must be provided",
+                            "rule": "self.addresses.size() > 0"
+                          }
+                        ],
+                        "additionalProperties": false
+                      },
+                      "ipv6Config": {
+                        "description": "ipv6Config contains information about available IPv6 address pools and the gateway.\nThis can be combined with ipv4Config in order to enable dual stack.\nEither IPv4Config or IPv6Config must be provided.",
+                        "properties": {
+                          "addresses": {
+                            "description": "addresses is a list of IP addresses that can be assigned. This set of addresses can be non-contiguous.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "set"
+                          },
+                          "gateway": {
+                            "description": "gateway is the network gateway",
+                            "minLength": 1,
+                            "type": "string"
+                          },
+                          "metric": {
+                            "default": 100,
+                            "description": "metric is the route priority applied to the default gateway",
+                            "format": "int32",
+                            "minimum": 0,
+                            "type": "integer"
+                          },
+                          "prefix": {
+                            "description": "prefix is the network prefix to use.",
+                            "format": "int32",
+                            "maximum": 128,
+                            "minimum": 1,
+                            "type": "integer"
+                          }
+                        },
+                        "required": [
+                          "addresses",
+                          "gateway",
+                          "prefix"
+                        ],
+                        "type": "object",
+                        "x-kubernetes-validations": [
+                          {
+                            "message": "IPv6Config addresses must be provided",
+                            "rule": "self.addresses.size() > 0"
+                          }
+                        ],
+                        "additionalProperties": false
+                      },
+                      "zone": {
+                        "description": "zone is the name of your deployment zone.",
+                        "pattern": "^[a-z0-9A-Z](?:[a-z0-9A-Z-_.]{0,61}[a-z0-9A-Z])?$",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "dnsServers",
+                      "zone"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array",
+                  "x-kubernetes-list-map-keys": [
+                    "zone"
+                  ],
+                  "x-kubernetes-list-type": "map"
+                }
+              },
+              "required": [
+                "dnsServers"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "required": [
+            "spec"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "template"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "required": [
+    "spec"
+  ],
+  "type": "object"
+}

--- a/infrastructure.cluster.x-k8s.io/proxmoxmachine_v1alpha1.json
+++ b/infrastructure.cluster.x-k8s.io/proxmoxmachine_v1alpha1.json
@@ -1,0 +1,879 @@
+{
+  "description": "ProxmoxMachine is the Schema for the proxmoxmachines API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "ProxmoxMachineSpec defines the desired state of a ProxmoxMachine.",
+      "properties": {
+        "allowedNodes": {
+          "description": "AllowedNodes specifies all Proxmox nodes which will be considered\nfor operations. This implies that VMs can be cloned on different nodes from\nthe node which holds the VM template.\n\nThis field is optional and should only be set if you want to restrict\nthe nodes where the VM can be cloned.\nIf not set, the ProxmoxCluster will be used to determine the nodes.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "checks": {
+          "description": "Checks defines possibles checks to skip.",
+          "properties": {
+            "skipCloudInitStatus": {
+              "description": "Skip checking CloudInit which can be very useful for specific Operating Systems like TalOS",
+              "type": "boolean"
+            },
+            "skipQemuGuestAgent": {
+              "description": "Skip checking QEMU Agent readiness which can be very useful for specific Operating Systems like TalOS",
+              "type": "boolean"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "description": {
+          "description": "Description for the new VM.",
+          "type": "string"
+        },
+        "disks": {
+          "description": "Disks contains a set of disk configuration options,\nwhich will be applied before the first startup.",
+          "properties": {
+            "bootVolume": {
+              "description": "BootVolume defines the storage size for the boot volume.\nThis field is optional, and should only be set if you want\nto change the size of the boot volume.",
+              "properties": {
+                "disk": {
+                  "description": "Disk is the name of the disk device, that should be resized.\nExample values are: ide[0-3], scsi[0-30], sata[0-5].",
+                  "type": "string"
+                },
+                "sizeGb": {
+                  "description": "Size defines the size in gigabyte.\n\nAs Proxmox does not support shrinking, the size\nmust be bigger than the already configured size in the\ntemplate.",
+                  "format": "int32",
+                  "minimum": 5,
+                  "type": "integer"
+                }
+              },
+              "required": [
+                "disk",
+                "sizeGb"
+              ],
+              "type": "object",
+              "x-kubernetes-validations": [
+                {
+                  "message": "Value is immutable",
+                  "rule": "self == oldSelf"
+                }
+              ],
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "format": {
+          "description": "Format for file storage. Only valid for full clone.",
+          "enum": [
+            "raw",
+            "qcow2",
+            "vmdk"
+          ],
+          "type": "string"
+        },
+        "full": {
+          "default": true,
+          "description": "Full Create a full copy of all disks.\nThis is always done when you clone a normal VM.\nCreate a Full clone by default.",
+          "type": "boolean"
+        },
+        "memoryMiB": {
+          "description": "MemoryMiB is the size of a virtual machine's memory, in MiB.\nDefaults to the property value in the template from which the virtual machine is cloned.",
+          "format": "int32",
+          "multipleOf": 8,
+          "type": "integer"
+        },
+        "metadataSettings": {
+          "description": "MetadataSettings defines the metadata settings for this machine's VM.",
+          "properties": {
+            "providerIDInjection": {
+              "description": "ProviderIDInjection enables the injection of the `providerID` into the cloudinit metadata.\nthis will basically set the `provider-id` field in the metadata to `proxmox://<instanceID>`.",
+              "type": "boolean"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "network": {
+          "description": "Network is the network configuration for this machine's VM.",
+          "properties": {
+            "additionalDevices": {
+              "description": "AdditionalDevices defines additional network devices bound to the virtual machine.",
+              "items": {
+                "description": "AdditionalNetworkDevice the definition of a Proxmox network device.",
+                "properties": {
+                  "bridge": {
+                    "description": "Bridge is the network bridge to attach to the machine.",
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "dnsServers": {
+                    "description": "DNSServers contains information about nameservers to be used for this interface.\nIf this field is not set, it will use the default dns servers from the ProxmoxCluster.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "minItems": 1,
+                    "type": "array"
+                  },
+                  "ipv4PoolRef": {
+                    "description": "IPv4PoolRef is a reference to an IPAM Pool resource, which exposes IPv4 addresses.\nThe network device will use an available IP address from the referenced pool.\nThis can be combined with `IPv6PoolRef` in order to enable dual stack.",
+                    "properties": {
+                      "apiGroup": {
+                        "description": "APIGroup is the group for the resource being referenced.\nIf APIGroup is not specified, the specified Kind must be in the core API group.\nFor any other third-party types, APIGroup is required.",
+                        "type": "string"
+                      },
+                      "kind": {
+                        "description": "Kind is the type of resource being referenced",
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "Name is the name of resource being referenced",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "kind",
+                      "name"
+                    ],
+                    "type": "object",
+                    "x-kubernetes-map-type": "atomic",
+                    "x-kubernetes-validations": [
+                      {
+                        "message": "ipv4PoolRef allows only IPAM apiGroup ipam.cluster.x-k8s.io",
+                        "rule": "self.apiGroup == 'ipam.cluster.x-k8s.io'"
+                      },
+                      {
+                        "message": "ipv4PoolRef allows either InClusterIPPool or GlobalInClusterIPPool",
+                        "rule": "self.kind == 'InClusterIPPool' || self.kind == 'GlobalInClusterIPPool'"
+                      }
+                    ],
+                    "additionalProperties": false
+                  },
+                  "ipv6PoolRef": {
+                    "description": "IPv6PoolRef is a reference to an IPAM pool resource, which exposes IPv6 addresses.\nThe network device will use an available IP address from the referenced pool.\nthis can be combined with `IPv4PoolRef` in order to enable dual stack.",
+                    "properties": {
+                      "apiGroup": {
+                        "description": "APIGroup is the group for the resource being referenced.\nIf APIGroup is not specified, the specified Kind must be in the core API group.\nFor any other third-party types, APIGroup is required.",
+                        "type": "string"
+                      },
+                      "kind": {
+                        "description": "Kind is the type of resource being referenced",
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "Name is the name of resource being referenced",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "kind",
+                      "name"
+                    ],
+                    "type": "object",
+                    "x-kubernetes-map-type": "atomic",
+                    "x-kubernetes-validations": [
+                      {
+                        "message": "ipv6PoolRef allows only IPAM apiGroup ipam.cluster.x-k8s.io",
+                        "rule": "self.apiGroup == 'ipam.cluster.x-k8s.io'"
+                      },
+                      {
+                        "message": "ipv6PoolRef allows either InClusterIPPool or GlobalInClusterIPPool",
+                        "rule": "self.kind == 'InClusterIPPool' || self.kind == 'GlobalInClusterIPPool'"
+                      }
+                    ],
+                    "additionalProperties": false
+                  },
+                  "linkMtu": {
+                    "description": "LinkMTU is the network device Maximum Transmission Unit.",
+                    "type": "integer",
+                    "x-kubernetes-validations": [
+                      {
+                        "message": "invalid MTU value",
+                        "rule": "self == 1 || ( self >= 576 && self <= 65520)"
+                      }
+                    ]
+                  },
+                  "model": {
+                    "default": "virtio",
+                    "description": "Model is the network device model.",
+                    "enum": [
+                      "e1000",
+                      "virtio",
+                      "rtl8139",
+                      "vmxnet3"
+                    ],
+                    "type": "string"
+                  },
+                  "mtu": {
+                    "description": "MTU is the network device Maximum Transmission Unit.\nWhen set to 1, virtio devices inherit the MTU value from the underlying bridge.",
+                    "type": "integer",
+                    "x-kubernetes-validations": [
+                      {
+                        "message": "invalid MTU value",
+                        "rule": "self == 1 || ( self >= 576 && self <= 65520)"
+                      }
+                    ]
+                  },
+                  "name": {
+                    "description": "Name is the network device name.\nMust be unique within the virtual machine and different from the primary device 'net0'.",
+                    "minLength": 1,
+                    "type": "string",
+                    "x-kubernetes-validations": [
+                      {
+                        "message": "additional network devices doesn't allow net0",
+                        "rule": "self != 'net0'"
+                      }
+                    ]
+                  },
+                  "routes": {
+                    "description": "Routes are the routes associated with this interface.",
+                    "items": {
+                      "description": "RouteSpec describes an IPv4/IPv6 Route.",
+                      "properties": {
+                        "metric": {
+                          "description": "Metric is the priority of the route in the routing table.",
+                          "format": "int32",
+                          "type": "integer"
+                        },
+                        "table": {
+                          "description": "Table is the routing table used for this route.",
+                          "format": "int32",
+                          "type": "integer"
+                        },
+                        "to": {
+                          "description": "To is the subnet to be routed.",
+                          "type": "string"
+                        },
+                        "via": {
+                          "description": "Via is the gateway to the subnet.",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "minItems": 1,
+                    "type": "array"
+                  },
+                  "routingPolicy": {
+                    "description": "RoutingPolicy is an interface-specific policy inserted into FIB (forwarding information base).",
+                    "items": {
+                      "description": "RoutingPolicySpec is a Linux FIB rule.",
+                      "properties": {
+                        "from": {
+                          "description": "From is the subnet of the source.",
+                          "type": "string"
+                        },
+                        "priority": {
+                          "description": "Priority is the position in the ip rule FIB table.",
+                          "format": "int32",
+                          "maximum": 4294967295,
+                          "type": "integer",
+                          "x-kubernetes-validations": [
+                            {
+                              "message": "Cowardly refusing to insert FIB rule matching kernel rules",
+                              "rule": "(self > 0 && self < 32765) || (self > 32766)"
+                            }
+                          ]
+                        },
+                        "table": {
+                          "description": "Table is the routing table ID.\nwhen used in the networks, the value should be the VRF Table.",
+                          "format": "int32",
+                          "type": "integer"
+                        },
+                        "to": {
+                          "description": "To is the subnet of the target.",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "minItems": 1,
+                    "type": "array"
+                  },
+                  "vlan": {
+                    "description": "VLAN is the network L2 VLAN.",
+                    "maximum": 4094,
+                    "minimum": 1,
+                    "type": "integer"
+                  }
+                },
+                "required": [
+                  "bridge",
+                  "name"
+                ],
+                "type": "object",
+                "x-kubernetes-validations": [
+                  {
+                    "message": "at least one pool reference must be set, either ipv4PoolRef or ipv6PoolRef",
+                    "rule": "self.ipv4PoolRef != null || self.ipv6PoolRef != null"
+                  }
+                ],
+                "additionalProperties": false
+              },
+              "type": "array",
+              "x-kubernetes-list-map-keys": [
+                "name"
+              ],
+              "x-kubernetes-list-type": "map"
+            },
+            "default": {
+              "description": "Default is the default network device,\nwhich will be used for the primary network interface.\nnet0 is always the default network device.",
+              "properties": {
+                "bridge": {
+                  "description": "Bridge is the network bridge to attach to the machine.",
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "dnsServers": {
+                  "description": "DNSServers contains information about nameservers to be used for this interface.\nIf this field is not set, it will use the default dns servers from the ProxmoxCluster.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "minItems": 1,
+                  "type": "array"
+                },
+                "ipv4PoolRef": {
+                  "description": "IPv4PoolRef is a reference to an IPAM Pool resource, which exposes IPv4 addresses.\nThe network device will use an available IP address from the referenced pool.\nThis can be combined with `IPv6PoolRef` in order to enable dual stack.",
+                  "properties": {
+                    "apiGroup": {
+                      "description": "APIGroup is the group for the resource being referenced.\nIf APIGroup is not specified, the specified Kind must be in the core API group.\nFor any other third-party types, APIGroup is required.",
+                      "type": "string"
+                    },
+                    "kind": {
+                      "description": "Kind is the type of resource being referenced",
+                      "type": "string"
+                    },
+                    "name": {
+                      "description": "Name is the name of resource being referenced",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "kind",
+                    "name"
+                  ],
+                  "type": "object",
+                  "x-kubernetes-map-type": "atomic",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "ipv4PoolRef allows only IPAM apiGroup ipam.cluster.x-k8s.io",
+                      "rule": "self.apiGroup == 'ipam.cluster.x-k8s.io'"
+                    },
+                    {
+                      "message": "ipv4PoolRef allows either InClusterIPPool or GlobalInClusterIPPool",
+                      "rule": "self.kind == 'InClusterIPPool' || self.kind == 'GlobalInClusterIPPool'"
+                    }
+                  ],
+                  "additionalProperties": false
+                },
+                "ipv6PoolRef": {
+                  "description": "IPv6PoolRef is a reference to an IPAM pool resource, which exposes IPv6 addresses.\nThe network device will use an available IP address from the referenced pool.\nthis can be combined with `IPv4PoolRef` in order to enable dual stack.",
+                  "properties": {
+                    "apiGroup": {
+                      "description": "APIGroup is the group for the resource being referenced.\nIf APIGroup is not specified, the specified Kind must be in the core API group.\nFor any other third-party types, APIGroup is required.",
+                      "type": "string"
+                    },
+                    "kind": {
+                      "description": "Kind is the type of resource being referenced",
+                      "type": "string"
+                    },
+                    "name": {
+                      "description": "Name is the name of resource being referenced",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "kind",
+                    "name"
+                  ],
+                  "type": "object",
+                  "x-kubernetes-map-type": "atomic",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "ipv6PoolRef allows only IPAM apiGroup ipam.cluster.x-k8s.io",
+                      "rule": "self.apiGroup == 'ipam.cluster.x-k8s.io'"
+                    },
+                    {
+                      "message": "ipv6PoolRef allows either InClusterIPPool or GlobalInClusterIPPool",
+                      "rule": "self.kind == 'InClusterIPPool' || self.kind == 'GlobalInClusterIPPool'"
+                    }
+                  ],
+                  "additionalProperties": false
+                },
+                "model": {
+                  "default": "virtio",
+                  "description": "Model is the network device model.",
+                  "enum": [
+                    "e1000",
+                    "virtio",
+                    "rtl8139",
+                    "vmxnet3"
+                  ],
+                  "type": "string"
+                },
+                "mtu": {
+                  "description": "MTU is the network device Maximum Transmission Unit.\nWhen set to 1, virtio devices inherit the MTU value from the underlying bridge.",
+                  "type": "integer",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "invalid MTU value",
+                      "rule": "self == 1 || ( self >= 576 && self <= 65520)"
+                    }
+                  ]
+                },
+                "vlan": {
+                  "description": "VLAN is the network L2 VLAN.",
+                  "maximum": 4094,
+                  "minimum": 1,
+                  "type": "integer"
+                }
+              },
+              "required": [
+                "bridge"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "vrfs": {
+              "description": "Definition of a VRF Device.",
+              "items": {
+                "description": "VRFDevice defines Virtual Routing Flow devices.",
+                "properties": {
+                  "interfaces": {
+                    "description": "Interfaces is the list of proxmox network devices managed by this virtual device.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "name": {
+                    "description": "Name is the virtual network device name.\nMust be unique within the virtual machine.",
+                    "minLength": 3,
+                    "type": "string"
+                  },
+                  "routes": {
+                    "description": "Routes are the routes associated with this interface.",
+                    "items": {
+                      "description": "RouteSpec describes an IPv4/IPv6 Route.",
+                      "properties": {
+                        "metric": {
+                          "description": "Metric is the priority of the route in the routing table.",
+                          "format": "int32",
+                          "type": "integer"
+                        },
+                        "table": {
+                          "description": "Table is the routing table used for this route.",
+                          "format": "int32",
+                          "type": "integer"
+                        },
+                        "to": {
+                          "description": "To is the subnet to be routed.",
+                          "type": "string"
+                        },
+                        "via": {
+                          "description": "Via is the gateway to the subnet.",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "minItems": 1,
+                    "type": "array"
+                  },
+                  "routingPolicy": {
+                    "description": "RoutingPolicy is an interface-specific policy inserted into FIB (forwarding information base).",
+                    "items": {
+                      "description": "RoutingPolicySpec is a Linux FIB rule.",
+                      "properties": {
+                        "from": {
+                          "description": "From is the subnet of the source.",
+                          "type": "string"
+                        },
+                        "priority": {
+                          "description": "Priority is the position in the ip rule FIB table.",
+                          "format": "int32",
+                          "maximum": 4294967295,
+                          "type": "integer",
+                          "x-kubernetes-validations": [
+                            {
+                              "message": "Cowardly refusing to insert FIB rule matching kernel rules",
+                              "rule": "(self > 0 && self < 32765) || (self > 32766)"
+                            }
+                          ]
+                        },
+                        "table": {
+                          "description": "Table is the routing table ID.\nwhen used in the networks, the value should be the VRF Table.",
+                          "format": "int32",
+                          "type": "integer"
+                        },
+                        "to": {
+                          "description": "To is the subnet of the target.",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "minItems": 1,
+                    "type": "array"
+                  },
+                  "table": {
+                    "description": "Table is the ID of the routing table used for the l3mdev vrf device.",
+                    "format": "int32",
+                    "maximum": 4294967295,
+                    "type": "integer",
+                    "x-kubernetes-validations": [
+                      {
+                        "message": "Cowardly refusing to insert l3mdev rules into kernel tables",
+                        "rule": "(self > 0 && self < 254) || (self > 255)"
+                      }
+                    ]
+                  }
+                },
+                "required": [
+                  "name",
+                  "table"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array",
+              "x-kubernetes-list-map-keys": [
+                "name"
+              ],
+              "x-kubernetes-list-type": "map"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "numCores": {
+          "description": "NumCores is the number of cores per CPU socket in a virtual machine.\nDefaults to the property value in the template from which the virtual machine is cloned.",
+          "format": "int32",
+          "minimum": 1,
+          "type": "integer"
+        },
+        "numSockets": {
+          "description": "NumSockets is the number of CPU sockets in a virtual machine.\nDefaults to the property value in the template from which the virtual machine is cloned.",
+          "format": "int32",
+          "minimum": 1,
+          "type": "integer"
+        },
+        "pool": {
+          "description": "Pool Add the new VM to the specified pool.",
+          "type": "string"
+        },
+        "providerID": {
+          "description": "ProviderID is the virtual machine BIOS UUID formatted as\nproxmox://6c3fa683-bef9-4425-b413-eaa45a9d6191",
+          "type": "string"
+        },
+        "snapName": {
+          "description": "SnapName The name of the snapshot.",
+          "type": "string"
+        },
+        "sourceNode": {
+          "description": "SourceNode is the initially selected proxmox node.\nThis node will be used to locate the template VM, which will\nbe used for cloning operations.\n\nCloning will be performed according to the configuration.\nSetting the `Target` field will tell Proxmox to clone the\nVM on that target node.\n\nWhen Target is not set and the ProxmoxCluster contains\na set of `AllowedNodes`, the algorithm will instead evenly\ndistribute the VMs across the nodes from that list.\n\nIf neither a `Target` nor `AllowedNodes` was set, the VM\nwill be cloned onto the same node as SourceNode.",
+          "minLength": 1,
+          "type": "string"
+        },
+        "storage": {
+          "description": "Storage for full clone.",
+          "type": "string"
+        },
+        "tags": {
+          "description": "Tags is a list of tags to be applied to the virtual machine.",
+          "items": {
+            "pattern": "^(?i)[a-z0-9_][a-z0-9_\\-\\+\\.]*$",
+            "type": "string"
+          },
+          "minItems": 1,
+          "type": "array",
+          "x-kubernetes-list-type": "set"
+        },
+        "target": {
+          "description": "Target node. Only allowed if the original VM is on shared storage.",
+          "type": "string"
+        },
+        "templateID": {
+          "description": "TemplateID the vm_template vmid used for cloning a new VM.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "templateSelector": {
+          "description": "TemplateSelector defines MatchTags for looking up VM templates.",
+          "properties": {
+            "matchPolicy": {
+              "default": "exact",
+              "description": "MatchPolicy controls how MatchTags are evaluated against template tags.\nWhen not set, or set to \"exact\", the behaviour is identical to the previous implementation\nand requires an exact 1:1 tag match. When set to \"subset\", the template's tags must contain\nall MatchTags, but may include additional tags.",
+              "enum": [
+                "exact",
+                "uniqueSubset",
+                "bestSubset"
+              ],
+              "type": "string"
+            },
+            "matchTags": {
+              "description": "Specifies all tags to look for, when looking up the VM template.\nWhen MatchPolicy is \"exact\" (the default), the template's tags must be an exact 1:1 match\nwith MatchTags. If multiple VM templates with the same set of tags are found, provisioning will fail.\nWhen MatchPolicy is \"subset\", the template's tags must contain all of the MatchTags, but may\nhave additional tags.",
+              "items": {
+                "pattern": "^(?i)[a-z0-9_][a-z0-9_\\-\\+\\.]*$",
+                "type": "string"
+              },
+              "minItems": 1,
+              "type": "array",
+              "x-kubernetes-list-type": "set"
+            }
+          },
+          "required": [
+            "matchTags"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "virtualMachineID": {
+          "description": "VirtualMachineID is the Proxmox identifier for the ProxmoxMachine VM.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "vmIDRange": {
+          "description": "VMIDRange is the range of VMIDs to use for VMs.",
+          "properties": {
+            "end": {
+              "description": "VMIDRangeEnd is the end of the VMID range to use for VMs.\nOnly used if VMIDRangeStart is set.",
+              "format": "int64",
+              "maximum": 999999999,
+              "minimum": 100,
+              "type": "integer"
+            },
+            "start": {
+              "description": "VMIDRangeStart is the start of the VMID range to use for VMs.",
+              "format": "int64",
+              "maximum": 999999999,
+              "minimum": 100,
+              "type": "integer"
+            }
+          },
+          "required": [
+            "end",
+            "start"
+          ],
+          "type": "object",
+          "x-kubernetes-validations": [
+            {
+              "message": "end should be greater than or equal to start",
+              "rule": "self.end >= self.start"
+            }
+          ],
+          "additionalProperties": false
+        }
+      },
+      "type": "object",
+      "x-kubernetes-validations": [
+        {
+          "message": "must define either SourceNode with TemplateID, OR TemplateSelector",
+          "rule": "[has(self.sourceNode), has(self.templateSelector)].exists_one(c, c)"
+        },
+        {
+          "message": "must define either SourceNode with TemplateID, OR TemplateSelector.",
+          "rule": "[has(self.templateID), has(self.templateSelector)].exists_one(c, c)"
+        },
+        {
+          "message": "Must set full=true when specifying format",
+          "rule": "self.full || !has(self.format)"
+        },
+        {
+          "message": "Must set full=true when specifying storage",
+          "rule": "self.full || !has(self.storage)"
+        }
+      ],
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "ProxmoxMachineStatus defines the observed state of a ProxmoxMachine.",
+      "properties": {
+        "addresses": {
+          "description": "Addresses contains the Proxmox VM instance associated addresses.",
+          "items": {
+            "description": "MachineAddress contains information for the node's address.",
+            "properties": {
+              "address": {
+                "description": "address is the machine address.",
+                "maxLength": 256,
+                "minLength": 1,
+                "type": "string"
+              },
+              "type": {
+                "description": "type is the machine address type, one of Hostname, ExternalIP, InternalIP, ExternalDNS or InternalDNS.",
+                "enum": [
+                  "Hostname",
+                  "ExternalIP",
+                  "InternalIP",
+                  "ExternalDNS",
+                  "InternalDNS"
+                ],
+                "type": "string"
+              }
+            },
+            "required": [
+              "address",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "bootstrapDataProvided": {
+          "description": "BootstrapDataProvided whether the virtual machine has an injected bootstrap data.",
+          "type": "boolean"
+        },
+        "conditions": {
+          "description": "Conditions defines current service state of the ProxmoxMachine.",
+          "items": {
+            "description": "Condition defines an observation of a Cluster API resource operational state.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "lastTransitionTime is the last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed. If that is not known, then using the time when\nthe API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "message is a human readable message indicating details about the transition.\nThis field may be empty.",
+                "maxLength": 10240,
+                "minLength": 1,
+                "type": "string"
+              },
+              "reason": {
+                "description": "reason is the reason for the condition's last transition in CamelCase.\nThe specific API may choose whether or not this field is considered a guaranteed API.\nThis field may be empty.",
+                "maxLength": 256,
+                "minLength": 1,
+                "type": "string"
+              },
+              "severity": {
+                "description": "severity provides an explicit classification of Reason code, so the users or machines can immediately\nunderstand the current situation and act accordingly.\nThe Severity field MUST be set only when Status=False.",
+                "maxLength": 32,
+                "type": "string"
+              },
+              "status": {
+                "description": "status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "type of condition in CamelCase or in foo.example.com/CamelCase.\nMany .condition.type values are consistent across resources like Available, but because arbitrary conditions\ncan be useful (see .node.status.conditions), the ability to deconflict is important.",
+                "maxLength": 256,
+                "minLength": 1,
+                "type": "string"
+              }
+            },
+            "required": [
+              "lastTransitionTime",
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "failureMessage": {
+          "description": "FailureMessage will be set in the event that there is a terminal problem\nreconciling the Machine and will contain a more verbose string suitable\nfor logging and human consumption.\n\nThis field should not be set for transitive errors that a controller\nfaces that are expected to be fixed automatically over\ntime (like service outages), but instead indicate that something is\nfundamentally wrong with the Machine's spec or the configuration of\nthe controller, and that manual intervention is required. Examples\nof terminal errors would be invalid combinations of settings in the\nspec, values that are unsupported by the controller, or the\nresponsible controller itself being critically misconfigured.\n\nAny transient errors that occur during the reconciliation of ProxmoxMachines\ncan be added as events to the ProxmoxMachine object and/or logged in the\ncontroller's output.",
+          "type": "string"
+        },
+        "failureReason": {
+          "description": "FailureReason will be set in the event that there is a terminal problem\nreconciling the Machine and will contain a succinct value suitable\nfor machine interpretation.\n\nThis field should not be set for transitive errors that a controller\nfaces that are expected to be fixed automatically over\ntime (like service outages), but instead indicate that something is\nfundamentally wrong with the Machine's spec or the configuration of\nthe controller, and that manual intervention is required. Examples\nof terminal errors would be invalid combinations of settings in the\nspec, values that are unsupported by the controller, or the\nresponsible controller itself being critically misconfigured.\n\nAny transient errors that occur during the reconciliation of ProxmoxMachines\ncan be added as events to the ProxmoxMachine object and/or logged in the\ncontroller's output.",
+          "type": "string"
+        },
+        "ipAddresses": {
+          "additionalProperties": {
+            "description": "IPAddress defines the IP addresses of a network interface.",
+            "properties": {
+              "ipv4": {
+                "description": "IPV4 is the IPv4 address.",
+                "type": "string"
+              },
+              "ipv6": {
+                "description": "IPV6 is the IPv6 address.",
+                "type": "string"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "description": "IPAddresses are the IP addresses used to access the virtual machine.",
+          "type": "object"
+        },
+        "network": {
+          "description": "Network returns the network status for each of the machine's configured.\nnetwork interfaces.",
+          "items": {
+            "description": "NetworkStatus provides information about one of a VM's networks.",
+            "properties": {
+              "connected": {
+                "description": "Connected is a flag that indicates whether this network is currently\nconnected to the VM.",
+                "type": "boolean"
+              },
+              "ipAddrs": {
+                "description": "IPAddrs is one or more IP addresses reported by vm-tools.",
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "macAddr": {
+                "description": "MACAddr is the MAC address of the network device.",
+                "type": "string"
+              },
+              "networkName": {
+                "description": "NetworkName is the name of the network.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "macAddr"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "proxmoxNode": {
+          "description": "ProxmoxNode is the name of the proxmox node, which was chosen for this\nmachine to be deployed on.",
+          "type": "string"
+        },
+        "ready": {
+          "description": "Ready indicates the Docker infrastructure has been provisioned and is ready.",
+          "type": "boolean"
+        },
+        "retryAfter": {
+          "description": "RetryAfter tracks the time we can retry queueing a task.",
+          "format": "date-time",
+          "type": "string"
+        },
+        "taskRef": {
+          "description": "TaskRef is a managed object reference to a Task related to the ProxmoxMachine.\nThis value is set automatically at runtime and should not be set or\nmodified by users.",
+          "type": "string"
+        },
+        "vmStatus": {
+          "description": "VMStatus is used to identify the virtual machine status.",
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/infrastructure.cluster.x-k8s.io/proxmoxmachine_v1alpha2.json
+++ b/infrastructure.cluster.x-k8s.io/proxmoxmachine_v1alpha2.json
@@ -1,0 +1,830 @@
+{
+  "description": "ProxmoxMachine is the Schema for the proxmoxmachines API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "spec is the Proxmox machine spec.",
+      "properties": {
+        "allowedNodes": {
+          "description": "allowedNodes specifies all Proxmox nodes which will be considered\nfor operations. This implies that VMs can be cloned on different nodes from\nthe node which holds the VM template.\n\nThis field is optional and should only be set if you want to restrict\nthe nodes where the VM can be cloned.\nIf not set, the ProxmoxCluster will be used to determine the nodes.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "set"
+        },
+        "checks": {
+          "description": "checks defines possible checks to skip.",
+          "properties": {
+            "skipCloudInitStatus": {
+              "description": "skipCloudInitStatus skip checking CloudInit status which can be useful with specific Operating Systems like TalOS",
+              "type": "boolean"
+            },
+            "skipQemuGuestAgent": {
+              "description": "skipQemuGuestAgent skips checking QEMU Agent readiness which can be useful with specific Operating Systems like TalOS",
+              "type": "boolean"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "description": {
+          "description": "description for the new VM.",
+          "type": "string"
+        },
+        "disks": {
+          "description": "disks contains a set of disk configuration options,\nwhich will be applied before the first startup.",
+          "properties": {
+            "bootVolume": {
+              "description": "bootVolume defines the storage size for the boot volume.\nThis field is optional, and should only be set if you want\nto change the size of the boot volume.",
+              "properties": {
+                "disk": {
+                  "description": "disk is the name of the disk device that should be resized.\nExample values are: ide[0-3], scsi[0-30], sata[0-5].",
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "sizeGb": {
+                  "description": "sizeGb defines the size in gigabytes.\n\nAs Proxmox does not support shrinking, the size\nmust be bigger than the already configured size in the\ntemplate.",
+                  "format": "int32",
+                  "minimum": 5,
+                  "type": "integer"
+                }
+              },
+              "required": [
+                "disk",
+                "sizeGb"
+              ],
+              "type": "object",
+              "x-kubernetes-validations": [
+                {
+                  "message": "Value is immutable",
+                  "rule": "self == oldSelf"
+                }
+              ],
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "format": {
+          "description": "format for file storage. Only valid for full clone.",
+          "enum": [
+            "raw",
+            "qcow2",
+            "vmdk"
+          ],
+          "type": "string"
+        },
+        "full": {
+          "default": true,
+          "description": "full Create a full copy of all disks.\nThis is always done when you clone a normal VM.\nDefaults to true when not specified, creating a full clone by default.",
+          "type": "boolean"
+        },
+        "memoryMiB": {
+          "description": "memoryMiB is the size of a virtual machine's memory, in MiB.\nDefaults to the property value in the template from which the virtual machine is cloned.",
+          "format": "int32",
+          "minimum": 0,
+          "multipleOf": 8,
+          "type": "integer"
+        },
+        "metadataSettings": {
+          "description": "metadataSettings defines the metadata settings for this machine's VM.",
+          "properties": {
+            "providerIDInjection": {
+              "description": "providerIDInjection enables the injection of the `providerID` into the cloudinit metadata.\nthis will basically set the `provider-id` field in the metadata to `proxmox://<instanceID>`.",
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "providerIDInjection"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "network": {
+          "description": "network is the network configuration for this machine's VM.",
+          "properties": {
+            "networkDevices": {
+              "description": "networkDevices is a list of network devices.",
+              "items": {
+                "description": "NetworkDevice defines the required details of a virtual machine network device.",
+                "properties": {
+                  "bridge": {
+                    "description": "bridge is the network bridge to attach to the machine.",
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "defaultIPv4": {
+                    "description": "defaultIPv4 attaches the ipv4 host network to this interface.",
+                    "type": "boolean"
+                  },
+                  "defaultIPv6": {
+                    "description": "defaultIPv6 attaches the ipv6 host network to this interface.",
+                    "type": "boolean"
+                  },
+                  "dnsServers": {
+                    "description": "dnsServers contains information about nameservers to be used for this interface.\nIf this field is not set, it will use the default dns servers from the ProxmoxCluster.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "minItems": 1,
+                    "type": "array",
+                    "x-kubernetes-list-type": "set"
+                  },
+                  "ipPoolRef": {
+                    "description": "ipPoolRef is a reference to an IPAM Pool resource, which exposes IPv4 addresses.\nThe network device will use an available IP address from the referenced pool.\nThis can be combined with `IPv6PoolRef` in order to enable dual stack.",
+                    "items": {
+                      "description": "TypedLocalObjectReference contains enough information to let you locate the\ntyped referenced object inside the same namespace.",
+                      "properties": {
+                        "apiGroup": {
+                          "description": "APIGroup is the group for the resource being referenced.\nIf APIGroup is not specified, the specified Kind must be in the core API group.\nFor any other third-party types, APIGroup is required.",
+                          "type": "string"
+                        },
+                        "kind": {
+                          "description": "Kind is the type of resource being referenced",
+                          "type": "string"
+                        },
+                        "name": {
+                          "description": "Name is the name of resource being referenced",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "kind",
+                        "name"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "x-kubernetes-validations": [
+                        {
+                          "message": "ipPoolRef allows only IPAM apiGroup ipam.cluster.x-k8s.io",
+                          "rule": "self.apiGroup == 'ipam.cluster.x-k8s.io'"
+                        },
+                        {
+                          "message": "ipPoolRef allows either InClusterIPPool or GlobalInClusterIPPool",
+                          "rule": "self.kind == 'InClusterIPPool' || self.kind == 'GlobalInClusterIPPool'"
+                        }
+                      ],
+                      "additionalProperties": false
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
+                  },
+                  "linkMtu": {
+                    "description": "linkMtu is the network device Maximum Transmission Unit.",
+                    "format": "int32",
+                    "type": "integer",
+                    "x-kubernetes-validations": [
+                      {
+                        "message": "invalid MTU value",
+                        "rule": "self == 1 || (self >= 576 && self <= 65520)"
+                      }
+                    ]
+                  },
+                  "model": {
+                    "default": "virtio",
+                    "description": "model is the network device model.\nDefaults to \"virtio\" when not specified.",
+                    "enum": [
+                      "e1000",
+                      "virtio",
+                      "rtl8139",
+                      "vmxnet3"
+                    ],
+                    "type": "string"
+                  },
+                  "mtu": {
+                    "description": "mtu is the network device Maximum Transmission Unit.\nWhen set to 1, virtio devices inherit the MTU value from the underlying bridge.",
+                    "format": "int32",
+                    "type": "integer",
+                    "x-kubernetes-validations": [
+                      {
+                        "message": "invalid MTU value",
+                        "rule": "self == 1 || (self >= 576 && self <= 65520)"
+                      }
+                    ]
+                  },
+                  "name": {
+                    "default": "net0",
+                    "description": "name is the network device name.",
+                    "minLength": 4,
+                    "pattern": "^net[0-9]+$",
+                    "type": "string"
+                  },
+                  "queues": {
+                    "description": "queues is the number of queues assigned to the device.\nThis value is passed to the Multiqueue field in PROXMOX.",
+                    "format": "int32",
+                    "maximum": 65535,
+                    "minimum": 1,
+                    "type": "integer"
+                  },
+                  "routes": {
+                    "description": "routes are the routes associated with this interface.",
+                    "items": {
+                      "description": "RouteSpec describes an IPv4/IPv6 Route.",
+                      "properties": {
+                        "is6": {
+                          "description": "is6 defines if a RouteSpec is IPv6.\nIt is only required to disambiguate a 'default'|'all' placeholder 'to'\nwhen 'via' is unset, otherwise the family is derived from 'via'.",
+                          "type": "boolean"
+                        },
+                        "metric": {
+                          "description": "metric is the priority of the route in the routing table.",
+                          "format": "int32",
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "table": {
+                          "description": "table is the routing table used for this route.",
+                          "format": "int32",
+                          "type": "integer"
+                        },
+                        "to": {
+                          "description": "to is the subnet to be routed.",
+                          "type": "string"
+                        },
+                        "via": {
+                          "description": "via is the gateway to the subnet.",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "minItems": 1,
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
+                  },
+                  "routingPolicy": {
+                    "description": "routingPolicy is an interface-specific policy inserted into FIB (forwarding information base).",
+                    "items": {
+                      "description": "RoutingPolicySpec is a Linux FIB rule.",
+                      "properties": {
+                        "from": {
+                          "description": "from is the subnet of the source.",
+                          "type": "string"
+                        },
+                        "is6": {
+                          "description": "is6 defines if a RoutingPolicySpec is IPv6.\nIt is only required to disambiguate a 'default'|'all' placeholder when\nneither 'to' nor 'from' carries a concrete address to derive the family.",
+                          "type": "boolean"
+                        },
+                        "priority": {
+                          "description": "priority is the position in the ip rule FIB table.",
+                          "format": "int64",
+                          "maximum": 4294967295,
+                          "type": "integer",
+                          "x-kubernetes-validations": [
+                            {
+                              "message": "Cowardly refusing to insert FIB rule matching kernel rules",
+                              "rule": "(self > 0 && self < 32765) || (self > 32766)"
+                            }
+                          ]
+                        },
+                        "table": {
+                          "description": "table is the routing table ID.",
+                          "format": "int32",
+                          "type": "integer"
+                        },
+                        "to": {
+                          "description": "to is the subnet of the target.",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "minItems": 1,
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
+                  },
+                  "vlan": {
+                    "description": "vlan is the network L2 VLAN.",
+                    "format": "int32",
+                    "maximum": 4094,
+                    "minimum": 1,
+                    "type": "integer"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array",
+              "x-kubernetes-list-map-keys": [
+                "name"
+              ],
+              "x-kubernetes-list-type": "map"
+            },
+            "vrfs": {
+              "description": "vrfs defines VRF Devices.",
+              "items": {
+                "description": "VRFDevice defines Virtual Routing Flow devices.",
+                "properties": {
+                  "interfaces": {
+                    "description": "interfaces is the list of proxmox network devices managed by this virtual device.",
+                    "items": {
+                      "description": "NetName is a formally verified Proxmox network name string.",
+                      "minLength": 4,
+                      "pattern": "^net[0-9]+$",
+                      "type": "string"
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
+                  },
+                  "name": {
+                    "description": "name is the virtual network device name.\nMust be unique within the virtual machine.",
+                    "minLength": 3,
+                    "type": "string"
+                  },
+                  "routes": {
+                    "description": "routes are the routes associated with this interface.",
+                    "items": {
+                      "description": "RouteSpec describes an IPv4/IPv6 Route.",
+                      "properties": {
+                        "is6": {
+                          "description": "is6 defines if a RouteSpec is IPv6.\nIt is only required to disambiguate a 'default'|'all' placeholder 'to'\nwhen 'via' is unset, otherwise the family is derived from 'via'.",
+                          "type": "boolean"
+                        },
+                        "metric": {
+                          "description": "metric is the priority of the route in the routing table.",
+                          "format": "int32",
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "table": {
+                          "description": "table is the routing table used for this route.",
+                          "format": "int32",
+                          "type": "integer"
+                        },
+                        "to": {
+                          "description": "to is the subnet to be routed.",
+                          "type": "string"
+                        },
+                        "via": {
+                          "description": "via is the gateway to the subnet.",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "minItems": 1,
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
+                  },
+                  "routingPolicy": {
+                    "description": "routingPolicy is an interface-specific policy inserted into FIB (forwarding information base).",
+                    "items": {
+                      "description": "RoutingPolicySpec is a Linux FIB rule.",
+                      "properties": {
+                        "from": {
+                          "description": "from is the subnet of the source.",
+                          "type": "string"
+                        },
+                        "is6": {
+                          "description": "is6 defines if a RoutingPolicySpec is IPv6.\nIt is only required to disambiguate a 'default'|'all' placeholder when\nneither 'to' nor 'from' carries a concrete address to derive the family.",
+                          "type": "boolean"
+                        },
+                        "priority": {
+                          "description": "priority is the position in the ip rule FIB table.",
+                          "format": "int64",
+                          "maximum": 4294967295,
+                          "type": "integer",
+                          "x-kubernetes-validations": [
+                            {
+                              "message": "Cowardly refusing to insert FIB rule matching kernel rules",
+                              "rule": "(self > 0 && self < 32765) || (self > 32766)"
+                            }
+                          ]
+                        },
+                        "table": {
+                          "description": "table is the routing table ID.",
+                          "format": "int32",
+                          "type": "integer"
+                        },
+                        "to": {
+                          "description": "to is the subnet of the target.",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "minItems": 1,
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
+                  },
+                  "table": {
+                    "description": "table is the ID of the routing table used for the l3mdev vrf device.",
+                    "format": "int32",
+                    "maximum": 4294967295,
+                    "minimum": 1,
+                    "type": "integer",
+                    "x-kubernetes-validations": [
+                      {
+                        "message": "Cowardly refusing to insert l3mdev rules into kernel tables",
+                        "rule": "(self > 0 && self < 254) || (self > 255)"
+                      }
+                    ]
+                  }
+                },
+                "required": [
+                  "name",
+                  "table"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array",
+              "x-kubernetes-list-map-keys": [
+                "name"
+              ],
+              "x-kubernetes-list-type": "map"
+            },
+            "zone": {
+              "description": "zone is the cluster deployment zone this machine will refer to.",
+              "pattern": "^[a-z0-9A-Z](?:[a-z0-9A-Z-_.]{0,61}[a-z0-9A-Z])?$",
+              "type": "string"
+            }
+          },
+          "required": [
+            "networkDevices"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "numCores": {
+          "description": "numCores is the number of cores per CPU socket in a virtual machine.\nDefaults to the property value in the template from which the virtual machine is cloned.",
+          "format": "int32",
+          "minimum": 1,
+          "type": "integer"
+        },
+        "numSockets": {
+          "description": "numSockets is the number of CPU sockets in a virtual machine.\nDefaults to the property value in the template from which the virtual machine is cloned.",
+          "format": "int32",
+          "minimum": 1,
+          "type": "integer"
+        },
+        "pool": {
+          "description": "pool Add the new VM to the specified pool.",
+          "type": "string"
+        },
+        "providerID": {
+          "description": "providerID is the virtual machine BIOS UUID formatted as\nproxmox://6c3fa683-bef9-4425-b413-eaa45a9d6191",
+          "maxLength": 46,
+          "minLength": 46,
+          "pattern": "^proxmox://[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
+          "type": "string"
+        },
+        "snapName": {
+          "description": "snapName is the name of the snapshot.",
+          "type": "string"
+        },
+        "sourceNode": {
+          "description": "sourceNode is the initially selected proxmox node.\nThis node will be used to locate the template VM, which will\nbe used for cloning operations.\n\nCloning will be performed according to the configuration.\nSetting the `Target` field will tell Proxmox to clone the\nVM on that target node.\n\nWhen Target is not set and the ProxmoxCluster contains\na set of `AllowedNodes`, the algorithm will instead evenly\ndistribute the VMs across the nodes from that list.\n\nIf neither a `Target` nor `AllowedNodes` was set, the VM\nwill be cloned onto the same node as SourceNode.",
+          "minLength": 1,
+          "type": "string"
+        },
+        "storage": {
+          "description": "storage for full clone.",
+          "type": "string"
+        },
+        "tags": {
+          "description": "tags is a list of tags to be applied to the virtual machine.",
+          "items": {
+            "pattern": "^(?i)[a-z0-9_][a-z0-9_\\-\\+\\.]*$",
+            "type": "string"
+          },
+          "minItems": 1,
+          "type": "array",
+          "x-kubernetes-list-type": "set"
+        },
+        "templateID": {
+          "description": "templateID the vm_template vmid used for cloning a new VM.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "templateSelector": {
+          "description": "templateSelector defines MatchTags for looking up VM templates.\nIf a templateID is defined, templateSelector will be ignored.",
+          "properties": {
+            "matchPolicy": {
+              "default": "exact",
+              "description": "matchPolicy controls how MatchTags are evaluated against template tags.\nWhen not set, or set to \"exact\", the behaviour is identical to the previous implementation\nand requires an exact 1:1 tag match. When set to \"subset\", the template's tags must contain\nall MatchTags, but may include additional tags.",
+              "enum": [
+                "exact",
+                "uniqueSubset",
+                "bestSubset"
+              ],
+              "type": "string"
+            },
+            "matchTags": {
+              "description": "matchTags specifies all tags to look for when looking up the VM template.\nPassed tags must be an exact 1:1 match with the tags on the template you want to use.\nIf multiple VM templates with the same set of tags are found, provisioning will fail.",
+              "items": {
+                "pattern": "^(?i)[a-z0-9_][a-z0-9_\\-\\+\\.]*$",
+                "type": "string"
+              },
+              "minItems": 1,
+              "type": "array",
+              "x-kubernetes-list-type": "set"
+            }
+          },
+          "required": [
+            "matchTags"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "virtualMachineID": {
+          "description": "virtualMachineID is the Proxmox identifier for the ProxmoxMachine VM.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "vmIDRange": {
+          "description": "vmIDRange is the range of VMIDs to use for VMs.",
+          "properties": {
+            "end": {
+              "description": "end is the end of the VMID range to use for VMs.\nOnly used if VMIDRangeStart is set.",
+              "format": "int64",
+              "maximum": 999999999,
+              "minimum": 100,
+              "type": "integer"
+            },
+            "start": {
+              "description": "start is the start of the VMID range to use for VMs.",
+              "format": "int64",
+              "maximum": 999999999,
+              "minimum": 100,
+              "type": "integer"
+            }
+          },
+          "required": [
+            "end",
+            "start"
+          ],
+          "type": "object",
+          "x-kubernetes-validations": [
+            {
+              "message": "end should be greater than or equal to start",
+              "rule": "self.end >= self.start"
+            }
+          ],
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "network"
+      ],
+      "type": "object",
+      "x-kubernetes-validations": [
+        {
+          "message": "must define either a SourceNode with a TemplateID or a TemplateSelector",
+          "rule": "[has(self.sourceNode), has(self.templateSelector)].exists_one(c, c)"
+        },
+        {
+          "message": "must define either a SourceNode with a TemplateID or a TemplateSelector",
+          "rule": "[has(self.templateID), has(self.templateSelector)].exists_one(c, c)"
+        },
+        {
+          "message": "Must set full=true when specifying format",
+          "rule": "self.full || !has(self.format)"
+        },
+        {
+          "message": "Must set full=true when specifying storage",
+          "rule": "self.full || !has(self.storage)"
+        },
+        {
+          "message": "Must specify either templateID or templateSelector",
+          "rule": "has(self.templateSelector) || (has(self.templateID) && has(self.sourceNode))"
+        }
+      ],
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "status is the status of the Proxmox machine.",
+      "properties": {
+        "addresses": {
+          "description": "addresses contains the Proxmox VM instance associated addresses.",
+          "items": {
+            "description": "MachineAddress contains information for the node's address.",
+            "properties": {
+              "address": {
+                "description": "address is the machine address.",
+                "maxLength": 256,
+                "minLength": 1,
+                "type": "string"
+              },
+              "type": {
+                "description": "type is the machine address type, one of Hostname, ExternalIP, InternalIP, ExternalDNS or InternalDNS.",
+                "enum": [
+                  "Hostname",
+                  "ExternalIP",
+                  "InternalIP",
+                  "ExternalDNS",
+                  "InternalDNS"
+                ],
+                "type": "string"
+              }
+            },
+            "required": [
+              "address",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        },
+        "bootstrapDataProvided": {
+          "description": "bootstrapDataProvided whether the virtual machine has an injected bootstrap data.",
+          "type": "boolean"
+        },
+        "conditions": {
+          "description": "conditions defines current service state of the ProxmoxMachine.",
+          "items": {
+            "description": "Condition contains details for one aspect of the current state of this API Resource.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "lastTransitionTime is the last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "message is a human readable message indicating details about the transition.\nThis may be an empty string.",
+                "maxLength": 32768,
+                "type": "string"
+              },
+              "observedGeneration": {
+                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon.\nFor instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date\nwith respect to the current state of the instance.",
+                "format": "int64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "reason": {
+                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition.\nProducers of specific condition types may define expected values and meanings for this field,\nand whether the values are considered a guaranteed API.\nThe value should be a CamelCase string.\nThis field may not be empty.",
+                "maxLength": 1024,
+                "minLength": 1,
+                "pattern": "^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$",
+                "type": "string"
+              },
+              "status": {
+                "description": "status of the condition, one of True, False, Unknown.",
+                "enum": [
+                  "True",
+                  "False",
+                  "Unknown"
+                ],
+                "type": "string"
+              },
+              "type": {
+                "description": "type of condition in CamelCase or in foo.example.com/CamelCase.",
+                "maxLength": 316,
+                "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$",
+                "type": "string"
+              }
+            },
+            "required": [
+              "lastTransitionTime",
+              "message",
+              "reason",
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "maxItems": 32,
+          "type": "array",
+          "x-kubernetes-list-map-keys": [
+            "type"
+          ],
+          "x-kubernetes-list-type": "map"
+        },
+        "initialization": {
+          "description": "initialization provides observations of the ProxmoxMachine initialization process.\nNOTE: Fields in this struct are part of the Cluster API contract and are used to orchestrate initial Machine provisioning.",
+          "minProperties": 1,
+          "properties": {
+            "provisioned": {
+              "description": "provisioned is true when the infrastructure provider reports that the Machine's infrastructure is fully provisioned.\nNOTE: this field is part of the Cluster API contract, and it is used to orchestrate initial Machine provisioning.",
+              "type": "boolean"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "ipAddresses": {
+          "description": "ipAddresses are the IP addresses used to access the virtual machine.",
+          "items": {
+            "description": "IPAddressesSpec stores the IP addresses of a network interface. Used for status.",
+            "properties": {
+              "ipv4": {
+                "description": "ipv4 is the IPv4 address.",
+                "items": {
+                  "type": "string"
+                },
+                "type": "array",
+                "x-kubernetes-list-type": "set"
+              },
+              "ipv6": {
+                "description": "ipv6 is the IPv6 address.",
+                "items": {
+                  "type": "string"
+                },
+                "type": "array",
+                "x-kubernetes-list-type": "set"
+              },
+              "net": {
+                "description": "net is the proxmox network name these ipaddresses are attached to.",
+                "minLength": 4,
+                "pattern": "^(net[0-9]+|default)$",
+                "type": "string"
+              }
+            },
+            "required": [
+              "net"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array",
+          "x-kubernetes-list-map-keys": [
+            "net"
+          ],
+          "x-kubernetes-list-type": "map"
+        },
+        "network": {
+          "description": "network returns the network status for each of the machine's configured\nnetwork interfaces.",
+          "items": {
+            "description": "NetworkStatus provides information about one of a VM's networks.",
+            "properties": {
+              "connected": {
+                "description": "connected is a flag that indicates whether this network is currently\nconnected to the VM.",
+                "type": "boolean"
+              },
+              "ipAddrs": {
+                "description": "ipAddrs is one or more IP addresses reported by vm-tools.",
+                "items": {
+                  "type": "string"
+                },
+                "type": "array",
+                "x-kubernetes-list-type": "set"
+              },
+              "macAddr": {
+                "description": "macAddr is the MAC address of the network device.",
+                "maxLength": 17,
+                "minLength": 17,
+                "pattern": "^([0-9A-Fa-f]{2}[:]){5}([0-9A-Fa-f]{2})$",
+                "type": "string"
+              },
+              "networkName": {
+                "description": "networkName is the name of the network.",
+                "minLength": 4,
+                "pattern": "^net[0-9]+$",
+                "type": "string"
+              }
+            },
+            "required": [
+              "connected",
+              "macAddr"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        },
+        "proxmoxNode": {
+          "description": "proxmoxNode is the name of the proxmox node, which was chosen for this\nmachine to be deployed on.",
+          "type": "string"
+        },
+        "retryAfter": {
+          "description": "retryAfter tracks the time we can retry queueing a task.",
+          "format": "date-time",
+          "type": "string"
+        },
+        "taskRef": {
+          "description": "taskRef is a managed object reference to a Task related to the ProxmoxMachine.\nThis value is set automatically at runtime and should not be set or\nmodified by users.",
+          "type": "string"
+        },
+        "vmStatus": {
+          "description": "vmStatus is used to identify the virtual machine status.",
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "required": [
+    "spec"
+  ],
+  "type": "object"
+}

--- a/infrastructure.cluster.x-k8s.io/proxmoxmachinetemplate_v1alpha1.json
+++ b/infrastructure.cluster.x-k8s.io/proxmoxmachinetemplate_v1alpha1.json
@@ -1,0 +1,740 @@
+{
+  "description": "ProxmoxMachineTemplate is the Schema for the proxmoxmachinetemplates API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "ProxmoxMachineTemplateSpec defines the desired state of ProxmoxMachineTemplate.",
+      "properties": {
+        "template": {
+          "description": "ProxmoxMachineTemplateResource defines the spec and metadata for ProxmoxMachineTemplate supported by capi.",
+          "properties": {
+            "metadata": {
+              "description": "Standard object's metadata.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+              "properties": {
+                "annotations": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "annotations is an unstructured key value map stored with a resource that may be\nset by external tools to store and retrieve arbitrary metadata. They are not\nqueryable and should be preserved when modifying objects.\nMore info: http://kubernetes.io/docs/user-guide/annotations",
+                  "type": "object"
+                },
+                "labels": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "labels is a map of string keys and values that can be used to organize and categorize\n(scope and select) objects. May match selectors of replication controllers\nand services.\nMore info: http://kubernetes.io/docs/user-guide/labels",
+                  "type": "object"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "spec": {
+              "description": "ProxmoxMachineSpec defines the desired state of a ProxmoxMachine.",
+              "properties": {
+                "allowedNodes": {
+                  "description": "AllowedNodes specifies all Proxmox nodes which will be considered\nfor operations. This implies that VMs can be cloned on different nodes from\nthe node which holds the VM template.\n\nThis field is optional and should only be set if you want to restrict\nthe nodes where the VM can be cloned.\nIf not set, the ProxmoxCluster will be used to determine the nodes.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "checks": {
+                  "description": "Checks defines possibles checks to skip.",
+                  "properties": {
+                    "skipCloudInitStatus": {
+                      "description": "Skip checking CloudInit which can be very useful for specific Operating Systems like TalOS",
+                      "type": "boolean"
+                    },
+                    "skipQemuGuestAgent": {
+                      "description": "Skip checking QEMU Agent readiness which can be very useful for specific Operating Systems like TalOS",
+                      "type": "boolean"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "description": {
+                  "description": "Description for the new VM.",
+                  "type": "string"
+                },
+                "disks": {
+                  "description": "Disks contains a set of disk configuration options,\nwhich will be applied before the first startup.",
+                  "properties": {
+                    "bootVolume": {
+                      "description": "BootVolume defines the storage size for the boot volume.\nThis field is optional, and should only be set if you want\nto change the size of the boot volume.",
+                      "properties": {
+                        "disk": {
+                          "description": "Disk is the name of the disk device, that should be resized.\nExample values are: ide[0-3], scsi[0-30], sata[0-5].",
+                          "type": "string"
+                        },
+                        "sizeGb": {
+                          "description": "Size defines the size in gigabyte.\n\nAs Proxmox does not support shrinking, the size\nmust be bigger than the already configured size in the\ntemplate.",
+                          "format": "int32",
+                          "minimum": 5,
+                          "type": "integer"
+                        }
+                      },
+                      "required": [
+                        "disk",
+                        "sizeGb"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-validations": [
+                        {
+                          "message": "Value is immutable",
+                          "rule": "self == oldSelf"
+                        }
+                      ],
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "format": {
+                  "description": "Format for file storage. Only valid for full clone.",
+                  "enum": [
+                    "raw",
+                    "qcow2",
+                    "vmdk"
+                  ],
+                  "type": "string"
+                },
+                "full": {
+                  "default": true,
+                  "description": "Full Create a full copy of all disks.\nThis is always done when you clone a normal VM.\nCreate a Full clone by default.",
+                  "type": "boolean"
+                },
+                "memoryMiB": {
+                  "description": "MemoryMiB is the size of a virtual machine's memory, in MiB.\nDefaults to the property value in the template from which the virtual machine is cloned.",
+                  "format": "int32",
+                  "multipleOf": 8,
+                  "type": "integer"
+                },
+                "metadataSettings": {
+                  "description": "MetadataSettings defines the metadata settings for this machine's VM.",
+                  "properties": {
+                    "providerIDInjection": {
+                      "description": "ProviderIDInjection enables the injection of the `providerID` into the cloudinit metadata.\nthis will basically set the `provider-id` field in the metadata to `proxmox://<instanceID>`.",
+                      "type": "boolean"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "network": {
+                  "description": "Network is the network configuration for this machine's VM.",
+                  "properties": {
+                    "additionalDevices": {
+                      "description": "AdditionalDevices defines additional network devices bound to the virtual machine.",
+                      "items": {
+                        "description": "AdditionalNetworkDevice the definition of a Proxmox network device.",
+                        "properties": {
+                          "bridge": {
+                            "description": "Bridge is the network bridge to attach to the machine.",
+                            "minLength": 1,
+                            "type": "string"
+                          },
+                          "dnsServers": {
+                            "description": "DNSServers contains information about nameservers to be used for this interface.\nIf this field is not set, it will use the default dns servers from the ProxmoxCluster.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "minItems": 1,
+                            "type": "array"
+                          },
+                          "ipv4PoolRef": {
+                            "description": "IPv4PoolRef is a reference to an IPAM Pool resource, which exposes IPv4 addresses.\nThe network device will use an available IP address from the referenced pool.\nThis can be combined with `IPv6PoolRef` in order to enable dual stack.",
+                            "properties": {
+                              "apiGroup": {
+                                "description": "APIGroup is the group for the resource being referenced.\nIf APIGroup is not specified, the specified Kind must be in the core API group.\nFor any other third-party types, APIGroup is required.",
+                                "type": "string"
+                              },
+                              "kind": {
+                                "description": "Kind is the type of resource being referenced",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "Name is the name of resource being referenced",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "kind",
+                              "name"
+                            ],
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "x-kubernetes-validations": [
+                              {
+                                "message": "ipv4PoolRef allows only IPAM apiGroup ipam.cluster.x-k8s.io",
+                                "rule": "self.apiGroup == 'ipam.cluster.x-k8s.io'"
+                              },
+                              {
+                                "message": "ipv4PoolRef allows either InClusterIPPool or GlobalInClusterIPPool",
+                                "rule": "self.kind == 'InClusterIPPool' || self.kind == 'GlobalInClusterIPPool'"
+                              }
+                            ],
+                            "additionalProperties": false
+                          },
+                          "ipv6PoolRef": {
+                            "description": "IPv6PoolRef is a reference to an IPAM pool resource, which exposes IPv6 addresses.\nThe network device will use an available IP address from the referenced pool.\nthis can be combined with `IPv4PoolRef` in order to enable dual stack.",
+                            "properties": {
+                              "apiGroup": {
+                                "description": "APIGroup is the group for the resource being referenced.\nIf APIGroup is not specified, the specified Kind must be in the core API group.\nFor any other third-party types, APIGroup is required.",
+                                "type": "string"
+                              },
+                              "kind": {
+                                "description": "Kind is the type of resource being referenced",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "Name is the name of resource being referenced",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "kind",
+                              "name"
+                            ],
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "x-kubernetes-validations": [
+                              {
+                                "message": "ipv6PoolRef allows only IPAM apiGroup ipam.cluster.x-k8s.io",
+                                "rule": "self.apiGroup == 'ipam.cluster.x-k8s.io'"
+                              },
+                              {
+                                "message": "ipv6PoolRef allows either InClusterIPPool or GlobalInClusterIPPool",
+                                "rule": "self.kind == 'InClusterIPPool' || self.kind == 'GlobalInClusterIPPool'"
+                              }
+                            ],
+                            "additionalProperties": false
+                          },
+                          "linkMtu": {
+                            "description": "LinkMTU is the network device Maximum Transmission Unit.",
+                            "type": "integer",
+                            "x-kubernetes-validations": [
+                              {
+                                "message": "invalid MTU value",
+                                "rule": "self == 1 || ( self >= 576 && self <= 65520)"
+                              }
+                            ]
+                          },
+                          "model": {
+                            "default": "virtio",
+                            "description": "Model is the network device model.",
+                            "enum": [
+                              "e1000",
+                              "virtio",
+                              "rtl8139",
+                              "vmxnet3"
+                            ],
+                            "type": "string"
+                          },
+                          "mtu": {
+                            "description": "MTU is the network device Maximum Transmission Unit.\nWhen set to 1, virtio devices inherit the MTU value from the underlying bridge.",
+                            "type": "integer",
+                            "x-kubernetes-validations": [
+                              {
+                                "message": "invalid MTU value",
+                                "rule": "self == 1 || ( self >= 576 && self <= 65520)"
+                              }
+                            ]
+                          },
+                          "name": {
+                            "description": "Name is the network device name.\nMust be unique within the virtual machine and different from the primary device 'net0'.",
+                            "minLength": 1,
+                            "type": "string",
+                            "x-kubernetes-validations": [
+                              {
+                                "message": "additional network devices doesn't allow net0",
+                                "rule": "self != 'net0'"
+                              }
+                            ]
+                          },
+                          "routes": {
+                            "description": "Routes are the routes associated with this interface.",
+                            "items": {
+                              "description": "RouteSpec describes an IPv4/IPv6 Route.",
+                              "properties": {
+                                "metric": {
+                                  "description": "Metric is the priority of the route in the routing table.",
+                                  "format": "int32",
+                                  "type": "integer"
+                                },
+                                "table": {
+                                  "description": "Table is the routing table used for this route.",
+                                  "format": "int32",
+                                  "type": "integer"
+                                },
+                                "to": {
+                                  "description": "To is the subnet to be routed.",
+                                  "type": "string"
+                                },
+                                "via": {
+                                  "description": "Via is the gateway to the subnet.",
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "minItems": 1,
+                            "type": "array"
+                          },
+                          "routingPolicy": {
+                            "description": "RoutingPolicy is an interface-specific policy inserted into FIB (forwarding information base).",
+                            "items": {
+                              "description": "RoutingPolicySpec is a Linux FIB rule.",
+                              "properties": {
+                                "from": {
+                                  "description": "From is the subnet of the source.",
+                                  "type": "string"
+                                },
+                                "priority": {
+                                  "description": "Priority is the position in the ip rule FIB table.",
+                                  "format": "int32",
+                                  "maximum": 4294967295,
+                                  "type": "integer",
+                                  "x-kubernetes-validations": [
+                                    {
+                                      "message": "Cowardly refusing to insert FIB rule matching kernel rules",
+                                      "rule": "(self > 0 && self < 32765) || (self > 32766)"
+                                    }
+                                  ]
+                                },
+                                "table": {
+                                  "description": "Table is the routing table ID.\nwhen used in the networks, the value should be the VRF Table.",
+                                  "format": "int32",
+                                  "type": "integer"
+                                },
+                                "to": {
+                                  "description": "To is the subnet of the target.",
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "minItems": 1,
+                            "type": "array"
+                          },
+                          "vlan": {
+                            "description": "VLAN is the network L2 VLAN.",
+                            "maximum": 4094,
+                            "minimum": 1,
+                            "type": "integer"
+                          }
+                        },
+                        "required": [
+                          "bridge",
+                          "name"
+                        ],
+                        "type": "object",
+                        "x-kubernetes-validations": [
+                          {
+                            "message": "at least one pool reference must be set, either ipv4PoolRef or ipv6PoolRef",
+                            "rule": "self.ipv4PoolRef != null || self.ipv6PoolRef != null"
+                          }
+                        ],
+                        "additionalProperties": false
+                      },
+                      "type": "array",
+                      "x-kubernetes-list-map-keys": [
+                        "name"
+                      ],
+                      "x-kubernetes-list-type": "map"
+                    },
+                    "default": {
+                      "description": "Default is the default network device,\nwhich will be used for the primary network interface.\nnet0 is always the default network device.",
+                      "properties": {
+                        "bridge": {
+                          "description": "Bridge is the network bridge to attach to the machine.",
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "dnsServers": {
+                          "description": "DNSServers contains information about nameservers to be used for this interface.\nIf this field is not set, it will use the default dns servers from the ProxmoxCluster.",
+                          "items": {
+                            "type": "string"
+                          },
+                          "minItems": 1,
+                          "type": "array"
+                        },
+                        "ipv4PoolRef": {
+                          "description": "IPv4PoolRef is a reference to an IPAM Pool resource, which exposes IPv4 addresses.\nThe network device will use an available IP address from the referenced pool.\nThis can be combined with `IPv6PoolRef` in order to enable dual stack.",
+                          "properties": {
+                            "apiGroup": {
+                              "description": "APIGroup is the group for the resource being referenced.\nIf APIGroup is not specified, the specified Kind must be in the core API group.\nFor any other third-party types, APIGroup is required.",
+                              "type": "string"
+                            },
+                            "kind": {
+                              "description": "Kind is the type of resource being referenced",
+                              "type": "string"
+                            },
+                            "name": {
+                              "description": "Name is the name of resource being referenced",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "kind",
+                            "name"
+                          ],
+                          "type": "object",
+                          "x-kubernetes-map-type": "atomic",
+                          "x-kubernetes-validations": [
+                            {
+                              "message": "ipv4PoolRef allows only IPAM apiGroup ipam.cluster.x-k8s.io",
+                              "rule": "self.apiGroup == 'ipam.cluster.x-k8s.io'"
+                            },
+                            {
+                              "message": "ipv4PoolRef allows either InClusterIPPool or GlobalInClusterIPPool",
+                              "rule": "self.kind == 'InClusterIPPool' || self.kind == 'GlobalInClusterIPPool'"
+                            }
+                          ],
+                          "additionalProperties": false
+                        },
+                        "ipv6PoolRef": {
+                          "description": "IPv6PoolRef is a reference to an IPAM pool resource, which exposes IPv6 addresses.\nThe network device will use an available IP address from the referenced pool.\nthis can be combined with `IPv4PoolRef` in order to enable dual stack.",
+                          "properties": {
+                            "apiGroup": {
+                              "description": "APIGroup is the group for the resource being referenced.\nIf APIGroup is not specified, the specified Kind must be in the core API group.\nFor any other third-party types, APIGroup is required.",
+                              "type": "string"
+                            },
+                            "kind": {
+                              "description": "Kind is the type of resource being referenced",
+                              "type": "string"
+                            },
+                            "name": {
+                              "description": "Name is the name of resource being referenced",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "kind",
+                            "name"
+                          ],
+                          "type": "object",
+                          "x-kubernetes-map-type": "atomic",
+                          "x-kubernetes-validations": [
+                            {
+                              "message": "ipv6PoolRef allows only IPAM apiGroup ipam.cluster.x-k8s.io",
+                              "rule": "self.apiGroup == 'ipam.cluster.x-k8s.io'"
+                            },
+                            {
+                              "message": "ipv6PoolRef allows either InClusterIPPool or GlobalInClusterIPPool",
+                              "rule": "self.kind == 'InClusterIPPool' || self.kind == 'GlobalInClusterIPPool'"
+                            }
+                          ],
+                          "additionalProperties": false
+                        },
+                        "model": {
+                          "default": "virtio",
+                          "description": "Model is the network device model.",
+                          "enum": [
+                            "e1000",
+                            "virtio",
+                            "rtl8139",
+                            "vmxnet3"
+                          ],
+                          "type": "string"
+                        },
+                        "mtu": {
+                          "description": "MTU is the network device Maximum Transmission Unit.\nWhen set to 1, virtio devices inherit the MTU value from the underlying bridge.",
+                          "type": "integer",
+                          "x-kubernetes-validations": [
+                            {
+                              "message": "invalid MTU value",
+                              "rule": "self == 1 || ( self >= 576 && self <= 65520)"
+                            }
+                          ]
+                        },
+                        "vlan": {
+                          "description": "VLAN is the network L2 VLAN.",
+                          "maximum": 4094,
+                          "minimum": 1,
+                          "type": "integer"
+                        }
+                      },
+                      "required": [
+                        "bridge"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "vrfs": {
+                      "description": "Definition of a VRF Device.",
+                      "items": {
+                        "description": "VRFDevice defines Virtual Routing Flow devices.",
+                        "properties": {
+                          "interfaces": {
+                            "description": "Interfaces is the list of proxmox network devices managed by this virtual device.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "name": {
+                            "description": "Name is the virtual network device name.\nMust be unique within the virtual machine.",
+                            "minLength": 3,
+                            "type": "string"
+                          },
+                          "routes": {
+                            "description": "Routes are the routes associated with this interface.",
+                            "items": {
+                              "description": "RouteSpec describes an IPv4/IPv6 Route.",
+                              "properties": {
+                                "metric": {
+                                  "description": "Metric is the priority of the route in the routing table.",
+                                  "format": "int32",
+                                  "type": "integer"
+                                },
+                                "table": {
+                                  "description": "Table is the routing table used for this route.",
+                                  "format": "int32",
+                                  "type": "integer"
+                                },
+                                "to": {
+                                  "description": "To is the subnet to be routed.",
+                                  "type": "string"
+                                },
+                                "via": {
+                                  "description": "Via is the gateway to the subnet.",
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "minItems": 1,
+                            "type": "array"
+                          },
+                          "routingPolicy": {
+                            "description": "RoutingPolicy is an interface-specific policy inserted into FIB (forwarding information base).",
+                            "items": {
+                              "description": "RoutingPolicySpec is a Linux FIB rule.",
+                              "properties": {
+                                "from": {
+                                  "description": "From is the subnet of the source.",
+                                  "type": "string"
+                                },
+                                "priority": {
+                                  "description": "Priority is the position in the ip rule FIB table.",
+                                  "format": "int32",
+                                  "maximum": 4294967295,
+                                  "type": "integer",
+                                  "x-kubernetes-validations": [
+                                    {
+                                      "message": "Cowardly refusing to insert FIB rule matching kernel rules",
+                                      "rule": "(self > 0 && self < 32765) || (self > 32766)"
+                                    }
+                                  ]
+                                },
+                                "table": {
+                                  "description": "Table is the routing table ID.\nwhen used in the networks, the value should be the VRF Table.",
+                                  "format": "int32",
+                                  "type": "integer"
+                                },
+                                "to": {
+                                  "description": "To is the subnet of the target.",
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "minItems": 1,
+                            "type": "array"
+                          },
+                          "table": {
+                            "description": "Table is the ID of the routing table used for the l3mdev vrf device.",
+                            "format": "int32",
+                            "maximum": 4294967295,
+                            "type": "integer",
+                            "x-kubernetes-validations": [
+                              {
+                                "message": "Cowardly refusing to insert l3mdev rules into kernel tables",
+                                "rule": "(self > 0 && self < 254) || (self > 255)"
+                              }
+                            ]
+                          }
+                        },
+                        "required": [
+                          "name",
+                          "table"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array",
+                      "x-kubernetes-list-map-keys": [
+                        "name"
+                      ],
+                      "x-kubernetes-list-type": "map"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "numCores": {
+                  "description": "NumCores is the number of cores per CPU socket in a virtual machine.\nDefaults to the property value in the template from which the virtual machine is cloned.",
+                  "format": "int32",
+                  "minimum": 1,
+                  "type": "integer"
+                },
+                "numSockets": {
+                  "description": "NumSockets is the number of CPU sockets in a virtual machine.\nDefaults to the property value in the template from which the virtual machine is cloned.",
+                  "format": "int32",
+                  "minimum": 1,
+                  "type": "integer"
+                },
+                "pool": {
+                  "description": "Pool Add the new VM to the specified pool.",
+                  "type": "string"
+                },
+                "providerID": {
+                  "description": "ProviderID is the virtual machine BIOS UUID formatted as\nproxmox://6c3fa683-bef9-4425-b413-eaa45a9d6191",
+                  "type": "string"
+                },
+                "snapName": {
+                  "description": "SnapName The name of the snapshot.",
+                  "type": "string"
+                },
+                "sourceNode": {
+                  "description": "SourceNode is the initially selected proxmox node.\nThis node will be used to locate the template VM, which will\nbe used for cloning operations.\n\nCloning will be performed according to the configuration.\nSetting the `Target` field will tell Proxmox to clone the\nVM on that target node.\n\nWhen Target is not set and the ProxmoxCluster contains\na set of `AllowedNodes`, the algorithm will instead evenly\ndistribute the VMs across the nodes from that list.\n\nIf neither a `Target` nor `AllowedNodes` was set, the VM\nwill be cloned onto the same node as SourceNode.",
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "storage": {
+                  "description": "Storage for full clone.",
+                  "type": "string"
+                },
+                "tags": {
+                  "description": "Tags is a list of tags to be applied to the virtual machine.",
+                  "items": {
+                    "pattern": "^(?i)[a-z0-9_][a-z0-9_\\-\\+\\.]*$",
+                    "type": "string"
+                  },
+                  "minItems": 1,
+                  "type": "array",
+                  "x-kubernetes-list-type": "set"
+                },
+                "target": {
+                  "description": "Target node. Only allowed if the original VM is on shared storage.",
+                  "type": "string"
+                },
+                "templateID": {
+                  "description": "TemplateID the vm_template vmid used for cloning a new VM.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "templateSelector": {
+                  "description": "TemplateSelector defines MatchTags for looking up VM templates.",
+                  "properties": {
+                    "matchPolicy": {
+                      "default": "exact",
+                      "description": "MatchPolicy controls how MatchTags are evaluated against template tags.\nWhen not set, or set to \"exact\", the behaviour is identical to the previous implementation\nand requires an exact 1:1 tag match. When set to \"subset\", the template's tags must contain\nall MatchTags, but may include additional tags.",
+                      "enum": [
+                        "exact",
+                        "uniqueSubset",
+                        "bestSubset"
+                      ],
+                      "type": "string"
+                    },
+                    "matchTags": {
+                      "description": "Specifies all tags to look for, when looking up the VM template.\nWhen MatchPolicy is \"exact\" (the default), the template's tags must be an exact 1:1 match\nwith MatchTags. If multiple VM templates with the same set of tags are found, provisioning will fail.\nWhen MatchPolicy is \"subset\", the template's tags must contain all of the MatchTags, but may\nhave additional tags.",
+                      "items": {
+                        "pattern": "^(?i)[a-z0-9_][a-z0-9_\\-\\+\\.]*$",
+                        "type": "string"
+                      },
+                      "minItems": 1,
+                      "type": "array",
+                      "x-kubernetes-list-type": "set"
+                    }
+                  },
+                  "required": [
+                    "matchTags"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "virtualMachineID": {
+                  "description": "VirtualMachineID is the Proxmox identifier for the ProxmoxMachine VM.",
+                  "format": "int64",
+                  "type": "integer"
+                },
+                "vmIDRange": {
+                  "description": "VMIDRange is the range of VMIDs to use for VMs.",
+                  "properties": {
+                    "end": {
+                      "description": "VMIDRangeEnd is the end of the VMID range to use for VMs.\nOnly used if VMIDRangeStart is set.",
+                      "format": "int64",
+                      "maximum": 999999999,
+                      "minimum": 100,
+                      "type": "integer"
+                    },
+                    "start": {
+                      "description": "VMIDRangeStart is the start of the VMID range to use for VMs.",
+                      "format": "int64",
+                      "maximum": 999999999,
+                      "minimum": 100,
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "end",
+                    "start"
+                  ],
+                  "type": "object",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "end should be greater than or equal to start",
+                      "rule": "self.end >= self.start"
+                    }
+                  ],
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "x-kubernetes-validations": [
+                {
+                  "message": "Must set full=true when specifying format",
+                  "rule": "self.full || !has(self.format)"
+                },
+                {
+                  "message": "Must set full=true when specifying storage",
+                  "rule": "self.full || !has(self.storage)"
+                }
+              ],
+              "additionalProperties": false
+            }
+          },
+          "required": [
+            "spec"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "template"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/infrastructure.cluster.x-k8s.io/proxmoxmachinetemplate_v1alpha2.json
+++ b/infrastructure.cluster.x-k8s.io/proxmoxmachinetemplate_v1alpha2.json
@@ -1,0 +1,649 @@
+{
+  "description": "ProxmoxMachineTemplate is the Schema for the proxmoxmachinetemplates API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "spec is the machine template spec.",
+      "properties": {
+        "template": {
+          "description": "template is the Proxmox machine template resource.",
+          "properties": {
+            "metadata": {
+              "description": "metadata is the standard object metadata.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+              "minProperties": 1,
+              "properties": {
+                "annotations": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "annotations is an unstructured key value map stored with a resource that may be\nset by external tools to store and retrieve arbitrary metadata. They are not\nqueryable and should be preserved when modifying objects.\nMore info: http://kubernetes.io/docs/user-guide/annotations",
+                  "type": "object"
+                },
+                "labels": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "labels is a map of string keys and values that can be used to organize and categorize\n(scope and select) objects. May match selectors of replication controllers\nand services.\nMore info: http://kubernetes.io/docs/user-guide/labels",
+                  "type": "object"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "spec": {
+              "description": "spec is the Proxmox machine spec.",
+              "properties": {
+                "allowedNodes": {
+                  "description": "allowedNodes specifies all Proxmox nodes which will be considered\nfor operations. This implies that VMs can be cloned on different nodes from\nthe node which holds the VM template.\n\nThis field is optional and should only be set if you want to restrict\nthe nodes where the VM can be cloned.\nIf not set, the ProxmoxCluster will be used to determine the nodes.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array",
+                  "x-kubernetes-list-type": "set"
+                },
+                "checks": {
+                  "description": "checks defines possible checks to skip.",
+                  "properties": {
+                    "skipCloudInitStatus": {
+                      "description": "skipCloudInitStatus skip checking CloudInit status which can be useful with specific Operating Systems like TalOS",
+                      "type": "boolean"
+                    },
+                    "skipQemuGuestAgent": {
+                      "description": "skipQemuGuestAgent skips checking QEMU Agent readiness which can be useful with specific Operating Systems like TalOS",
+                      "type": "boolean"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "description": {
+                  "description": "description for the new VM.",
+                  "type": "string"
+                },
+                "disks": {
+                  "description": "disks contains a set of disk configuration options,\nwhich will be applied before the first startup.",
+                  "properties": {
+                    "bootVolume": {
+                      "description": "bootVolume defines the storage size for the boot volume.\nThis field is optional, and should only be set if you want\nto change the size of the boot volume.",
+                      "properties": {
+                        "disk": {
+                          "description": "disk is the name of the disk device that should be resized.\nExample values are: ide[0-3], scsi[0-30], sata[0-5].",
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "sizeGb": {
+                          "description": "sizeGb defines the size in gigabytes.\n\nAs Proxmox does not support shrinking, the size\nmust be bigger than the already configured size in the\ntemplate.",
+                          "format": "int32",
+                          "minimum": 5,
+                          "type": "integer"
+                        }
+                      },
+                      "required": [
+                        "disk",
+                        "sizeGb"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-validations": [
+                        {
+                          "message": "Value is immutable",
+                          "rule": "self == oldSelf"
+                        }
+                      ],
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "format": {
+                  "description": "format for file storage. Only valid for full clone.",
+                  "enum": [
+                    "raw",
+                    "qcow2",
+                    "vmdk"
+                  ],
+                  "type": "string"
+                },
+                "full": {
+                  "default": true,
+                  "description": "full Create a full copy of all disks.\nThis is always done when you clone a normal VM.\nDefaults to true when not specified, creating a full clone by default.",
+                  "type": "boolean"
+                },
+                "memoryMiB": {
+                  "description": "memoryMiB is the size of a virtual machine's memory, in MiB.\nDefaults to the property value in the template from which the virtual machine is cloned.",
+                  "format": "int32",
+                  "minimum": 0,
+                  "multipleOf": 8,
+                  "type": "integer"
+                },
+                "metadataSettings": {
+                  "description": "metadataSettings defines the metadata settings for this machine's VM.",
+                  "properties": {
+                    "providerIDInjection": {
+                      "description": "providerIDInjection enables the injection of the `providerID` into the cloudinit metadata.\nthis will basically set the `provider-id` field in the metadata to `proxmox://<instanceID>`.",
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "providerIDInjection"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "network": {
+                  "description": "network is the network configuration for this machine's VM.",
+                  "properties": {
+                    "networkDevices": {
+                      "description": "networkDevices is a list of network devices.",
+                      "items": {
+                        "description": "NetworkDevice defines the required details of a virtual machine network device.",
+                        "properties": {
+                          "bridge": {
+                            "description": "bridge is the network bridge to attach to the machine.",
+                            "minLength": 1,
+                            "type": "string"
+                          },
+                          "defaultIPv4": {
+                            "description": "defaultIPv4 attaches the ipv4 host network to this interface.",
+                            "type": "boolean"
+                          },
+                          "defaultIPv6": {
+                            "description": "defaultIPv6 attaches the ipv6 host network to this interface.",
+                            "type": "boolean"
+                          },
+                          "dnsServers": {
+                            "description": "dnsServers contains information about nameservers to be used for this interface.\nIf this field is not set, it will use the default dns servers from the ProxmoxCluster.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "minItems": 1,
+                            "type": "array",
+                            "x-kubernetes-list-type": "set"
+                          },
+                          "ipPoolRef": {
+                            "description": "ipPoolRef is a reference to an IPAM Pool resource, which exposes IPv4 addresses.\nThe network device will use an available IP address from the referenced pool.\nThis can be combined with `IPv6PoolRef` in order to enable dual stack.",
+                            "items": {
+                              "description": "TypedLocalObjectReference contains enough information to let you locate the\ntyped referenced object inside the same namespace.",
+                              "properties": {
+                                "apiGroup": {
+                                  "description": "APIGroup is the group for the resource being referenced.\nIf APIGroup is not specified, the specified Kind must be in the core API group.\nFor any other third-party types, APIGroup is required.",
+                                  "type": "string"
+                                },
+                                "kind": {
+                                  "description": "Kind is the type of resource being referenced",
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "description": "Name is the name of resource being referenced",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "kind",
+                                "name"
+                              ],
+                              "type": "object",
+                              "x-kubernetes-map-type": "atomic",
+                              "x-kubernetes-validations": [
+                                {
+                                  "message": "ipPoolRef allows only IPAM apiGroup ipam.cluster.x-k8s.io",
+                                  "rule": "self.apiGroup == 'ipam.cluster.x-k8s.io'"
+                                },
+                                {
+                                  "message": "ipPoolRef allows either InClusterIPPool or GlobalInClusterIPPool",
+                                  "rule": "self.kind == 'InClusterIPPool' || self.kind == 'GlobalInClusterIPPool'"
+                                }
+                              ],
+                              "additionalProperties": false
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "linkMtu": {
+                            "description": "linkMtu is the network device Maximum Transmission Unit.",
+                            "format": "int32",
+                            "type": "integer",
+                            "x-kubernetes-validations": [
+                              {
+                                "message": "invalid MTU value",
+                                "rule": "self == 1 || (self >= 576 && self <= 65520)"
+                              }
+                            ]
+                          },
+                          "model": {
+                            "default": "virtio",
+                            "description": "model is the network device model.\nDefaults to \"virtio\" when not specified.",
+                            "enum": [
+                              "e1000",
+                              "virtio",
+                              "rtl8139",
+                              "vmxnet3"
+                            ],
+                            "type": "string"
+                          },
+                          "mtu": {
+                            "description": "mtu is the network device Maximum Transmission Unit.\nWhen set to 1, virtio devices inherit the MTU value from the underlying bridge.",
+                            "format": "int32",
+                            "type": "integer",
+                            "x-kubernetes-validations": [
+                              {
+                                "message": "invalid MTU value",
+                                "rule": "self == 1 || (self >= 576 && self <= 65520)"
+                              }
+                            ]
+                          },
+                          "name": {
+                            "default": "net0",
+                            "description": "name is the network device name.",
+                            "minLength": 4,
+                            "pattern": "^net[0-9]+$",
+                            "type": "string"
+                          },
+                          "queues": {
+                            "description": "queues is the number of queues assigned to the device.\nThis value is passed to the Multiqueue field in PROXMOX.",
+                            "format": "int32",
+                            "maximum": 65535,
+                            "minimum": 1,
+                            "type": "integer"
+                          },
+                          "routes": {
+                            "description": "routes are the routes associated with this interface.",
+                            "items": {
+                              "description": "RouteSpec describes an IPv4/IPv6 Route.",
+                              "properties": {
+                                "is6": {
+                                  "description": "is6 defines if a RouteSpec is IPv6.\nIt is only required to disambiguate a 'default'|'all' placeholder 'to'\nwhen 'via' is unset, otherwise the family is derived from 'via'.",
+                                  "type": "boolean"
+                                },
+                                "metric": {
+                                  "description": "metric is the priority of the route in the routing table.",
+                                  "format": "int32",
+                                  "minimum": 0,
+                                  "type": "integer"
+                                },
+                                "table": {
+                                  "description": "table is the routing table used for this route.",
+                                  "format": "int32",
+                                  "type": "integer"
+                                },
+                                "to": {
+                                  "description": "to is the subnet to be routed.",
+                                  "type": "string"
+                                },
+                                "via": {
+                                  "description": "via is the gateway to the subnet.",
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "minItems": 1,
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "routingPolicy": {
+                            "description": "routingPolicy is an interface-specific policy inserted into FIB (forwarding information base).",
+                            "items": {
+                              "description": "RoutingPolicySpec is a Linux FIB rule.",
+                              "properties": {
+                                "from": {
+                                  "description": "from is the subnet of the source.",
+                                  "type": "string"
+                                },
+                                "is6": {
+                                  "description": "is6 defines if a RoutingPolicySpec is IPv6.\nIt is only required to disambiguate a 'default'|'all' placeholder when\nneither 'to' nor 'from' carries a concrete address to derive the family.",
+                                  "type": "boolean"
+                                },
+                                "priority": {
+                                  "description": "priority is the position in the ip rule FIB table.",
+                                  "format": "int64",
+                                  "maximum": 4294967295,
+                                  "type": "integer",
+                                  "x-kubernetes-validations": [
+                                    {
+                                      "message": "Cowardly refusing to insert FIB rule matching kernel rules",
+                                      "rule": "(self > 0 && self < 32765) || (self > 32766)"
+                                    }
+                                  ]
+                                },
+                                "table": {
+                                  "description": "table is the routing table ID.",
+                                  "format": "int32",
+                                  "type": "integer"
+                                },
+                                "to": {
+                                  "description": "to is the subnet of the target.",
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "minItems": 1,
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "vlan": {
+                            "description": "vlan is the network L2 VLAN.",
+                            "format": "int32",
+                            "maximum": 4094,
+                            "minimum": 1,
+                            "type": "integer"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array",
+                      "x-kubernetes-list-map-keys": [
+                        "name"
+                      ],
+                      "x-kubernetes-list-type": "map"
+                    },
+                    "vrfs": {
+                      "description": "vrfs defines VRF Devices.",
+                      "items": {
+                        "description": "VRFDevice defines Virtual Routing Flow devices.",
+                        "properties": {
+                          "interfaces": {
+                            "description": "interfaces is the list of proxmox network devices managed by this virtual device.",
+                            "items": {
+                              "description": "NetName is a formally verified Proxmox network name string.",
+                              "minLength": 4,
+                              "pattern": "^net[0-9]+$",
+                              "type": "string"
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "name": {
+                            "description": "name is the virtual network device name.\nMust be unique within the virtual machine.",
+                            "minLength": 3,
+                            "type": "string"
+                          },
+                          "routes": {
+                            "description": "routes are the routes associated with this interface.",
+                            "items": {
+                              "description": "RouteSpec describes an IPv4/IPv6 Route.",
+                              "properties": {
+                                "is6": {
+                                  "description": "is6 defines if a RouteSpec is IPv6.\nIt is only required to disambiguate a 'default'|'all' placeholder 'to'\nwhen 'via' is unset, otherwise the family is derived from 'via'.",
+                                  "type": "boolean"
+                                },
+                                "metric": {
+                                  "description": "metric is the priority of the route in the routing table.",
+                                  "format": "int32",
+                                  "minimum": 0,
+                                  "type": "integer"
+                                },
+                                "table": {
+                                  "description": "table is the routing table used for this route.",
+                                  "format": "int32",
+                                  "type": "integer"
+                                },
+                                "to": {
+                                  "description": "to is the subnet to be routed.",
+                                  "type": "string"
+                                },
+                                "via": {
+                                  "description": "via is the gateway to the subnet.",
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "minItems": 1,
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "routingPolicy": {
+                            "description": "routingPolicy is an interface-specific policy inserted into FIB (forwarding information base).",
+                            "items": {
+                              "description": "RoutingPolicySpec is a Linux FIB rule.",
+                              "properties": {
+                                "from": {
+                                  "description": "from is the subnet of the source.",
+                                  "type": "string"
+                                },
+                                "is6": {
+                                  "description": "is6 defines if a RoutingPolicySpec is IPv6.\nIt is only required to disambiguate a 'default'|'all' placeholder when\nneither 'to' nor 'from' carries a concrete address to derive the family.",
+                                  "type": "boolean"
+                                },
+                                "priority": {
+                                  "description": "priority is the position in the ip rule FIB table.",
+                                  "format": "int64",
+                                  "maximum": 4294967295,
+                                  "type": "integer",
+                                  "x-kubernetes-validations": [
+                                    {
+                                      "message": "Cowardly refusing to insert FIB rule matching kernel rules",
+                                      "rule": "(self > 0 && self < 32765) || (self > 32766)"
+                                    }
+                                  ]
+                                },
+                                "table": {
+                                  "description": "table is the routing table ID.",
+                                  "format": "int32",
+                                  "type": "integer"
+                                },
+                                "to": {
+                                  "description": "to is the subnet of the target.",
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "minItems": 1,
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "table": {
+                            "description": "table is the ID of the routing table used for the l3mdev vrf device.",
+                            "format": "int32",
+                            "maximum": 4294967295,
+                            "minimum": 1,
+                            "type": "integer",
+                            "x-kubernetes-validations": [
+                              {
+                                "message": "Cowardly refusing to insert l3mdev rules into kernel tables",
+                                "rule": "(self > 0 && self < 254) || (self > 255)"
+                              }
+                            ]
+                          }
+                        },
+                        "required": [
+                          "name",
+                          "table"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array",
+                      "x-kubernetes-list-map-keys": [
+                        "name"
+                      ],
+                      "x-kubernetes-list-type": "map"
+                    },
+                    "zone": {
+                      "description": "zone is the cluster deployment zone this machine will refer to.",
+                      "pattern": "^[a-z0-9A-Z](?:[a-z0-9A-Z-_.]{0,61}[a-z0-9A-Z])?$",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "networkDevices"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "numCores": {
+                  "description": "numCores is the number of cores per CPU socket in a virtual machine.\nDefaults to the property value in the template from which the virtual machine is cloned.",
+                  "format": "int32",
+                  "minimum": 1,
+                  "type": "integer"
+                },
+                "numSockets": {
+                  "description": "numSockets is the number of CPU sockets in a virtual machine.\nDefaults to the property value in the template from which the virtual machine is cloned.",
+                  "format": "int32",
+                  "minimum": 1,
+                  "type": "integer"
+                },
+                "pool": {
+                  "description": "pool Add the new VM to the specified pool.",
+                  "type": "string"
+                },
+                "providerID": {
+                  "description": "providerID is the virtual machine BIOS UUID formatted as\nproxmox://6c3fa683-bef9-4425-b413-eaa45a9d6191",
+                  "maxLength": 46,
+                  "minLength": 46,
+                  "pattern": "^proxmox://[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
+                  "type": "string"
+                },
+                "snapName": {
+                  "description": "snapName is the name of the snapshot.",
+                  "type": "string"
+                },
+                "sourceNode": {
+                  "description": "sourceNode is the initially selected proxmox node.\nThis node will be used to locate the template VM, which will\nbe used for cloning operations.\n\nCloning will be performed according to the configuration.\nSetting the `Target` field will tell Proxmox to clone the\nVM on that target node.\n\nWhen Target is not set and the ProxmoxCluster contains\na set of `AllowedNodes`, the algorithm will instead evenly\ndistribute the VMs across the nodes from that list.\n\nIf neither a `Target` nor `AllowedNodes` was set, the VM\nwill be cloned onto the same node as SourceNode.",
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "storage": {
+                  "description": "storage for full clone.",
+                  "type": "string"
+                },
+                "tags": {
+                  "description": "tags is a list of tags to be applied to the virtual machine.",
+                  "items": {
+                    "pattern": "^(?i)[a-z0-9_][a-z0-9_\\-\\+\\.]*$",
+                    "type": "string"
+                  },
+                  "minItems": 1,
+                  "type": "array",
+                  "x-kubernetes-list-type": "set"
+                },
+                "templateID": {
+                  "description": "templateID the vm_template vmid used for cloning a new VM.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "templateSelector": {
+                  "description": "templateSelector defines MatchTags for looking up VM templates.\nIf a templateID is defined, templateSelector will be ignored.",
+                  "properties": {
+                    "matchPolicy": {
+                      "default": "exact",
+                      "description": "matchPolicy controls how MatchTags are evaluated against template tags.\nWhen not set, or set to \"exact\", the behaviour is identical to the previous implementation\nand requires an exact 1:1 tag match. When set to \"subset\", the template's tags must contain\nall MatchTags, but may include additional tags.",
+                      "enum": [
+                        "exact",
+                        "uniqueSubset",
+                        "bestSubset"
+                      ],
+                      "type": "string"
+                    },
+                    "matchTags": {
+                      "description": "matchTags specifies all tags to look for when looking up the VM template.\nPassed tags must be an exact 1:1 match with the tags on the template you want to use.\nIf multiple VM templates with the same set of tags are found, provisioning will fail.",
+                      "items": {
+                        "pattern": "^(?i)[a-z0-9_][a-z0-9_\\-\\+\\.]*$",
+                        "type": "string"
+                      },
+                      "minItems": 1,
+                      "type": "array",
+                      "x-kubernetes-list-type": "set"
+                    }
+                  },
+                  "required": [
+                    "matchTags"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "virtualMachineID": {
+                  "description": "virtualMachineID is the Proxmox identifier for the ProxmoxMachine VM.",
+                  "format": "int64",
+                  "type": "integer"
+                },
+                "vmIDRange": {
+                  "description": "vmIDRange is the range of VMIDs to use for VMs.",
+                  "properties": {
+                    "end": {
+                      "description": "end is the end of the VMID range to use for VMs.\nOnly used if VMIDRangeStart is set.",
+                      "format": "int64",
+                      "maximum": 999999999,
+                      "minimum": 100,
+                      "type": "integer"
+                    },
+                    "start": {
+                      "description": "start is the start of the VMID range to use for VMs.",
+                      "format": "int64",
+                      "maximum": 999999999,
+                      "minimum": 100,
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "end",
+                    "start"
+                  ],
+                  "type": "object",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "end should be greater than or equal to start",
+                      "rule": "self.end >= self.start"
+                    }
+                  ],
+                  "additionalProperties": false
+                }
+              },
+              "required": [
+                "network"
+              ],
+              "type": "object",
+              "x-kubernetes-validations": [
+                {
+                  "message": "Must set full=true when specifying format",
+                  "rule": "self.full || !has(self.format)"
+                },
+                {
+                  "message": "Must set full=true when specifying storage",
+                  "rule": "self.full || !has(self.storage)"
+                },
+                {
+                  "message": "Must specify either templateID or templateSelector",
+                  "rule": "has(self.templateSelector) || (has(self.templateID) && has(self.sourceNode))"
+                }
+              ],
+              "additionalProperties": false
+            }
+          },
+          "required": [
+            "spec"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "template"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "required": [
+    "spec"
+  ],
+  "type": "object"
+}


### PR DESCRIPTION
## Information

Adds JSON schemas for the [Cluster-API Provider for Proxmox VE (CAPMOX)](https://github.com/ionos-cloud/cluster-api-provider-proxmox) project's CRDs (`infrastructure.cluster.x-k8s.io` / `v1alpha1` & `v1alpha2`) :

- `ProxmoxCluster`
- `ProxmoxClusterTemplate`
- `ProxmoxMachine`
- `ProxmoxMachineTemplate`

Generated on a fresh `kind` cluster, Kubernetes version `v1.31.0`, Cluster-API provider `infrastructure-proxmox` version [`v0.9.0`](https://github.com/ionos-cloud/cluster-api-provider-proxmox/releases/tag/v0.9.0).

## PR Checklist

- [x] I generated these CRs using the [CRD Extractor tool](https://github.com/datreeio/CRDs-catalog?tab=readme-ov-file#crd-extractor). If I used a different method, I have described the method in this PR.
- [x] I am adding new schemas and included a link to the GitHub repository that contains the source of these schemas.
