### PR TITLE
feat: add postgresql.cnpg.io/databaserole_v1.json

### DIFF
--- a/postgresql.cnpg.io/databaserole_v1.json
+++ b/postgresql.cnpg.io/databaserole_v1.json
@@ -1,0 +1,280 @@
+{
+  "description": "DatabaseRole is the Schema for the databaseroles API",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "Specification of the desired DatabaseRole.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status",
+      "properties": {
+        "bypassrls": {
+          "description": "Whether a role bypasses every row-level security (RLS) policy.\nDefault is `false`.",
+          "type": "boolean"
+        },
+        "clientCertificate": {
+          "description": "ClientCertificate configures the operator to generate and renew a TLS client\ncertificate for this role, signed by the cluster's client CA. The certificate\nis stored in a Secret named `<databaserole-name>-client-cert`.\nRequires login to be true.",
+          "properties": {
+            "enabled": {
+              "default": true,
+              "description": "Enabled turns on client certificate issuance for this role. When true,\nthe role must have login enabled. Defaults to true when the block is present.",
+              "type": "boolean"
+            }
+          },
+          "type": "object"
+        },
+        "cluster": {
+          "description": "The corresponding cluster",
+          "properties": {
+            "name": {
+              "default": "",
+              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "x-kubernetes-map-type": "atomic",
+          "x-kubernetes-validations": [
+            {
+              "message": "cluster reference is immutable after creation",
+              "rule": "self == oldSelf"
+            }
+          ]
+        },
+        "comment": {
+          "description": "Description of the role",
+          "type": "string"
+        },
+        "connectionLimit": {
+          "default": -1,
+          "description": "If the role can log in, this specifies how many concurrent\nconnections the role can make. `-1` (the default) means no limit.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "createdb": {
+          "description": "When set to `true`, the role being defined will be allowed to create\nnew databases. Specifying `false` (default) will deny a role the\nability to create databases.",
+          "type": "boolean"
+        },
+        "createrole": {
+          "description": "Whether the role will be permitted to create, alter, drop, comment\non, change the security label for, and grant or revoke membership in\nother roles. Default is `false`.",
+          "type": "boolean"
+        },
+        "databaseRoleReclaimPolicy": {
+          "default": "retain",
+          "description": "The policy for end-of-life maintenance of this role",
+          "enum": [
+            "delete",
+            "retain"
+          ],
+          "type": "string"
+        },
+        "disablePassword": {
+          "description": "DisablePassword indicates that a role's password should be set to NULL in Postgres",
+          "type": "boolean"
+        },
+        "ensure": {
+          "default": "present",
+          "description": "Ensure the role is `present` or `absent` - defaults to \"present\"",
+          "enum": [
+            "present",
+            "absent"
+          ],
+          "type": "string"
+        },
+        "inRoles": {
+          "description": "List of one or more existing roles to which this role will be\nimmediately added as a new member. Default empty.\nChanges to the list are applied to an existing role through\n`GRANT` and `REVOKE` statements, not only at role creation.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "inherit": {
+          "default": true,
+          "description": "Whether a role \"inherits\" the privileges of roles it is a member of.\nDefault is `true`.",
+          "type": "boolean"
+        },
+        "login": {
+          "description": "Whether the role is allowed to log in. A role having the `login`\nattribute can be thought of as a user. Roles without this attribute\nare useful for managing database privileges, but are not users in\nthe usual sense of the word. Default is `false`.",
+          "type": "boolean"
+        },
+        "name": {
+          "description": "Name of the role",
+          "type": "string"
+        },
+        "passwordSecret": {
+          "description": "Secret containing the password of the role (if present).\nIf null, the password will be ignored unless DisablePassword is set.\nWhen set, the secret must follow the `kubernetes.io/basic-auth` format\nand contain both a `username` and a `password` field.",
+          "properties": {
+            "name": {
+              "description": "Name of the referent.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "name"
+          ],
+          "type": "object"
+        },
+        "replication": {
+          "description": "Whether a role is a replication role. A role must have this\nattribute (or be a superuser) in order to be able to connect to the\nserver in replication mode (physical or logical replication) and in\norder to be able to create or drop replication slots. A role having\nthe `replication` attribute is a very highly privileged role, and\nshould only be used on roles actually used for replication. Default\nis `false`.",
+          "type": "boolean"
+        },
+        "superuser": {
+          "description": "Whether the role is a `superuser` who can override all access\nrestrictions within the database - superuser status is dangerous and\nshould be used only when really needed. You must yourself be a\nsuperuser to create a new superuser. Defaults is `false`.",
+          "type": "boolean"
+        },
+        "validUntil": {
+          "description": "Date and time after which the role's password is no longer valid.\nWhen omitted, the password will never expire (default).",
+          "format": "date-time",
+          "type": "string"
+        }
+      },
+      "required": [
+        "cluster",
+        "name"
+      ],
+      "type": "object",
+      "x-kubernetes-validations": [
+        {
+          "message": "name is immutable",
+          "rule": "self.name == oldSelf.name"
+        },
+        {
+          "message": "ensure: absent is not supported for DatabaseRole; delete the resource with databaseRoleReclaimPolicy: delete instead",
+          "rule": "!has(self.ensure) || self.ensure != 'absent'"
+        },
+        {
+          "message": "the role name postgres is reserved",
+          "rule": "self.name != 'postgres'"
+        },
+        {
+          "message": "the role name streaming_replica is reserved",
+          "rule": "self.name != 'streaming_replica'"
+        },
+        {
+          "message": "role names starting with pg_ are reserved by PostgreSQL",
+          "rule": "!self.name.startsWith('pg_')"
+        },
+        {
+          "message": "role names starting with cnpg_ are reserved by the operator",
+          "rule": "!self.name.startsWith('cnpg_')"
+        },
+        {
+          "message": "role name must not be empty",
+          "rule": "self.name.size() != 0"
+        },
+        {
+          "message": "passwordSecret and disablePassword are mutually exclusive",
+          "rule": "!has(self.passwordSecret) || !has(self.disablePassword) || !self.disablePassword"
+        },
+        {
+          "message": "clientCertificate requires the role to have login enabled",
+          "rule": "!has(self.clientCertificate) || !self.clientCertificate.enabled || self.login"
+        }
+      ]
+    },
+    "status": {
+      "description": "Most recently observed status of the DatabaseRole. This data may not be up\nto date. Populated by the system. Read-only.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status",
+      "properties": {
+        "applied": {
+          "description": "Applied is true if the role was reconciled correctly",
+          "type": "boolean"
+        },
+        "clientCertificate": {
+          "description": "ClientCertificate holds the observed state of the generated TLS client\ncertificate, when client certificate issuance is enabled.",
+          "properties": {
+            "expiration": {
+              "description": "Expiration is the expiration time of the generated client certificate, in RFC3339 format.",
+              "type": "string"
+            },
+            "message": {
+              "description": "Message contains a human-readable explanation of the current certificate status,\nsuch as why issuance was skipped or why an existing Secret was left untouched.",
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "conditions": {
+          "description": "Conditions for the DatabaseRole object",
+          "items": {
+            "description": "Condition contains details for one aspect of the current state of this API Resource.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "lastTransitionTime is the last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "message is a human readable message indicating details about the transition.\nThis may be an empty string.",
+                "maxLength": 32768,
+                "type": "string"
+              },
+              "observedGeneration": {
+                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon.\nFor instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date\nwith respect to the current state of the instance.",
+                "format": "int64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "reason": {
+                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition.\nProducers of specific condition types may define expected values and meanings for this field,\nand whether the values are considered a guaranteed API.\nThe value should be a CamelCase string.\nThis field may not be empty.",
+                "maxLength": 1024,
+                "minLength": 1,
+                "pattern": "^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$",
+                "type": "string"
+              },
+              "status": {
+                "description": "status of the condition, one of True, False, Unknown.",
+                "enum": [
+                  "True",
+                  "False",
+                  "Unknown"
+                ],
+                "type": "string"
+              },
+              "type": {
+                "description": "type of condition in CamelCase or in foo.example.com/CamelCase.",
+                "maxLength": 316,
+                "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$",
+                "type": "string"
+              }
+            },
+            "required": [
+              "lastTransitionTime",
+              "message",
+              "reason",
+              "status",
+              "type"
+            ],
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "message": {
+          "description": "Message is the reconciliation error message",
+          "type": "string"
+        },
+        "observedGeneration": {
+          "description": "A sequence number representing the latest\ndesired state that was synchronized",
+          "format": "int64",
+          "type": "integer"
+        },
+        "secretResourceVersion": {
+          "description": "SecretResourceVersion is the resource version of the password secret\nlast applied to the role; a change to it triggers reconciliation.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    }
+  },
+  "required": [
+    "metadata",
+    "spec"
+  ],
+  "type": "object"
+}


### PR DESCRIPTION
## PR Checklist

- [X] I generated these CRs using the [CRD Extractor tool](https://github.com/datreeio/CRDs-catalog?tab=readme-ov-file#crd-extractor). If I used a different method, I have described the method in this PR.
- [ ] I am updating existing schemas and have specified the updated schema version.
- [ ] I am adding new schemas and included a link to the GitHub repository that contains the source of these schemas.

## PR Description
Adds the schema for declarative database roles to postgresql.cnpg.io