### PR TITLE
feat: update renovate-operator RenovateJob schema for v5.5.0

### DIFF
--- a/renovate-operator.mogenius.com/renovatejob_v1alpha1.json
+++ b/renovate-operator.mogenius.com/renovatejob_v1alpha1.json
@@ -1829,7 +1829,7 @@
                 "additionalProperties": false
               },
               "image": {
-                "description": "image represents an OCI object (a container image or artifact) pulled and mounted on the kubelet's host machine.\nThe volume is resolved at pod startup depending on which PullPolicy value is provided:\n\n- Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.\n- Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.\n- IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.\n\nThe volume gets re-resolved if the pod gets deleted and recreated, which means that new remote content will become available on pod recreation.\nA failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.\nThe types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.\nThe OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.\nThe volume will be mounted read-only (ro) and non-executable files (noexec).\nSub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath) before 1.33.\nThe field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.",
+                "description": "image represents an OCI object (a container image or artifact) pulled and mounted on the kubelet's host machine.\nThe volume is resolved at pod startup depending on which PullPolicy value is provided:\n\n- Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.\n- Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.\n- IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.\n\nThe volume gets re-resolved if the pod gets deleted and recreated, which means that new remote content will become available on pod recreation.\nA failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.\nThe types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.\nThe OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.\nThe volume will be mounted read-only (ro).\nSub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath) before 1.33.\nThe field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.",
                 "properties": {
                   "pullPolicy": {
                     "description": "Policy for pulling OCI objects. Possible values are:\nAlways: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.\nNever: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.\nIfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.\nDefaults to Always if :latest tag is specified, or IfNotPresent otherwise.",
@@ -1978,7 +1978,7 @@
                 "additionalProperties": false
               },
               "portworxVolume": {
-                "description": "portworxVolume represents a portworx volume attached and mounted on kubelets host machine.\nDeprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type\nare redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate\nis on.",
+                "description": "portworxVolume represents a portworx volume attached and mounted on kubelets host machine.\nDeprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type\nare redirected to the pxd.portworx.com CSI driver.",
                 "properties": {
                   "fsType": {
                     "description": "fSType represents the filesystem type to mount\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\". Implicitly inferred to be \"ext4\" if unspecified.",
@@ -2613,6 +2613,31 @@
           },
           "type": "array"
         },
+        "githubAppReference": {
+          "description": "Reference to a Github App for authentication, this will automatically mount a secret with\nRENOVATE_TOKEN",
+          "properties": {
+            "appIdSecretKey": {
+              "type": "string"
+            },
+            "installationIdSecretKey": {
+              "type": "string"
+            },
+            "pemSecretKey": {
+              "type": "string"
+            },
+            "secretName": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "appIdSecretKey",
+            "installationIdSecretKey",
+            "pemSecretKey",
+            "secretName"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
         "image": {
           "description": "Renovate Docker image to use",
           "type": "string"
@@ -2665,6 +2690,10 @@
           "format": "int32",
           "type": "integer"
         },
+        "priorityClassName": {
+          "description": "PriorityClassName for the resulting pod, used to set the pod's scheduling priority.",
+          "type": "string"
+        },
         "provider": {
           "description": "Renovate Provider Information to fill \"RENOVATE_ENDPOINT\" and \"RENOVATE_PLATFORM\" environment variables in the renovate container",
           "properties": {
@@ -2672,6 +2701,10 @@
               "type": "string"
             },
             "name": {
+              "type": "string"
+            },
+            "publicEndpoint": {
+              "description": "PublicEndpoint is the externally reachable URL for the provider, used only for UI links.\nWhen set, this overrides Endpoint for dashboard links while Endpoint continues to be\nused for Renovate API calls and cloning. Defaults to Endpoint when omitted.",
               "type": "string"
             }
           },
@@ -2745,6 +2778,10 @@
           },
           "type": "object",
           "additionalProperties": false
+        },
+        "runtimeClassName": {
+          "description": "RuntimeClassName for the resulting pod, used to select a non-default container runtime",
+          "type": "string"
         },
         "schedule": {
           "description": "Cron schedule in standard cron format",
@@ -3035,7 +3072,7 @@
                   "type": "boolean"
                 },
                 "procMount": {
-                  "description": "procMount denotes the type of proc mount to use for the containers.\nThe default value is Default which uses the container runtime defaults for\nreadonly paths and masked paths.\nThis requires the ProcMountType feature flag to be enabled.\nNote that this field cannot be set when spec.os.name is windows.",
+                  "description": "procMount denotes the type of proc mount to use for the containers.\nThe default value is Default which uses the container runtime defaults for\nreadonly paths and masked paths.\nNote that this field cannot be set when spec.os.name is windows.",
                   "type": "string"
                 },
                 "readOnlyRootFilesystem": {
@@ -3298,6 +3335,10 @@
           "description": "If true, forked repositories discovered during autodiscovery will be excluded by querying the platform API",
           "type": "boolean"
         },
+        "skipPendingDeletion": {
+          "description": "If true, repositories marked for delayed deletion (pending deletion) will be excluded by querying the platform API. Only GitLab exposes this state.",
+          "type": "boolean"
+        },
         "tolerations": {
           "description": "Tolerations for scheduling the resulting pod",
           "items": {
@@ -3456,65 +3497,38 @@
               "type": "object",
               "additionalProperties": false
             },
+            "baseUrl": {
+              "description": "Externally reachable base URL of the operator's webhook server for this\njob, e.g. https://renovate.example.com. The platform-specific path is\nappended to it. Takes precedence over the operator-wide\nWEBHOOK_BASE_URL environment variable, which is used when this is empty.\nSet it when a platform needs a different hostname to reach the operator\nthan the operator-wide default provides.",
+              "pattern": "^https?://[^?#]+$",
+              "type": "string"
+            },
             "enabled": {
               "type": "boolean"
             },
-            "forgejo": {
-              "description": "Forgejo-specific webhook configuration",
+            "sync": {
+              "description": "configuration for syncing webhooks onto the repositories discovered for this\njob.",
               "properties": {
-                "sync": {
-                  "description": "configuration for syncing webhooks to Forgejo repos by topic",
+                "enabled": {
+                  "description": "Flag to enable the automatic repo webhook sync",
+                  "type": "boolean"
+                },
+                "secretRef": {
+                  "description": "Optional reference to a secret key holding the platform token used for\nwebhook management. When not set, the job's platform token\n(spec.secretRef or spec.githubAppReference) is used. If key is empty,\nthe common Renovate token key names are tried.",
                   "properties": {
-                    "authTokenSecretRef": {
-                      "description": "reference to a secret and key",
-                      "properties": {
-                        "key": {
-                          "type": "string"
-                        },
-                        "name": {
-                          "type": "string"
-                        }
-                      },
-                      "type": "object",
-                      "additionalProperties": false
-                    },
-                    "enabled": {
-                      "type": "boolean"
-                    },
-                    "events": {
-                      "items": {
-                        "type": "string"
-                      },
-                      "type": "array"
-                    },
-                    "tokenSecretRef": {
-                      "description": "reference to a secret and key",
-                      "properties": {
-                        "key": {
-                          "type": "string"
-                        },
-                        "name": {
-                          "type": "string"
-                        }
-                      },
-                      "type": "object",
-                      "additionalProperties": false
-                    },
-                    "topic": {
+                    "key": {
                       "type": "string"
                     },
-                    "webhookURL": {
+                    "name": {
                       "type": "string"
                     }
                   },
-                  "required": [
-                    "enabled",
-                    "webhookURL"
-                  ],
                   "type": "object",
                   "additionalProperties": false
                 }
               },
+              "required": [
+                "enabled"
+              ],
               "type": "object",
               "additionalProperties": false
             }
@@ -3541,7 +3555,7 @@
         "executionOptions": {
           "properties": {
             "debug": {
-              "description": "If true, the renovate job will be executed with LOG_LEVEL=debug",
+              "description": "If true, the renovate job will be executed with RENOVATE_LOG_LEVEL=debug",
               "type": "boolean"
             }
           },
@@ -3555,7 +3569,8 @@
               "duration": {
                 "type": "string"
               },
-              "lastRun": {
+              "lastTransition": {
+                "description": "LastTransition records when the project most recently changed state.",
                 "format": "date-time",
                 "type": "string"
               },
@@ -3611,6 +3626,9 @@
                   "created": {
                     "type": "integer"
                   },
+                  "needsApproval": {
+                    "type": "integer"
+                  },
                   "prs": {
                     "items": {
                       "description": "PRDetail represents a single PR found in Renovate logs.",
@@ -3651,6 +3669,7 @@
                 "required": [
                   "automerged",
                   "created",
+                  "needsApproval",
                   "unchanged",
                   "updated"
                 ],
@@ -3669,7 +3688,6 @@
               }
             },
             "required": [
-              "lastRun",
               "name",
               "status"
             ],


### PR DESCRIPTION
## PR Checklist

- [x] I generated these CRs using the [CRD Extractor tool](https://github.com/datreeio/CRDs-catalog?tab=readme-ov-file#crd-extractor). If I used a different method, I have described the method in this PR.
- [x] I am updating existing schemas and have specified the updated schema version.
- [ ] I am adding new schemas and included a link to the GitHub repository that contains the source of these schemas.
