### PR TITLE
fix(traefik.io): add missing ingressClassName to IngressRoute, IngressRouteTCP, IngressRouteUD

### DIFF
--- a/traefik.io/ingressroute_v1alpha1.json
+++ b/traefik.io/ingressroute_v1alpha1.json
@@ -22,6 +22,10 @@
           },
           "type": "array"
         },
+        "ingressClassName": {
+          "description": "IngressClassName defines the name of the IngressClass cluster resource.",
+          "type": "string"
+        },
         "parentRefs": {
           "description": "ParentRefs defines references to parent IngressRoute resources for multi-layer routing.\nWhen set, this IngressRoute's routers will be children of the referenced parent IngressRoute's routers.\nMore info: https://doc.traefik.io/traefik/v3.6/routing/routers/#parentrefs",
           "items": {

--- a/traefik.io/ingressroutetcp_v1alpha1.json
+++ b/traefik.io/ingressroutetcp_v1alpha1.json
@@ -22,6 +22,10 @@
           },
           "type": "array"
         },
+        "ingressClassName": {
+          "description": "IngressClassName defines the name of the IngressClass cluster resource.",
+          "type": "string"
+        },
         "routes": {
           "description": "Routes defines the list of routes.",
           "items": {

--- a/traefik.io/ingressrouteudp_v1alpha1.json
+++ b/traefik.io/ingressrouteudp_v1alpha1.json
@@ -22,6 +22,10 @@
           },
           "type": "array"
         },
+        "ingressClassName": {
+          "description": "IngressClassName defines the name of the IngressClass cluster resource.",
+          "type": "string"
+        },
         "routes": {
           "description": "Routes defines the list of routes.",
           "items": {


### PR DESCRIPTION
Traefik v3.1.0+ added a spec.ingressClassName field to IngressRoute, IngressRouteTCP, and IngressRouteUDP (traefik.io/v1alpha1), replacing the older kubernetes.io/ingress.class annotation as the recommended way to select an IngressClass. The generated schemas here were missing that field, so additionalProperties: false on spec rejects any manifest that sets it, causing kubeconform to fail

**References:**
[https://doc.traefik.io/traefik/migrate/v3/#kubernetes-crd-provider](https://doc.traefik.io/traefik/migrate/v3/#kubernetes-crd-provider)
[https://raw.githubusercontent.com/traefik/traefik/v3.1.0/docs/content/reference/dynamic-configuration/kubernetes-crd-definition-v1.yml](https://raw.githubusercontent.com/traefik/traefik/v3.1.0/docs/content/reference/dynamic-configuration/kubernetes-crd-definition-v1.yml)

## PR Checklist

- [x] I generated these CRs using the [CRD Extractor tool](https://github.com/datreeio/CRDs-catalog?tab=readme-ov-file#crd-extractor). If I used a different method, I have described the method in this PR.
- [x] I am updating existing schemas and have specified the updated schema version.
- [ ] I am adding new schemas and included a link to the GitHub repository that contains the source of these schemas.
