### PR TITLE
Update valkey.io CRDs: ValkeyCluster and ValkeyNode (v1alpha1) to v0.5.0

### DIFF
--- a/valkey.io/valkeycluster_v1alpha1.json
+++ b/valkey.io/valkeycluster_v1alpha1.json
@@ -1422,6 +1422,13 @@
           },
           "description": "Metrics exporter options",
           "properties": {
+            "args": {
+              "description": "Additional cmdline arguments passed to exporter sidecar container.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
             "enabled": {
               "description": "Enable or disable the exporter sidecar container",
               "type": "boolean"
@@ -1663,6 +1670,39 @@
             "additionalProperties": false
           },
           "type": "array"
+        },
+        "networking": {
+          "description": "Networking groups how clients and peers reach cluster nodes (TLS today;\ndiscovery and external access land in follow-ups under this object).",
+          "properties": {
+            "tls": {
+              "description": "TLS configuration for the cluster.",
+              "properties": {
+                "certificate": {
+                  "description": "Certificate is a reference to a Kubernetes secret that contains the certificate and private key for enabling TLS.\nThe referenced secret should contain the following:\n\n- `ca.crt`: The certificate authority.\n- `tls.crt`: The certificate (or a chain).\n- `tls.key`: The private key to the first certificate in the certificate chain.",
+                  "properties": {
+                    "secretName": {
+                      "description": "SecretName is the name of the secret.",
+                      "maxLength": 253,
+                      "minLength": 1,
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "secretName"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "required": [
+                "certificate"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
         },
         "persistence": {
           "description": "Persistence defines durable storage that is propagated to each ValkeyNode.",
@@ -1944,7 +1984,7 @@
           "description": "Scheduling groups pod placement configuration (affinity, node selector,\ntolerations, topology spread constraints, priority class) for the\ncluster's pods.",
           "properties": {
             "affinity": {
-              "description": "Affinity to apply to the pods, overrides NodeSelector if set.",
+              "description": "Affinity to apply to the pods. Kubernetes ANDs nodeAffinity with\nNodeSelector rather than one overriding the other: a node must satisfy\nboth for the pod to be scheduled there.",
               "properties": {
                 "nodeAffinity": {
                   "description": "Describes node affinity scheduling rules for the pod.",
@@ -2933,6 +2973,97 @@
                 "additionalProperties": false
               },
               "type": "array"
+            },
+            "zone": {
+              "description": "Zone groups scheduling constraints on the zone axis\n(topologyKey topology.kubernetes.io/zone). When unset, every zone spread is\nDisabled and no scheduling primitives are emitted.",
+              "properties": {
+                "pinning": {
+                  "description": "Pinning assigns every pod a deterministic zone by round-robin over an\nordered zone list. Mutually exclusive with any non-Disabled Spread field\non this axis: pinning already fixes each pod's zone, so a zone spread\nconstraint can only contradict it. Unset means no pinning.",
+                  "properties": {
+                    "zones": {
+                      "description": "Zones is the ordered round-robin sequence. A pod's zone is\nzones[(shardIndex + nodeIndex) % len(zones)], so each shard's pods walk\nthe list from a different starting point, and while there are at least\nas many zones as shards, primaries land in distinct zones as a side\neffect. When replicas+1 exceeds the zone count, some members of a shard\nnecessarily share a zone.\n\nAdding shards or replicas never moves an existing pod, because a pod's\nindices never change. Changing this list would move nearly all of them,\nso it is immutable while set: remove pinning, reconcile, then re-add it\nwith the new sequence. On a cluster with persistence, note that zonal\nvolumes cannot follow a pod to a new zone.\n\nThe list is ordered, so it is atomic rather than a set: a set list is\nunordered under server-side apply, which would scramble the assignment.\nUniqueness is enforced by CEL for the same reason.\n\nEach entry must be a valid Kubernetes label value, because it is rendered\nas the value of a topology.kubernetes.io/zone nodeSelector entry. Without\nthat constraint an entry such as \"eu-west-1a!\" is accepted here and then\nrejected when the StatefulSet is created, surfacing on the ValkeyNode\nrather than on the ValkeyCluster the user edited.",
+                      "items": {
+                        "maxLength": 63,
+                        "minLength": 1,
+                        "pattern": "^[A-Za-z0-9]([-A-Za-z0-9_.]*[A-Za-z0-9])?$",
+                        "type": "string"
+                      },
+                      "maxItems": 32,
+                      "minItems": 1,
+                      "type": "array",
+                      "x-kubernetes-list-type": "atomic"
+                    }
+                  },
+                  "required": [
+                    "zones"
+                  ],
+                  "type": "object",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "zone.pinning.zones entries must be unique: a repeated zone silently biases the round-robin",
+                      "rule": "self.zones.all(z, self.zones.exists_one(y, y == z))"
+                    }
+                  ],
+                  "additionalProperties": false
+                },
+                "spread": {
+                  "description": "Spread distributes the cluster's pods across zones.",
+                  "properties": {
+                    "pods": {
+                      "description": "Pods balances all of the cluster's pods across zones, rendered as a\ntopology spread constraint. Defaults to Disabled when unset. Enabling this\nalongside an explicit shard or primaries spread of the same strength is\nrejected (only one topology spread constraint per strength is permitted per\nzone).",
+                      "properties": {
+                        "mode": {
+                          "description": "Mode selects the strength of the constraint. When unset, the dimension's\ndocumented default applies.",
+                          "enum": [
+                            "Disabled",
+                            "Preferred",
+                            "Required"
+                          ],
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "primaries": {
+                      "description": "Primaries balances each shard's node-index-0 pod across zones, rendered as\na topology spread constraint. Defaults to Disabled when unset.",
+                      "properties": {
+                        "mode": {
+                          "description": "Mode selects the strength of the constraint. When unset, the dimension's\ndocumented default applies.",
+                          "enum": [
+                            "Disabled",
+                            "Preferred",
+                            "Required"
+                          ],
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "shard": {
+                      "description": "Shard balances the pods of each shard across zones, rendered as a topology\nspread constraint. Defaults to Disabled when unset.",
+                      "properties": {
+                        "mode": {
+                          "description": "Mode selects the strength of the constraint. When unset, the dimension's\ndocumented default applies.",
+                          "enum": [
+                            "Disabled",
+                            "Preferred",
+                            "Required"
+                          ],
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
             }
           },
           "type": "object",
@@ -2949,24 +3080,6 @@
           "format": "int64",
           "minimum": 1,
           "type": "integer"
-        },
-        "tls": {
-          "description": "TLS configuration for the cluster",
-          "properties": {
-            "certificate": {
-              "description": "Certificate is a reference to a Kubernetes secret that contains the certificate and private key for enabling TLS.\nThe referenced secret should contain the following:\n\n- `ca.crt`: The certificate authority.\n- `tls.crt`: The certificate (or a chain).\n- `tls.key`: The private key to the first certificate in the certificate chain.",
-              "properties": {
-                "secretName": {
-                  "description": "SecretName is the name of the secret.",
-                  "type": "string"
-                }
-              },
-              "type": "object",
-              "additionalProperties": false
-            }
-          },
-          "type": "object",
-          "additionalProperties": false
         },
         "users": {
           "description": "Users, and ACL-related configuration; see valkeyacls_types.go",
@@ -3152,6 +3265,34 @@
         {
           "message": "a topologySpreadConstraints entry on kubernetes.io/hostname with whenUnsatisfiable ScheduleAnyway collides with node.spread.primaries or node.spread.pods set to Preferred, which render the same hostname ScheduleAnyway constraint: set that node.spread mode to Disabled or Required, or remove the passthrough constraint",
           "rule": "!has(self.scheduling) || !has(self.scheduling.topologySpreadConstraints) || !self.scheduling.topologySpreadConstraints.exists(c, c.topologyKey == 'kubernetes.io/hostname' && c.whenUnsatisfiable == 'ScheduleAnyway') || !has(self.scheduling.node) || !has(self.scheduling.node.spread) || !( ((has(self.scheduling.node.spread.primaries) && has(self.scheduling.node.spread.primaries.mode)) ? self.scheduling.node.spread.primaries.mode : 'Disabled') == 'Preferred' || ((has(self.scheduling.node.spread.pods) && has(self.scheduling.node.spread.pods.mode)) ? self.scheduling.node.spread.pods.mode : 'Disabled') == 'Preferred' )"
+        },
+        {
+          "message": "at most one of zone.spread.shard, zone.spread.primaries, zone.spread.pods may be Required: they render duplicate topology.kubernetes.io/zone DoNotSchedule topology spread constraints",
+          "rule": "!has(self.scheduling) || !has(self.scheduling.zone) || !has(self.scheduling.zone.spread) || !( (((has(self.scheduling.zone.spread.shard) && has(self.scheduling.zone.spread.shard.mode)) ? self.scheduling.zone.spread.shard.mode : 'Disabled') == 'Required' && ((has(self.scheduling.zone.spread.primaries) && has(self.scheduling.zone.spread.primaries.mode)) ? self.scheduling.zone.spread.primaries.mode : 'Disabled') == 'Required') || (((has(self.scheduling.zone.spread.shard) && has(self.scheduling.zone.spread.shard.mode)) ? self.scheduling.zone.spread.shard.mode : 'Disabled') == 'Required' && ((has(self.scheduling.zone.spread.pods) && has(self.scheduling.zone.spread.pods.mode)) ? self.scheduling.zone.spread.pods.mode : 'Disabled') == 'Required') || (((has(self.scheduling.zone.spread.primaries) && has(self.scheduling.zone.spread.primaries.mode)) ? self.scheduling.zone.spread.primaries.mode : 'Disabled') == 'Required' && ((has(self.scheduling.zone.spread.pods) && has(self.scheduling.zone.spread.pods.mode)) ? self.scheduling.zone.spread.pods.mode : 'Disabled') == 'Required') )"
+        },
+        {
+          "message": "at most one of zone.spread.shard, zone.spread.primaries, zone.spread.pods may be Preferred: they render duplicate topology.kubernetes.io/zone ScheduleAnyway topology spread constraints (set one to Disabled or Required)",
+          "rule": "!has(self.scheduling) || !has(self.scheduling.zone) || !has(self.scheduling.zone.spread) || !( (((has(self.scheduling.zone.spread.shard) && has(self.scheduling.zone.spread.shard.mode)) ? self.scheduling.zone.spread.shard.mode : 'Disabled') == 'Preferred' && ((has(self.scheduling.zone.spread.primaries) && has(self.scheduling.zone.spread.primaries.mode)) ? self.scheduling.zone.spread.primaries.mode : 'Disabled') == 'Preferred') || (((has(self.scheduling.zone.spread.shard) && has(self.scheduling.zone.spread.shard.mode)) ? self.scheduling.zone.spread.shard.mode : 'Disabled') == 'Preferred' && ((has(self.scheduling.zone.spread.pods) && has(self.scheduling.zone.spread.pods.mode)) ? self.scheduling.zone.spread.pods.mode : 'Disabled') == 'Preferred') || (((has(self.scheduling.zone.spread.primaries) && has(self.scheduling.zone.spread.primaries.mode)) ? self.scheduling.zone.spread.primaries.mode : 'Disabled') == 'Preferred' && ((has(self.scheduling.zone.spread.pods) && has(self.scheduling.zone.spread.pods.mode)) ? self.scheduling.zone.spread.pods.mode : 'Disabled') == 'Preferred') )"
+        },
+        {
+          "message": "a topologySpreadConstraints entry on topology.kubernetes.io/zone with whenUnsatisfiable DoNotSchedule collides with zone.spread.shard, primaries, or pods set to Required, which render the same zone DoNotSchedule constraint: set that zone.spread mode to Disabled, or remove the passthrough constraint",
+          "rule": "!has(self.scheduling) || !has(self.scheduling.topologySpreadConstraints) || !self.scheduling.topologySpreadConstraints.exists(c, c.topologyKey == 'topology.kubernetes.io/zone' && c.whenUnsatisfiable == 'DoNotSchedule') || !has(self.scheduling.zone) || !has(self.scheduling.zone.spread) || !( ((has(self.scheduling.zone.spread.shard) && has(self.scheduling.zone.spread.shard.mode)) ? self.scheduling.zone.spread.shard.mode : 'Disabled') == 'Required' || ((has(self.scheduling.zone.spread.primaries) && has(self.scheduling.zone.spread.primaries.mode)) ? self.scheduling.zone.spread.primaries.mode : 'Disabled') == 'Required' || ((has(self.scheduling.zone.spread.pods) && has(self.scheduling.zone.spread.pods.mode)) ? self.scheduling.zone.spread.pods.mode : 'Disabled') == 'Required' )"
+        },
+        {
+          "message": "a topologySpreadConstraints entry on topology.kubernetes.io/zone with whenUnsatisfiable ScheduleAnyway collides with zone.spread.shard, primaries, or pods set to Preferred, which render the same zone ScheduleAnyway constraint: set that zone.spread mode to Disabled or Required, or remove the passthrough constraint",
+          "rule": "!has(self.scheduling) || !has(self.scheduling.topologySpreadConstraints) || !self.scheduling.topologySpreadConstraints.exists(c, c.topologyKey == 'topology.kubernetes.io/zone' && c.whenUnsatisfiable == 'ScheduleAnyway') || !has(self.scheduling.zone) || !has(self.scheduling.zone.spread) || !( ((has(self.scheduling.zone.spread.shard) && has(self.scheduling.zone.spread.shard.mode)) ? self.scheduling.zone.spread.shard.mode : 'Disabled') == 'Preferred' || ((has(self.scheduling.zone.spread.primaries) && has(self.scheduling.zone.spread.primaries.mode)) ? self.scheduling.zone.spread.primaries.mode : 'Disabled') == 'Preferred' || ((has(self.scheduling.zone.spread.pods) && has(self.scheduling.zone.spread.pods.mode)) ? self.scheduling.zone.spread.pods.mode : 'Disabled') == 'Preferred' )"
+        },
+        {
+          "message": "zone.pinning cannot be combined with a non-Disabled zone.spread.shard, primaries, or pods: pinning already assigns every pod a fixed zone, which a zone spread constraint can contradict",
+          "rule": "!has(self.scheduling) || !has(self.scheduling.zone) || !has(self.scheduling.zone.pinning) || !has(self.scheduling.zone.spread) || ( ((has(self.scheduling.zone.spread.shard) && has(self.scheduling.zone.spread.shard.mode)) ? self.scheduling.zone.spread.shard.mode : 'Disabled') == 'Disabled' && ((has(self.scheduling.zone.spread.primaries) && has(self.scheduling.zone.spread.primaries.mode)) ? self.scheduling.zone.spread.primaries.mode : 'Disabled') == 'Disabled' && ((has(self.scheduling.zone.spread.pods) && has(self.scheduling.zone.spread.pods.mode)) ? self.scheduling.zone.spread.pods.mode : 'Disabled') == 'Disabled' )"
+        },
+        {
+          "message": "zone.pinning.zones is immutable while set: changing it reassigns nearly every pod. Remove zone.pinning, reconcile, then re-add it with the new list",
+          "rule": "!has(oldSelf.scheduling) || !has(oldSelf.scheduling.zone) || !has(oldSelf.scheduling.zone.pinning) || !has(self.scheduling) || !has(self.scheduling.zone) || !has(self.scheduling.zone.pinning) || self.scheduling.zone.pinning.zones == oldSelf.scheduling.zone.pinning.zones"
+        },
+        {
+          "message": "scheduling.nodeSelector cannot set topology.kubernetes.io/zone while zone.pinning is set: pinning renders that key itself, and the curated value would overwrite yours",
+          "rule": "!has(self.scheduling) || !has(self.scheduling.zone) || !has(self.scheduling.zone.pinning) || !has(self.scheduling.nodeSelector) || !('topology.kubernetes.io/zone' in self.scheduling.nodeSelector)"
         }
       ],
       "additionalProperties": false

--- a/valkey.io/valkeynode_v1alpha1.json
+++ b/valkey.io/valkeynode_v1alpha1.json
@@ -2208,6 +2208,13 @@
         "exporter": {
           "description": "Exporter defines the metrics exporter sidecar configuration.",
           "properties": {
+            "args": {
+              "description": "Additional cmdline arguments passed to exporter sidecar container.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
             "enabled": {
               "description": "Enable or disable the exporter sidecar container",
               "type": "boolean"
@@ -2737,13 +2744,21 @@
               "properties": {
                 "secretName": {
                   "description": "SecretName is the name of the secret.",
+                  "maxLength": 253,
+                  "minLength": 1,
                   "type": "string"
                 }
               },
+              "required": [
+                "secretName"
+              ],
               "type": "object",
               "additionalProperties": false
             }
           },
+          "required": [
+            "certificate"
+          ],
           "type": "object",
           "additionalProperties": false
         },
@@ -2878,6 +2893,10 @@
         },
         "usersACLSecretName": {
           "description": "UsersACLSecretName is the name of the Secret containing the ACL user\nfile. When set, mounts a users-acl volume from this Secret so the\ncontainer can load aclfile /config/users/users.acl.",
+          "type": "string"
+        },
+        "workloadRevision": {
+          "description": "WorkloadRevision is a hash of the fully built pod template the ValkeyCluster\ncontroller authorizes this node to apply. The ValkeyCluster controller sets\nit (cluster-owned nodes only) when advancing a roll. The ValkeyNode\ncontroller applies a rolling StatefulSet/Deployment template update only\nwhen the template it builds hashes to this value. Standalone nodes ignore\nthe field and apply immediately.",
           "type": "string"
         },
         "workloadType": {


### PR DESCRIPTION
## PR Checklist

- [x] I generated these CRs using the [CRD Extractor tool](https://github.com/datreeio/CRDs-catalog?tab=readme-ov-file#crd-extractor). If I used a different method, I have described the method in this PR.
- [x] I am updating existing schemas and have specified the updated schema version.
- [ ] I am adding new schemas and included a link to the GitHub repository that contains the source of these schemas.

## Method
Converted using the `openapi2jsonschema-go` tool from [kubeconform](https://github.com/yannh/kubeconform).

## Source
Converted from the valkey-io/valkey-operator CRD manifests (v0.5.0):
- https://github.com/valkey-io/valkey-operator/raw/refs/tags/v0.5.0/config/crd/bases/valkey.io_valkeyclusters.yaml
- https://github.com/valkey-io/valkey-operator/raw/refs/tags/v0.5.0/config/crd/bases/valkey.io_valkeynodes.yaml