### PR TITLE
feat: add ImageCatalog.componentImages from CNPG 1.30.0

### DIFF
--- a/postgresql.cnpg.io/clusterimagecatalog_v1.json
+++ b/postgresql.cnpg.io/clusterimagecatalog_v1.json
@@ -15,6 +15,42 @@
     "spec": {
       "description": "Specification of the desired behavior of the ClusterImageCatalog.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status",
       "properties": {
+        "componentImages": {
+          "description": "ComponentImages is a list of named images for components other than PostgreSQL\n(e.g. pgbouncer). Keys must be unique within a catalog.",
+          "items": {
+            "description": "CatalogComponentImage is a named image entry for a non-PostgreSQL component.",
+            "properties": {
+              "image": {
+                "description": "Image is the container image reference.",
+                "type": "string"
+              },
+              "key": {
+                "description": "Key is the unique identifier for this image within the catalog.",
+                "maxLength": 63,
+                "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                "type": "string"
+              }
+            },
+            "required": [
+              "image",
+              "key"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "maxItems": 32,
+          "type": "array",
+          "x-kubernetes-list-map-keys": [
+            "key"
+          ],
+          "x-kubernetes-list-type": "map",
+          "x-kubernetes-validations": [
+            {
+              "message": "Component image keys must be unique",
+              "rule": "self.all(e, self.filter(f, f.key==e.key).size() == 1)"
+            }
+          ]
+        },
         "images": {
           "description": "List of CatalogImages available in the catalog",
           "items": {
@@ -99,7 +135,8 @@
                       "type": "array"
                     },
                     "name": {
-                      "description": "The name of the extension, required",
+                      "description": "The name of the extension, required. The limit of 59 characters\nleaves room for the prefix the operator adds when deriving the\nextension's Kubernetes Volume name (capped at 63 characters).",
+                      "maxLength": 59,
                       "minLength": 1,
                       "pattern": "^[a-z0-9]([-a-z0-9_]*[a-z0-9])?$",
                       "type": "string"

--- a/postgresql.cnpg.io/imagecatalog_v1.json
+++ b/postgresql.cnpg.io/imagecatalog_v1.json
@@ -15,6 +15,42 @@
     "spec": {
       "description": "Specification of the desired behavior of the ImageCatalog.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status",
       "properties": {
+        "componentImages": {
+          "description": "ComponentImages is a list of named images for components other than PostgreSQL\n(e.g. pgbouncer). Keys must be unique within a catalog.",
+          "items": {
+            "description": "CatalogComponentImage is a named image entry for a non-PostgreSQL component.",
+            "properties": {
+              "image": {
+                "description": "Image is the container image reference.",
+                "type": "string"
+              },
+              "key": {
+                "description": "Key is the unique identifier for this image within the catalog.",
+                "maxLength": 63,
+                "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                "type": "string"
+              }
+            },
+            "required": [
+              "image",
+              "key"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "maxItems": 32,
+          "type": "array",
+          "x-kubernetes-list-map-keys": [
+            "key"
+          ],
+          "x-kubernetes-list-type": "map",
+          "x-kubernetes-validations": [
+            {
+              "message": "Component image keys must be unique",
+              "rule": "self.all(e, self.filter(f, f.key==e.key).size() == 1)"
+            }
+          ]
+        },
         "images": {
           "description": "List of CatalogImages available in the catalog",
           "items": {
@@ -99,7 +135,8 @@
                       "type": "array"
                     },
                     "name": {
-                      "description": "The name of the extension, required",
+                      "description": "The name of the extension, required. The limit of 59 characters\nleaves room for the prefix the operator adds when deriving the\nextension's Kubernetes Volume name (capped at 63 characters).",
+                      "maxLength": 59,
                       "minLength": 1,
                       "pattern": "^[a-z0-9]([-a-z0-9_]*[a-z0-9])?$",
                       "type": "string"


### PR DESCRIPTION
## PR Checklist

- [x] I generated these CRs using the [CRD Extractor tool](https://github.com/datreeio/CRDs-catalog?tab=readme-ov-file#crd-extractor). If I used a different method, I have described the method in this PR.
- [x] I am updating existing schemas and have specified the updated schema version.
- [ ] I am adding new schemas and included a link to the GitHub repository that contains the source of these schemas.

Updated schema version: **CloudNativePG 1.30.0** (Helm chart `cloudnative-pg` 0.29.0).

Source CRDs: https://github.com/cloudnative-pg/cloudnative-pg/tree/v1.30.0/config/crd/bases

Release: https://github.com/cloudnative-pg/cloudnative-pg/releases/tag/v1.30.0

### Method

I did not extract from a live cluster. I converted the official v1.30.0 CRDs with the same [`openapi2jsonschema.py`](https://github.com/yannh/kubeconform/blob/master/scripts/openapi2jsonschema.py) script the CRD Extractor uses:

```text
postgresql.cnpg.io_imagecatalogs.yaml
postgresql.cnpg.io_clusterimagecatalogs.yaml
```

### What changed

CNPG 1.30.0 added `spec.componentImages` so a `Pooler` can pin the PgBouncer image via `spec.pgbouncer.imageCatalogRef` ([cloudnative-pg#10568](https://github.com/cloudnative-pg/cloudnative-pg/pull/10568)). The catalog schemas still have `additionalProperties: false` on `spec` and only allow `images`, so kubeconform rejects any ImageCatalog that sets `componentImages`.

This updates:

- `postgresql.cnpg.io/imagecatalog_v1.json`
- `postgresql.cnpg.io/clusterimagecatalog_v1.json` (same spec)

Also picks up the 1.30.0 `extensions[].name` `maxLength: 59` clarification from the same CRDs. Other CNPG resources were left unchanged.

Made with [Cursor](https://cursor.com)