### PR TITLE
feat: update autoscaling.k8s.io CRDs to 1.7.1

### DIFF
--- a/autoscaling.k8s.io/verticalpodautoscaler_v1.json
+++ b/autoscaling.k8s.io/verticalpodautoscaler_v1.json
@@ -1,24 +1,24 @@
 {
-  "description": "VerticalPodAutoscaler is the configuration for a vertical pod autoscaler, which automatically manages pod resources based on historical and real time resource utilization.",
+  "description": "VerticalPodAutoscaler is the configuration for a vertical pod\nautoscaler, which automatically manages pod resources based on historical and\nreal time resource utilization.",
   "properties": {
     "apiVersion": {
-      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
       "type": "string"
     },
     "kind": {
-      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
       "type": "string"
     },
     "metadata": {
       "type": "object"
     },
     "spec": {
-      "description": "Specification of the behavior of the autoscaler. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status.",
+      "description": "Specification of the behavior of the autoscaler.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status.",
       "properties": {
         "recommenders": {
-          "description": "Recommender responsible for generating recommendation for this object. List should be empty (then the default recommender will generate the recommendation) or contain exactly one recommender.",
+          "description": "Recommender responsible for generating recommendation for this object.\nList should be empty (then the default recommender will generate the\nrecommendation) or contain exactly one recommender.",
           "items": {
-            "description": "VerticalPodAutoscalerRecommenderSelector points to a specific Vertical Pod Autoscaler recommender. In the future it might pass parameters to the recommender.",
+            "description": "VerticalPodAutoscalerRecommenderSelector points to a specific Vertical Pod Autoscaler recommender.\nIn the future it might pass parameters to the recommender.",
             "properties": {
               "name": {
                 "description": "Name of the recommender responsible for generating recommendation for this object.",
@@ -28,25 +28,24 @@
             "required": [
               "name"
             ],
-            "type": "object",
-            "additionalProperties": false
+            "type": "object"
           },
           "type": "array"
         },
         "resourcePolicy": {
-          "description": "Controls how the autoscaler computes recommended resources. The resource policy may be used to set constraints on the recommendations for individual containers. If any individual containers need to be excluded from getting the VPA recommendations, then it must be disabled explicitly by setting mode to \"Off\" under containerPolicies. If not specified, the autoscaler computes recommended resources for all containers in the pod, without additional constraints.",
+          "description": "Controls how the autoscaler computes recommended resources.\nThe resource policy may be used to set constraints on the recommendations\nfor individual containers.\nIf any individual containers need to be excluded from getting the VPA recommendations, then\nit must be disabled explicitly by setting mode to \"Off\" under containerPolicies.\nIf not specified, the autoscaler computes recommended resources for all containers in the pod,\nwithout additional constraints.",
           "properties": {
             "containerPolicies": {
               "description": "Per-container resource policies.",
               "items": {
-                "description": "ContainerResourcePolicy controls how autoscaler computes the recommended resources for a specific container.",
+                "description": "ContainerResourcePolicy controls how autoscaler computes the recommended\nresources for a specific container.",
                 "properties": {
                   "containerName": {
-                    "description": "Name of the container or DefaultContainerResourcePolicy, in which case the policy is used by the containers that don't have their own policy specified.",
+                    "description": "Name of the container or DefaultContainerResourcePolicy, in which\ncase the policy is used by the containers that don't have their own\npolicy specified.",
                     "type": "string"
                   },
                   "controlledResources": {
-                    "description": "Specifies the type of recommendations that will be computed (and possibly applied) by VPA. If not specified, the default of [ResourceCPU, ResourceMemory] will be used.",
+                    "description": "Specifies the type of recommendations that will be computed\n(and possibly applied) by VPA.\nIf not specified, the default of [ResourceCPU, ResourceMemory] will be used.",
                     "items": {
                       "description": "ResourceName is the name identifying various resources in a ResourceList.",
                       "type": "string"
@@ -54,7 +53,7 @@
                     "type": "array"
                   },
                   "controlledValues": {
-                    "description": "Specifies which resource values should be controlled. The default is \"RequestsAndLimits\".",
+                    "description": "Specifies which resource values should be controlled.\nThe default is \"RequestsAndLimits\".",
                     "enum": [
                       "RequestsAndLimits",
                       "RequestsOnly"
@@ -74,8 +73,20 @@
                       "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                       "x-kubernetes-int-or-string": true
                     },
-                    "description": "Specifies the maximum amount of resources that will be recommended for the container. The default is no maximum.",
+                    "description": "Specifies the maximum amount of resources that will be recommended\nfor the container. The default is no maximum.",
                     "type": "object"
+                  },
+                  "memoryAggregationIntervalCount": {
+                    "description": "memoryAggregationIntervalCount is the number of consecutive\nmemoryAggregationIntervals which make up the memory aggregation window.\nThe total window length is:\nMemoryAggregationIntervalSeconds * MemoryAggregationIntervalCount.",
+                    "format": "int64",
+                    "minimum": 1,
+                    "type": "integer"
+                  },
+                  "memoryAggregationIntervalSeconds": {
+                    "description": "memoryAggregationIntervalSeconds is the length of a single interval\n(in seconds) for which the peak memory usage is computed.\nMemory usage peaks are aggregated in multiples of this interval.\nIn other words, there is one memory usage sample per interval\n(the maximum usage over that interval).",
+                    "format": "int32",
+                    "minimum": 1,
+                    "type": "integer"
                   },
                   "minAllowed": {
                     "additionalProperties": {
@@ -90,7 +101,7 @@
                       "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                       "x-kubernetes-int-or-string": true
                     },
-                    "description": "Specifies the minimal amount of resources that will be recommended for the container. The default is no minimum.",
+                    "description": "Specifies the minimal amount of resources that will be recommended\nfor the container. The default is no minimum.",
                     "type": "object"
                   },
                   "mode": {
@@ -100,30 +111,166 @@
                       "Off"
                     ],
                     "type": "string"
+                  },
+                  "oomBumpUpRatio": {
+                    "anyOf": [
+                      {
+                        "type": "integer"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ],
+                    "description": "oomBumpUpRatio is the ratio to increase memory when OOM is detected.",
+                    "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                    "x-kubernetes-int-or-string": true
+                  },
+                  "oomMinBumpUp": {
+                    "anyOf": [
+                      {
+                        "type": "integer"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ],
+                    "description": "oomMinBumpUp is the minimum increase in memory when OOM is detected.",
+                    "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                    "x-kubernetes-int-or-string": true
+                  },
+                  "startupBoost": {
+                    "description": "startupBoost specifies the startup boost policy for the container.\nThis overrides any pod-level startup boost policy.\nThe startup boost policy takes precedence over the rest of the fields in\nthis struct, except for ContainerName and ControlledValues.",
+                    "properties": {
+                      "cpu": {
+                        "description": "cpu specifies the CPU startup boost policy.\nIf this field is not set, no startup boost is applied.",
+                        "properties": {
+                          "durationSeconds": {
+                            "description": "durationSeconds indicates for how long to keep the pod boosted after it goes to Ready.\nDefaults to 0.",
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "factor": {
+                            "description": "factor specifies the factor to apply to the resource request.\nThis field is required when Type is \"Factor\".",
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "quantity": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "description": "quantity specifies the absolute resource quantity to be used as the\nresource request and limit during the boost phase.\nThis field is required when Type is \"Quantity\".",
+                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                            "x-kubernetes-int-or-string": true
+                          },
+                          "type": {
+                            "description": "type specifies the kind of boost to apply.\nSupported values are: \"Factor\", \"Quantity\".\nNo startupboost will be applied for unrecognized values.",
+                            "enum": [
+                              "Factor",
+                              "Quantity"
+                            ],
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "type"
+                        ],
+                        "type": "object",
+                        "x-kubernetes-validations": [
+                          {
+                            "message": "factor is required when type is Factor and forbidden otherwise",
+                            "rule": "(self.type == 'Factor') == has(self.factor)"
+                          },
+                          {
+                            "message": "quantity is required when type is Quantity and forbidden otherwise",
+                            "rule": "(self.type == 'Quantity') == has(self.quantity)"
+                          }
+                        ]
+                      }
+                    },
+                    "type": "object"
                   }
                 },
-                "type": "object",
-                "additionalProperties": false
+                "type": "object"
               },
               "type": "array"
             }
           },
-          "type": "object",
-          "additionalProperties": false
+          "type": "object"
+        },
+        "startupBoost": {
+          "description": "startupBoost specifies the startup boost policy for the pod.",
+          "properties": {
+            "cpu": {
+              "description": "cpu specifies the CPU startup boost policy.\nIf this field is not set, no startup boost is applied.",
+              "properties": {
+                "durationSeconds": {
+                  "description": "durationSeconds indicates for how long to keep the pod boosted after it goes to Ready.\nDefaults to 0.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "factor": {
+                  "description": "factor specifies the factor to apply to the resource request.\nThis field is required when Type is \"Factor\".",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "quantity": {
+                  "anyOf": [
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ],
+                  "description": "quantity specifies the absolute resource quantity to be used as the\nresource request and limit during the boost phase.\nThis field is required when Type is \"Quantity\".",
+                  "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                  "x-kubernetes-int-or-string": true
+                },
+                "type": {
+                  "description": "type specifies the kind of boost to apply.\nSupported values are: \"Factor\", \"Quantity\".\nNo startupboost will be applied for unrecognized values.",
+                  "enum": [
+                    "Factor",
+                    "Quantity"
+                  ],
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type"
+              ],
+              "type": "object",
+              "x-kubernetes-validations": [
+                {
+                  "message": "factor is required when type is Factor and forbidden otherwise",
+                  "rule": "(self.type == 'Factor') == has(self.factor)"
+                },
+                {
+                  "message": "quantity is required when type is Quantity and forbidden otherwise",
+                  "rule": "(self.type == 'Quantity') == has(self.quantity)"
+                }
+              ]
+            }
+          },
+          "type": "object"
         },
         "targetRef": {
-          "description": "TargetRef points to the controller managing the set of pods for the autoscaler to control - e.g. Deployment, StatefulSet. VerticalPodAutoscaler can be targeted at controller implementing scale subresource (the pod set is retrieved from the controller's ScaleStatus) or some well known controllers (e.g. for DaemonSet the pod set is read from the controller's spec). If VerticalPodAutoscaler cannot use specified target it will report ConfigUnsupported condition. Note that VerticalPodAutoscaler does not require full implementation of scale subresource - it will not use it to modify the replica count. The only thing retrieved is a label selector matching pods grouped by the target resource.",
+          "description": "TargetRef points to the controller managing the set of pods for the\nautoscaler to control - e.g. Deployment, StatefulSet. VerticalPodAutoscaler\ncan be targeted at controller implementing scale subresource (the pod set is\nretrieved from the controller's ScaleStatus) or some well known controllers\n(e.g. for DaemonSet the pod set is read from the controller's spec).\nIf VerticalPodAutoscaler cannot use specified target it will report\nConfigUnsupported condition.\nNote that VerticalPodAutoscaler does not require full implementation\nof scale subresource - it will not use it to modify the replica count.\nThe only thing retrieved is a label selector matching pods grouped by\nthe target resource.",
           "properties": {
             "apiVersion": {
-              "description": "API version of the referent",
+              "description": "apiVersion is the API version of the referent",
               "type": "string"
             },
             "kind": {
-              "description": "Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+              "description": "kind is the kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
               "type": "string"
             },
             "name": {
-              "description": "Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names",
+              "description": "name is the name of the referent; More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
               "type": "string"
             }
           },
@@ -132,16 +279,21 @@
             "name"
           ],
           "type": "object",
-          "x-kubernetes-map-type": "atomic",
-          "additionalProperties": false
+          "x-kubernetes-map-type": "atomic"
         },
         "updatePolicy": {
-          "description": "Describes the rules on how changes are applied to the pods. If not specified, all fields in the `PodUpdatePolicy` are set to their default values.",
+          "description": "Describes the rules on how changes are applied to the pods.\nIf not specified, all fields in the `PodUpdatePolicy` are set to their\ndefault values.",
           "properties": {
+            "evictAfterOOMSeconds": {
+              "description": "evictAfterOOMSeconds specifies the time in seconds to wait after an OOM event before\nconsidering the pod for eviction. Pods that have OOMed in less than this time\nsince start will be evicted.",
+              "format": "int32",
+              "minimum": 1,
+              "type": "integer"
+            },
             "evictionRequirements": {
-              "description": "EvictionRequirements is a list of EvictionRequirements that need to evaluate to true in order for a Pod to be evicted. If more than one EvictionRequirement is specified, all of them need to be fulfilled to allow eviction.",
+              "description": "EvictionRequirements is a list of EvictionRequirements that need to\nevaluate to true in order for a Pod to be evicted. If more than one\nEvictionRequirement is specified, all of them need to be fulfilled to allow eviction.",
               "items": {
-                "description": "EvictionRequirement defines a single condition which needs to be true in order to evict a Pod",
+                "description": "EvictionRequirement defines a single condition which needs to be true in\norder to evict a Pod",
                 "properties": {
                   "changeRequirement": {
                     "description": "EvictionChangeRequirement refers to the relationship between the new target recommendation for a Pod and its current requests, what kind of change is necessary for the Pod to be evicted",
@@ -152,7 +304,7 @@
                     "type": "string"
                   },
                   "resources": {
-                    "description": "Resources is a list of one or more resources that the condition applies to. If more than one resource is given, the EvictionRequirement is fulfilled if at least one resource meets `changeRequirement`.",
+                    "description": "Resources is a list of one or more resources that the condition applies\nto. If more than one resource is given, the EvictionRequirement is fulfilled\nif at least one resource meets `changeRequirement`.",
                     "items": {
                       "description": "ResourceName is the name identifying various resources in a ResourceList.",
                       "type": "string"
@@ -164,54 +316,58 @@
                   "changeRequirement",
                   "resources"
                 ],
-                "type": "object",
-                "additionalProperties": false
+                "type": "object"
               },
               "type": "array"
             },
             "minReplicas": {
-              "description": "Minimal number of replicas which need to be alive for Updater to attempt pod eviction (pending other checks like PDB). Only positive values are allowed. Overrides global '--min-replicas' flag.",
+              "description": "Minimal number of replicas which need to be alive for Updater to attempt\npod eviction (pending other checks like PDB). Only positive values are\nallowed. Overrides global '--min-replicas' flag.",
               "format": "int32",
               "type": "integer"
             },
             "updateMode": {
-              "description": "Controls when autoscaler applies changes to the pod resources. The default is 'Auto'.",
+              "description": "Controls when autoscaler applies changes to the pod resources.\nThe default is 'Recreate'.",
               "enum": [
                 "Off",
                 "Initial",
                 "Recreate",
                 "InPlaceOrRecreate",
+                "InPlace",
                 "Auto"
               ],
               "type": "string"
             }
           },
-          "type": "object",
-          "additionalProperties": false
+          "type": "object"
         }
       },
       "required": [
         "targetRef"
       ],
-      "type": "object",
-      "additionalProperties": false
+      "type": "object"
     },
     "status": {
       "description": "Current information about the autoscaler.",
       "properties": {
         "conditions": {
-          "description": "Conditions is the set of conditions required for this autoscaler to scale its target, and indicates whether or not those conditions are met.",
+          "description": "Conditions is the set of conditions required for this autoscaler to scale its target,\nand indicates whether or not those conditions are met.",
           "items": {
-            "description": "VerticalPodAutoscalerCondition describes the state of a VerticalPodAutoscaler at a certain point.",
+            "description": "VerticalPodAutoscalerCondition describes the state of\na VerticalPodAutoscaler at a certain point.",
             "properties": {
               "lastTransitionTime": {
-                "description": "lastTransitionTime is the last time the condition transitioned from one status to another",
+                "description": "lastTransitionTime is the last time the condition transitioned from\none status to another",
                 "format": "date-time",
                 "type": "string"
               },
               "message": {
-                "description": "message is a human-readable explanation containing details about the transition",
+                "description": "message is a human-readable explanation containing details about\nthe transition",
                 "type": "string"
+              },
+              "observedGeneration": {
+                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon.\nFor instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date\nwith respect to the current state of the instance.",
+                "format": "int64",
+                "minimum": 0,
+                "type": "integer"
               },
               "reason": {
                 "description": "reason is the reason for the condition's last transition.",
@@ -230,18 +386,23 @@
               "status",
               "type"
             ],
-            "type": "object",
-            "additionalProperties": false
+            "type": "object"
           },
           "type": "array"
         },
+        "observedGeneration": {
+          "description": "observedGeneration is the most recent generation observed by this autoscaler.",
+          "format": "int64",
+          "minimum": 0,
+          "type": "integer"
+        },
         "recommendation": {
-          "description": "The most recently computed amount of resources recommended by the autoscaler for the controlled pods.",
+          "description": "The most recently computed amount of resources recommended by the\nautoscaler for the controlled pods.",
           "properties": {
             "containerRecommendations": {
               "description": "Resources recommended by the autoscaler for each container.",
               "items": {
-                "description": "RecommendedContainerResources is the recommendation of resources computed by autoscaler for a specific container. Respects the container resource policy if present in the spec. In particular the recommendation is not produced for containers with `ContainerScalingMode` set to 'Off'.",
+                "description": "RecommendedContainerResources is the recommendation of resources computed by\nautoscaler for a specific container. Respects the container resource policy\nif present in the spec. In particular the recommendation is not produced for\ncontainers with `ContainerScalingMode` set to 'Off'.",
                 "properties": {
                   "containerName": {
                     "description": "Name of the container.",
@@ -260,7 +421,7 @@
                       "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                       "x-kubernetes-int-or-string": true
                     },
-                    "description": "Minimum recommended amount of resources. Observes ContainerResourcePolicy. This amount is not guaranteed to be sufficient for the application to operate in a stable way, however running with less resources is likely to have significant impact on performance/availability.",
+                    "description": "Minimum recommended amount of resources. Observes ContainerResourcePolicy.\nThis amount is not guaranteed to be sufficient for the application to operate in a stable way, however\nrunning with less resources is likely to have significant impact on performance/availability.",
                     "type": "object"
                   },
                   "target": {
@@ -292,7 +453,7 @@
                       "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                       "x-kubernetes-int-or-string": true
                     },
-                    "description": "The most recent recommended resources target computed by the autoscaler for the controlled pods, based only on actual resource usage, not taking into account the ContainerResourcePolicy. May differ from the Recommendation if the actual resource usage causes the target to violate the ContainerResourcePolicy (lower than MinAllowed or higher that MaxAllowed). Used only as status indication, will not affect actual resource assignment.",
+                    "description": "The most recent recommended resources target computed by the autoscaler\nfor the controlled pods, based only on actual resource usage, not taking\ninto account the ContainerResourcePolicy.\nMay differ from the Recommendation if the actual resource usage causes\nthe target to violate the ContainerResourcePolicy (lower than MinAllowed\nor higher that MaxAllowed).\nUsed only as status indication, will not affect actual resource assignment.",
                     "type": "object"
                   },
                   "upperBound": {
@@ -308,25 +469,22 @@
                       "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                       "x-kubernetes-int-or-string": true
                     },
-                    "description": "Maximum recommended amount of resources. Observes ContainerResourcePolicy. Any resources allocated beyond this value are likely wasted. This value may be larger than the maximum amount of application is actually capable of consuming.",
+                    "description": "Maximum recommended amount of resources. Observes ContainerResourcePolicy.\nAny resources allocated beyond this value are likely wasted. This value may be larger than the maximum\namount of application is actually capable of consuming.",
                     "type": "object"
                   }
                 },
                 "required": [
                   "target"
                 ],
-                "type": "object",
-                "additionalProperties": false
+                "type": "object"
               },
               "type": "array"
             }
           },
-          "type": "object",
-          "additionalProperties": false
+          "type": "object"
         }
       },
-      "type": "object",
-      "additionalProperties": false
+      "type": "object"
     }
   },
   "required": [


### PR DESCRIPTION
## PR Checklist

Making this change to get the new `InPlace` released in VPA.

- [ ] I generated these CRs using the [CRD Extractor tool](https://github.com/datreeio/CRDs-catalog?tab=readme-ov-file#crd-extractor). If I used a different method, I have described the method in this PR.
- [X] I am updating existing schemas and have specified the updated schema version.
- [X] I am adding new schemas and included a link to the GitHub repository that contains the source of these schemas.

Followed previous https://github.com/datreeio/CRDs-catalog/pull/728 to make the updates. 

