### PR TITLE
feat(external-snapshotter): add groupsnapshot.storage.k8s.io CRD:s

### DIFF
--- a/groupsnapshot.storage.k8s.io/volumegroupsnapshot_v1.json
+++ b/groupsnapshot.storage.k8s.io/volumegroupsnapshot_v1.json
@@ -1,0 +1,166 @@
+{
+  "description": "VolumeGroupSnapshot is a user's request for creating either a point-in-time\ngroup snapshot or binding to a pre-existing group snapshot.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "Spec defines the desired characteristics of a group snapshot requested by a user.\nRequired.",
+      "properties": {
+        "source": {
+          "description": "Source specifies where a group snapshot will be created from.\nThis field is immutable after creation.\nRequired.",
+          "properties": {
+            "selector": {
+              "description": "Selector is a label query over persistent volume claims that are to be\ngrouped together for snapshotting.\nThis labelSelector will be used to match the label added to a PVC.\nIf the label is added or removed to a volume after a group snapshot\nis created, the existing group snapshots won't be modified.\nOnce a VolumeGroupSnapshotContent is created and the sidecar starts to process\nit, the volume list will not change with retries.",
+              "properties": {
+                "matchExpressions": {
+                  "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                  "items": {
+                    "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                    "properties": {
+                      "key": {
+                        "description": "key is the label key that the selector applies to.",
+                        "type": "string"
+                      },
+                      "operator": {
+                        "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                        "type": "string"
+                      },
+                      "values": {
+                        "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
+                      }
+                    },
+                    "required": [
+                      "key",
+                      "operator"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
+                },
+                "matchLabels": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                  "type": "object"
+                }
+              },
+              "type": "object",
+              "x-kubernetes-map-type": "atomic",
+              "x-kubernetes-validations": [
+                {
+                  "message": "selector is immutable",
+                  "rule": "self == oldSelf"
+                }
+              ],
+              "additionalProperties": false
+            },
+            "volumeGroupSnapshotContentName": {
+              "description": "VolumeGroupSnapshotContentName specifies the name of a pre-existing VolumeGroupSnapshotContent\nobject representing an existing volume group snapshot.\nThis field should be set if the volume group snapshot already exists and\nonly needs a representation in Kubernetes.\nThis field is immutable.",
+              "type": "string",
+              "x-kubernetes-validations": [
+                {
+                  "message": "volumeGroupSnapshotContentName is immutable",
+                  "rule": "self == oldSelf"
+                }
+              ]
+            }
+          },
+          "type": "object",
+          "x-kubernetes-validations": [
+            {
+              "message": "selector is required once set",
+              "rule": "!has(oldSelf.selector) || has(self.selector)"
+            },
+            {
+              "message": "volumeGroupSnapshotContentName is required once set",
+              "rule": "!has(oldSelf.volumeGroupSnapshotContentName) || has(self.volumeGroupSnapshotContentName)"
+            },
+            {
+              "message": "exactly one of selector and volumeGroupSnapshotContentName must be set",
+              "rule": "(has(self.selector) && !has(self.volumeGroupSnapshotContentName)) || (!has(self.selector) && has(self.volumeGroupSnapshotContentName))"
+            }
+          ],
+          "additionalProperties": false
+        },
+        "volumeGroupSnapshotClassName": {
+          "description": "VolumeGroupSnapshotClassName is the name of the VolumeGroupSnapshotClass\nrequested by the VolumeGroupSnapshot.\nVolumeGroupSnapshotClassName may be left nil to indicate that the default\nclass will be used.\nEmpty string is not allowed for this field.",
+          "type": "string",
+          "x-kubernetes-validations": [
+            {
+              "message": "volumeGroupSnapshotClassName must not be the empty string when set",
+              "rule": "size(self) > 0"
+            }
+          ]
+        }
+      },
+      "required": [
+        "source"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "Status represents the current information of a group snapshot.\nConsumers must verify binding between VolumeGroupSnapshot and\nVolumeGroupSnapshotContent objects is successful (by validating that both\nVolumeGroupSnapshot and VolumeGroupSnapshotContent point to each other) before\nusing this object.",
+      "properties": {
+        "boundVolumeGroupSnapshotContentName": {
+          "description": "BoundVolumeGroupSnapshotContentName is the name of the VolumeGroupSnapshotContent\nobject to which this VolumeGroupSnapshot object intends to bind to.\nIf not specified, it indicates that the VolumeGroupSnapshot object has not\nbeen successfully bound to a VolumeGroupSnapshotContent object yet.\nNOTE: To avoid possible security issues, consumers must verify binding between\nVolumeGroupSnapshot and VolumeGroupSnapshotContent objects is successful\n(by validating that both VolumeGroupSnapshot and VolumeGroupSnapshotContent\npoint at each other) before using this object.",
+          "type": "string",
+          "x-kubernetes-validations": [
+            {
+              "message": "boundVolumeGroupSnapshotContentName is immutable once set",
+              "rule": "self == oldSelf"
+            }
+          ]
+        },
+        "creationTime": {
+          "description": "CreationTime is the timestamp when the point-in-time group snapshot is taken\nby the underlying storage system.\nIf not specified, it may indicate that the creation time of the group snapshot\nis unknown.\nThis field is updated based on the CreationTime field in VolumeGroupSnapshotContentStatus",
+          "format": "date-time",
+          "type": "string"
+        },
+        "error": {
+          "description": "Error is the last observed error during group snapshot creation, if any.\nThis field could be helpful to upper level controllers (i.e., application\ncontroller) to decide whether they should continue on waiting for the group\nsnapshot to be created based on the type of error reported.\nThe snapshot controller will keep retrying when an error occurs during the\ngroup snapshot creation. Upon success, this error field will be cleared.",
+          "properties": {
+            "message": {
+              "description": "message is a string detailing the encountered error during snapshot\ncreation if specified.\nNOTE: message may be logged, and it should not contain sensitive\ninformation.",
+              "type": "string"
+            },
+            "time": {
+              "description": "time is the timestamp when the error was encountered.",
+              "format": "date-time",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "readyToUse": {
+          "description": "ReadyToUse indicates if all the individual snapshots in the group are ready\nto be used to restore a group of volumes.\nReadyToUse becomes true when ReadyToUse of all individual snapshots become true.\nIf not specified, it means the readiness of a group snapshot is unknown.",
+          "type": "boolean"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "required": [
+    "spec"
+  ],
+  "type": "object"
+}

--- a/groupsnapshot.storage.k8s.io/volumegroupsnapshot_v1alpha1.json
+++ b/groupsnapshot.storage.k8s.io/volumegroupsnapshot_v1alpha1.json
@@ -1,0 +1,166 @@
+{
+  "description": "VolumeGroupSnapshot is a user's request for creating either a point-in-time\ngroup snapshot or binding to a pre-existing group snapshot.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "Spec defines the desired characteristics of a group snapshot requested by a user.\nRequired.",
+      "properties": {
+        "source": {
+          "description": "Source specifies where a group snapshot will be created from.\nThis field is immutable after creation.\nRequired.",
+          "properties": {
+            "selector": {
+              "description": "Selector is a label query over persistent volume claims that are to be\ngrouped together for snapshotting.\nThis labelSelector will be used to match the label added to a PVC.\nIf the label is added or removed to a volume after a group snapshot\nis created, the existing group snapshots won't be modified.\nOnce a VolumeGroupSnapshotContent is created and the sidecar starts to process\nit, the volume list will not change with retries.",
+              "properties": {
+                "matchExpressions": {
+                  "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                  "items": {
+                    "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                    "properties": {
+                      "key": {
+                        "description": "key is the label key that the selector applies to.",
+                        "type": "string"
+                      },
+                      "operator": {
+                        "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                        "type": "string"
+                      },
+                      "values": {
+                        "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
+                      }
+                    },
+                    "required": [
+                      "key",
+                      "operator"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
+                },
+                "matchLabels": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                  "type": "object"
+                }
+              },
+              "type": "object",
+              "x-kubernetes-map-type": "atomic",
+              "x-kubernetes-validations": [
+                {
+                  "message": "selector is immutable",
+                  "rule": "self == oldSelf"
+                }
+              ],
+              "additionalProperties": false
+            },
+            "volumeGroupSnapshotContentName": {
+              "description": "VolumeGroupSnapshotContentName specifies the name of a pre-existing VolumeGroupSnapshotContent\nobject representing an existing volume group snapshot.\nThis field should be set if the volume group snapshot already exists and\nonly needs a representation in Kubernetes.\nThis field is immutable.",
+              "type": "string",
+              "x-kubernetes-validations": [
+                {
+                  "message": "volumeGroupSnapshotContentName is immutable",
+                  "rule": "self == oldSelf"
+                }
+              ]
+            }
+          },
+          "type": "object",
+          "x-kubernetes-validations": [
+            {
+              "message": "selector is required once set",
+              "rule": "!has(oldSelf.selector) || has(self.selector)"
+            },
+            {
+              "message": "volumeGroupSnapshotContentName is required once set",
+              "rule": "!has(oldSelf.volumeGroupSnapshotContentName) || has(self.volumeGroupSnapshotContentName)"
+            },
+            {
+              "message": "exactly one of selector and volumeGroupSnapshotContentName must be set",
+              "rule": "(has(self.selector) && !has(self.volumeGroupSnapshotContentName)) || (!has(self.selector) && has(self.volumeGroupSnapshotContentName))"
+            }
+          ],
+          "additionalProperties": false
+        },
+        "volumeGroupSnapshotClassName": {
+          "description": "VolumeGroupSnapshotClassName is the name of the VolumeGroupSnapshotClass\nrequested by the VolumeGroupSnapshot.\nVolumeGroupSnapshotClassName may be left nil to indicate that the default\nclass will be used.\nEmpty string is not allowed for this field.",
+          "type": "string",
+          "x-kubernetes-validations": [
+            {
+              "message": "volumeGroupSnapshotClassName must not be the empty string when set",
+              "rule": "size(self) > 0"
+            }
+          ]
+        }
+      },
+      "required": [
+        "source"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "Status represents the current information of a group snapshot.\nConsumers must verify binding between VolumeGroupSnapshot and\nVolumeGroupSnapshotContent objects is successful (by validating that both\nVolumeGroupSnapshot and VolumeGroupSnapshotContent point to each other) before\nusing this object.",
+      "properties": {
+        "boundVolumeGroupSnapshotContentName": {
+          "description": "BoundVolumeGroupSnapshotContentName is the name of the VolumeGroupSnapshotContent\nobject to which this VolumeGroupSnapshot object intends to bind to.\nIf not specified, it indicates that the VolumeGroupSnapshot object has not\nbeen successfully bound to a VolumeGroupSnapshotContent object yet.\nNOTE: To avoid possible security issues, consumers must verify binding between\nVolumeGroupSnapshot and VolumeGroupSnapshotContent objects is successful\n(by validating that both VolumeGroupSnapshot and VolumeGroupSnapshotContent\npoint at each other) before using this object.",
+          "type": "string",
+          "x-kubernetes-validations": [
+            {
+              "message": "boundVolumeGroupSnapshotContentName is immutable once set",
+              "rule": "self == oldSelf"
+            }
+          ]
+        },
+        "creationTime": {
+          "description": "CreationTime is the timestamp when the point-in-time group snapshot is taken\nby the underlying storage system.\nIf not specified, it may indicate that the creation time of the group snapshot\nis unknown.\nThis field is updated based on the CreationTime field in VolumeGroupSnapshotContentStatus",
+          "format": "date-time",
+          "type": "string"
+        },
+        "error": {
+          "description": "Error is the last observed error during group snapshot creation, if any.\nThis field could be helpful to upper level controllers (i.e., application\ncontroller) to decide whether they should continue on waiting for the group\nsnapshot to be created based on the type of error reported.\nThe snapshot controller will keep retrying when an error occurs during the\ngroup snapshot creation. Upon success, this error field will be cleared.",
+          "properties": {
+            "message": {
+              "description": "message is a string detailing the encountered error during snapshot\ncreation if specified.\nNOTE: message may be logged, and it should not contain sensitive\ninformation.",
+              "type": "string"
+            },
+            "time": {
+              "description": "time is the timestamp when the error was encountered.",
+              "format": "date-time",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "readyToUse": {
+          "description": "ReadyToUse indicates if all the individual snapshots in the group are ready\nto be used to restore a group of volumes.\nReadyToUse becomes true when ReadyToUse of all individual snapshots become true.\nIf not specified, it means the readiness of a group snapshot is unknown.",
+          "type": "boolean"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "required": [
+    "spec"
+  ],
+  "type": "object"
+}

--- a/groupsnapshot.storage.k8s.io/volumegroupsnapshot_v1beta2.json
+++ b/groupsnapshot.storage.k8s.io/volumegroupsnapshot_v1beta2.json
@@ -1,0 +1,166 @@
+{
+  "description": "VolumeGroupSnapshot is a user's request for creating either a point-in-time\ngroup snapshot or binding to a pre-existing group snapshot.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "Spec defines the desired characteristics of a group snapshot requested by a user.\nRequired.",
+      "properties": {
+        "source": {
+          "description": "Source specifies where a group snapshot will be created from.\nThis field is immutable after creation.\nRequired.",
+          "properties": {
+            "selector": {
+              "description": "Selector is a label query over persistent volume claims that are to be\ngrouped together for snapshotting.\nThis labelSelector will be used to match the label added to a PVC.\nIf the label is added or removed to a volume after a group snapshot\nis created, the existing group snapshots won't be modified.\nOnce a VolumeGroupSnapshotContent is created and the sidecar starts to process\nit, the volume list will not change with retries.",
+              "properties": {
+                "matchExpressions": {
+                  "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                  "items": {
+                    "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                    "properties": {
+                      "key": {
+                        "description": "key is the label key that the selector applies to.",
+                        "type": "string"
+                      },
+                      "operator": {
+                        "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                        "type": "string"
+                      },
+                      "values": {
+                        "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
+                      }
+                    },
+                    "required": [
+                      "key",
+                      "operator"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
+                },
+                "matchLabels": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                  "type": "object"
+                }
+              },
+              "type": "object",
+              "x-kubernetes-map-type": "atomic",
+              "x-kubernetes-validations": [
+                {
+                  "message": "selector is immutable",
+                  "rule": "self == oldSelf"
+                }
+              ],
+              "additionalProperties": false
+            },
+            "volumeGroupSnapshotContentName": {
+              "description": "VolumeGroupSnapshotContentName specifies the name of a pre-existing VolumeGroupSnapshotContent\nobject representing an existing volume group snapshot.\nThis field should be set if the volume group snapshot already exists and\nonly needs a representation in Kubernetes.\nThis field is immutable.",
+              "type": "string",
+              "x-kubernetes-validations": [
+                {
+                  "message": "volumeGroupSnapshotContentName is immutable",
+                  "rule": "self == oldSelf"
+                }
+              ]
+            }
+          },
+          "type": "object",
+          "x-kubernetes-validations": [
+            {
+              "message": "selector is required once set",
+              "rule": "!has(oldSelf.selector) || has(self.selector)"
+            },
+            {
+              "message": "volumeGroupSnapshotContentName is required once set",
+              "rule": "!has(oldSelf.volumeGroupSnapshotContentName) || has(self.volumeGroupSnapshotContentName)"
+            },
+            {
+              "message": "exactly one of selector and volumeGroupSnapshotContentName must be set",
+              "rule": "(has(self.selector) && !has(self.volumeGroupSnapshotContentName)) || (!has(self.selector) && has(self.volumeGroupSnapshotContentName))"
+            }
+          ],
+          "additionalProperties": false
+        },
+        "volumeGroupSnapshotClassName": {
+          "description": "VolumeGroupSnapshotClassName is the name of the VolumeGroupSnapshotClass\nrequested by the VolumeGroupSnapshot.\nVolumeGroupSnapshotClassName may be left nil to indicate that the default\nclass will be used.\nEmpty string is not allowed for this field.",
+          "type": "string",
+          "x-kubernetes-validations": [
+            {
+              "message": "volumeGroupSnapshotClassName must not be the empty string when set",
+              "rule": "size(self) > 0"
+            }
+          ]
+        }
+      },
+      "required": [
+        "source"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "Status represents the current information of a group snapshot.\nConsumers must verify binding between VolumeGroupSnapshot and\nVolumeGroupSnapshotContent objects is successful (by validating that both\nVolumeGroupSnapshot and VolumeGroupSnapshotContent point to each other) before\nusing this object.",
+      "properties": {
+        "boundVolumeGroupSnapshotContentName": {
+          "description": "BoundVolumeGroupSnapshotContentName is the name of the VolumeGroupSnapshotContent\nobject to which this VolumeGroupSnapshot object intends to bind to.\nIf not specified, it indicates that the VolumeGroupSnapshot object has not\nbeen successfully bound to a VolumeGroupSnapshotContent object yet.\nNOTE: To avoid possible security issues, consumers must verify binding between\nVolumeGroupSnapshot and VolumeGroupSnapshotContent objects is successful\n(by validating that both VolumeGroupSnapshot and VolumeGroupSnapshotContent\npoint at each other) before using this object.",
+          "type": "string",
+          "x-kubernetes-validations": [
+            {
+              "message": "boundVolumeGroupSnapshotContentName is immutable once set",
+              "rule": "self == oldSelf"
+            }
+          ]
+        },
+        "creationTime": {
+          "description": "CreationTime is the timestamp when the point-in-time group snapshot is taken\nby the underlying storage system.\nIf not specified, it may indicate that the creation time of the group snapshot\nis unknown.\nThis field is updated based on the CreationTime field in VolumeGroupSnapshotContentStatus",
+          "format": "date-time",
+          "type": "string"
+        },
+        "error": {
+          "description": "Error is the last observed error during group snapshot creation, if any.\nThis field could be helpful to upper level controllers (i.e., application\ncontroller) to decide whether they should continue on waiting for the group\nsnapshot to be created based on the type of error reported.\nThe snapshot controller will keep retrying when an error occurs during the\ngroup snapshot creation. Upon success, this error field will be cleared.",
+          "properties": {
+            "message": {
+              "description": "message is a string detailing the encountered error during snapshot\ncreation if specified.\nNOTE: message may be logged, and it should not contain sensitive\ninformation.",
+              "type": "string"
+            },
+            "time": {
+              "description": "time is the timestamp when the error was encountered.",
+              "format": "date-time",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "readyToUse": {
+          "description": "ReadyToUse indicates if all the individual snapshots in the group are ready\nto be used to restore a group of volumes.\nReadyToUse becomes true when ReadyToUse of all individual snapshots become true.\nIf not specified, it means the readiness of a group snapshot is unknown.",
+          "type": "boolean"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "required": [
+    "spec"
+  ],
+  "type": "object"
+}

--- a/groupsnapshot.storage.k8s.io/volumegroupsnapshotclass_v1.json
+++ b/groupsnapshot.storage.k8s.io/volumegroupsnapshotclass_v1.json
@@ -1,0 +1,58 @@
+{
+  "description": "VolumeGroupSnapshotClass specifies parameters that a underlying storage system\nuses when creating a volume group snapshot. A specific VolumeGroupSnapshotClass\nis used by specifying its name in a VolumeGroupSnapshot object.\nVolumeGroupSnapshotClasses are non-namespaced.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "deletionPolicy": {
+      "description": "DeletionPolicy determines whether a VolumeGroupSnapshotContent created\nthrough the VolumeGroupSnapshotClass should be deleted when its bound\nVolumeGroupSnapshot is deleted.\nSupported values are \"Retain\" and \"Delete\".\n\"Retain\" means that the VolumeGroupSnapshotContent and its physical group\nsnapshot on underlying storage system are kept.\n\"Delete\" means that the VolumeGroupSnapshotContent and its physical group\nsnapshot on underlying storage system are deleted.\nRequired.",
+      "enum": [
+        "Delete",
+        "Retain"
+      ],
+      "type": "string",
+      "x-kubernetes-validations": [
+        {
+          "message": "deletionPolicy is immutable once set",
+          "rule": "self == oldSelf"
+        }
+      ]
+    },
+    "driver": {
+      "description": "Driver is the name of the storage driver expected to handle this VolumeGroupSnapshotClass.\nRequired.",
+      "type": "string",
+      "x-kubernetes-validations": [
+        {
+          "message": "driver is immutable once set",
+          "rule": "self == oldSelf"
+        }
+      ]
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "parameters": {
+      "additionalProperties": {
+        "type": "string"
+      },
+      "description": "Parameters is a key-value map with storage driver specific parameters for\ncreating group snapshots.\nThese values are opaque to Kubernetes and are passed directly to the driver.",
+      "type": "object",
+      "x-kubernetes-validations": [
+        {
+          "message": "parameters are immutable once set",
+          "rule": "self == oldSelf"
+        }
+      ]
+    }
+  },
+  "required": [
+    "deletionPolicy",
+    "driver"
+  ],
+  "type": "object"
+}

--- a/groupsnapshot.storage.k8s.io/volumegroupsnapshotclass_v1alpha1.json
+++ b/groupsnapshot.storage.k8s.io/volumegroupsnapshotclass_v1alpha1.json
@@ -1,0 +1,58 @@
+{
+  "description": "VolumeGroupSnapshotClass specifies parameters that a underlying storage system\nuses when creating a volume group snapshot. A specific VolumeGroupSnapshotClass\nis used by specifying its name in a VolumeGroupSnapshot object.\nVolumeGroupSnapshotClasses are non-namespaced.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "deletionPolicy": {
+      "description": "DeletionPolicy determines whether a VolumeGroupSnapshotContent created\nthrough the VolumeGroupSnapshotClass should be deleted when its bound\nVolumeGroupSnapshot is deleted.\nSupported values are \"Retain\" and \"Delete\".\n\"Retain\" means that the VolumeGroupSnapshotContent and its physical group\nsnapshot on underlying storage system are kept.\n\"Delete\" means that the VolumeGroupSnapshotContent and its physical group\nsnapshot on underlying storage system are deleted.\nRequired.",
+      "enum": [
+        "Delete",
+        "Retain"
+      ],
+      "type": "string",
+      "x-kubernetes-validations": [
+        {
+          "message": "deletionPolicy is immutable once set",
+          "rule": "self == oldSelf"
+        }
+      ]
+    },
+    "driver": {
+      "description": "Driver is the name of the storage driver expected to handle this VolumeGroupSnapshotClass.\nRequired.",
+      "type": "string",
+      "x-kubernetes-validations": [
+        {
+          "message": "driver is immutable once set",
+          "rule": "self == oldSelf"
+        }
+      ]
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "parameters": {
+      "additionalProperties": {
+        "type": "string"
+      },
+      "description": "Parameters is a key-value map with storage driver specific parameters for\ncreating group snapshots.\nThese values are opaque to Kubernetes and are passed directly to the driver.",
+      "type": "object",
+      "x-kubernetes-validations": [
+        {
+          "message": "parameters are immutable once set",
+          "rule": "self == oldSelf"
+        }
+      ]
+    }
+  },
+  "required": [
+    "deletionPolicy",
+    "driver"
+  ],
+  "type": "object"
+}

--- a/groupsnapshot.storage.k8s.io/volumegroupsnapshotclass_v1beta2.json
+++ b/groupsnapshot.storage.k8s.io/volumegroupsnapshotclass_v1beta2.json
@@ -1,0 +1,58 @@
+{
+  "description": "VolumeGroupSnapshotClass specifies parameters that a underlying storage system\nuses when creating a volume group snapshot. A specific VolumeGroupSnapshotClass\nis used by specifying its name in a VolumeGroupSnapshot object.\nVolumeGroupSnapshotClasses are non-namespaced.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "deletionPolicy": {
+      "description": "DeletionPolicy determines whether a VolumeGroupSnapshotContent created\nthrough the VolumeGroupSnapshotClass should be deleted when its bound\nVolumeGroupSnapshot is deleted.\nSupported values are \"Retain\" and \"Delete\".\n\"Retain\" means that the VolumeGroupSnapshotContent and its physical group\nsnapshot on underlying storage system are kept.\n\"Delete\" means that the VolumeGroupSnapshotContent and its physical group\nsnapshot on underlying storage system are deleted.\nRequired.",
+      "enum": [
+        "Delete",
+        "Retain"
+      ],
+      "type": "string",
+      "x-kubernetes-validations": [
+        {
+          "message": "deletionPolicy is immutable once set",
+          "rule": "self == oldSelf"
+        }
+      ]
+    },
+    "driver": {
+      "description": "Driver is the name of the storage driver expected to handle this VolumeGroupSnapshotClass.\nRequired.",
+      "type": "string",
+      "x-kubernetes-validations": [
+        {
+          "message": "driver is immutable once set",
+          "rule": "self == oldSelf"
+        }
+      ]
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "parameters": {
+      "additionalProperties": {
+        "type": "string"
+      },
+      "description": "Parameters is a key-value map with storage driver specific parameters for\ncreating group snapshots.\nThese values are opaque to Kubernetes and are passed directly to the driver.",
+      "type": "object",
+      "x-kubernetes-validations": [
+        {
+          "message": "parameters are immutable once set",
+          "rule": "self == oldSelf"
+        }
+      ]
+    }
+  },
+  "required": [
+    "deletionPolicy",
+    "driver"
+  ],
+  "type": "object"
+}

--- a/groupsnapshot.storage.k8s.io/volumegroupsnapshotcontent_v1.json
+++ b/groupsnapshot.storage.k8s.io/volumegroupsnapshotcontent_v1.json
@@ -1,0 +1,248 @@
+{
+  "description": "VolumeGroupSnapshotContent represents the actual \"on-disk\" group snapshot object\nin the underlying storage system",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "Spec defines properties of a VolumeGroupSnapshotContent created by the underlying storage system.\nRequired.",
+      "properties": {
+        "deletionPolicy": {
+          "description": "DeletionPolicy determines whether this VolumeGroupSnapshotContent and the\nphysical group snapshot on the underlying storage system should be deleted\nwhen the bound VolumeGroupSnapshot is deleted.\nSupported values are \"Retain\" and \"Delete\".\n\"Retain\" means that the VolumeGroupSnapshotContent and its physical group\nsnapshot on underlying storage system are kept.\n\"Delete\" means that the VolumeGroupSnapshotContent and its physical group\nsnapshot on underlying storage system are deleted.\nFor dynamically provisioned group snapshots, this field will automatically\nbe filled in by the CSI snapshotter sidecar with the \"DeletionPolicy\" field\ndefined in the corresponding VolumeGroupSnapshotClass.\nFor pre-existing snapshots, users MUST specify this field when creating the\nVolumeGroupSnapshotContent object.\nRequired.",
+          "enum": [
+            "Delete",
+            "Retain"
+          ],
+          "type": "string"
+        },
+        "driver": {
+          "description": "Driver is the name of the CSI driver used to create the physical group snapshot on\nthe underlying storage system.\nThis MUST be the same as the name returned by the CSI GetPluginName() call for\nthat driver.\nRequired.",
+          "type": "string",
+          "x-kubernetes-validations": [
+            {
+              "message": "driver is immutable once set",
+              "rule": "self == oldSelf"
+            }
+          ]
+        },
+        "source": {
+          "description": "Source specifies whether the snapshot is (or should be) dynamically provisioned\nor already exists, and just requires a Kubernetes object representation.\nThis field is immutable after creation.\nRequired.",
+          "properties": {
+            "groupSnapshotHandles": {
+              "description": "GroupSnapshotHandles specifies the CSI \"group_snapshot_id\" of a pre-existing\ngroup snapshot and a list of CSI \"snapshot_id\" of pre-existing snapshots\non the underlying storage system for which a Kubernetes object\nrepresentation was (or should be) created.\nThis field is immutable.",
+              "properties": {
+                "volumeGroupSnapshotHandle": {
+                  "description": "VolumeGroupSnapshotHandle specifies the CSI \"group_snapshot_id\" of a pre-existing\ngroup snapshot on the underlying storage system for which a Kubernetes object\nrepresentation was (or should be) created.\nThis field is immutable.\nRequired.",
+                  "type": "string"
+                },
+                "volumeSnapshotHandles": {
+                  "description": "VolumeSnapshotHandles is a list of CSI \"snapshot_id\" of pre-existing\nsnapshots on the underlying storage system for which Kubernetes objects\nrepresentation were (or should be) created.\nThis field is immutable.\nRequired.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                }
+              },
+              "required": [
+                "volumeGroupSnapshotHandle",
+                "volumeSnapshotHandles"
+              ],
+              "type": "object",
+              "x-kubernetes-validations": [
+                {
+                  "message": "groupSnapshotHandles is immutable",
+                  "rule": "self == oldSelf"
+                }
+              ],
+              "additionalProperties": false
+            },
+            "volumeHandles": {
+              "description": "VolumeHandles is a list of volume handles on the backend to be snapshotted\ntogether. It is specified for dynamic provisioning of the VolumeGroupSnapshot.\nThis field is immutable.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array",
+              "x-kubernetes-validations": [
+                {
+                  "message": "volumeHandles is immutable",
+                  "rule": "self == oldSelf"
+                }
+              ]
+            }
+          },
+          "type": "object",
+          "x-kubernetes-validations": [
+            {
+              "message": "volumeHandles is required once set",
+              "rule": "!has(oldSelf.volumeHandles) || has(self.volumeHandles)"
+            },
+            {
+              "message": "groupSnapshotHandles is required once set",
+              "rule": "!has(oldSelf.groupSnapshotHandles) || has(self.groupSnapshotHandles)"
+            },
+            {
+              "message": "exactly one of volumeHandles and groupSnapshotHandles must be set",
+              "rule": "(has(self.volumeHandles) && !has(self.groupSnapshotHandles)) || (!has(self.volumeHandles) && has(self.groupSnapshotHandles))"
+            }
+          ],
+          "additionalProperties": false
+        },
+        "volumeGroupSnapshotClassName": {
+          "description": "VolumeGroupSnapshotClassName is the name of the VolumeGroupSnapshotClass from\nwhich this group snapshot was (or will be) created.\nNote that after provisioning, the VolumeGroupSnapshotClass may be deleted or\nrecreated with different set of values, and as such, should not be referenced\npost-snapshot creation.\nFor dynamic provisioning, this field must be set.\nThis field may be unset for pre-provisioned snapshots.",
+          "type": "string",
+          "x-kubernetes-validations": [
+            {
+              "message": "volumeGroupSnapshotClassName is immutable once set",
+              "rule": "self == oldSelf"
+            }
+          ]
+        },
+        "volumeGroupSnapshotRef": {
+          "description": "VolumeGroupSnapshotRef specifies the VolumeGroupSnapshot object to which this\nVolumeGroupSnapshotContent object is bound.\nVolumeGroupSnapshot.Spec.VolumeGroupSnapshotContentName field must reference to\nthis VolumeGroupSnapshotContent's name for the bidirectional binding to be valid.\nFor a pre-existing VolumeGroupSnapshotContent object, name and namespace of the\nVolumeGroupSnapshot object MUST be provided for binding to happen.\nThis field is immutable after creation.\nRequired.",
+          "properties": {
+            "apiVersion": {
+              "description": "API version of the referent.",
+              "type": "string"
+            },
+            "fieldPath": {
+              "description": "If referring to a piece of an object instead of an entire object, this string\nshould contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].\nFor example, if the object reference is to a container within a pod, this would take on a value like:\n\"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered\nthe event) or if no container name is specified \"spec.containers[2]\" (container with\nindex 2 in this pod). This syntax is chosen only to have some well-defined way of\nreferencing a part of an object.\nTODO: this design is not final and this field is subject to change in the future.",
+              "type": "string"
+            },
+            "kind": {
+              "description": "Kind of the referent.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+              "type": "string"
+            },
+            "name": {
+              "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+              "type": "string"
+            },
+            "namespace": {
+              "description": "Namespace of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+              "type": "string"
+            },
+            "resourceVersion": {
+              "description": "Specific resourceVersion to which this reference is made, if any.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+              "type": "string"
+            },
+            "uid": {
+              "description": "UID of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "x-kubernetes-map-type": "atomic",
+          "x-kubernetes-validations": [
+            {
+              "message": "both volumeGroupSnapshotRef.name and volumeGroupSnapshotRef.namespace must be set",
+              "rule": "has(self.name) && has(self.__namespace__)"
+            },
+            {
+              "message": "volumeGroupSnapshotRef.name and volumeGroupSnapshotRef.namespace are immutable",
+              "rule": "self.name == oldSelf.name && self.__namespace__ == oldSelf.__namespace__"
+            },
+            {
+              "message": "volumeGroupSnapshotRef.uid is immutable once set",
+              "rule": "!has(oldSelf.uid) || (has(self.uid) && self.uid == oldSelf.uid)"
+            }
+          ],
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "deletionPolicy",
+        "driver",
+        "source",
+        "volumeGroupSnapshotRef"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "status represents the current information of a group snapshot.",
+      "properties": {
+        "creationTime": {
+          "description": "CreationTime is the timestamp when the point-in-time group snapshot is taken\nby the underlying storage system.\nIf not specified, it indicates the creation time is unknown.\nIf not specified, it means the readiness of a group snapshot is unknown.\nThis field is the source for the CreationTime field in VolumeGroupSnapshotStatus",
+          "format": "date-time",
+          "type": "string"
+        },
+        "error": {
+          "description": "Error is the last observed error during group snapshot creation, if any.\nUpon success after retry, this error field will be cleared.",
+          "properties": {
+            "message": {
+              "description": "message is a string detailing the encountered error during snapshot\ncreation if specified.\nNOTE: message may be logged, and it should not contain sensitive\ninformation.",
+              "type": "string"
+            },
+            "time": {
+              "description": "time is the timestamp when the error was encountered.",
+              "format": "date-time",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "readyToUse": {
+          "description": "ReadyToUse indicates if all the individual snapshots in the group are ready to be\nused to restore a group of volumes.\nReadyToUse becomes true when ReadyToUse of all individual snapshots become true.",
+          "type": "boolean"
+        },
+        "volumeGroupSnapshotHandle": {
+          "description": "VolumeGroupSnapshotHandle is a unique id returned by the CSI driver\nto identify the VolumeGroupSnapshot on the storage system.\nIf a storage system does not provide such an id, the\nCSI driver can choose to return the VolumeGroupSnapshot name.",
+          "type": "string",
+          "x-kubernetes-validations": [
+            {
+              "message": "volumeGroupSnapshotHandle is immutable once set",
+              "rule": "self == oldSelf"
+            }
+          ]
+        },
+        "volumeSnapshotInfoList": {
+          "description": "This field is introduced in v1beta2\nIt is replacing VolumeSnapshotHandlePairList\nVolumeSnapshotInfoList is a list of snapshot information returned by\nby the CSI driver to identify snapshots on the storage system.",
+          "items": {
+            "description": "The VolumeSnapshotInfo struct is added in v1beta2\nVolumeSnapshotInfo contains information for a snapshot",
+            "properties": {
+              "creationTime": {
+                "description": "creationTime is the timestamp when the point-in-time snapshot is taken\nby the underlying storage system.",
+                "format": "int64",
+                "type": "integer"
+              },
+              "readyToUse": {
+                "description": "ReadyToUse indicates if the snapshot is ready to be used to restore a volume.",
+                "type": "boolean"
+              },
+              "restoreSize": {
+                "description": "RestoreSize represents the minimum size of volume required to create a volume\nfrom this snapshot.",
+                "format": "int64",
+                "type": "integer"
+              },
+              "snapshotHandle": {
+                "description": "SnapshotHandle is the CSI \"snapshot_id\" of this snapshot on the underlying storage system.",
+                "type": "string"
+              },
+              "volumeHandle": {
+                "description": "VolumeHandle specifies the CSI \"volume_id\" of the volume from which this snapshot\nwas taken from.",
+                "type": "string"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "required": [
+    "spec"
+  ],
+  "type": "object"
+}

--- a/groupsnapshot.storage.k8s.io/volumegroupsnapshotcontent_v1alpha1.json
+++ b/groupsnapshot.storage.k8s.io/volumegroupsnapshotcontent_v1alpha1.json
@@ -1,0 +1,248 @@
+{
+  "description": "VolumeGroupSnapshotContent represents the actual \"on-disk\" group snapshot object\nin the underlying storage system",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "Spec defines properties of a VolumeGroupSnapshotContent created by the underlying storage system.\nRequired.",
+      "properties": {
+        "deletionPolicy": {
+          "description": "DeletionPolicy determines whether this VolumeGroupSnapshotContent and the\nphysical group snapshot on the underlying storage system should be deleted\nwhen the bound VolumeGroupSnapshot is deleted.\nSupported values are \"Retain\" and \"Delete\".\n\"Retain\" means that the VolumeGroupSnapshotContent and its physical group\nsnapshot on underlying storage system are kept.\n\"Delete\" means that the VolumeGroupSnapshotContent and its physical group\nsnapshot on underlying storage system are deleted.\nFor dynamically provisioned group snapshots, this field will automatically\nbe filled in by the CSI snapshotter sidecar with the \"DeletionPolicy\" field\ndefined in the corresponding VolumeGroupSnapshotClass.\nFor pre-existing snapshots, users MUST specify this field when creating the\nVolumeGroupSnapshotContent object.\nRequired.",
+          "enum": [
+            "Delete",
+            "Retain"
+          ],
+          "type": "string"
+        },
+        "driver": {
+          "description": "Driver is the name of the CSI driver used to create the physical group snapshot on\nthe underlying storage system.\nThis MUST be the same as the name returned by the CSI GetPluginName() call for\nthat driver.\nRequired.",
+          "type": "string",
+          "x-kubernetes-validations": [
+            {
+              "message": "driver is immutable once set",
+              "rule": "self == oldSelf"
+            }
+          ]
+        },
+        "source": {
+          "description": "Source specifies whether the snapshot is (or should be) dynamically provisioned\nor already exists, and just requires a Kubernetes object representation.\nThis field is immutable after creation.\nRequired.",
+          "properties": {
+            "groupSnapshotHandles": {
+              "description": "GroupSnapshotHandles specifies the CSI \"group_snapshot_id\" of a pre-existing\ngroup snapshot and a list of CSI \"snapshot_id\" of pre-existing snapshots\non the underlying storage system for which a Kubernetes object\nrepresentation was (or should be) created.\nThis field is immutable.",
+              "properties": {
+                "volumeGroupSnapshotHandle": {
+                  "description": "VolumeGroupSnapshotHandle specifies the CSI \"group_snapshot_id\" of a pre-existing\ngroup snapshot on the underlying storage system for which a Kubernetes object\nrepresentation was (or should be) created.\nThis field is immutable.\nRequired.",
+                  "type": "string"
+                },
+                "volumeSnapshotHandles": {
+                  "description": "VolumeSnapshotHandles is a list of CSI \"snapshot_id\" of pre-existing\nsnapshots on the underlying storage system for which Kubernetes objects\nrepresentation were (or should be) created.\nThis field is immutable.\nRequired.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                }
+              },
+              "required": [
+                "volumeGroupSnapshotHandle",
+                "volumeSnapshotHandles"
+              ],
+              "type": "object",
+              "x-kubernetes-validations": [
+                {
+                  "message": "groupSnapshotHandles is immutable",
+                  "rule": "self == oldSelf"
+                }
+              ],
+              "additionalProperties": false
+            },
+            "volumeHandles": {
+              "description": "VolumeHandles is a list of volume handles on the backend to be snapshotted\ntogether. It is specified for dynamic provisioning of the VolumeGroupSnapshot.\nThis field is immutable.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array",
+              "x-kubernetes-validations": [
+                {
+                  "message": "volumeHandles is immutable",
+                  "rule": "self == oldSelf"
+                }
+              ]
+            }
+          },
+          "type": "object",
+          "x-kubernetes-validations": [
+            {
+              "message": "volumeHandles is required once set",
+              "rule": "!has(oldSelf.volumeHandles) || has(self.volumeHandles)"
+            },
+            {
+              "message": "groupSnapshotHandles is required once set",
+              "rule": "!has(oldSelf.groupSnapshotHandles) || has(self.groupSnapshotHandles)"
+            },
+            {
+              "message": "exactly one of volumeHandles and groupSnapshotHandles must be set",
+              "rule": "(has(self.volumeHandles) && !has(self.groupSnapshotHandles)) || (!has(self.volumeHandles) && has(self.groupSnapshotHandles))"
+            }
+          ],
+          "additionalProperties": false
+        },
+        "volumeGroupSnapshotClassName": {
+          "description": "VolumeGroupSnapshotClassName is the name of the VolumeGroupSnapshotClass from\nwhich this group snapshot was (or will be) created.\nNote that after provisioning, the VolumeGroupSnapshotClass may be deleted or\nrecreated with different set of values, and as such, should not be referenced\npost-snapshot creation.\nFor dynamic provisioning, this field must be set.\nThis field may be unset for pre-provisioned snapshots.",
+          "type": "string",
+          "x-kubernetes-validations": [
+            {
+              "message": "volumeGroupSnapshotClassName is immutable once set",
+              "rule": "self == oldSelf"
+            }
+          ]
+        },
+        "volumeGroupSnapshotRef": {
+          "description": "VolumeGroupSnapshotRef specifies the VolumeGroupSnapshot object to which this\nVolumeGroupSnapshotContent object is bound.\nVolumeGroupSnapshot.Spec.VolumeGroupSnapshotContentName field must reference to\nthis VolumeGroupSnapshotContent's name for the bidirectional binding to be valid.\nFor a pre-existing VolumeGroupSnapshotContent object, name and namespace of the\nVolumeGroupSnapshot object MUST be provided for binding to happen.\nThis field is immutable after creation.\nRequired.",
+          "properties": {
+            "apiVersion": {
+              "description": "API version of the referent.",
+              "type": "string"
+            },
+            "fieldPath": {
+              "description": "If referring to a piece of an object instead of an entire object, this string\nshould contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].\nFor example, if the object reference is to a container within a pod, this would take on a value like:\n\"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered\nthe event) or if no container name is specified \"spec.containers[2]\" (container with\nindex 2 in this pod). This syntax is chosen only to have some well-defined way of\nreferencing a part of an object.\nTODO: this design is not final and this field is subject to change in the future.",
+              "type": "string"
+            },
+            "kind": {
+              "description": "Kind of the referent.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+              "type": "string"
+            },
+            "name": {
+              "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+              "type": "string"
+            },
+            "namespace": {
+              "description": "Namespace of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+              "type": "string"
+            },
+            "resourceVersion": {
+              "description": "Specific resourceVersion to which this reference is made, if any.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+              "type": "string"
+            },
+            "uid": {
+              "description": "UID of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "x-kubernetes-map-type": "atomic",
+          "x-kubernetes-validations": [
+            {
+              "message": "both volumeGroupSnapshotRef.name and volumeGroupSnapshotRef.namespace must be set",
+              "rule": "has(self.name) && has(self.__namespace__)"
+            },
+            {
+              "message": "volumeGroupSnapshotRef.name and volumeGroupSnapshotRef.namespace are immutable",
+              "rule": "self.name == oldSelf.name && self.__namespace__ == oldSelf.__namespace__"
+            },
+            {
+              "message": "volumeGroupSnapshotRef.uid is immutable once set",
+              "rule": "!has(oldSelf.uid) || (has(self.uid) && self.uid == oldSelf.uid)"
+            }
+          ],
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "deletionPolicy",
+        "driver",
+        "source",
+        "volumeGroupSnapshotRef"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "status represents the current information of a group snapshot.",
+      "properties": {
+        "creationTime": {
+          "description": "CreationTime is the timestamp when the point-in-time group snapshot is taken\nby the underlying storage system.\nIf not specified, it indicates the creation time is unknown.\nIf not specified, it means the readiness of a group snapshot is unknown.\nThis field is the source for the CreationTime field in VolumeGroupSnapshotStatus",
+          "format": "date-time",
+          "type": "string"
+        },
+        "error": {
+          "description": "Error is the last observed error during group snapshot creation, if any.\nUpon success after retry, this error field will be cleared.",
+          "properties": {
+            "message": {
+              "description": "message is a string detailing the encountered error during snapshot\ncreation if specified.\nNOTE: message may be logged, and it should not contain sensitive\ninformation.",
+              "type": "string"
+            },
+            "time": {
+              "description": "time is the timestamp when the error was encountered.",
+              "format": "date-time",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "readyToUse": {
+          "description": "ReadyToUse indicates if all the individual snapshots in the group are ready to be\nused to restore a group of volumes.\nReadyToUse becomes true when ReadyToUse of all individual snapshots become true.",
+          "type": "boolean"
+        },
+        "volumeGroupSnapshotHandle": {
+          "description": "VolumeGroupSnapshotHandle is a unique id returned by the CSI driver\nto identify the VolumeGroupSnapshot on the storage system.\nIf a storage system does not provide such an id, the\nCSI driver can choose to return the VolumeGroupSnapshot name.",
+          "type": "string",
+          "x-kubernetes-validations": [
+            {
+              "message": "volumeGroupSnapshotHandle is immutable once set",
+              "rule": "self == oldSelf"
+            }
+          ]
+        },
+        "volumeSnapshotInfoList": {
+          "description": "This field is introduced in v1beta2\nIt is replacing VolumeSnapshotHandlePairList\nVolumeSnapshotInfoList is a list of snapshot information returned by\nby the CSI driver to identify snapshots on the storage system.",
+          "items": {
+            "description": "The VolumeSnapshotInfo struct is added in v1beta2\nVolumeSnapshotInfo contains information for a snapshot",
+            "properties": {
+              "creationTime": {
+                "description": "creationTime is the timestamp when the point-in-time snapshot is taken\nby the underlying storage system.",
+                "format": "int64",
+                "type": "integer"
+              },
+              "readyToUse": {
+                "description": "ReadyToUse indicates if the snapshot is ready to be used to restore a volume.",
+                "type": "boolean"
+              },
+              "restoreSize": {
+                "description": "RestoreSize represents the minimum size of volume required to create a volume\nfrom this snapshot.",
+                "format": "int64",
+                "type": "integer"
+              },
+              "snapshotHandle": {
+                "description": "SnapshotHandle is the CSI \"snapshot_id\" of this snapshot on the underlying storage system.",
+                "type": "string"
+              },
+              "volumeHandle": {
+                "description": "VolumeHandle specifies the CSI \"volume_id\" of the volume from which this snapshot\nwas taken from.",
+                "type": "string"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "required": [
+    "spec"
+  ],
+  "type": "object"
+}

--- a/groupsnapshot.storage.k8s.io/volumegroupsnapshotcontent_v1beta2.json
+++ b/groupsnapshot.storage.k8s.io/volumegroupsnapshotcontent_v1beta2.json
@@ -1,0 +1,248 @@
+{
+  "description": "VolumeGroupSnapshotContent represents the actual \"on-disk\" group snapshot object\nin the underlying storage system",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "Spec defines properties of a VolumeGroupSnapshotContent created by the underlying storage system.\nRequired.",
+      "properties": {
+        "deletionPolicy": {
+          "description": "DeletionPolicy determines whether this VolumeGroupSnapshotContent and the\nphysical group snapshot on the underlying storage system should be deleted\nwhen the bound VolumeGroupSnapshot is deleted.\nSupported values are \"Retain\" and \"Delete\".\n\"Retain\" means that the VolumeGroupSnapshotContent and its physical group\nsnapshot on underlying storage system are kept.\n\"Delete\" means that the VolumeGroupSnapshotContent and its physical group\nsnapshot on underlying storage system are deleted.\nFor dynamically provisioned group snapshots, this field will automatically\nbe filled in by the CSI snapshotter sidecar with the \"DeletionPolicy\" field\ndefined in the corresponding VolumeGroupSnapshotClass.\nFor pre-existing snapshots, users MUST specify this field when creating the\nVolumeGroupSnapshotContent object.\nRequired.",
+          "enum": [
+            "Delete",
+            "Retain"
+          ],
+          "type": "string"
+        },
+        "driver": {
+          "description": "Driver is the name of the CSI driver used to create the physical group snapshot on\nthe underlying storage system.\nThis MUST be the same as the name returned by the CSI GetPluginName() call for\nthat driver.\nRequired.",
+          "type": "string",
+          "x-kubernetes-validations": [
+            {
+              "message": "driver is immutable once set",
+              "rule": "self == oldSelf"
+            }
+          ]
+        },
+        "source": {
+          "description": "Source specifies whether the snapshot is (or should be) dynamically provisioned\nor already exists, and just requires a Kubernetes object representation.\nThis field is immutable after creation.\nRequired.",
+          "properties": {
+            "groupSnapshotHandles": {
+              "description": "GroupSnapshotHandles specifies the CSI \"group_snapshot_id\" of a pre-existing\ngroup snapshot and a list of CSI \"snapshot_id\" of pre-existing snapshots\non the underlying storage system for which a Kubernetes object\nrepresentation was (or should be) created.\nThis field is immutable.",
+              "properties": {
+                "volumeGroupSnapshotHandle": {
+                  "description": "VolumeGroupSnapshotHandle specifies the CSI \"group_snapshot_id\" of a pre-existing\ngroup snapshot on the underlying storage system for which a Kubernetes object\nrepresentation was (or should be) created.\nThis field is immutable.\nRequired.",
+                  "type": "string"
+                },
+                "volumeSnapshotHandles": {
+                  "description": "VolumeSnapshotHandles is a list of CSI \"snapshot_id\" of pre-existing\nsnapshots on the underlying storage system for which Kubernetes objects\nrepresentation were (or should be) created.\nThis field is immutable.\nRequired.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                }
+              },
+              "required": [
+                "volumeGroupSnapshotHandle",
+                "volumeSnapshotHandles"
+              ],
+              "type": "object",
+              "x-kubernetes-validations": [
+                {
+                  "message": "groupSnapshotHandles is immutable",
+                  "rule": "self == oldSelf"
+                }
+              ],
+              "additionalProperties": false
+            },
+            "volumeHandles": {
+              "description": "VolumeHandles is a list of volume handles on the backend to be snapshotted\ntogether. It is specified for dynamic provisioning of the VolumeGroupSnapshot.\nThis field is immutable.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array",
+              "x-kubernetes-validations": [
+                {
+                  "message": "volumeHandles is immutable",
+                  "rule": "self == oldSelf"
+                }
+              ]
+            }
+          },
+          "type": "object",
+          "x-kubernetes-validations": [
+            {
+              "message": "volumeHandles is required once set",
+              "rule": "!has(oldSelf.volumeHandles) || has(self.volumeHandles)"
+            },
+            {
+              "message": "groupSnapshotHandles is required once set",
+              "rule": "!has(oldSelf.groupSnapshotHandles) || has(self.groupSnapshotHandles)"
+            },
+            {
+              "message": "exactly one of volumeHandles and groupSnapshotHandles must be set",
+              "rule": "(has(self.volumeHandles) && !has(self.groupSnapshotHandles)) || (!has(self.volumeHandles) && has(self.groupSnapshotHandles))"
+            }
+          ],
+          "additionalProperties": false
+        },
+        "volumeGroupSnapshotClassName": {
+          "description": "VolumeGroupSnapshotClassName is the name of the VolumeGroupSnapshotClass from\nwhich this group snapshot was (or will be) created.\nNote that after provisioning, the VolumeGroupSnapshotClass may be deleted or\nrecreated with different set of values, and as such, should not be referenced\npost-snapshot creation.\nFor dynamic provisioning, this field must be set.\nThis field may be unset for pre-provisioned snapshots.",
+          "type": "string",
+          "x-kubernetes-validations": [
+            {
+              "message": "volumeGroupSnapshotClassName is immutable once set",
+              "rule": "self == oldSelf"
+            }
+          ]
+        },
+        "volumeGroupSnapshotRef": {
+          "description": "VolumeGroupSnapshotRef specifies the VolumeGroupSnapshot object to which this\nVolumeGroupSnapshotContent object is bound.\nVolumeGroupSnapshot.Spec.VolumeGroupSnapshotContentName field must reference to\nthis VolumeGroupSnapshotContent's name for the bidirectional binding to be valid.\nFor a pre-existing VolumeGroupSnapshotContent object, name and namespace of the\nVolumeGroupSnapshot object MUST be provided for binding to happen.\nThis field is immutable after creation.\nRequired.",
+          "properties": {
+            "apiVersion": {
+              "description": "API version of the referent.",
+              "type": "string"
+            },
+            "fieldPath": {
+              "description": "If referring to a piece of an object instead of an entire object, this string\nshould contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].\nFor example, if the object reference is to a container within a pod, this would take on a value like:\n\"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered\nthe event) or if no container name is specified \"spec.containers[2]\" (container with\nindex 2 in this pod). This syntax is chosen only to have some well-defined way of\nreferencing a part of an object.\nTODO: this design is not final and this field is subject to change in the future.",
+              "type": "string"
+            },
+            "kind": {
+              "description": "Kind of the referent.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+              "type": "string"
+            },
+            "name": {
+              "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+              "type": "string"
+            },
+            "namespace": {
+              "description": "Namespace of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+              "type": "string"
+            },
+            "resourceVersion": {
+              "description": "Specific resourceVersion to which this reference is made, if any.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+              "type": "string"
+            },
+            "uid": {
+              "description": "UID of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "x-kubernetes-map-type": "atomic",
+          "x-kubernetes-validations": [
+            {
+              "message": "both volumeGroupSnapshotRef.name and volumeGroupSnapshotRef.namespace must be set",
+              "rule": "has(self.name) && has(self.__namespace__)"
+            },
+            {
+              "message": "volumeGroupSnapshotRef.name and volumeGroupSnapshotRef.namespace are immutable",
+              "rule": "self.name == oldSelf.name && self.__namespace__ == oldSelf.__namespace__"
+            },
+            {
+              "message": "volumeGroupSnapshotRef.uid is immutable once set",
+              "rule": "!has(oldSelf.uid) || (has(self.uid) && self.uid == oldSelf.uid)"
+            }
+          ],
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "deletionPolicy",
+        "driver",
+        "source",
+        "volumeGroupSnapshotRef"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "status represents the current information of a group snapshot.",
+      "properties": {
+        "creationTime": {
+          "description": "CreationTime is the timestamp when the point-in-time group snapshot is taken\nby the underlying storage system.\nIf not specified, it indicates the creation time is unknown.\nIf not specified, it means the readiness of a group snapshot is unknown.\nThis field is the source for the CreationTime field in VolumeGroupSnapshotStatus",
+          "format": "date-time",
+          "type": "string"
+        },
+        "error": {
+          "description": "Error is the last observed error during group snapshot creation, if any.\nUpon success after retry, this error field will be cleared.",
+          "properties": {
+            "message": {
+              "description": "message is a string detailing the encountered error during snapshot\ncreation if specified.\nNOTE: message may be logged, and it should not contain sensitive\ninformation.",
+              "type": "string"
+            },
+            "time": {
+              "description": "time is the timestamp when the error was encountered.",
+              "format": "date-time",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "readyToUse": {
+          "description": "ReadyToUse indicates if all the individual snapshots in the group are ready to be\nused to restore a group of volumes.\nReadyToUse becomes true when ReadyToUse of all individual snapshots become true.",
+          "type": "boolean"
+        },
+        "volumeGroupSnapshotHandle": {
+          "description": "VolumeGroupSnapshotHandle is a unique id returned by the CSI driver\nto identify the VolumeGroupSnapshot on the storage system.\nIf a storage system does not provide such an id, the\nCSI driver can choose to return the VolumeGroupSnapshot name.",
+          "type": "string",
+          "x-kubernetes-validations": [
+            {
+              "message": "volumeGroupSnapshotHandle is immutable once set",
+              "rule": "self == oldSelf"
+            }
+          ]
+        },
+        "volumeSnapshotInfoList": {
+          "description": "This field is introduced in v1beta2\nIt is replacing VolumeSnapshotHandlePairList\nVolumeSnapshotInfoList is a list of snapshot information returned by\nby the CSI driver to identify snapshots on the storage system.",
+          "items": {
+            "description": "The VolumeSnapshotInfo struct is added in v1beta2\nVolumeSnapshotInfo contains information for a snapshot",
+            "properties": {
+              "creationTime": {
+                "description": "creationTime is the timestamp when the point-in-time snapshot is taken\nby the underlying storage system.",
+                "format": "int64",
+                "type": "integer"
+              },
+              "readyToUse": {
+                "description": "ReadyToUse indicates if the snapshot is ready to be used to restore a volume.",
+                "type": "boolean"
+              },
+              "restoreSize": {
+                "description": "RestoreSize represents the minimum size of volume required to create a volume\nfrom this snapshot.",
+                "format": "int64",
+                "type": "integer"
+              },
+              "snapshotHandle": {
+                "description": "SnapshotHandle is the CSI \"snapshot_id\" of this snapshot on the underlying storage system.",
+                "type": "string"
+              },
+              "volumeHandle": {
+                "description": "VolumeHandle specifies the CSI \"volume_id\" of the volume from which this snapshot\nwas taken from.",
+                "type": "string"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "required": [
+    "spec"
+  ],
+  "type": "object"
+}


### PR DESCRIPTION
## PR Checklist

Adding support for external-snapshotter CRD:s. The CRD:s can be found [here](https://github.com/kubernetes-csi/external-snapshotter/tree/master/client/config/crd), generated from release [v8.6.0 [latest]](https://github.com/kubernetes-csi/external-snapshotter/releases/tag/v8.6.0).

- [x] I generated these CRs using the [CRD Extractor tool](https://github.com/datreeio/CRDs-catalog?tab=readme-ov-file#crd-extractor). If I used a different method, I have described the method in this PR.
- [ ] I am updating existing schemas and have specified the updated schema version.
- [x] I am adding new schemas and included a link to the GitHub repository that contains the source of these schemas.
