### PR TITLE
feat: add Flink 2.3 and 2.4 support

### DIFF
--- a/flink.apache.org/flinkdeployment_v1beta1.json
+++ b/flink.apache.org/flinkdeployment_v1beta1.json
@@ -17,7 +17,9 @@
             "v1_20",
             "v2_0",
             "v2_1",
-            "v2_2"
+            "v2_2",
+            "v2_3",
+            "v2_4"
           ],
           "type": "string"
         },
@@ -18096,6 +18098,33 @@
             "type": "string"
           },
           "type": "object"
+        },
+        "conditions": {
+          "items": {
+            "properties": {
+              "lastTransitionTime": {
+                "type": "string"
+              },
+              "message": {
+                "type": "string"
+              },
+              "observedGeneration": {
+                "type": "integer"
+              },
+              "reason": {
+                "type": "string"
+              },
+              "status": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
         },
         "error": {
           "type": "string"


### PR DESCRIPTION
## PR Checklist

- [ ] I generated these CRs using the CRD Extractor tool. If I used a different method, I have described the method in this PR.
- [x] I am updating existing schemas and have specified the updated schema version.
- [ ] I am adding new schemas and included a link to the GitHub repository that contains the source of these schemas.

## What changed

Regenerates `flink.apache.org/flinkdeployment_v1beta1.json` from the `FlinkDeployment` CRD used by Apache Flink Kubernetes Operator 1.15.

The full extractor script requires Bash 4+, so the schema was generated by running the catalog's own `Utilities/openapi2jsonschema.py` converter directly against the CRD. This is the same converter invoked by the CRD Extractor.

This update:

- adds Flink `v2_3` and `v2_4` to `spec.flinkVersion.enum`;
- adds the generated `status.conditions` schema present in the Operator 1.15 CRD.

Source/reference:

- Apache Flink Kubernetes Operator PR: https://github.com/apache/flink-kubernetes-operator/pull/1140

## Why

The catalog schema currently ends at `v2_2`, causing schema validators such as kubeconform to reject valid Flink 2.3 deployments.

## Validation

- `jq empty flink.apache.org/flinkdeployment_v1beta1.json`
- `git diff --check`
- kubeconform 0.6.7:
  - 17 rendered `FlinkDeployment` manifests using `v2_3`: valid
  - minimal `FlinkDeployment` using `v2_4`: valid
  - unsupported `v9_9`: rejected as expected
