### PR TITLE
feat: Update Argo CD schemas for Argo CD 3.5.0 CRDs

### DIFF
--- a/argoproj.io/application_v1alpha1.json
+++ b/argoproj.io/application_v1alpha1.json
@@ -589,6 +589,10 @@
                   "description": "RepoURL is the URL to the repository (Git or Helm) that contains the application manifests",
                   "type": "string"
                 },
+                "tagPrefix": {
+                  "description": "TagPrefix filters git tags to only those with this prefix before evaluating targetRevision as a semver constraint.\nThe prefix is stripped from tag names before comparison and re-added to the resolved version.\nFor example, with tagPrefix \"component-b/\" and targetRevision \"1.0.*\", tags like \"component-b/1.0.0\" and\n\"component-b/1.0.1\" are candidates, and the constraint resolves to \"component-b/1.0.1\".",
+                  "type": "string"
+                },
                 "targetRevision": {
                   "description": "TargetRevision defines the revision of the source to sync the application to.\nIn case of Git, this can be commit, tag, or branch. If omitted, will equal to HEAD.\nIn case of Helm, this is a semver tag for the Chart's version.",
                   "type": "string"
@@ -1042,6 +1046,10 @@
                   },
                   "repoURL": {
                     "description": "RepoURL is the URL to the repository (Git or Helm) that contains the application manifests",
+                    "type": "string"
+                  },
+                  "tagPrefix": {
+                    "description": "TagPrefix filters git tags to only those with this prefix before evaluating targetRevision as a semver constraint.\nThe prefix is stripped from tag names before comparison and re-added to the resolved version.\nFor example, with tagPrefix \"component-b/\" and targetRevision \"1.0.*\", tags like \"component-b/1.0.0\" and\n\"component-b/1.0.1\" are candidates, and the constraint resolves to \"component-b/1.0.1\".",
                     "type": "string"
                   },
                   "targetRevision": {
@@ -1639,6 +1647,10 @@
               "description": "RepoURL is the URL to the repository (Git or Helm) that contains the application manifests",
               "type": "string"
             },
+            "tagPrefix": {
+              "description": "TagPrefix filters git tags to only those with this prefix before evaluating targetRevision as a semver constraint.\nThe prefix is stripped from tag names before comparison and re-added to the resolved version.\nFor example, with tagPrefix \"component-b/\" and targetRevision \"1.0.*\", tags like \"component-b/1.0.0\" and\n\"component-b/1.0.1\" are candidates, and the constraint resolves to \"component-b/1.0.1\".",
+              "type": "string"
+            },
             "targetRevision": {
               "description": "TargetRevision defines the revision of the source to sync the application to.\nIn case of Git, this can be commit, tag, or branch. If omitted, will equal to HEAD.\nIn case of Helm, this is a semver tag for the Chart's version.",
               "type": "string"
@@ -2119,6 +2131,10 @@
                   "pattern": "^.{2,}|[^./]$",
                   "type": "string"
                 },
+                "repoURL": {
+                  "description": "RepoURL is the URL to the git repository that contains the hydrated manifests. If not set, defaults to\nthe DrySource.RepoURL.",
+                  "type": "string"
+                },
                 "targetBranch": {
                   "description": "TargetBranch is the branch from which hydrated manifests will be synced.\nIf HydrateTo is not set, this is also the branch to which hydrated manifests are committed.",
                   "type": "string"
@@ -2581,6 +2597,10 @@
               },
               "repoURL": {
                 "description": "RepoURL is the URL to the repository (Git or Helm) that contains the application manifests",
+                "type": "string"
+              },
+              "tagPrefix": {
+                "description": "TagPrefix filters git tags to only those with this prefix before evaluating targetRevision as a semver constraint.\nThe prefix is stripped from tag names before comparison and re-added to the resolved version.\nFor example, with tagPrefix \"component-b/\" and targetRevision \"1.0.*\", tags like \"component-b/1.0.0\" and\n\"component-b/1.0.1\" are candidates, and the constraint resolves to \"component-b/1.0.1\".",
                 "type": "string"
               },
               "targetRevision": {
@@ -3239,6 +3259,10 @@
                     "description": "RepoURL is the URL to the repository (Git or Helm) that contains the application manifests",
                     "type": "string"
                   },
+                  "tagPrefix": {
+                    "description": "TagPrefix filters git tags to only those with this prefix before evaluating targetRevision as a semver constraint.\nThe prefix is stripped from tag names before comparison and re-added to the resolved version.\nFor example, with tagPrefix \"component-b/\" and targetRevision \"1.0.*\", tags like \"component-b/1.0.0\" and\n\"component-b/1.0.1\" are candidates, and the constraint resolves to \"component-b/1.0.1\".",
+                    "type": "string"
+                  },
                   "targetRevision": {
                     "description": "TargetRevision defines the revision of the source to sync the application to.\nIn case of Git, this can be commit, tag, or branch. If omitted, will equal to HEAD.\nIn case of Helm, this is a semver tag for the Chart's version.",
                     "type": "string"
@@ -3692,6 +3716,10 @@
                     },
                     "repoURL": {
                       "description": "RepoURL is the URL to the repository (Git or Helm) that contains the application manifests",
+                      "type": "string"
+                    },
+                    "tagPrefix": {
+                      "description": "TagPrefix filters git tags to only those with this prefix before evaluating targetRevision as a semver constraint.\nThe prefix is stripped from tag names before comparison and re-added to the resolved version.\nFor example, with tagPrefix \"component-b/\" and targetRevision \"1.0.*\", tags like \"component-b/1.0.0\" and\n\"component-b/1.0.1\" are candidates, and the constraint resolves to \"component-b/1.0.1\".",
                       "type": "string"
                     },
                     "targetRevision": {
@@ -4311,6 +4339,10 @@
                           "description": "RepoURL is the URL to the repository (Git or Helm) that contains the application manifests",
                           "type": "string"
                         },
+                        "tagPrefix": {
+                          "description": "TagPrefix filters git tags to only those with this prefix before evaluating targetRevision as a semver constraint.\nThe prefix is stripped from tag names before comparison and re-added to the resolved version.\nFor example, with tagPrefix \"component-b/\" and targetRevision \"1.0.*\", tags like \"component-b/1.0.0\" and\n\"component-b/1.0.1\" are candidates, and the constraint resolves to \"component-b/1.0.1\".",
+                          "type": "string"
+                        },
                         "targetRevision": {
                           "description": "TargetRevision defines the revision of the source to sync the application to.\nIn case of Git, this can be commit, tag, or branch. If omitted, will equal to HEAD.\nIn case of Helm, this is a semver tag for the Chart's version.",
                           "type": "string"
@@ -4764,6 +4796,10 @@
                           },
                           "repoURL": {
                             "description": "RepoURL is the URL to the repository (Git or Helm) that contains the application manifests",
+                            "type": "string"
+                          },
+                          "tagPrefix": {
+                            "description": "TagPrefix filters git tags to only those with this prefix before evaluating targetRevision as a semver constraint.\nThe prefix is stripped from tag names before comparison and re-added to the resolved version.\nFor example, with tagPrefix \"component-b/\" and targetRevision \"1.0.*\", tags like \"component-b/1.0.0\" and\n\"component-b/1.0.1\" are candidates, and the constraint resolves to \"component-b/1.0.1\".",
                             "type": "string"
                           },
                           "targetRevision": {
@@ -5377,6 +5413,10 @@
                       "description": "RepoURL is the URL to the repository (Git or Helm) that contains the application manifests",
                       "type": "string"
                     },
+                    "tagPrefix": {
+                      "description": "TagPrefix filters git tags to only those with this prefix before evaluating targetRevision as a semver constraint.\nThe prefix is stripped from tag names before comparison and re-added to the resolved version.\nFor example, with tagPrefix \"component-b/\" and targetRevision \"1.0.*\", tags like \"component-b/1.0.0\" and\n\"component-b/1.0.1\" are candidates, and the constraint resolves to \"component-b/1.0.1\".",
+                      "type": "string"
+                    },
                     "targetRevision": {
                       "description": "TargetRevision defines the revision of the source to sync the application to.\nIn case of Git, this can be commit, tag, or branch. If omitted, will equal to HEAD.\nIn case of Helm, this is a semver tag for the Chart's version.",
                       "type": "string"
@@ -5830,6 +5870,10 @@
                       },
                       "repoURL": {
                         "description": "RepoURL is the URL to the repository (Git or Helm) that contains the application manifests",
+                        "type": "string"
+                      },
+                      "tagPrefix": {
+                        "description": "TagPrefix filters git tags to only those with this prefix before evaluating targetRevision as a semver constraint.\nThe prefix is stripped from tag names before comparison and re-added to the resolved version.\nFor example, with tagPrefix \"component-b/\" and targetRevision \"1.0.*\", tags like \"component-b/1.0.0\" and\n\"component-b/1.0.1\" are candidates, and the constraint resolves to \"component-b/1.0.1\".",
                         "type": "string"
                       },
                       "targetRevision": {
@@ -6443,6 +6487,10 @@
                           "pattern": "^.{2,}|[^./]$",
                           "type": "string"
                         },
+                        "repoURL": {
+                          "description": "RepoURL is the URL to the git repository that contains the hydrated manifests. If not set, defaults to\nthe DrySource.RepoURL.",
+                          "type": "string"
+                        },
                         "targetBranch": {
                           "description": "TargetBranch is the branch from which hydrated manifests will be synced.\nIf HydrateTo is not set, this is also the branch to which hydrated manifests are committed.",
                           "type": "string"
@@ -6475,6 +6523,10 @@
               ],
               "type": "object",
               "additionalProperties": false
+            },
+            "lastComparedDryRevision": {
+              "description": "LastComparedDryRevision holds the resolved revision from the most recent dry source comparison.\nThis is updated on every evaluation, even when hydration is skipped due to no changes.",
+              "type": "string"
             },
             "lastSuccessfulOperation": {
               "description": "LastSuccessfulOperation holds info about the most recent successful hydration",
@@ -6956,6 +7008,10 @@
                           "pattern": "^.{2,}|[^./]$",
                           "type": "string"
                         },
+                        "repoURL": {
+                          "description": "RepoURL is the URL to the git repository that contains the hydrated manifests. If not set, defaults to\nthe DrySource.RepoURL.",
+                          "type": "string"
+                        },
                         "targetBranch": {
                           "description": "TargetBranch is the branch from which hydrated manifests will be synced.\nIf HydrateTo is not set, this is also the branch to which hydrated manifests are committed.",
                           "type": "string"
@@ -7012,6 +7068,10 @@
                 "type": "string"
               },
               "type": "array"
+            },
+            "isAppOfApps": {
+              "description": "IsAppOfApps holds true if the application has any application for child resource.",
+              "type": "boolean"
             }
           },
           "type": "object",
@@ -7529,6 +7589,10 @@
                       "description": "RepoURL is the URL to the repository (Git or Helm) that contains the application manifests",
                       "type": "string"
                     },
+                    "tagPrefix": {
+                      "description": "TagPrefix filters git tags to only those with this prefix before evaluating targetRevision as a semver constraint.\nThe prefix is stripped from tag names before comparison and re-added to the resolved version.\nFor example, with tagPrefix \"component-b/\" and targetRevision \"1.0.*\", tags like \"component-b/1.0.0\" and\n\"component-b/1.0.1\" are candidates, and the constraint resolves to \"component-b/1.0.1\".",
+                      "type": "string"
+                    },
                     "targetRevision": {
                       "description": "TargetRevision defines the revision of the source to sync the application to.\nIn case of Git, this can be commit, tag, or branch. If omitted, will equal to HEAD.\nIn case of Helm, this is a semver tag for the Chart's version.",
                       "type": "string"
@@ -7982,6 +8046,10 @@
                       },
                       "repoURL": {
                         "description": "RepoURL is the URL to the repository (Git or Helm) that contains the application manifests",
+                        "type": "string"
+                      },
+                      "tagPrefix": {
+                        "description": "TagPrefix filters git tags to only those with this prefix before evaluating targetRevision as a semver constraint.\nThe prefix is stripped from tag names before comparison and re-added to the resolved version.\nFor example, with tagPrefix \"component-b/\" and targetRevision \"1.0.*\", tags like \"component-b/1.0.0\" and\n\"component-b/1.0.1\" are candidates, and the constraint resolves to \"component-b/1.0.1\".",
                         "type": "string"
                       },
                       "targetRevision": {

--- a/argoproj.io/applicationset_v1alpha1.json
+++ b/argoproj.io/applicationset_v1alpha1.json
@@ -558,6 +558,9 @@
                               "repoURL": {
                                 "type": "string"
                               },
+                              "tagPrefix": {
+                                "type": "string"
+                              },
                               "targetRevision": {
                                 "type": "string"
                               }
@@ -964,6 +967,9 @@
                                     "pattern": "^.{2,}|[^./]$",
                                     "type": "string"
                                   },
+                                  "repoURL": {
+                                    "type": "string"
+                                  },
                                   "targetBranch": {
                                     "type": "string"
                                   }
@@ -1354,6 +1360,9 @@
                                   "type": "string"
                                 },
                                 "repoURL": {
+                                  "type": "string"
+                                },
+                                "tagPrefix": {
                                   "type": "string"
                                 },
                                 "targetRevision": {
@@ -2008,6 +2017,9 @@
                               "repoURL": {
                                 "type": "string"
                               },
+                              "tagPrefix": {
+                                "type": "string"
+                              },
                               "targetRevision": {
                                 "type": "string"
                               }
@@ -2414,6 +2426,9 @@
                                     "pattern": "^.{2,}|[^./]$",
                                     "type": "string"
                                   },
+                                  "repoURL": {
+                                    "type": "string"
+                                  },
                                   "targetBranch": {
                                     "type": "string"
                                   }
@@ -2804,6 +2819,9 @@
                                   "type": "string"
                                 },
                                 "repoURL": {
+                                  "type": "string"
+                                },
+                                "tagPrefix": {
                                   "type": "string"
                                 },
                                 "targetRevision": {
@@ -3461,6 +3479,9 @@
                               "repoURL": {
                                 "type": "string"
                               },
+                              "tagPrefix": {
+                                "type": "string"
+                              },
                               "targetRevision": {
                                 "type": "string"
                               }
@@ -3867,6 +3888,9 @@
                                     "pattern": "^.{2,}|[^./]$",
                                     "type": "string"
                                   },
+                                  "repoURL": {
+                                    "type": "string"
+                                  },
                                   "targetBranch": {
                                     "type": "string"
                                   }
@@ -4257,6 +4281,9 @@
                                   "type": "string"
                                 },
                                 "repoURL": {
+                                  "type": "string"
+                                },
+                                "tagPrefix": {
                                   "type": "string"
                                 },
                                 "targetRevision": {
@@ -4878,6 +4905,9 @@
                               "repoURL": {
                                 "type": "string"
                               },
+                              "tagPrefix": {
+                                "type": "string"
+                              },
                               "targetRevision": {
                                 "type": "string"
                               }
@@ -5284,6 +5314,9 @@
                                     "pattern": "^.{2,}|[^./]$",
                                     "type": "string"
                                   },
+                                  "repoURL": {
+                                    "type": "string"
+                                  },
                                   "targetBranch": {
                                     "type": "string"
                                   }
@@ -5674,6 +5707,9 @@
                                   "type": "string"
                                 },
                                 "repoURL": {
+                                  "type": "string"
+                                },
+                                "tagPrefix": {
                                   "type": "string"
                                 },
                                 "targetRevision": {
@@ -6331,6 +6367,9 @@
                                         "repoURL": {
                                           "type": "string"
                                         },
+                                        "tagPrefix": {
+                                          "type": "string"
+                                        },
                                         "targetRevision": {
                                           "type": "string"
                                         }
@@ -6737,6 +6776,9 @@
                                               "pattern": "^.{2,}|[^./]$",
                                               "type": "string"
                                             },
+                                            "repoURL": {
+                                              "type": "string"
+                                            },
                                             "targetBranch": {
                                               "type": "string"
                                             }
@@ -7127,6 +7169,9 @@
                                             "type": "string"
                                           },
                                           "repoURL": {
+                                            "type": "string"
+                                          },
+                                          "tagPrefix": {
                                             "type": "string"
                                           },
                                           "targetRevision": {
@@ -7781,6 +7826,9 @@
                                         "repoURL": {
                                           "type": "string"
                                         },
+                                        "tagPrefix": {
+                                          "type": "string"
+                                        },
                                         "targetRevision": {
                                           "type": "string"
                                         }
@@ -8187,6 +8235,9 @@
                                               "pattern": "^.{2,}|[^./]$",
                                               "type": "string"
                                             },
+                                            "repoURL": {
+                                              "type": "string"
+                                            },
                                             "targetBranch": {
                                               "type": "string"
                                             }
@@ -8577,6 +8628,9 @@
                                             "type": "string"
                                           },
                                           "repoURL": {
+                                            "type": "string"
+                                          },
+                                          "tagPrefix": {
                                             "type": "string"
                                           },
                                           "targetRevision": {
@@ -9234,6 +9288,9 @@
                                         "repoURL": {
                                           "type": "string"
                                         },
+                                        "tagPrefix": {
+                                          "type": "string"
+                                        },
                                         "targetRevision": {
                                           "type": "string"
                                         }
@@ -9640,6 +9697,9 @@
                                               "pattern": "^.{2,}|[^./]$",
                                               "type": "string"
                                             },
+                                            "repoURL": {
+                                              "type": "string"
+                                            },
                                             "targetBranch": {
                                               "type": "string"
                                             }
@@ -10030,6 +10090,9 @@
                                             "type": "string"
                                           },
                                           "repoURL": {
+                                            "type": "string"
+                                          },
+                                          "tagPrefix": {
                                             "type": "string"
                                           },
                                           "targetRevision": {
@@ -10651,6 +10714,9 @@
                                         "repoURL": {
                                           "type": "string"
                                         },
+                                        "tagPrefix": {
+                                          "type": "string"
+                                        },
                                         "targetRevision": {
                                           "type": "string"
                                         }
@@ -11057,6 +11123,9 @@
                                               "pattern": "^.{2,}|[^./]$",
                                               "type": "string"
                                             },
+                                            "repoURL": {
+                                              "type": "string"
+                                            },
                                             "targetBranch": {
                                               "type": "string"
                                             }
@@ -11447,6 +11516,9 @@
                                             "type": "string"
                                           },
                                           "repoURL": {
+                                            "type": "string"
+                                          },
+                                          "tagPrefix": {
                                             "type": "string"
                                           },
                                           "targetRevision": {
@@ -12083,6 +12155,9 @@
                                         "repoURL": {
                                           "type": "string"
                                         },
+                                        "tagPrefix": {
+                                          "type": "string"
+                                        },
                                         "targetRevision": {
                                           "type": "string"
                                         }
@@ -12489,6 +12564,9 @@
                                               "pattern": "^.{2,}|[^./]$",
                                               "type": "string"
                                             },
+                                            "repoURL": {
+                                              "type": "string"
+                                            },
                                             "targetBranch": {
                                               "type": "string"
                                             }
@@ -12879,6 +12957,9 @@
                                             "type": "string"
                                           },
                                           "repoURL": {
+                                            "type": "string"
+                                          },
+                                          "tagPrefix": {
                                             "type": "string"
                                           },
                                           "targetRevision": {
@@ -13874,6 +13955,9 @@
                                         "repoURL": {
                                           "type": "string"
                                         },
+                                        "tagPrefix": {
+                                          "type": "string"
+                                        },
                                         "targetRevision": {
                                           "type": "string"
                                         }
@@ -14280,6 +14364,9 @@
                                               "pattern": "^.{2,}|[^./]$",
                                               "type": "string"
                                             },
+                                            "repoURL": {
+                                              "type": "string"
+                                            },
                                             "targetBranch": {
                                               "type": "string"
                                             }
@@ -14672,6 +14759,9 @@
                                           "repoURL": {
                                             "type": "string"
                                           },
+                                          "tagPrefix": {
+                                            "type": "string"
+                                          },
                                           "targetRevision": {
                                             "type": "string"
                                           }
@@ -15030,6 +15120,9 @@
                                 "api": {
                                   "type": "string"
                                 },
+                                "excludeArchivedRepos": {
+                                  "type": "boolean"
+                                },
                                 "insecure": {
                                   "type": "boolean"
                                 },
@@ -15070,6 +15163,9 @@
                                 },
                                 "appSecretName": {
                                   "type": "string"
+                                },
+                                "excludeArchivedRepos": {
+                                  "type": "boolean"
                                 },
                                 "organization": {
                                   "type": "string"
@@ -15123,6 +15219,9 @@
                                 },
                                 "group": {
                                   "type": "string"
+                                },
+                                "includeArchivedRepos": {
+                                  "type": "boolean"
                                 },
                                 "includeSharedProjects": {
                                   "type": "boolean"
@@ -15652,6 +15751,9 @@
                                         "repoURL": {
                                           "type": "string"
                                         },
+                                        "tagPrefix": {
+                                          "type": "string"
+                                        },
                                         "targetRevision": {
                                           "type": "string"
                                         }
@@ -16058,6 +16160,9 @@
                                               "pattern": "^.{2,}|[^./]$",
                                               "type": "string"
                                             },
+                                            "repoURL": {
+                                              "type": "string"
+                                            },
                                             "targetBranch": {
                                               "type": "string"
                                             }
@@ -16448,6 +16553,9 @@
                                             "type": "string"
                                           },
                                           "repoURL": {
+                                            "type": "string"
+                                          },
+                                          "tagPrefix": {
                                             "type": "string"
                                           },
                                           "targetRevision": {
@@ -17100,6 +17208,9 @@
                               "repoURL": {
                                 "type": "string"
                               },
+                              "tagPrefix": {
+                                "type": "string"
+                              },
                               "targetRevision": {
                                 "type": "string"
                               }
@@ -17506,6 +17617,9 @@
                                     "pattern": "^.{2,}|[^./]$",
                                     "type": "string"
                                   },
+                                  "repoURL": {
+                                    "type": "string"
+                                  },
                                   "targetBranch": {
                                     "type": "string"
                                   }
@@ -17896,6 +18010,9 @@
                                   "type": "string"
                                 },
                                 "repoURL": {
+                                  "type": "string"
+                                },
+                                "tagPrefix": {
                                   "type": "string"
                                 },
                                 "targetRevision": {
@@ -18556,6 +18673,9 @@
                                         "repoURL": {
                                           "type": "string"
                                         },
+                                        "tagPrefix": {
+                                          "type": "string"
+                                        },
                                         "targetRevision": {
                                           "type": "string"
                                         }
@@ -18962,6 +19082,9 @@
                                               "pattern": "^.{2,}|[^./]$",
                                               "type": "string"
                                             },
+                                            "repoURL": {
+                                              "type": "string"
+                                            },
                                             "targetBranch": {
                                               "type": "string"
                                             }
@@ -19352,6 +19475,9 @@
                                             "type": "string"
                                           },
                                           "repoURL": {
+                                            "type": "string"
+                                          },
+                                          "tagPrefix": {
                                             "type": "string"
                                           },
                                           "targetRevision": {
@@ -20006,6 +20132,9 @@
                                         "repoURL": {
                                           "type": "string"
                                         },
+                                        "tagPrefix": {
+                                          "type": "string"
+                                        },
                                         "targetRevision": {
                                           "type": "string"
                                         }
@@ -20412,6 +20541,9 @@
                                               "pattern": "^.{2,}|[^./]$",
                                               "type": "string"
                                             },
+                                            "repoURL": {
+                                              "type": "string"
+                                            },
                                             "targetBranch": {
                                               "type": "string"
                                             }
@@ -20802,6 +20934,9 @@
                                             "type": "string"
                                           },
                                           "repoURL": {
+                                            "type": "string"
+                                          },
+                                          "tagPrefix": {
                                             "type": "string"
                                           },
                                           "targetRevision": {
@@ -21459,6 +21594,9 @@
                                         "repoURL": {
                                           "type": "string"
                                         },
+                                        "tagPrefix": {
+                                          "type": "string"
+                                        },
                                         "targetRevision": {
                                           "type": "string"
                                         }
@@ -21865,6 +22003,9 @@
                                               "pattern": "^.{2,}|[^./]$",
                                               "type": "string"
                                             },
+                                            "repoURL": {
+                                              "type": "string"
+                                            },
                                             "targetBranch": {
                                               "type": "string"
                                             }
@@ -22255,6 +22396,9 @@
                                             "type": "string"
                                           },
                                           "repoURL": {
+                                            "type": "string"
+                                          },
+                                          "tagPrefix": {
                                             "type": "string"
                                           },
                                           "targetRevision": {
@@ -22876,6 +23020,9 @@
                                         "repoURL": {
                                           "type": "string"
                                         },
+                                        "tagPrefix": {
+                                          "type": "string"
+                                        },
                                         "targetRevision": {
                                           "type": "string"
                                         }
@@ -23282,6 +23429,9 @@
                                               "pattern": "^.{2,}|[^./]$",
                                               "type": "string"
                                             },
+                                            "repoURL": {
+                                              "type": "string"
+                                            },
                                             "targetBranch": {
                                               "type": "string"
                                             }
@@ -23672,6 +23822,9 @@
                                             "type": "string"
                                           },
                                           "repoURL": {
+                                            "type": "string"
+                                          },
+                                          "tagPrefix": {
                                             "type": "string"
                                           },
                                           "targetRevision": {
@@ -24308,6 +24461,9 @@
                                         "repoURL": {
                                           "type": "string"
                                         },
+                                        "tagPrefix": {
+                                          "type": "string"
+                                        },
                                         "targetRevision": {
                                           "type": "string"
                                         }
@@ -24714,6 +24870,9 @@
                                               "pattern": "^.{2,}|[^./]$",
                                               "type": "string"
                                             },
+                                            "repoURL": {
+                                              "type": "string"
+                                            },
                                             "targetBranch": {
                                               "type": "string"
                                             }
@@ -25104,6 +25263,9 @@
                                             "type": "string"
                                           },
                                           "repoURL": {
+                                            "type": "string"
+                                          },
+                                          "tagPrefix": {
                                             "type": "string"
                                           },
                                           "targetRevision": {
@@ -26099,6 +26261,9 @@
                                         "repoURL": {
                                           "type": "string"
                                         },
+                                        "tagPrefix": {
+                                          "type": "string"
+                                        },
                                         "targetRevision": {
                                           "type": "string"
                                         }
@@ -26505,6 +26670,9 @@
                                               "pattern": "^.{2,}|[^./]$",
                                               "type": "string"
                                             },
+                                            "repoURL": {
+                                              "type": "string"
+                                            },
                                             "targetBranch": {
                                               "type": "string"
                                             }
@@ -26897,6 +27065,9 @@
                                           "repoURL": {
                                             "type": "string"
                                           },
+                                          "tagPrefix": {
+                                            "type": "string"
+                                          },
                                           "targetRevision": {
                                             "type": "string"
                                           }
@@ -27255,6 +27426,9 @@
                                 "api": {
                                   "type": "string"
                                 },
+                                "excludeArchivedRepos": {
+                                  "type": "boolean"
+                                },
                                 "insecure": {
                                   "type": "boolean"
                                 },
@@ -27295,6 +27469,9 @@
                                 },
                                 "appSecretName": {
                                   "type": "string"
+                                },
+                                "excludeArchivedRepos": {
+                                  "type": "boolean"
                                 },
                                 "organization": {
                                   "type": "string"
@@ -27348,6 +27525,9 @@
                                 },
                                 "group": {
                                   "type": "string"
+                                },
+                                "includeArchivedRepos": {
+                                  "type": "boolean"
                                 },
                                 "includeSharedProjects": {
                                   "type": "boolean"
@@ -27877,6 +28057,9 @@
                                         "repoURL": {
                                           "type": "string"
                                         },
+                                        "tagPrefix": {
+                                          "type": "string"
+                                        },
                                         "targetRevision": {
                                           "type": "string"
                                         }
@@ -28283,6 +28466,9 @@
                                               "pattern": "^.{2,}|[^./]$",
                                               "type": "string"
                                             },
+                                            "repoURL": {
+                                              "type": "string"
+                                            },
                                             "targetBranch": {
                                               "type": "string"
                                             }
@@ -28673,6 +28859,9 @@
                                             "type": "string"
                                           },
                                           "repoURL": {
+                                            "type": "string"
+                                          },
+                                          "tagPrefix": {
                                             "type": "string"
                                           },
                                           "targetRevision": {
@@ -29331,6 +29520,9 @@
                               "repoURL": {
                                 "type": "string"
                               },
+                              "tagPrefix": {
+                                "type": "string"
+                              },
                               "targetRevision": {
                                 "type": "string"
                               }
@@ -29737,6 +29929,9 @@
                                     "pattern": "^.{2,}|[^./]$",
                                     "type": "string"
                                   },
+                                  "repoURL": {
+                                    "type": "string"
+                                  },
                                   "targetBranch": {
                                     "type": "string"
                                   }
@@ -30127,6 +30322,9 @@
                                   "type": "string"
                                 },
                                 "repoURL": {
+                                  "type": "string"
+                                },
+                                "tagPrefix": {
                                   "type": "string"
                                 },
                                 "targetRevision": {
@@ -30761,6 +30959,9 @@
                               "repoURL": {
                                 "type": "string"
                               },
+                              "tagPrefix": {
+                                "type": "string"
+                              },
                               "targetRevision": {
                                 "type": "string"
                               }
@@ -31167,6 +31368,9 @@
                                     "pattern": "^.{2,}|[^./]$",
                                     "type": "string"
                                   },
+                                  "repoURL": {
+                                    "type": "string"
+                                  },
                                   "targetBranch": {
                                     "type": "string"
                                   }
@@ -31557,6 +31761,9 @@
                                   "type": "string"
                                 },
                                 "repoURL": {
+                                  "type": "string"
+                                },
+                                "tagPrefix": {
                                   "type": "string"
                                 },
                                 "targetRevision": {
@@ -32552,6 +32759,9 @@
                               "repoURL": {
                                 "type": "string"
                               },
+                              "tagPrefix": {
+                                "type": "string"
+                              },
                               "targetRevision": {
                                 "type": "string"
                               }
@@ -32958,6 +33168,9 @@
                                     "pattern": "^.{2,}|[^./]$",
                                     "type": "string"
                                   },
+                                  "repoURL": {
+                                    "type": "string"
+                                  },
                                   "targetBranch": {
                                     "type": "string"
                                   }
@@ -33350,6 +33563,9 @@
                                 "repoURL": {
                                   "type": "string"
                                 },
+                                "tagPrefix": {
+                                  "type": "string"
+                                },
                                 "targetRevision": {
                                   "type": "string"
                                 }
@@ -33708,6 +33924,9 @@
                       "api": {
                         "type": "string"
                       },
+                      "excludeArchivedRepos": {
+                        "type": "boolean"
+                      },
                       "insecure": {
                         "type": "boolean"
                       },
@@ -33748,6 +33967,9 @@
                       },
                       "appSecretName": {
                         "type": "string"
+                      },
+                      "excludeArchivedRepos": {
+                        "type": "boolean"
                       },
                       "organization": {
                         "type": "string"
@@ -33801,6 +34023,9 @@
                       },
                       "group": {
                         "type": "string"
+                      },
+                      "includeArchivedRepos": {
+                        "type": "boolean"
                       },
                       "includeSharedProjects": {
                         "type": "boolean"
@@ -34330,6 +34555,9 @@
                               "repoURL": {
                                 "type": "string"
                               },
+                              "tagPrefix": {
+                                "type": "string"
+                              },
                               "targetRevision": {
                                 "type": "string"
                               }
@@ -34736,6 +34964,9 @@
                                     "pattern": "^.{2,}|[^./]$",
                                     "type": "string"
                                   },
+                                  "repoURL": {
+                                    "type": "string"
+                                  },
                                   "targetBranch": {
                                     "type": "string"
                                   }
@@ -35126,6 +35357,9 @@
                                   "type": "string"
                                 },
                                 "repoURL": {
+                                  "type": "string"
+                                },
+                                "tagPrefix": {
                                   "type": "string"
                                 },
                                 "targetRevision": {
@@ -35906,6 +36140,9 @@
                     "repoURL": {
                       "type": "string"
                     },
+                    "tagPrefix": {
+                      "type": "string"
+                    },
                     "targetRevision": {
                       "type": "string"
                     }
@@ -36312,6 +36549,9 @@
                           "pattern": "^.{2,}|[^./]$",
                           "type": "string"
                         },
+                        "repoURL": {
+                          "type": "string"
+                        },
                         "targetBranch": {
                           "type": "string"
                         }
@@ -36702,6 +36942,9 @@
                         "type": "string"
                       },
                       "repoURL": {
+                        "type": "string"
+                      },
+                      "tagPrefix": {
                         "type": "string"
                       },
                       "targetRevision": {

--- a/argoproj.io/appproject_v1alpha1.json
+++ b/argoproj.io/appproject_v1alpha1.json
@@ -259,9 +259,9 @@
           "type": "array"
         },
         "signatureKeys": {
-          "description": "SignatureKeys contains a list of PGP key IDs that commits in Git must be signed with in order to be allowed for sync",
+          "description": "SignatureKeys contains a list of PGP key IDs that commits in Git must be signed with in order to be allowed for sync\n\nDeprecated: Use SourceIntegrity instead. SignatureKeys will be removed with the next major version.",
           "items": {
-            "description": "SignatureKey is the specification of a key required to verify commit signatures with",
+            "description": "SignatureKey is the specification of a key required to verify commit signatures with\n\nDeprecated: Use SourceIntegrity instead. SignatureKeys will be removed with the next major version.",
             "properties": {
               "keyID": {
                 "description": "The ID of the key in hexadecimal notation",
@@ -275,6 +275,77 @@
             "additionalProperties": false
           },
           "type": "array"
+        },
+        "sourceIntegrity": {
+          "description": "SourceIntegrity represents a constraint on manifest sources integrity to be met before they can be used.\nDo not access directly, use EffectiveSourceIntegrity() for correct backwards compatibility handling.",
+          "properties": {
+            "git": {
+              "description": "Git - policies for git source verification",
+              "properties": {
+                "policies": {
+                  "items": {
+                    "properties": {
+                      "gpg": {
+                        "description": "Verify GPG commit/tag signatures",
+                        "properties": {
+                          "keys": {
+                            "description": "List of key IDs to trust. The keys need to be in the repository server keyring.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "mode": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "keys",
+                          "mode"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "repos": {
+                        "description": "List of repository criteria restricting repositories the policy will apply to",
+                        "items": {
+                          "properties": {
+                            "url": {
+                              "description": "URL specifier, glob.",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "url"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "required": [
+                      "gpg",
+                      "repos"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                }
+              },
+              "required": [
+                "policies"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "required": [
+            "git"
+          ],
+          "type": "object",
+          "additionalProperties": false
         },
         "sourceNamespaces": {
           "description": "SourceNamespaces defines the namespaces application resources are allowed to be created in",
@@ -339,6 +410,10 @@
               "schedule": {
                 "description": "Schedule is the time the window will begin, specified in cron format",
                 "type": "string"
+              },
+              "syncOverrun": {
+                "description": "SyncOverrun allows ongoing syncs to continue in two scenarios:\nFor deny windows: allows syncs that started before the deny window became active to continue running\nFor allow windows: allows syncs that started during the allow window to continue after the window ends",
+                "type": "boolean"
               },
               "timeZone": {
                 "description": "TimeZone of the sync that will be applied to the schedule",


### PR DESCRIPTION
## PR Checklist

- [x] I generated these CRs using the [CRD Extractor tool](https://github.com/datreeio/CRDs-catalog?tab=readme-ov-file#crd-extractor). If I used a different method, I have described the method in this PR.
- [x] I am updating existing schemas and have specified the updated schema version.
- [ ] I am adding new schemas and included a link to the GitHub repository that contains the source of these schemas.
