### PR TITLE
chore: update karpenter.sh & karpenter.k8s.aws CRDs to v1.14.0

### DIFF
--- a/karpenter.k8s.aws/ec2nodeclass_v1.json
+++ b/karpenter.k8s.aws/ec2nodeclass_v1.json
@@ -259,9 +259,58 @@
             }
           ]
         },
+        "connectionTracking": {
+          "description": "ConnectionTracking configures idle connection tracking timeouts for\nENIs Karpenter provisions in the launch template. EFA-only interfaces\nare excluded. See ConnectionTracking.",
+          "properties": {
+            "tcpEstablishedTimeout": {
+              "description": "TCPEstablishedTimeout is the timeout (in seconds) for idle TCP connections\nin an established state.\nValue must be between 60 and 432,000 (5 days).\nIf unset, EC2 applies its default which is 350 seconds for Nitro v6\ninstance types (excluding P6e-GB200) and 432,000 seconds for other\ninstance types.",
+              "format": "int32",
+              "maximum": 432000,
+              "minimum": 60,
+              "type": "integer"
+            },
+            "udpStreamTimeout": {
+              "description": "UDPStreamTimeout is the timeout (in seconds) for idle UDP \"stream\" flows\nthat have seen more than one request-response transaction.\nValue must be between 60 and 180.\nIf unset, EC2 applies its default of 180 seconds.",
+              "format": "int32",
+              "maximum": 180,
+              "minimum": 60,
+              "type": "integer"
+            },
+            "udpTimeout": {
+              "description": "UDPTimeout is the timeout (in seconds) for idle UDP flows that have seen\ntraffic only in a single direction or a single request-response transaction.\nValue must be between 30 and 60.\nIf unset, EC2 applies its default of 30 seconds.",
+              "format": "int32",
+              "maximum": 60,
+              "minimum": 30,
+              "type": "integer"
+            }
+          },
+          "type": "object",
+          "x-kubernetes-validations": [
+            {
+              "message": "at least one of tcpEstablishedTimeout, udpStreamTimeout, or udpTimeout must be set",
+              "rule": "has(self.tcpEstablishedTimeout) || has(self.udpStreamTimeout) || has(self.udpTimeout)"
+            }
+          ],
+          "additionalProperties": false
+        },
         "context": {
           "description": "Context is a Reserved field in EC2 APIs\nhttps://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateFleet.html",
           "type": "string"
+        },
+        "cpuOptions": {
+          "description": "CPUOptions defines the CPU options for the instance.",
+          "properties": {
+            "nestedVirtualization": {
+              "description": "NestedVirtualization enables or disables nested virtualization on the instance.\nWhen enabled, Karpenter filters instance types to only those reporting\n\"nested-virtualization\" in ProcessorInfo.SupportedFeatures from DescribeInstanceTypes.",
+              "enum": [
+                "enabled",
+                "disabled"
+              ],
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
         },
         "detailedMonitoring": {
           "description": "DetailedMonitoring controls if detailed monitoring is enabled for instances that are launched",
@@ -476,6 +525,80 @@
             }
           },
           "type": "object",
+          "additionalProperties": false
+        },
+        "networkInterfaces": {
+          "description": "NetworkInterfaces specifies the network interface configurations to be attached to provisioned instances.",
+          "items": {
+            "description": "NetworkInterface specifies the configuration for a network interface to be attached\nto provisioned instances.",
+            "properties": {
+              "deviceIndex": {
+                "description": "DeviceIndex is the device index for the network interface attachment.",
+                "format": "int32",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "interfaceType": {
+                "description": "InterfaceType is the type of network interface. Valid values are \"interface\" and \"efa-only\".",
+                "enum": [
+                  "interface",
+                  "efa-only"
+                ],
+                "type": "string"
+              },
+              "networkCardIndex": {
+                "description": "NetworkCardIndex is the index of the network card to attach the interface to.",
+                "format": "int32",
+                "minimum": 0,
+                "type": "integer"
+              }
+            },
+            "required": [
+              "deviceIndex",
+              "interfaceType",
+              "networkCardIndex"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "maxItems": 150,
+          "type": "array",
+          "x-kubernetes-validations": [
+            {
+              "message": "networkInterfaces must include a primary interface with interfaceType='interface'",
+              "rule": "self.size() == 0 || self.exists(x, x.deviceIndex == 0 && x.networkCardIndex == 0 && x.interfaceType == 'interface')"
+            },
+            {
+              "message": "networkInterfaces must not have duplicate networkCardIndex and deviceIndex pairs, and can have at most one efa device per network card",
+              "rule": "self.all(x, self.filter(y, x.networkCardIndex == y.networkCardIndex && x.deviceIndex == y.deviceIndex).size() == 1 && (x.interfaceType != 'efa-only' || self.filter(y, x.networkCardIndex == y.networkCardIndex && y.interfaceType == 'efa-only').size() == 1))"
+            }
+          ]
+        },
+        "placementGroupSelector": {
+          "description": "PlacementGroupSelector defines the name or the id of the placement to resolve with the nodeclass.",
+          "properties": {
+            "id": {
+              "description": "ID is the placement group id in EC2",
+              "pattern": "^pg-[0-9a-z]+$",
+              "type": "string"
+            },
+            "name": {
+              "description": "Name is the placement group name in EC2",
+              "minLength": 1,
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "x-kubernetes-validations": [
+            {
+              "message": "expected at least one, got none, ['name', 'id']",
+              "rule": "has(self.name) || has(self.id)"
+            },
+            {
+              "message": "'name' and 'id' are mutually exclusive",
+              "rule": "!(has(self.name) && has(self.id))"
+            }
+          ],
           "additionalProperties": false
         },
         "role": {
@@ -756,6 +879,10 @@
               "instanceType": {
                 "description": "The instance type for the capacity reservation.",
                 "type": "string"
+              },
+              "interruptible": {
+                "description": "Indicates whether this capacity reservation is interruptible",
+                "type": "boolean"
               },
               "ownerID": {
                 "description": "The ID of the AWS account that owns the capacity reservation.",

--- a/karpenter.sh/nodeclaim_v1.json
+++ b/karpenter.sh/nodeclaim_v1.json
@@ -85,7 +85,7 @@
                   },
                   {
                     "message": "label domain \"karpenter.k8s.aws\" is restricted",
-                    "rule": "self in [\"karpenter.k8s.aws/instance-tenancy\", \"karpenter.k8s.aws/capacity-reservation-type\", \"karpenter.k8s.aws/capacity-reservation-id\", \"karpenter.k8s.aws/ec2nodeclass\", \"karpenter.k8s.aws/instance-encryption-in-transit-supported\", \"karpenter.k8s.aws/instance-category\", \"karpenter.k8s.aws/instance-hypervisor\", \"karpenter.k8s.aws/instance-family\", \"karpenter.k8s.aws/instance-generation\", \"karpenter.k8s.aws/instance-local-nvme\", \"karpenter.k8s.aws/instance-size\", \"karpenter.k8s.aws/instance-cpu\", \"karpenter.k8s.aws/instance-cpu-manufacturer\", \"karpenter.k8s.aws/instance-cpu-sustained-clock-speed-mhz\", \"karpenter.k8s.aws/instance-memory\", \"karpenter.k8s.aws/instance-ebs-bandwidth\", \"karpenter.k8s.aws/instance-network-bandwidth\", \"karpenter.k8s.aws/instance-gpu-name\", \"karpenter.k8s.aws/instance-gpu-manufacturer\", \"karpenter.k8s.aws/instance-gpu-count\", \"karpenter.k8s.aws/instance-gpu-memory\", \"karpenter.k8s.aws/instance-accelerator-name\", \"karpenter.k8s.aws/instance-accelerator-manufacturer\", \"karpenter.k8s.aws/instance-accelerator-count\", \"karpenter.k8s.aws/instance-capability-flex\"] || !self.find(\"^([^/]+)\").endsWith(\"karpenter.k8s.aws\")"
+                    "rule": "self in [\"karpenter.k8s.aws/instance-tenancy\", \"karpenter.k8s.aws/capacity-reservation-type\", \"karpenter.k8s.aws/capacity-reservation-id\", \"karpenter.k8s.aws/capacity-reservation-interruptible\", \"karpenter.k8s.aws/ec2nodeclass\", \"karpenter.k8s.aws/instance-encryption-in-transit-supported\", \"karpenter.k8s.aws/instance-category\", \"karpenter.k8s.aws/instance-hypervisor\", \"karpenter.k8s.aws/instance-family\", \"karpenter.k8s.aws/instance-generation\", \"karpenter.k8s.aws/instance-local-nvme\", \"karpenter.k8s.aws/instance-size\", \"karpenter.k8s.aws/instance-cpu\", \"karpenter.k8s.aws/instance-cpu-manufacturer\", \"karpenter.k8s.aws/instance-cpu-sustained-clock-speed-mhz\", \"karpenter.k8s.aws/instance-memory\", \"karpenter.k8s.aws/instance-ebs-bandwidth\", \"karpenter.k8s.aws/instance-network-bandwidth\", \"karpenter.k8s.aws/instance-gpu-name\", \"karpenter.k8s.aws/instance-gpu-manufacturer\", \"karpenter.k8s.aws/instance-gpu-count\", \"karpenter.k8s.aws/instance-gpu-memory\", \"karpenter.k8s.aws/instance-accelerator-name\", \"karpenter.k8s.aws/instance-accelerator-manufacturer\", \"karpenter.k8s.aws/instance-accelerator-count\", \"karpenter.k8s.aws/instance-capability-flex\", \"karpenter.k8s.aws/placement-group-id\", \"karpenter.k8s.aws/placement-group-partition\"] || !self.find(\"^([^/]+)\").endsWith(\"karpenter.k8s.aws\")"
                   }
                 ]
               },
@@ -129,6 +129,7 @@
           },
           "maxItems": 100,
           "type": "array",
+          "x-kubernetes-list-type": "atomic",
           "x-kubernetes-validations": [
             {
               "message": "requirements with operator 'In' must have a value defined",
@@ -168,7 +169,7 @@
           "additionalProperties": false
         },
         "startupTaints": {
-          "description": "StartupTaints are taints that are applied to nodes upon startup which are expected to be removed automatically\nwithin a short period of time, typically by a DaemonSet that tolerates the taint. These are commonly used by\ndaemonsets to allow initialization and enforce startup ordering.  StartupTaints are ignored for provisioning\npurposes in that pods are not required to tolerate a StartupTaint in order to have nodes provisioned for them.",
+          "description": "startupTaints are taints that are applied to nodes upon startup which are expected to be removed automatically\nwithin a short period of time, typically by a DaemonSet that tolerates the taint. These are commonly used by\ndaemonsets to allow initialization and enforce startup ordering.  StartupTaints are ignored for provisioning\npurposes in that pods are not required to tolerate a StartupTaint in order to have nodes provisioned for them.",
           "items": {
             "description": "The node this Taint is attached to has the \"effect\" on\nany pod that does not tolerate the Taint.",
             "properties": {
@@ -205,10 +206,11 @@
             "type": "object",
             "additionalProperties": false
           },
-          "type": "array"
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
         },
         "taints": {
-          "description": "Taints will be applied to the NodeClaim's node.",
+          "description": "taints will be applied to the NodeClaim's node.",
           "items": {
             "description": "The node this Taint is attached to has the \"effect\" on\nany pod that does not tolerate the Taint.",
             "properties": {
@@ -245,7 +247,8 @@
             "type": "object",
             "additionalProperties": false
           },
-          "type": "array"
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
         },
         "terminationGracePeriod": {
           "description": "TerminationGracePeriod is the maximum duration the controller will wait before forcefully deleting the pods on a node, measured from when deletion is first initiated.\n\nWarning: this feature takes precedence over a Pod's terminationGracePeriodSeconds value, and bypasses any blocked PDBs or the karpenter.sh/do-not-disrupt annotation.\n\nThis field is intended to be used by cluster administrators to enforce that nodes can be cycled within a given time period.\nWhen set, drifted nodes will begin draining even if there are pods blocking eviction. Draining will respect PDBs and the do-not-disrupt annotation until the TGP is reached.\n\nKarpenter will preemptively delete pods so their terminationGracePeriodSeconds align with the node's terminationGracePeriod.\nIf a pod would be terminated without being granted its full terminationGracePeriodSeconds prior to the node timeout,\nthat pod will be deleted at T = node timeout - pod terminationGracePeriodSeconds.\n\nThe feature can also be used to allow maximum time limits for long-running jobs which can delay node termination with preStop hooks.\nIf left undefined, the controller will wait indefinitely for pods to be drained.",
@@ -352,7 +355,11 @@
             "type": "object",
             "additionalProperties": false
           },
-          "type": "array"
+          "type": "array",
+          "x-kubernetes-list-map-keys": [
+            "type"
+          ],
+          "x-kubernetes-list-type": "map"
         },
         "imageID": {
           "description": "ImageID is an identifier for the image that runs on the node",

--- a/karpenter.sh/nodeoverlay_v1alpha1.json
+++ b/karpenter.sh/nodeoverlay_v1alpha1.json
@@ -46,7 +46,7 @@
           "type": "string"
         },
         "requirements": {
-          "description": "Requirements constrain when this NodeOverlay is applied during scheduling simulations.\nThese requirements can match:\n- Well-known labels (e.g., node.kubernetes.io/instance-type, karpenter.sh/nodepool)\n- Custom labels from NodePool's spec.template.labels",
+          "description": "requirements constrain when this NodeOverlay is applied during scheduling simulations.\nThese requirements can match:\n- Well-known labels (e.g., node.kubernetes.io/instance-type, karpenter.sh/nodepool)\n- Custom labels from NodePool's spec.template.labels",
           "items": {
             "description": "A node selector requirement is a selector that contains values, a key, an operator that relates the key and values\nto have at least that many values.",
             "properties": {
@@ -104,6 +104,7 @@
           },
           "maxItems": 100,
           "type": "array",
+          "x-kubernetes-list-type": "atomic",
           "x-kubernetes-validations": [
             {
               "message": "requirements with operator 'NotIn' must have a value defined",
@@ -196,7 +197,11 @@
             "type": "object",
             "additionalProperties": false
           },
-          "type": "array"
+          "type": "array",
+          "x-kubernetes-list-map-keys": [
+            "type"
+          ],
+          "x-kubernetes-list-type": "map"
         }
       },
       "type": "object",

--- a/karpenter.sh/nodepool_v1.json
+++ b/karpenter.sh/nodepool_v1.json
@@ -43,7 +43,7 @@
                     "type": "string"
                   },
                   "reasons": {
-                    "description": "Reasons is a list of disruption methods that this budget applies to. If Reasons is not set, this budget applies to all methods.\nOtherwise, this will apply to each reason defined.\nallowed reasons are Underutilized, Empty, and Drifted.",
+                    "description": "reasons is a list of disruption methods that this budget applies to. If Reasons is not set, this budget applies to all methods.\nOtherwise, this will apply to each reason defined.\nallowed reasons are Underutilized, Empty, and Drifted.",
                     "items": {
                       "description": "DisruptionReason defines valid reasons for disruption budgets.",
                       "enum": [
@@ -54,7 +54,8 @@
                       "type": "string"
                     },
                     "maxItems": 50,
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-type": "set"
                   },
                   "schedule": {
                     "description": "Schedule specifies when a budget begins being active, following\nthe upstream cronjob syntax. If omitted, the budget is always active.\nTimezones are not supported.\nThis field is required if Duration is set.",
@@ -70,6 +71,7 @@
               },
               "maxItems": 50,
               "type": "array",
+              "x-kubernetes-list-type": "atomic",
               "x-kubernetes-validations": [
                 {
                   "message": "'schedule' must be set with 'duration'",
@@ -84,10 +86,11 @@
             },
             "consolidationPolicy": {
               "default": "WhenEmptyOrUnderutilized",
-              "description": "ConsolidationPolicy describes which nodes Karpenter can disrupt through its consolidation\nalgorithm. This policy defaults to \"WhenEmptyOrUnderutilized\" if not specified\nWhen replicas is set, ConsolidationPolicy is simply ignored",
+              "description": "ConsolidationPolicy describes which nodes Karpenter can disrupt through its consolidation\nalgorithm. This policy defaults to \"WhenEmptyOrUnderutilized\" if not specified.\nValid values: \"WhenEmpty\", \"WhenEmptyOrUnderutilized\", \"Balanced\".\nWhen replicas is set, ConsolidationPolicy is simply ignored.",
               "enum": [
                 "WhenEmpty",
-                "WhenEmptyOrUnderutilized"
+                "WhenEmptyOrUnderutilized",
+                "Balanced"
               ],
               "type": "string"
             }
@@ -129,8 +132,9 @@
                   "additionalProperties": {
                     "type": "string"
                   },
-                  "description": "Annotations is an unstructured key value map stored with a resource that may be\nset by external tools to store and retrieve arbitrary metadata. They are not\nqueryable and should be preserved when modifying objects.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations",
-                  "type": "object"
+                  "description": "annotations is an unstructured key value map stored with a resource that may be\nset by external tools to store and retrieve arbitrary metadata. They are not\nqueryable and should be preserved when modifying objects.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations",
+                  "type": "object",
+                  "x-kubernetes-map-type": "granular"
                 },
                 "labels": {
                   "additionalProperties": {
@@ -138,9 +142,10 @@
                     "pattern": "^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$",
                     "type": "string"
                   },
-                  "description": "Map of string keys and values that can be used to organize and categorize\n(scope and select) objects. May match selectors of replication controllers\nand services.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels",
+                  "description": "labels is a map of string keys and values that can be used to organize and categorize\n(scope and select) objects. May match selectors of replication controllers\nand services.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels",
                   "maxProperties": 100,
                   "type": "object",
+                  "x-kubernetes-map-type": "atomic",
                   "x-kubernetes-validations": [
                     {
                       "message": "label domain \"karpenter.sh\" is restricted",
@@ -156,7 +161,7 @@
                     },
                     {
                       "message": "label domain \"karpenter.k8s.aws\" is restricted",
-                      "rule": "self.all(x, x in [\"karpenter.k8s.aws/instance-tenancy\", \"karpenter.k8s.aws/capacity-reservation-type\", \"karpenter.k8s.aws/capacity-reservation-id\", \"karpenter.k8s.aws/ec2nodeclass\", \"karpenter.k8s.aws/instance-encryption-in-transit-supported\", \"karpenter.k8s.aws/instance-category\", \"karpenter.k8s.aws/instance-hypervisor\", \"karpenter.k8s.aws/instance-family\", \"karpenter.k8s.aws/instance-generation\", \"karpenter.k8s.aws/instance-local-nvme\", \"karpenter.k8s.aws/instance-size\", \"karpenter.k8s.aws/instance-cpu\", \"karpenter.k8s.aws/instance-cpu-manufacturer\", \"karpenter.k8s.aws/instance-cpu-sustained-clock-speed-mhz\", \"karpenter.k8s.aws/instance-memory\", \"karpenter.k8s.aws/instance-ebs-bandwidth\", \"karpenter.k8s.aws/instance-network-bandwidth\", \"karpenter.k8s.aws/instance-gpu-name\", \"karpenter.k8s.aws/instance-gpu-manufacturer\", \"karpenter.k8s.aws/instance-gpu-count\", \"karpenter.k8s.aws/instance-gpu-memory\", \"karpenter.k8s.aws/instance-accelerator-name\", \"karpenter.k8s.aws/instance-accelerator-manufacturer\", \"karpenter.k8s.aws/instance-accelerator-count\", \"karpenter.k8s.aws/instance-capability-flex\"] || !x.find(\"^([^/]+)\").endsWith(\"karpenter.k8s.aws\"))"
+                      "rule": "self.all(x, x in [\"karpenter.k8s.aws/instance-tenancy\", \"karpenter.k8s.aws/capacity-reservation-type\", \"karpenter.k8s.aws/capacity-reservation-id\", \"karpenter.k8s.aws/capacity-reservation-interruptible\", \"karpenter.k8s.aws/capacity-reservation-interruptible\", \"karpenter.k8s.aws/ec2nodeclass\", \"karpenter.k8s.aws/instance-encryption-in-transit-supported\", \"karpenter.k8s.aws/instance-category\", \"karpenter.k8s.aws/instance-hypervisor\", \"karpenter.k8s.aws/instance-family\", \"karpenter.k8s.aws/instance-generation\", \"karpenter.k8s.aws/instance-local-nvme\", \"karpenter.k8s.aws/instance-size\", \"karpenter.k8s.aws/instance-cpu\", \"karpenter.k8s.aws/instance-cpu-manufacturer\", \"karpenter.k8s.aws/instance-cpu-sustained-clock-speed-mhz\", \"karpenter.k8s.aws/instance-memory\", \"karpenter.k8s.aws/instance-ebs-bandwidth\", \"karpenter.k8s.aws/instance-network-bandwidth\", \"karpenter.k8s.aws/instance-gpu-name\", \"karpenter.k8s.aws/instance-gpu-manufacturer\", \"karpenter.k8s.aws/instance-gpu-count\", \"karpenter.k8s.aws/instance-gpu-memory\", \"karpenter.k8s.aws/instance-accelerator-name\", \"karpenter.k8s.aws/instance-accelerator-manufacturer\", \"karpenter.k8s.aws/instance-accelerator-count\", \"karpenter.k8s.aws/instance-capability-flex\", \"karpenter.k8s.aws/placement-group-id\", \"karpenter.k8s.aws/placement-group-partition\"] || !x.find(\"^([^/]+)\").endsWith(\"karpenter.k8s.aws\"))"
                     }
                   ]
                 }
@@ -251,7 +256,7 @@
                           },
                           {
                             "message": "label domain \"karpenter.k8s.aws\" is restricted",
-                            "rule": "self in [\"karpenter.k8s.aws/instance-tenancy\", \"karpenter.k8s.aws/capacity-reservation-type\", \"karpenter.k8s.aws/capacity-reservation-id\", \"karpenter.k8s.aws/ec2nodeclass\", \"karpenter.k8s.aws/instance-encryption-in-transit-supported\", \"karpenter.k8s.aws/instance-category\", \"karpenter.k8s.aws/instance-hypervisor\", \"karpenter.k8s.aws/instance-family\", \"karpenter.k8s.aws/instance-generation\", \"karpenter.k8s.aws/instance-local-nvme\", \"karpenter.k8s.aws/instance-size\", \"karpenter.k8s.aws/instance-cpu\", \"karpenter.k8s.aws/instance-cpu-manufacturer\", \"karpenter.k8s.aws/instance-cpu-sustained-clock-speed-mhz\", \"karpenter.k8s.aws/instance-memory\", \"karpenter.k8s.aws/instance-ebs-bandwidth\", \"karpenter.k8s.aws/instance-network-bandwidth\", \"karpenter.k8s.aws/instance-gpu-name\", \"karpenter.k8s.aws/instance-gpu-manufacturer\", \"karpenter.k8s.aws/instance-gpu-count\", \"karpenter.k8s.aws/instance-gpu-memory\", \"karpenter.k8s.aws/instance-accelerator-name\", \"karpenter.k8s.aws/instance-accelerator-manufacturer\", \"karpenter.k8s.aws/instance-accelerator-count\", \"karpenter.k8s.aws/instance-capability-flex\"] || !self.find(\"^([^/]+)\").endsWith(\"karpenter.k8s.aws\")"
+                            "rule": "self in [\"karpenter.k8s.aws/instance-tenancy\", \"karpenter.k8s.aws/capacity-reservation-type\", \"karpenter.k8s.aws/capacity-reservation-id\", \"karpenter.k8s.aws/capacity-reservation-interruptible\", \"karpenter.k8s.aws/ec2nodeclass\", \"karpenter.k8s.aws/instance-encryption-in-transit-supported\", \"karpenter.k8s.aws/instance-category\", \"karpenter.k8s.aws/instance-hypervisor\", \"karpenter.k8s.aws/instance-family\", \"karpenter.k8s.aws/instance-generation\", \"karpenter.k8s.aws/instance-local-nvme\", \"karpenter.k8s.aws/instance-size\", \"karpenter.k8s.aws/instance-cpu\", \"karpenter.k8s.aws/instance-cpu-manufacturer\", \"karpenter.k8s.aws/instance-cpu-sustained-clock-speed-mhz\", \"karpenter.k8s.aws/instance-memory\", \"karpenter.k8s.aws/instance-ebs-bandwidth\", \"karpenter.k8s.aws/instance-network-bandwidth\", \"karpenter.k8s.aws/instance-gpu-name\", \"karpenter.k8s.aws/instance-gpu-manufacturer\", \"karpenter.k8s.aws/instance-gpu-count\", \"karpenter.k8s.aws/instance-gpu-memory\", \"karpenter.k8s.aws/instance-accelerator-name\", \"karpenter.k8s.aws/instance-accelerator-manufacturer\", \"karpenter.k8s.aws/instance-accelerator-count\", \"karpenter.k8s.aws/instance-capability-flex\", \"karpenter.k8s.aws/placement-group-id\", \"karpenter.k8s.aws/placement-group-partition\"] || !self.find(\"^([^/]+)\").endsWith(\"karpenter.k8s.aws\")"
                           }
                         ]
                       },
@@ -295,6 +300,7 @@
                   },
                   "maxItems": 100,
                   "type": "array",
+                  "x-kubernetes-list-type": "atomic",
                   "x-kubernetes-validations": [
                     {
                       "message": "requirements with operator 'In' must have a value defined",
@@ -311,7 +317,7 @@
                   ]
                 },
                 "startupTaints": {
-                  "description": "StartupTaints are taints that are applied to nodes upon startup which are expected to be removed automatically\nwithin a short period of time, typically by a DaemonSet that tolerates the taint. These are commonly used by\ndaemonsets to allow initialization and enforce startup ordering.  StartupTaints are ignored for provisioning\npurposes in that pods are not required to tolerate a StartupTaint in order to have nodes provisioned for them.",
+                  "description": "startupTaints are taints that are applied to nodes upon startup which are expected to be removed automatically\nwithin a short period of time, typically by a DaemonSet that tolerates the taint. These are commonly used by\ndaemonsets to allow initialization and enforce startup ordering.  StartupTaints are ignored for provisioning\npurposes in that pods are not required to tolerate a StartupTaint in order to have nodes provisioned for them.",
                   "items": {
                     "description": "The node this Taint is attached to has the \"effect\" on\nany pod that does not tolerate the Taint.",
                     "properties": {
@@ -348,10 +354,11 @@
                     "type": "object",
                     "additionalProperties": false
                   },
-                  "type": "array"
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
                 },
                 "taints": {
-                  "description": "Taints will be applied to the NodeClaim's node.",
+                  "description": "taints will be applied to the NodeClaim's node.",
                   "items": {
                     "description": "The node this Taint is attached to has the \"effect\" on\nany pod that does not tolerate the Taint.",
                     "properties": {
@@ -388,7 +395,8 @@
                     "type": "object",
                     "additionalProperties": false
                   },
-                  "type": "array"
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
                 },
                 "terminationGracePeriod": {
                   "description": "TerminationGracePeriod is the maximum duration the controller will wait before forcefully deleting the pods on a node, measured from when deletion is first initiated.\n\nWarning: this feature takes precedence over a Pod's terminationGracePeriodSeconds value, and bypasses any blocked PDBs or the karpenter.sh/do-not-disrupt annotation.\n\nThis field is intended to be used by cluster administrators to enforce that nodes can be cycled within a given time period.\nWhen set, drifted nodes will begin draining even if there are pods blocking eviction. Draining will respect PDBs and the do-not-disrupt annotation until the TGP is reached.\n\nKarpenter will preemptively delete pods so their terminationGracePeriodSeconds align with the node's terminationGracePeriod.\nIf a pod would be terminated without being granted its full terminationGracePeriodSeconds prior to the node timeout,\nthat pod will be deleted at T = node timeout - pod terminationGracePeriodSeconds.\n\nThe feature can also be used to allow maximum time limits for long-running jobs which can delay node termination with preStop hooks.\nIf left undefined, the controller will wait indefinitely for pods to be drained.",
@@ -495,7 +503,11 @@
             "type": "object",
             "additionalProperties": false
           },
-          "type": "array"
+          "type": "array",
+          "x-kubernetes-list-map-keys": [
+            "type"
+          ],
+          "x-kubernetes-list-type": "map"
         },
         "nodeClassObservedGeneration": {
           "description": "NodeClassObservedGeneration represents the observed nodeClass generation for referenced nodeClass. If this does not match\nthe actual NodeClass Generation, NodeRegistrationHealthy status condition on the NodePool will be reset",


### PR DESCRIPTION
## Summary
Updates Karpenter schemas to **v1.14.0**, including the new NodePool `consolidationPolicy: Balanced` enum value (plus related NodeClaim / EC2NodeClass / NodeOverlay schema refreshes).

Without this, kubeconform against the catalog rejects valid 1.14 manifests with:
`value must be one of 'WhenEmpty', 'WhenEmptyOrUnderutilized'`.

## PR Checklist
- [x] I generated these CRs using the [CRD Extractor tool](https://github.com/datreeio/CRDs-catalog?tab=readme-ov-file#crd-extractor) (openapi2jsonschema.py from kubeconform against live CRDs). If I used a different method, I have described the method in this PR.
- [x] I am updating existing schemas and have specified the updated schema version (**Karpenter 1.14.0**).
- [ ] I am adding new schemas and included a link to the GitHub repository that contains the source of these schemas.

## Source
- Extracted from a cluster running `public.ecr.aws/karpenter/controller:1.14.0`
- Upstream CRDs: https://github.com/aws/karpenter-provider-aws / https://github.com/kubernetes-sigs/karpenter
- Files updated:
  - `karpenter.sh/nodepool_v1.json`
  - `karpenter.sh/nodeclaim_v1.json`
  - `karpenter.sh/nodeoverlay_v1alpha1.json`
  - `karpenter.k8s.aws/ec2nodeclass_v1.json`