### PR TITLE
Update gloo.solo.io settings_v1 schema from Gloo Edge 1.21.3 CRD

### DIFF
--- a/gloo.solo.io/settings_v1.json
+++ b/gloo.solo.io/settings_v1.json
@@ -59,15 +59,10 @@
               "additionalProperties": false
             },
             "maxPayloadSize": {
-              "properties": {
-                "value": {
-                  "format": "int64",
-                  "type": "integer",
-                  "x-kubernetes-int-or-string": true
-                }
-              },
-              "type": "object",
-              "additionalProperties": false
+              "maximum": 4294967295,
+              "minimum": 0,
+              "nullable": true,
+              "type": "integer"
             },
             "timeout": {
               "type": "string"
@@ -77,18 +72,7 @@
           "additionalProperties": false
         },
         "consoleOptions": {
-          "properties": {
-            "apiExplorerEnabled": {
-              "nullable": true,
-              "type": "boolean"
-            },
-            "readOnly": {
-              "nullable": true,
-              "type": "boolean"
-            }
-          },
-          "type": "object",
-          "additionalProperties": false
+          "type": "object"
         },
         "consul": {
           "properties": {
@@ -257,14 +241,7 @@
               "x-kubernetes-int-or-string": true
             },
             "fdsOptions": {
-              "properties": {
-                "graphqlEnabled": {
-                  "nullable": true,
-                  "type": "boolean"
-                }
-              },
-              "type": "object",
-              "additionalProperties": false
+              "type": "object"
             },
             "udsOptions": {
               "properties": {
@@ -288,6 +265,1020 @@
         },
         "discoveryNamespace": {
           "type": "string"
+        },
+        "extProc": {
+          "properties": {
+            "allowModeOverride": {
+              "nullable": true,
+              "type": "boolean"
+            },
+            "asyncMode": {
+              "nullable": true,
+              "type": "boolean"
+            },
+            "disableClearRouteCache": {
+              "nullable": true,
+              "type": "boolean"
+            },
+            "failureModeAllow": {
+              "nullable": true,
+              "type": "boolean"
+            },
+            "filterMetadata": {
+              "type": "object",
+              "x-kubernetes-preserve-unknown-fields": true
+            },
+            "filterStage": {
+              "properties": {
+                "predicate": {
+                  "type": "string",
+                  "x-kubernetes-int-or-string": true
+                },
+                "stage": {
+                  "type": "string",
+                  "x-kubernetes-int-or-string": true
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "forwardRules": {
+              "properties": {
+                "allowedHeaders": {
+                  "properties": {
+                    "patterns": {
+                      "items": {
+                        "properties": {
+                          "exact": {
+                            "type": "string"
+                          },
+                          "ignoreCase": {
+                            "type": "boolean"
+                          },
+                          "prefix": {
+                            "type": "string"
+                          },
+                          "safeRegex": {
+                            "properties": {
+                              "googleRe2": {
+                                "properties": {
+                                  "maxProgramSize": {
+                                    "maximum": 4294967295,
+                                    "minimum": 0,
+                                    "nullable": true,
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "regex": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "suffix": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "disallowedHeaders": {
+                  "properties": {
+                    "patterns": {
+                      "items": {
+                        "properties": {
+                          "exact": {
+                            "type": "string"
+                          },
+                          "ignoreCase": {
+                            "type": "boolean"
+                          },
+                          "prefix": {
+                            "type": "string"
+                          },
+                          "safeRegex": {
+                            "properties": {
+                              "googleRe2": {
+                                "properties": {
+                                  "maxProgramSize": {
+                                    "maximum": 4294967295,
+                                    "minimum": 0,
+                                    "nullable": true,
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "regex": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "suffix": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "grpcService": {
+              "properties": {
+                "authority": {
+                  "nullable": true,
+                  "type": "string"
+                },
+                "extProcServerRef": {
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "namespace": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "initialMetadata": {
+                  "items": {
+                    "properties": {
+                      "key": {
+                        "type": "string"
+                      },
+                      "value": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "retryPolicy": {
+                  "properties": {
+                    "numRetries": {
+                      "maximum": 4294967295,
+                      "minimum": 0,
+                      "nullable": true,
+                      "type": "integer"
+                    },
+                    "retryBackOff": {
+                      "properties": {
+                        "baseInterval": {
+                          "type": "string"
+                        },
+                        "maxInterval": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "timeout": {
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "maxMessageTimeout": {
+              "type": "string"
+            },
+            "messageTimeout": {
+              "type": "string"
+            },
+            "metadataContextNamespaces": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "mutationRules": {
+              "properties": {
+                "allowAllRouting": {
+                  "nullable": true,
+                  "type": "boolean"
+                },
+                "allowEnvoy": {
+                  "nullable": true,
+                  "type": "boolean"
+                },
+                "allowExpression": {
+                  "properties": {
+                    "googleRe2": {
+                      "properties": {
+                        "maxProgramSize": {
+                          "maximum": 4294967295,
+                          "minimum": 0,
+                          "nullable": true,
+                          "type": "integer"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "regex": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "disallowAll": {
+                  "nullable": true,
+                  "type": "boolean"
+                },
+                "disallowExpression": {
+                  "properties": {
+                    "googleRe2": {
+                      "properties": {
+                        "maxProgramSize": {
+                          "maximum": 4294967295,
+                          "minimum": 0,
+                          "nullable": true,
+                          "type": "integer"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "regex": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "disallowIsError": {
+                  "nullable": true,
+                  "type": "boolean"
+                },
+                "disallowSystem": {
+                  "nullable": true,
+                  "type": "boolean"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "processingMode": {
+              "properties": {
+                "requestBodyMode": {
+                  "type": "string",
+                  "x-kubernetes-int-or-string": true
+                },
+                "requestHeaderMode": {
+                  "type": "string",
+                  "x-kubernetes-int-or-string": true
+                },
+                "requestTrailerMode": {
+                  "type": "string",
+                  "x-kubernetes-int-or-string": true
+                },
+                "responseBodyMode": {
+                  "type": "string",
+                  "x-kubernetes-int-or-string": true
+                },
+                "responseHeaderMode": {
+                  "type": "string",
+                  "x-kubernetes-int-or-string": true
+                },
+                "responseTrailerMode": {
+                  "type": "string",
+                  "x-kubernetes-int-or-string": true
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "requestAttributes": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "responseAttributes": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "statPrefix": {
+              "nullable": true,
+              "type": "string"
+            },
+            "typedMetadataContextNamespaces": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "extProcEarly": {
+          "properties": {
+            "allowModeOverride": {
+              "nullable": true,
+              "type": "boolean"
+            },
+            "asyncMode": {
+              "nullable": true,
+              "type": "boolean"
+            },
+            "disableClearRouteCache": {
+              "nullable": true,
+              "type": "boolean"
+            },
+            "failureModeAllow": {
+              "nullable": true,
+              "type": "boolean"
+            },
+            "filterMetadata": {
+              "type": "object",
+              "x-kubernetes-preserve-unknown-fields": true
+            },
+            "filterStage": {
+              "properties": {
+                "predicate": {
+                  "type": "string",
+                  "x-kubernetes-int-or-string": true
+                },
+                "stage": {
+                  "type": "string",
+                  "x-kubernetes-int-or-string": true
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "forwardRules": {
+              "properties": {
+                "allowedHeaders": {
+                  "properties": {
+                    "patterns": {
+                      "items": {
+                        "properties": {
+                          "exact": {
+                            "type": "string"
+                          },
+                          "ignoreCase": {
+                            "type": "boolean"
+                          },
+                          "prefix": {
+                            "type": "string"
+                          },
+                          "safeRegex": {
+                            "properties": {
+                              "googleRe2": {
+                                "properties": {
+                                  "maxProgramSize": {
+                                    "maximum": 4294967295,
+                                    "minimum": 0,
+                                    "nullable": true,
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "regex": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "suffix": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "disallowedHeaders": {
+                  "properties": {
+                    "patterns": {
+                      "items": {
+                        "properties": {
+                          "exact": {
+                            "type": "string"
+                          },
+                          "ignoreCase": {
+                            "type": "boolean"
+                          },
+                          "prefix": {
+                            "type": "string"
+                          },
+                          "safeRegex": {
+                            "properties": {
+                              "googleRe2": {
+                                "properties": {
+                                  "maxProgramSize": {
+                                    "maximum": 4294967295,
+                                    "minimum": 0,
+                                    "nullable": true,
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "regex": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "suffix": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "grpcService": {
+              "properties": {
+                "authority": {
+                  "nullable": true,
+                  "type": "string"
+                },
+                "extProcServerRef": {
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "namespace": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "initialMetadata": {
+                  "items": {
+                    "properties": {
+                      "key": {
+                        "type": "string"
+                      },
+                      "value": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "retryPolicy": {
+                  "properties": {
+                    "numRetries": {
+                      "maximum": 4294967295,
+                      "minimum": 0,
+                      "nullable": true,
+                      "type": "integer"
+                    },
+                    "retryBackOff": {
+                      "properties": {
+                        "baseInterval": {
+                          "type": "string"
+                        },
+                        "maxInterval": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "timeout": {
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "maxMessageTimeout": {
+              "type": "string"
+            },
+            "messageTimeout": {
+              "type": "string"
+            },
+            "metadataContextNamespaces": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "mutationRules": {
+              "properties": {
+                "allowAllRouting": {
+                  "nullable": true,
+                  "type": "boolean"
+                },
+                "allowEnvoy": {
+                  "nullable": true,
+                  "type": "boolean"
+                },
+                "allowExpression": {
+                  "properties": {
+                    "googleRe2": {
+                      "properties": {
+                        "maxProgramSize": {
+                          "maximum": 4294967295,
+                          "minimum": 0,
+                          "nullable": true,
+                          "type": "integer"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "regex": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "disallowAll": {
+                  "nullable": true,
+                  "type": "boolean"
+                },
+                "disallowExpression": {
+                  "properties": {
+                    "googleRe2": {
+                      "properties": {
+                        "maxProgramSize": {
+                          "maximum": 4294967295,
+                          "minimum": 0,
+                          "nullable": true,
+                          "type": "integer"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "regex": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "disallowIsError": {
+                  "nullable": true,
+                  "type": "boolean"
+                },
+                "disallowSystem": {
+                  "nullable": true,
+                  "type": "boolean"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "processingMode": {
+              "properties": {
+                "requestBodyMode": {
+                  "type": "string",
+                  "x-kubernetes-int-or-string": true
+                },
+                "requestHeaderMode": {
+                  "type": "string",
+                  "x-kubernetes-int-or-string": true
+                },
+                "requestTrailerMode": {
+                  "type": "string",
+                  "x-kubernetes-int-or-string": true
+                },
+                "responseBodyMode": {
+                  "type": "string",
+                  "x-kubernetes-int-or-string": true
+                },
+                "responseHeaderMode": {
+                  "type": "string",
+                  "x-kubernetes-int-or-string": true
+                },
+                "responseTrailerMode": {
+                  "type": "string",
+                  "x-kubernetes-int-or-string": true
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "requestAttributes": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "responseAttributes": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "statPrefix": {
+              "nullable": true,
+              "type": "string"
+            },
+            "typedMetadataContextNamespaces": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "extProcLate": {
+          "properties": {
+            "allowModeOverride": {
+              "nullable": true,
+              "type": "boolean"
+            },
+            "asyncMode": {
+              "nullable": true,
+              "type": "boolean"
+            },
+            "disableClearRouteCache": {
+              "nullable": true,
+              "type": "boolean"
+            },
+            "failureModeAllow": {
+              "nullable": true,
+              "type": "boolean"
+            },
+            "filterMetadata": {
+              "type": "object",
+              "x-kubernetes-preserve-unknown-fields": true
+            },
+            "filterStage": {
+              "properties": {
+                "predicate": {
+                  "type": "string",
+                  "x-kubernetes-int-or-string": true
+                },
+                "stage": {
+                  "type": "string",
+                  "x-kubernetes-int-or-string": true
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "forwardRules": {
+              "properties": {
+                "allowedHeaders": {
+                  "properties": {
+                    "patterns": {
+                      "items": {
+                        "properties": {
+                          "exact": {
+                            "type": "string"
+                          },
+                          "ignoreCase": {
+                            "type": "boolean"
+                          },
+                          "prefix": {
+                            "type": "string"
+                          },
+                          "safeRegex": {
+                            "properties": {
+                              "googleRe2": {
+                                "properties": {
+                                  "maxProgramSize": {
+                                    "maximum": 4294967295,
+                                    "minimum": 0,
+                                    "nullable": true,
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "regex": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "suffix": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "disallowedHeaders": {
+                  "properties": {
+                    "patterns": {
+                      "items": {
+                        "properties": {
+                          "exact": {
+                            "type": "string"
+                          },
+                          "ignoreCase": {
+                            "type": "boolean"
+                          },
+                          "prefix": {
+                            "type": "string"
+                          },
+                          "safeRegex": {
+                            "properties": {
+                              "googleRe2": {
+                                "properties": {
+                                  "maxProgramSize": {
+                                    "maximum": 4294967295,
+                                    "minimum": 0,
+                                    "nullable": true,
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "regex": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "suffix": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "grpcService": {
+              "properties": {
+                "authority": {
+                  "nullable": true,
+                  "type": "string"
+                },
+                "extProcServerRef": {
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "namespace": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "initialMetadata": {
+                  "items": {
+                    "properties": {
+                      "key": {
+                        "type": "string"
+                      },
+                      "value": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "retryPolicy": {
+                  "properties": {
+                    "numRetries": {
+                      "maximum": 4294967295,
+                      "minimum": 0,
+                      "nullable": true,
+                      "type": "integer"
+                    },
+                    "retryBackOff": {
+                      "properties": {
+                        "baseInterval": {
+                          "type": "string"
+                        },
+                        "maxInterval": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "timeout": {
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "maxMessageTimeout": {
+              "type": "string"
+            },
+            "messageTimeout": {
+              "type": "string"
+            },
+            "metadataContextNamespaces": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "mutationRules": {
+              "properties": {
+                "allowAllRouting": {
+                  "nullable": true,
+                  "type": "boolean"
+                },
+                "allowEnvoy": {
+                  "nullable": true,
+                  "type": "boolean"
+                },
+                "allowExpression": {
+                  "properties": {
+                    "googleRe2": {
+                      "properties": {
+                        "maxProgramSize": {
+                          "maximum": 4294967295,
+                          "minimum": 0,
+                          "nullable": true,
+                          "type": "integer"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "regex": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "disallowAll": {
+                  "nullable": true,
+                  "type": "boolean"
+                },
+                "disallowExpression": {
+                  "properties": {
+                    "googleRe2": {
+                      "properties": {
+                        "maxProgramSize": {
+                          "maximum": 4294967295,
+                          "minimum": 0,
+                          "nullable": true,
+                          "type": "integer"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "regex": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "disallowIsError": {
+                  "nullable": true,
+                  "type": "boolean"
+                },
+                "disallowSystem": {
+                  "nullable": true,
+                  "type": "boolean"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "processingMode": {
+              "properties": {
+                "requestBodyMode": {
+                  "type": "string",
+                  "x-kubernetes-int-or-string": true
+                },
+                "requestHeaderMode": {
+                  "type": "string",
+                  "x-kubernetes-int-or-string": true
+                },
+                "requestTrailerMode": {
+                  "type": "string",
+                  "x-kubernetes-int-or-string": true
+                },
+                "responseBodyMode": {
+                  "type": "string",
+                  "x-kubernetes-int-or-string": true
+                },
+                "responseHeaderMode": {
+                  "type": "string",
+                  "x-kubernetes-int-or-string": true
+                },
+                "responseTrailerMode": {
+                  "type": "string",
+                  "x-kubernetes-int-or-string": true
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "requestAttributes": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "responseAttributes": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "statPrefix": {
+              "nullable": true,
+              "type": "string"
+            },
+            "typedMetadataContextNamespaces": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
         },
         "extauth": {
           "properties": {
@@ -381,7 +1372,8 @@
                   "type": "boolean"
                 },
                 "maxRequestBytes": {
-                  "format": "int32",
+                  "maximum": 4294967295,
+                  "minimum": 0,
                   "type": "integer"
                 },
                 "packAsBytes": {
@@ -398,7 +1390,8 @@
               "type": "string"
             },
             "statusOnError": {
-              "format": "int32",
+              "maximum": 4294967295,
+              "minimum": 0,
               "type": "integer"
             },
             "transportApiVersion": {
@@ -448,6 +1441,10 @@
             "readGatewaysFromAllNamespaces": {
               "type": "boolean"
             },
+            "translateEmptyGateways": {
+              "nullable": true,
+              "type": "boolean"
+            },
             "validation": {
               "properties": {
                 "allowWarnings": {
@@ -459,6 +1456,10 @@
                   "type": "boolean"
                 },
                 "disableTransformationValidation": {
+                  "nullable": true,
+                  "type": "boolean"
+                },
+                "fullEnvoyValidation": {
                   "nullable": true,
                   "type": "boolean"
                 },
@@ -483,6 +1484,10 @@
                 },
                 "validationWebhookTlsKey": {
                   "type": "string"
+                },
+                "warnMissingTlsSecret": {
+                  "nullable": true,
+                  "type": "boolean"
                 },
                 "warnRouteShortCircuiting": {
                   "nullable": true,
@@ -532,6 +1537,9 @@
                     "cluster": {
                       "type": "string"
                     },
+                    "region": {
+                      "type": "string"
+                    },
                     "timeout": {
                       "type": "string"
                     },
@@ -571,6 +1579,9 @@
                   "minimum": 0,
                   "nullable": true,
                   "type": "integer"
+                },
+                "trackRemaining": {
+                  "type": "boolean"
                 }
               },
               "type": "object",
@@ -584,6 +1595,10 @@
               "type": "boolean"
             },
             "disableProxyGarbageCollection": {
+              "nullable": true,
+              "type": "boolean"
+            },
+            "enableAutoWebsocketTransformationPassthrough": {
               "nullable": true,
               "type": "boolean"
             },
@@ -603,7 +1618,8 @@
                   "type": "string"
                 },
                 "invalidRouteResponseCode": {
-                  "format": "int32",
+                  "maximum": 4294967295,
+                  "minimum": 0,
                   "type": "integer"
                 },
                 "replaceInvalidRoutes": {
@@ -612,6 +1628,28 @@
               },
               "type": "object",
               "additionalProperties": false
+            },
+            "istioOptions": {
+              "properties": {
+                "appendXForwardedHost": {
+                  "nullable": true,
+                  "type": "boolean"
+                },
+                "enableAutoMtls": {
+                  "nullable": true,
+                  "type": "boolean"
+                },
+                "enableIntegration": {
+                  "nullable": true,
+                  "type": "boolean"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "logTransformationRequestResponseInfo": {
+              "nullable": true,
+              "type": "boolean"
             },
             "proxyDebugBindAddr": {
               "type": "string"
@@ -629,6 +1667,10 @@
             "restXdsBindAddr": {
               "type": "string"
             },
+            "transformationEscapeCharacters": {
+              "nullable": true,
+              "type": "boolean"
+            },
             "validationBindAddr": {
               "type": "string"
             },
@@ -639,28 +1681,8 @@
           "type": "object",
           "additionalProperties": false
         },
-        "graphqlOptions": {
-          "properties": {
-            "schemaChangeValidationOptions": {
-              "properties": {
-                "processingRules": {
-                  "items": {
-                    "type": "string",
-                    "x-kubernetes-int-or-string": true
-                  },
-                  "type": "array"
-                },
-                "rejectBreakingChanges": {
-                  "nullable": true,
-                  "type": "boolean"
-                }
-              },
-              "type": "object",
-              "additionalProperties": false
-            }
-          },
-          "type": "object",
-          "additionalProperties": false
+        "ipV4Only": {
+          "type": "boolean"
         },
         "knative": {
           "properties": {
@@ -685,7 +1707,8 @@
                   "type": "number"
                 },
                 "burst": {
-                  "format": "int32",
+                  "maximum": 4294967295,
+                  "minimum": 0,
                   "type": "integer"
                 }
               },
@@ -801,7 +1824,8 @@
                     "type": "boolean"
                   },
                   "maxRequestBytes": {
-                    "format": "int32",
+                    "maximum": 4294967295,
+                    "minimum": 0,
                     "type": "integer"
                   },
                   "packAsBytes": {
@@ -818,7 +1842,8 @@
                 "type": "string"
               },
               "statusOnError": {
-                "format": "int32",
+                "maximum": 4294967295,
+                "minimum": 0,
                 "type": "integer"
               },
               "transportApiVersion": {
@@ -866,11 +1891,17 @@
             },
             "grafanaIntegration": {
               "properties": {
+                "dashboardPrefix": {
+                  "type": "string"
+                },
                 "defaultDashboardFolderId": {
                   "maximum": 4294967295,
                   "minimum": 0,
                   "nullable": true,
                   "type": "integer"
+                },
+                "extraMetricQueryParameters": {
+                  "type": "string"
                 }
               },
               "type": "object",
@@ -898,7 +1929,8 @@
                   "rateLimit": {
                     "properties": {
                       "requestsPerUnit": {
-                        "format": "int32",
+                        "maximum": 4294967295,
+                        "minimum": 0,
                         "type": "integer"
                       },
                       "unit": {
@@ -942,6 +1974,15 @@
             "enableXRatelimitHeaders": {
               "type": "boolean"
             },
+            "grpcService": {
+              "properties": {
+                "authority": {
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
             "rateLimitBeforeAuth": {
               "type": "boolean"
             },
@@ -975,6 +2016,129 @@
         },
         "refreshRate": {
           "type": "string"
+        },
+        "secretOptions": {
+          "properties": {
+            "sources": {
+              "items": {
+                "properties": {
+                  "directory": {
+                    "properties": {
+                      "directory": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "kubernetes": {
+                    "type": "object"
+                  },
+                  "vault": {
+                    "properties": {
+                      "accessToken": {
+                        "type": "string"
+                      },
+                      "address": {
+                        "type": "string"
+                      },
+                      "aws": {
+                        "properties": {
+                          "accessKeyId": {
+                            "type": "string"
+                          },
+                          "iamServerIdHeader": {
+                            "type": "string"
+                          },
+                          "leaseIncrement": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "mountPath": {
+                            "type": "string"
+                          },
+                          "region": {
+                            "type": "string"
+                          },
+                          "secretAccessKey": {
+                            "type": "string"
+                          },
+                          "sessionToken": {
+                            "type": "string"
+                          },
+                          "vaultRole": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "caCert": {
+                        "type": "string"
+                      },
+                      "caPath": {
+                        "type": "string"
+                      },
+                      "clientCert": {
+                        "type": "string"
+                      },
+                      "clientKey": {
+                        "type": "string"
+                      },
+                      "insecure": {
+                        "nullable": true,
+                        "type": "boolean"
+                      },
+                      "pathPrefix": {
+                        "type": "string"
+                      },
+                      "rootKey": {
+                        "type": "string"
+                      },
+                      "tlsConfig": {
+                        "properties": {
+                          "caCert": {
+                            "type": "string"
+                          },
+                          "caPath": {
+                            "type": "string"
+                          },
+                          "clientCert": {
+                            "type": "string"
+                          },
+                          "clientKey": {
+                            "type": "string"
+                          },
+                          "insecure": {
+                            "nullable": true,
+                            "type": "boolean"
+                          },
+                          "tlsServerName": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "tlsServerName": {
+                        "type": "string"
+                      },
+                      "token": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
         },
         "upstreamOptions": {
           "properties": {
@@ -1016,8 +2180,42 @@
         },
         "vaultSecretSource": {
           "properties": {
+            "accessToken": {
+              "type": "string"
+            },
             "address": {
               "type": "string"
+            },
+            "aws": {
+              "properties": {
+                "accessKeyId": {
+                  "type": "string"
+                },
+                "iamServerIdHeader": {
+                  "type": "string"
+                },
+                "leaseIncrement": {
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "mountPath": {
+                  "type": "string"
+                },
+                "region": {
+                  "type": "string"
+                },
+                "secretAccessKey": {
+                  "type": "string"
+                },
+                "sessionToken": {
+                  "type": "string"
+                },
+                "vaultRole": {
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
             },
             "caCert": {
               "type": "string"
@@ -1041,6 +2239,31 @@
             "rootKey": {
               "type": "string"
             },
+            "tlsConfig": {
+              "properties": {
+                "caCert": {
+                  "type": "string"
+                },
+                "caPath": {
+                  "type": "string"
+                },
+                "clientCert": {
+                  "type": "string"
+                },
+                "clientKey": {
+                  "type": "string"
+                },
+                "insecure": {
+                  "nullable": true,
+                  "type": "boolean"
+                },
+                "tlsServerName": {
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
             "tlsServerName": {
               "type": "string"
             },
@@ -1050,6 +2273,42 @@
           },
           "type": "object",
           "additionalProperties": false
+        },
+        "watchNamespaceSelectors": {
+          "items": {
+            "properties": {
+              "matchExpressions": {
+                "items": {
+                  "properties": {
+                    "key": {
+                      "type": "string"
+                    },
+                    "operator": {
+                      "type": "string"
+                    },
+                    "values": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "array"
+              },
+              "matchLabels": {
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "type": "object"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
         },
         "watchNamespaces": {
           "items": {


### PR DESCRIPTION
The current `gloo.solo.io/settings_v1.json` lags the Settings CRD shipped with recent Gloo Edge versions. Valid manifests fail strict kubeconform validation with e.g.:

```
at '/spec/gateway/validation': additional properties 'fullEnvoyValidation', 'warnMissingTlsSecret' not allowed
at '/spec/gloo': additional properties 'istioOptions', 'enableAutoWebsocketTransformationPassthrough' not allowed
at '/spec/gloo/awsOptions/serviceAccountCredentials': additional properties 'region' not allowed
```

Regenerated with this repo's `Utilities/openapi2jsonschema.py` from the `settings.gloo.solo.io` CRD installed by the gloo-ee 1.21.3 Helm chart (openAPIV3Schema, version v1).

Verified: a rendered gloo-ee 1.21.3 release (69 resources) that previously failed now passes `kubeconform -strict` against the updated schema.