### PR TITLE
Update Flux CRD schemas to Flux 2.9.4 (adds HelmRelease spec.valuesFrom[].literal)

### DIFF
--- a/helm.toolkit.fluxcd.io/helmrelease_v2.json
+++ b/helm.toolkit.fluxcd.io/helmrelease_v2.json
@@ -222,14 +222,14 @@
         "dependsOn": {
           "description": "DependsOn may contain a DependencyReference slice with\nreferences to HelmRelease resources that must be ready before this HelmRelease\ncan be reconciled.",
           "items": {
-            "description": "DependencyReference defines a HelmRelease dependency on another HelmRelease resource.",
+            "description": "DependencyReference contains enough information to locate the referenced Kubernetes resource object\nand optional CEL expression to assess its readiness.",
             "properties": {
               "name": {
                 "description": "Name of the referent.",
                 "type": "string"
               },
               "namespace": {
-                "description": "Namespace of the referent, defaults to the namespace of the HelmRelease\nresource object that contains the reference.",
+                "description": "Namespace of the referent, defaults to the namespace of the resource\nobject that contains the reference.",
                 "type": "string"
               },
               "readyExpr": {
@@ -345,8 +345,7 @@
             },
             "required": [
               "apiVersion",
-              "current",
-              "kind"
+              "current"
             ],
             "type": "object",
             "additionalProperties": false
@@ -523,6 +522,15 @@
         "persistentClient": {
           "description": "PersistentClient tells the controller to use a persistent Kubernetes\nclient for this release. When enabled, the client will be reused for the\nduration of the reconciliation, instead of being created and destroyed\nfor each (step of a) Helm action.\n\nThis can improve performance, but may cause issues with some Helm charts\nthat for example do create Custom Resource Definitions during installation\noutside Helm's CRD lifecycle hooks, which are then not observed to be\navailable by e.g. post-install hooks.\n\nIf not set, it defaults to true.",
           "type": "boolean"
+        },
+        "postRenderStrategy": {
+          "description": "PostRenderStrategy defines the strategy for sending hooks to post-renderers.\nValid values are 'nohooks' (hooks not sent to post-renderers, Helm 3 behavior),\n'combined' (hooks and templates sent together, Helm 4 default), and 'separate'\n(hooks and templates sent in separate streams, Helm 4.2 opt-in).\nDefaults to 'combined', or 'nohooks' when the UseHelm3Defaults feature gate is enabled.",
+          "enum": [
+            "nohooks",
+            "combined",
+            "separate"
+          ],
+          "type": "string"
         },
         "postRenderers": {
           "description": "PostRenderers holds an array of Helm PostRenderers, which will be applied in order\nof their definition.",
@@ -784,6 +792,14 @@
         "upgrade": {
           "description": "Upgrade holds the configuration for Helm upgrade actions for this HelmRelease.",
           "properties": {
+            "chartNameChangeStrategy": {
+              "description": "ChartNameChangeStrategy defines the strategy to use when a Helm chart name changes.\nValid values are 'Reinstall' or 'InPlaceUpdate'. Defaults to 'Reinstall' if omitted.\n\nReinstall: Reinstall the Helm release, uninstalling the existing Helm release.\n\nInPlaceUpdate: Update the Helm release in place.",
+              "enum": [
+                "InPlaceUpdate",
+                "Reinstall"
+              ],
+              "type": "string"
+            },
             "cleanupOnFail": {
               "description": "CleanupOnFail allows deletion of new resources created during the Helm\nupgrade action when it fails.",
               "type": "boolean"
@@ -919,6 +935,10 @@
                   "ConfigMap"
                 ],
                 "type": "string"
+              },
+              "literal": {
+                "description": "Literal marks this ValuesReference as a literal value. When set in\ncombination with TargetPath, the referenced value is merged at the target\npath without interpreting Helm's `--set` syntax (commas, brackets, dots,\nequal signs, etc.), mirroring the behavior of `helm --set-literal`. This\nis the only safe way to inject arbitrary file content (config files, JSON\nblobs, multi-line strings containing special characters) through\n`valuesFrom`. Has no effect when TargetPath is empty: in that mode the\nreferenced value is always YAML-merged at the root.",
+                "type": "boolean"
               },
               "name": {
                 "description": "Name of the values referent. Should reside in the same namespace as the\nreferring resource.",

--- a/image.toolkit.fluxcd.io/imagerepository_v1.json
+++ b/image.toolkit.fluxcd.io/imagerepository_v1.json
@@ -242,7 +242,7 @@
           "additionalProperties": false
         },
         "observedExclusionList": {
-          "description": "ObservedExclusionList is a list of observed exclusion list. It reflects\nthe exclusion rules used for the observed scan result in\nspec.lastScanResult.",
+          "description": "ObservedExclusionList is a list of observed exclusion list. It reflects\nthe exclusion rules used for the observed scan result in\nstatus.lastScanResult.",
           "items": {
             "type": "string"
           },

--- a/image.toolkit.fluxcd.io/imageupdateautomation_v1.json
+++ b/image.toolkit.fluxcd.io/imageupdateautomation_v1.json
@@ -88,10 +88,10 @@
                   "type": "object"
                 },
                 "signingKey": {
-                  "description": "SigningKey provides the option to sign commits with a GPG key",
+                  "description": "SigningKey provides the option to sign commits with an OpenPGP or\nSSH signing key, referenced from a Secret. See SigningKey.",
                   "properties": {
                     "secretRef": {
-                      "description": "SecretRef holds the name to a secret that contains a 'git.asc' key\ncorresponding to the ASCII Armored file containing the GPG signing\nkeypair as the value. It must be in the same namespace as the\nImageUpdateAutomation.",
+                      "description": "SecretRef references a Secret containing the signing key. For type\n'gpg', the Secret must contain a 'git.asc' (ASCII-armored OpenPGP\nkeypair) and may contain a 'passphrase'. For type 'ssh', the Secret\nmust contain an 'identity' (an SSH private key in any format\ngolang.org/x/crypto/ssh.ParsePrivateKey accepts; typically the\nOpenSSH format produced by 'ssh-keygen') and may contain a 'password'\n(the key's passphrase). The SSH conventions match the GitRepository\nSSH transport-auth Secret format, allowing a single Secret to serve\nboth transport and signing when the ImageUpdateAutomation lives in\nthe same namespace as the GitRepository.\n\nThe Secret itself must live in the same namespace as the\nImageUpdateAutomation.\n\nSupported SSH key algorithms: ed25519, ecdsa-sha2-nistp256/384/521,\nand rsa (>= 2048-bit).",
                       "properties": {
                         "name": {
                           "description": "Name of the referent.",
@@ -103,6 +103,14 @@
                       ],
                       "type": "object",
                       "additionalProperties": false
+                    },
+                    "type": {
+                      "description": "Type selects the signing-key format expected in the referenced\nSecret. When empty, the controller defaults to 'gpg'.",
+                      "enum": [
+                        "gpg",
+                        "ssh"
+                      ],
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -133,7 +141,8 @@
                   "type": "object"
                 },
                 "refspec": {
-                  "description": "Refspec specifies the Git Refspec to use for a push operation.\nIf both Branch and Refspec are provided, then the commit is pushed\nto the branch and also using the specified refspec.\nFor more details about Git Refspecs, see:\nhttps://git-scm.com/book/en/v2/Git-Internals-The-Refspec",
+                  "description": "Refspec specifies the Git Refspec to use for a push operation.\nIf both Branch and Refspec are provided, then the commit is pushed\nto the branch and also using the specified refspec.\nDeletion refspecs and refspecs prefixed with '+' are not supported.\nFor more details about Git Refspecs, see:\nhttps://git-scm.com/book/en/v2/Git-Internals-The-Refspec",
+                  "pattern": "^$|^[^+:]",
                   "type": "string"
                 }
               },
@@ -375,7 +384,7 @@
           "type": "object"
         },
         "observedSourceRevision": {
-          "description": "ObservedPolicies []ObservedPolicy `json:\"observedPolicies,omitempty\"`\nObservedSourceRevision is the last observed source revision. This can be\nused to determine if the source has been updated since last observation.",
+          "description": "ObservedSourceRevision is the last observed source revision. This can be\nused to determine if the source has been updated since last observation.",
           "type": "string"
         }
       },

--- a/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+++ b/kustomize.toolkit.fluxcd.io/kustomization_v1.json
@@ -15,6 +15,18 @@
     "spec": {
       "description": "KustomizationSpec defines the configuration to calculate the desired state\nfrom a Source using Kustomize.",
       "properties": {
+        "buildMetadata": {
+          "description": "BuildMetadata specifies which kustomize build metadata should be added\nto the built resources. The allowed values are 'originAnnotations' to\nannotate resources with their source origin, and 'transformerAnnotations'\nto annotate resources with the transformers that produced them.",
+          "items": {
+            "description": "BuildMetadataOption defines the supported buildMetadata options.",
+            "enum": [
+              "originAnnotations",
+              "transformerAnnotations"
+            ],
+            "type": "string"
+          },
+          "type": "array"
+        },
         "commonMetadata": {
           "description": "CommonMetadata specifies the common labels and annotations that are\napplied to all resources. Any existing label or annotation will be\noverridden if its key matches a common one.",
           "properties": {
@@ -91,14 +103,14 @@
         "dependsOn": {
           "description": "DependsOn may contain a DependencyReference slice\nwith references to Kustomization resources that must be ready before this\nKustomization can be reconciled.",
           "items": {
-            "description": "DependencyReference defines a Kustomization dependency on another Kustomization resource.",
+            "description": "DependencyReference contains enough information to locate the referenced Kubernetes resource object\nand optional CEL expression to assess its readiness.",
             "properties": {
               "name": {
                 "description": "Name of the referent.",
                 "type": "string"
               },
               "namespace": {
-                "description": "Namespace of the referent, defaults to the namespace of the Kustomization\nresource object that contains the reference.",
+                "description": "Namespace of the referent, defaults to the namespace of the resource\nobject that contains the reference.",
                 "type": "string"
               },
               "readyExpr": {
@@ -147,8 +159,7 @@
             },
             "required": [
               "apiVersion",
-              "current",
-              "kind"
+              "current"
             ],
             "type": "object",
             "additionalProperties": false
@@ -180,6 +191,62 @@
             "required": [
               "kind",
               "name"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "ignore": {
+          "description": "Ignore is a list of rules for specifying which changes to ignore\nduring drift detection. These rules are applied to the resources managed\nby the Kustomization and are used to exclude specific JSON pointer paths\nfrom the drift detection and apply process.",
+          "items": {
+            "description": "IgnoreRule defines a rule to selectively disregard specific changes during\nthe drift detection process.",
+            "properties": {
+              "paths": {
+                "description": "Paths is a list of JSON Pointer (RFC 6901) paths to be excluded from\nconsideration in a Kubernetes object.",
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "target": {
+                "description": "Target is a selector for specifying Kubernetes objects to which this\nrule applies.\nIf Target is not set, the Paths will be ignored for all Kubernetes\nobjects within the manifest of the Kustomization.",
+                "properties": {
+                  "annotationSelector": {
+                    "description": "AnnotationSelector is a string that follows the label selection expression\nhttps://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api\nIt matches with the resource annotations.",
+                    "type": "string"
+                  },
+                  "group": {
+                    "description": "Group is the API group to select resources from.\nTogether with Version and Kind it is capable of unambiguously identifying and/or selecting resources.\nhttps://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md",
+                    "type": "string"
+                  },
+                  "kind": {
+                    "description": "Kind of the API Group to select resources from.\nTogether with Group and Version it is capable of unambiguously\nidentifying and/or selecting resources.\nhttps://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md",
+                    "type": "string"
+                  },
+                  "labelSelector": {
+                    "description": "LabelSelector is a string that follows the label selection expression\nhttps://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api\nIt matches with the resource labels.",
+                    "type": "string"
+                  },
+                  "name": {
+                    "description": "Name to match resources with.",
+                    "type": "string"
+                  },
+                  "namespace": {
+                    "description": "Namespace to select resources from.",
+                    "type": "string"
+                  },
+                  "version": {
+                    "description": "Version of the API Group to select resources from.\nTogether with Group and Kind it is capable of unambiguously identifying and/or selecting resources.\nhttps://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md",
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              }
+            },
+            "required": [
+              "paths"
             ],
             "type": "object",
             "additionalProperties": false
@@ -386,6 +453,14 @@
                 "additionalProperties": false
               },
               "type": "array"
+            },
+            "substituteStrategy": {
+              "description": "SubstituteStrategy defines the strategy for substituting variables in the YAML manifests.\nValid values are:\n\n - WithVariables (the default): require at least one variable to be defined,\n   either through the inline map or through the resolved references to ConfigMaps\n   and Secrets.\n - Always: perform the substitution even if no variables are defined.",
+              "enum": [
+                "WithVariables",
+                "Always"
+              ],
+              "type": "string"
             }
           },
           "type": "object",

--- a/notification.toolkit.fluxcd.io/receiver_v1.json
+++ b/notification.toolkit.fluxcd.io/receiver_v1.json
@@ -28,17 +28,96 @@
           "pattern": "^([0-9]+(\\.[0-9]+)?(ms|s|m|h))+$",
           "type": "string"
         },
+        "oidcProviders": {
+          "description": "OIDCProviders specifies the OIDC providers used to authenticate incoming\nrequests when Type is 'generic-oidc'. The provider whose IssuerURL matches\nthe token's 'iss' claim is used to verify the token signature, expiration\nand audience, and to evaluate the configured CEL validations against the\ntoken claims.",
+          "items": {
+            "description": "OIDCProvider configures an OIDC issuer used to authenticate requests for a\n'generic-oidc' Receiver.",
+            "properties": {
+              "audience": {
+                "description": "Audience is the expected audience ('aud' claim) for tokens issued by\nthis provider. Defaults to 'notification-controller'.",
+                "type": "string"
+              },
+              "issuerURL": {
+                "description": "IssuerURL is the OIDC issuer URL used for provider discovery. It must\nmatch the 'iss' claim of tokens issued by this provider.",
+                "pattern": "^https?://",
+                "type": "string"
+              },
+              "validations": {
+                "description": "Validations is the list of CEL boolean expressions evaluated against the\ntoken claims and the variables. The request is accepted only if all of\nthem evaluate to true; the message of each failing expression is returned\nto the caller.\n\nAt least one validation is required. A valid signature alone does not\nauthorize a request: public issuers issue tokens to any caller on the\nplatform, so the validations must constrain the caller's identity claims\n(e.g. 'repository_owner' for GitHub Actions).",
+                "items": {
+                  "description": "OIDCValidation is a CEL boolean expression evaluated against the OIDC token\nclaims and variables of a 'generic-oidc' Receiver.",
+                  "properties": {
+                    "expression": {
+                      "description": "Expression is the CEL boolean expression to evaluate.",
+                      "type": "string"
+                    },
+                    "message": {
+                      "description": "Message is returned to the caller when the expression evaluates to false.",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "expression",
+                    "message"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "minItems": 1,
+                "type": "array"
+              },
+              "variables": {
+                "description": "Variables is an optional list of named CEL expressions, evaluated in order\nand exposed as 'vars.<name>'. Each expression can read the token claims\nvia 'claims' and any variable defined before it. Use it to share\nsub-expressions across validations.",
+                "items": {
+                  "description": "OIDCVariable is a named CEL expression evaluated against the OIDC token\nclaims of a 'generic-oidc' Receiver.",
+                  "properties": {
+                    "expression": {
+                      "description": "Expression is the CEL expression that defines the variable value.",
+                      "type": "string"
+                    },
+                    "name": {
+                      "description": "Name is the variable name; it must be a valid CEL identifier.",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "expression",
+                    "name"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "array"
+              }
+            },
+            "required": [
+              "issuerURL",
+              "validations"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array",
+          "x-kubernetes-list-map-keys": [
+            "issuerURL"
+          ],
+          "x-kubernetes-list-type": "map"
+        },
         "resourceFilter": {
-          "description": "ResourceFilter is a CEL expression expected to return a boolean that is\nevaluated for each resource referenced in the Resources field when a\nwebhook is received. If the expression returns false then the controller\nwill not request a reconciliation for the resource.\nWhen the expression is specified the controller will parse it and mark\nthe object as terminally failed if the expression is invalid or does not\nreturn a boolean.",
+          "description": "ResourceFilter is a CEL expression expected to return a boolean that is\nevaluated for each resource referenced in the Resources field when a\nwebhook is received. If the expression returns false then the controller\nwill not request a reconciliation for the resource.\nThe expression can read the resource metadata via 'res' and the webhook\nrequest body via 'req'. For generic-oidc receivers, the verified OIDC\ntoken claims are also available via 'claims'.\nWhen the expression is specified the controller will parse it and mark\nthe object as terminally failed if the expression is invalid or does not\nreturn a boolean.",
           "type": "string"
         },
         "resources": {
           "description": "A list of resources to be notified about changes.",
           "items": {
-            "description": "CrossNamespaceObjectReference contains enough information to let you locate the\ntyped referenced object at cluster level",
+            "description": "ReceiverResource references a resource to be notified about changes, with an\noptional per-resource CEL filter.",
             "properties": {
               "apiVersion": {
                 "description": "API version of the referent",
+                "type": "string"
+              },
+              "filter": {
+                "description": "Filter is a CEL expression expected to return a boolean that is evaluated\nfor each resource matched by this reference when a webhook is received,\nin addition to the top-level resourceFilter. A reconciliation is requested\nonly when both expressions (when set) return true.\nThe expression can read the resource metadata via 'res' and the webhook\nrequest body via 'req'. For generic-oidc receivers, the verified OIDC\ntoken claims are also available via 'claims'.\nWhen the expression is specified the controller will parse it and mark\nthe object as terminally failed if the expression is invalid or does not\nreturn a boolean.",
                 "type": "string"
               },
               "kind": {
@@ -92,7 +171,7 @@
           "type": "array"
         },
         "secretRef": {
-          "description": "SecretRef specifies the Secret containing the token used\nto validate the payload authenticity. The Secret must contain a 'token'\nkey. For GCR receivers, the Secret must also contain an 'email' key\nwith the IAM service account email configured on the Pub/Sub push\nsubscription, and an 'audience' key with the expected OIDC token audience.",
+          "description": "SecretRef specifies the Secret containing the token used\nto validate the payload authenticity. The Secret must contain a 'token'\nkey. For GCR receivers, the Secret must also contain an 'email' key\nwith the IAM service account email configured on the Pub/Sub push\nsubscription, and an 'audience' key with the expected OIDC token audience.\n\nRequired for all receiver types except 'generic-oidc', which authenticates\nrequests using the OIDC token instead and must not set this field.",
           "properties": {
             "name": {
               "description": "Name of the referent.",
@@ -114,6 +193,7 @@
           "enum": [
             "generic",
             "generic-hmac",
+            "generic-oidc",
             "github",
             "gitlab",
             "bitbucket",
@@ -130,10 +210,27 @@
       },
       "required": [
         "resources",
-        "secretRef",
         "type"
       ],
       "type": "object",
+      "x-kubernetes-validations": [
+        {
+          "message": "generic-oidc receivers must define at least one oidcProvider",
+          "rule": "self.type != 'generic-oidc' || (has(self.oidcProviders) && size(self.oidcProviders) > 0)"
+        },
+        {
+          "message": "oidcProviders can only be set when type is generic-oidc",
+          "rule": "self.type == 'generic-oidc' || !has(self.oidcProviders) || size(self.oidcProviders) == 0"
+        },
+        {
+          "message": "secretRef cannot be set when type is generic-oidc",
+          "rule": "self.type != 'generic-oidc' || !has(self.secretRef)"
+        },
+        {
+          "message": "secretRef is required when type is not generic-oidc",
+          "rule": "self.type == 'generic-oidc' || has(self.secretRef)"
+        }
+      ],
       "additionalProperties": false
     },
     "status": {

--- a/source.extensions.fluxcd.io/artifactgenerator_v1beta1.json
+++ b/source.extensions.fluxcd.io/artifactgenerator_v1beta1.json
@@ -25,16 +25,18 @@
                 "items": {
                   "properties": {
                     "exclude": {
-                      "description": "Exclude specifies a list of glob patterns to exclude\nfiles and dirs matched by the 'From' field.",
+                      "description": "Exclude specifies a list of glob patterns to exclude\nfiles and dirs matched by the 'From' field. Patterns are matched\nagainst paths relative to the source alias root or to the non-glob\nprefix of 'From'. Patterns without a separator (e.g. \"*.md\") match\nthe file name at any depth.",
                       "items": {
+                        "maxLength": 1024,
                         "type": "string"
                       },
                       "maxItems": 100,
                       "type": "array"
                     },
                     "from": {
-                      "description": "From specifies the source (by alias) and the glob pattern to match files.\nThe format is \"@<alias>/<glob-pattern>\".",
+                      "description": "From specifies the source (by alias) and the glob pattern to match files.\nThe format is \"@<alias>/<glob-pattern>\". When pathPattern is set,\nthe path may use capture placeholders such as \"{app}\".",
                       "maxLength": 1024,
+                      "minLength": 1,
                       "pattern": "^@([a-z0-9]([a-z0-9_-]*[a-z0-9])?)/(.*)$",
                       "type": "string"
                     },
@@ -48,9 +50,10 @@
                       "type": "string"
                     },
                     "to": {
-                      "description": "To specifies the destination path within the artifact.\nThe format is \"@artifact/path\", the alias \"artifact\"\nrefers to the root path of the generated artifact.",
+                      "description": "To specifies the destination path within the artifact.\nThe format is \"@artifact/path\", the alias \"artifact\"\nrefers to the root path of the generated artifact. When pathPattern\nis set, the path may use capture placeholders such as \"{app}\".",
                       "maxLength": 1024,
-                      "pattern": "^@(artifact)/(.*)$",
+                      "minLength": 1,
+                      "pattern": "^@artifact/([^/]{0,1}|[^./][^/]|[.][^./]|[^/]{3,})(/([^/]{0,1}|[^./][^/]|[.][^./]|[^/]{3,}))*$",
                       "type": "string"
                     }
                   },
@@ -65,9 +68,9 @@
                 "type": "array"
               },
               "name": {
-                "description": "Name is the name of the generated artifact.",
+                "description": "Name is the name of the generated artifact.\nWhen pathPattern is set, this field may use capture placeholders such as \"{app}\".",
                 "maxLength": 253,
-                "pattern": "^[a-z0-9]([a-z0-9-]*[a-z0-9])?$",
+                "minLength": 1,
                 "type": "string"
               },
               "originRevision": {
@@ -93,6 +96,33 @@
           "maxItems": 1000,
           "minItems": 1,
           "type": "array"
+        },
+        "commonMetadata": {
+          "description": "CommonMetadata specifies the common labels and annotations that are\napplied to all resources. Any existing label or annotation will be\noverridden if its key matches a common one.",
+          "properties": {
+            "annotations": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "Annotations to be added to the object's metadata.",
+              "type": "object"
+            },
+            "labels": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "Labels to be added to the object's metadata.",
+              "type": "object"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "pathPattern": {
+          "description": "PathPattern specifies a directory traversal pattern to match within the sources.\nThe format is \"@<alias>/<pattern>\". Named captures in the pattern (e.g. \"{app}\")\ncan be used as placeholders in OutputArtifacts fields.",
+          "maxLength": 1024,
+          "pattern": "^@([a-z0-9]([a-z0-9_-]*[a-z0-9])?)/(.*)$",
+          "type": "string"
         },
         "sources": {
           "description": "Sources is a list of references to the Flux source-controller\nresources that will be used to generate the artifact.",
@@ -148,6 +178,12 @@
         "sources"
       ],
       "type": "object",
+      "x-kubernetes-validations": [
+        {
+          "message": "artifact names must be valid Kubernetes object names when pathPattern is not set",
+          "rule": "has(self.pathPattern) && size(self.pathPattern) > 0 || self.artifacts.all(a, a.name.matches('^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$'))"
+        }
+      ],
       "additionalProperties": false
     },
     "status": {

--- a/source.toolkit.fluxcd.io/gitrepository_v1.json
+++ b/source.toolkit.fluxcd.io/gitrepository_v1.json
@@ -61,9 +61,10 @@
           "type": "string"
         },
         "provider": {
-          "description": "Provider used for authentication, can be 'azure', 'github', 'generic'.\nWhen not specified, defaults to 'generic'.",
+          "description": "Provider used for authentication, can be 'aws', 'azure', 'github', 'generic'.\nWhen not specified, defaults to 'generic'.",
           "enum": [
             "generic",
+            "aws",
             "azure",
             "github"
           ],
@@ -129,7 +130,7 @@
           "additionalProperties": false
         },
         "serviceAccountName": {
-          "description": "ServiceAccountName is the name of the Kubernetes ServiceAccount used to\nauthenticate to the GitRepository. This field is only supported for 'azure' provider.",
+          "description": "ServiceAccountName is the name of the Kubernetes ServiceAccount used to\nauthenticate to the GitRepository. This field is only supported for 'azure' and 'aws' providers.",
           "type": "string"
         },
         "sparseCheckout": {
@@ -169,7 +170,7 @@
               "type": "string"
             },
             "secretRef": {
-              "description": "SecretRef specifies the Secret containing the public keys of trusted Git\nauthors.",
+              "description": "SecretRef specifies the Secret containing the public keys of trusted Git\nauthors. PGP public keys must be stored under keys with the .asc suffix,\nand SSH public keys must be stored under keys with the .sshpub suffix.",
               "properties": {
                 "name": {
                   "description": "Name of the referent.",
@@ -197,8 +198,8 @@
       "type": "object",
       "x-kubernetes-validations": [
         {
-          "message": "serviceAccountName can only be set when provider is 'azure'",
-          "rule": "!has(self.serviceAccountName) || (has(self.provider) && self.provider == 'azure')"
+          "message": "serviceAccountName can only be set when provider is 'azure' or 'aws'",
+          "rule": "!has(self.serviceAccountName) || (has(self.provider) && (self.provider == 'azure' || self.provider == 'aws'))"
         }
       ],
       "additionalProperties": false

--- a/source.toolkit.fluxcd.io/helmchart_v1.json
+++ b/source.toolkit.fluxcd.io/helmchart_v1.json
@@ -287,7 +287,7 @@
           "type": "array"
         },
         "url": {
-          "description": "URL is the dynamic fetch link for the latest Artifact.\nIt is provided on a \"best effort\" basis, and using the precise\nBucketStatus.Artifact data is recommended.",
+          "description": "URL is the dynamic fetch link for the latest Artifact.\nIt is provided on a \"best effort\" basis, and using the precise\nHelmChartStatus.Artifact data is recommended.",
           "type": "string"
         }
       },

--- a/source.toolkit.fluxcd.io/ocirepository_v1.json
+++ b/source.toolkit.fluxcd.io/ocirepository_v1.json
@@ -190,6 +190,20 @@
               ],
               "type": "object",
               "additionalProperties": false
+            },
+            "trustedRootSecretRef": {
+              "description": "TrustedRootSecretRef specifies the Kubernetes Secret containing a\nSigstore trusted_root.json file. This enables verification against\nself-hosted Sigstore infrastructure (custom Fulcio CA, self-hosted\nRekor instance). The Secret must contain a key named \"trusted_root.json\".",
+              "properties": {
+                "name": {
+                  "description": "Name of the referent.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "name"
+              ],
+              "type": "object",
+              "additionalProperties": false
             }
           },
           "required": [


### PR DESCRIPTION
Closes #945. Also covers #869 (Flux CRD refresh), now at 2.9.x rather than 2.8.x.

### What this does

Regenerates the Flux schemas with `scripts/openapi2jsonschema.py` from the controller tags that
[Flux 2.9.4](https://github.com/fluxcd/flux2/blob/v2.9.4/manifests/crds/kustomization.yaml) installs:

| Controller                  | Tag      | Group                            |
|-----------------------------|----------|----------------------------------|
| source-controller           | v1.9.4   | `source.toolkit.fluxcd.io`       |
| kustomize-controller        | v1.9.4   | `kustomize.toolkit.fluxcd.io`    |
| helm-controller             | v1.6.3   | `helm.toolkit.fluxcd.io`         |
| notification-controller     | v1.9.3   | `notification.toolkit.fluxcd.io` |
| image-reflector-controller  | v1.2.4   | `image.toolkit.fluxcd.io`        |
| image-automation-controller | v1.2.4   | `image.toolkit.fluxcd.io`        |
| source-watcher              | v2.2.3   | `source.extensions.fluxcd.io`    |

Each CRD came from `config/crd/bases/` at its controller's tag, so the output matches what
`crd-extractor.sh` produces against a cluster running Flux 2.9.4.

### The bug it fixes

`helmrelease_v2.json` predated helm-controller v1.6.0 and therefore lacked
`spec.valuesFrom[].literal`. Since the schema closes its objects with `additionalProperties: false`,
that made `kubeconform -strict` **reject valid manifests**. Verified before and after with the repro
from #945:

```console
# before
hr.yaml - HelmRelease example is invalid: ... at '/spec/valuesFrom/0': additional properties 'literal' not allowed

# after
Summary: 1 resource found in 1 file - Valid: 1, Invalid: 0, Errors: 0, Skipped: 0
```

A manifest carrying a genuinely unknown field is still rejected, so strictness is unchanged.

### One deliberate deviation from raw generator output

`receiver_v1.json` (and `alert_v1beta3.json`) carry three values in the `kind` enum that the upstream
CRDs do not have: `FluxInstance`, `ResourceSet` and `ResourceSetInputProvider`. Those come from
[flux-operator](https://github.com/controlplaneio-fluxcd/flux-operator), so the catalog's current
copies were evidently extracted from a cluster running it. A plain regeneration drops them and would
break anyone validating a `Receiver` or `Alert` that watches operator resources, so I appended them
back. `alert_v1beta3.json` had no other drift and is therefore unchanged in this PR.

Happy to drop that part if you would rather the files track upstream CRDs exactly.

### How I checked for regressions

Rather than eyeball the diff, I compared old and new structurally — the set of property paths, enum
values and `required` entries in each file — and confirmed nothing is lost. The only new `required`
entries sit on fields this diff introduces (`spec.ignore` on Kustomization, `spec.oidcProviders` on
Receiver, `spec.verify.trustedRootSecretRef` on OCIRepository), so they are upstream's own
constraints and cannot invalidate a manifest that was valid before.

Remaining diff is additive: new fields, new enum values, and reworded upstream descriptions.
