### PR TITLE
feat: add InPlace updateMode enum value for VerticalPodAutoscaler v1

### DIFF
--- a/autoscaling.k8s.io/verticalpodautoscaler_v1.json
+++ b/autoscaling.k8s.io/verticalpodautoscaler_v1.json
@@ -181,6 +181,7 @@
                 "Initial",
                 "Recreate",
                 "InPlaceOrRecreate",
+                "InPlace",
                 "Auto"
               ],
               "type": "string"


### PR DESCRIPTION
VPA fork (v1.7.0) supports a distinct InPlace updateMode alongside InPlaceOrRecreate, but the schema only listed the latter.
