### PR TITLE
update schemas for gateway.kgateway.dev

### DIFF
--- a/gateway.kgateway.dev/backend_v1alpha1.json
+++ b/gateway.kgateway.dev/backend_v1alpha1.json
@@ -18,7 +18,7 @@
           "description": "Aws is the AWS backend configuration.",
           "properties": {
             "accountId": {
-              "description": "AccountId is the AWS account ID to use for the backend.",
+              "description": "AccountId is the AWS account ID to use for the backend.\nDeprecated: Set accountId on spec.aws.lambda instead. This field is kept for backward compatibility.\nWhen both fields are set, spec.aws.lambda.accountId takes precedence.",
               "maxLength": 12,
               "minLength": 1,
               "pattern": "^[0-9]{12}$",
@@ -27,8 +27,25 @@
             "auth": {
               "description": "Auth specifies an explicit AWS authentication method for the backend.\nWhen omitted, the following credential providers are tried in order, stopping when one\nof them returns an access key ID and a secret access key (the session token is optional):\n1. Environment variables: when the environment variables AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, and AWS_SESSION_TOKEN are set.\n2. AssumeRoleWithWebIdentity API call: when the environment variables AWS_WEB_IDENTITY_TOKEN_FILE and AWS_ROLE_ARN are set.\n3. EKS Pod Identity: when the environment variable AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE is set.\n\nSee the Envoy docs for more info:\nhttps://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/aws_request_signing_filter#credentials",
               "properties": {
+                "assumeRole": {
+                  "description": "AssumeRole configures STS role chaining. The backend's ambient credentials\n(the gateway ServiceAccount's IRSA identity for Lambda request signing, or the\ncontroller's identity for EC2 discovery; more generally any credential resolved\nby the default provider chain) are used to assume the target role. The resulting\ntemporary credentials are then used to sign requests to the backend (Lambda) or\nto list instances (EC2). This enables per-backend, least-privilege roles without\ngranting the gateway/controller role direct access to every target.\nRequired when type is 'AssumeRole'.",
+                  "properties": {
+                    "roleArn": {
+                      "description": "RoleArn is the ARN of the IAM role to assume, e.g.\n\"arn:aws:iam::123456789012:role/my-invoke-role\".",
+                      "maxLength": 2048,
+                      "minLength": 1,
+                      "pattern": "^arn:aws[a-z-]*:iam::[0-9]{12}:role/.+$",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "roleArn"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
                 "secretRef": {
-                  "description": "SecretRef references a Kubernetes Secret containing the AWS credentials.\nThe Secret must have keys \"accessKey\", \"secretKey\", and optionally \"sessionToken\".",
+                  "description": "SecretRef references a Kubernetes Secret containing the AWS credentials.\nThe Secret must have keys \"accessKey\", \"secretKey\", and optionally \"sessionToken\".\nRequired when type is 'Secret'.",
                   "properties": {
                     "name": {
                       "default": "",
@@ -43,7 +60,8 @@
                 "type": {
                   "description": "Type specifies the authentication method to use for the backend.",
                   "enum": [
-                    "Secret"
+                    "Secret",
+                    "AssumeRole"
                   ],
                   "type": "string"
                 }
@@ -60,13 +78,97 @@
                 {
                   "message": "secretRef must be specified when type is 'Secret'",
                   "rule": "!(!has(self.secretRef) && self.type == 'Secret')"
+                },
+                {
+                  "message": "assumeRole must be nil if the type is not 'AssumeRole'",
+                  "rule": "!(has(self.assumeRole) && self.type != 'AssumeRole')"
+                },
+                {
+                  "message": "assumeRole must be specified when type is 'AssumeRole'",
+                  "rule": "!(!has(self.assumeRole) && self.type == 'AssumeRole')"
                 }
               ],
               "additionalProperties": false
             },
-            "lambda": {
-              "description": "Lambda configures the AWS lambda service.",
+            "ec2": {
+              "description": "Ec2 configures dynamic discovery of AWS EC2 instances.",
               "properties": {
+                "addressType": {
+                  "default": "PrivateIP",
+                  "description": "AddressType selects whether to route to the instance private or public IP.\nDefaults to PrivateIP.",
+                  "enum": [
+                    "PrivateIP",
+                    "PublicIP"
+                  ],
+                  "type": "string"
+                },
+                "filters": {
+                  "description": "Filters select which instances should be associated with this backend.\nWhen multiple filters are provided, an instance must match all of them.\nIf this list is omitted or empty, all running instances in the configured\nregion are selected. Be careful: an accidentally empty filter list broadens\nthe backend to the whole regional fleet rather than matching nothing.",
+                  "items": {
+                    "description": "AwsTagFilter matches EC2 instances by tag.",
+                    "properties": {
+                      "key": {
+                        "description": "Key matches instances that contain the given tag key, regardless of value.",
+                        "maxLength": 128,
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "keyValue": {
+                        "description": "KeyValue matches instances that contain the given tag key/value pair.",
+                        "properties": {
+                          "key": {
+                            "description": "Key is the tag key to match.",
+                            "maxLength": 128,
+                            "minLength": 1,
+                            "type": "string"
+                          },
+                          "value": {
+                            "description": "Value is the tag value to match.",
+                            "maxLength": 256,
+                            "minLength": 1,
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "key",
+                          "value"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "x-kubernetes-validations": [
+                      {
+                        "message": "exactly one of the fields in [key keyValue] must be set",
+                        "rule": "[has(self.key),has(self.keyValue)].filter(x,x==true).size() == 1"
+                      }
+                    ],
+                    "additionalProperties": false
+                  },
+                  "maxItems": 16,
+                  "type": "array"
+                },
+                "port": {
+                  "default": 80,
+                  "description": "Port is the port to use for discovered instances.\nDefaults to 80.",
+                  "format": "int32",
+                  "type": "integer"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "lambda": {
+              "description": "Lambda configures the AWS Lambda service.",
+              "properties": {
+                "accountId": {
+                  "description": "AccountId is the AWS account ID to use for the backend.\nThis is the preferred location for Lambda backends.",
+                  "maxLength": 12,
+                  "minLength": 1,
+                  "pattern": "^[0-9]{12}$",
+                  "type": "string"
+                },
                 "endpointURL": {
                   "description": "EndpointURL is the URL or domain for the Lambda service. This is primarily\nuseful for testing and development purposes. When omitted, the default\nlambda hostname will be used.",
                   "maxLength": 2048,
@@ -118,11 +220,17 @@
               "type": "string"
             }
           },
-          "required": [
-            "accountId",
-            "lambda"
-          ],
           "type": "object",
+          "x-kubernetes-validations": [
+            {
+              "message": "accountId must be specified on aws or aws.lambda for lambda backends",
+              "rule": "!has(self.lambda) || has(self.accountId) || has(self.lambda.accountId)"
+            },
+            {
+              "message": "exactly one of the fields in [lambda ec2] must be set",
+              "rule": "[has(self.lambda),has(self.ec2)].filter(x,x==true).size() == 1"
+            }
+          ],
           "additionalProperties": false
         },
         "dynamicForwardProxy": {
@@ -155,6 +263,51 @@
           ],
           "type": "object",
           "additionalProperties": false
+        },
+        "priorityGroups": {
+          "description": "PriorityGroups is an ordered list of backend groups used for failover.\nTraffic is sent to the backends of the first group; each subsequent\ngroup is only used when the backends of all preceding groups are\nunhealthy. The health check can be configured via the BackendConfigPolicy\nthat targets this Backend\n\nNote: This field is part of an experimental API and subject to breaking changes in future releases.",
+          "items": {
+            "description": "PriorityGroup defines one failover priority level of a priority groups backend.\n\nNote: This struct is part of an experimental API and subject to breaking changes in future releases.",
+            "properties": {
+              "backendRefs": {
+                "description": "BackendRefs references the Backends that make up this priority group.\nReferenced Backends must be in the same namespace and must not be\npriority groups backends themselves.",
+                "items": {
+                  "description": "LocalObjectReference contains enough information to let you locate the\nreferenced object inside the same namespace.",
+                  "properties": {
+                    "name": {
+                      "default": "",
+                      "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "x-kubernetes-map-type": "atomic",
+                  "additionalProperties": false
+                },
+                "maxItems": 16,
+                "minItems": 1,
+                "type": "array",
+                "x-kubernetes-list-map-keys": [
+                  "name"
+                ],
+                "x-kubernetes-list-type": "map",
+                "x-kubernetes-validations": [
+                  {
+                    "message": "backend reference name must not be empty",
+                    "rule": "self.all(r, size(r.name) > 0)"
+                  }
+                ]
+              }
+            },
+            "required": [
+              "backendRefs"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "maxItems": 16,
+          "minItems": 1,
+          "type": "array"
         },
         "static": {
           "description": "Static is the static backend configuration.",
@@ -209,7 +362,8 @@
             "AWS",
             "Static",
             "DynamicForwardProxy",
-            "GCP"
+            "GCP",
+            "PriorityGroups"
           ],
           "type": "string"
         }
@@ -218,23 +372,27 @@
       "x-kubernetes-validations": [
         {
           "message": "aws backend must be specified when type is 'AWS'",
-          "rule": "self.type == 'AWS' ? has(self.aws) : true"
+          "rule": "!has(self.type) || (self.type == 'AWS' ? has(self.aws) : true)"
         },
         {
           "message": "static backend must be specified when type is 'Static'",
-          "rule": "self.type == 'Static' ? has(self.static) : true"
+          "rule": "!has(self.type) || (self.type == 'Static' ? has(self.static) : true)"
         },
         {
           "message": "dynamicForwardProxy backend must be specified when type is 'DynamicForwardProxy'",
-          "rule": "self.type == 'DynamicForwardProxy' ? has(self.dynamicForwardProxy) : true"
+          "rule": "!has(self.type) || (self.type == 'DynamicForwardProxy' ? has(self.dynamicForwardProxy) : true)"
         },
         {
           "message": "gcp backend must be specified when type is 'GCP'",
-          "rule": "self.type == 'GCP' ? has(self.gcp) : true"
+          "rule": "!has(self.type) || (self.type == 'GCP' ? has(self.gcp) : true)"
         },
         {
-          "message": "exactly one of the fields in [aws static dynamicForwardProxy gcp] must be set",
-          "rule": "[has(self.aws),has(self.static),has(self.dynamicForwardProxy),has(self.gcp)].filter(x,x==true).size() == 1"
+          "message": "priorityGroups backend must be specified when type is 'PriorityGroups'",
+          "rule": "!has(self.type) || (self.type == 'PriorityGroups' ? has(self.priorityGroups) : true)"
+        },
+        {
+          "message": "exactly one of the fields in [aws static dynamicForwardProxy gcp priorityGroups] must be set",
+          "rule": "[has(self.aws),has(self.static),has(self.dynamicForwardProxy),has(self.gcp),has(self.priorityGroups)].filter(x,x==true).size() == 1"
         }
       ],
       "additionalProperties": false

--- a/gateway.kgateway.dev/backendconfigpolicy_v1alpha1.json
+++ b/gateway.kgateway.dev/backendconfigpolicy_v1alpha1.json
@@ -265,6 +265,58 @@
         "http2ProtocolOptions": {
           "description": "Http2ProtocolOptions contains the options necessary to configure HTTP/2 backends.\nNote: Http2ProtocolOptions can only be applied to HTTP/2 backends.\nSee [Envoy documentation](https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/transport_sockets/tls/v3/tls.proto#envoy-v3-api-msg-extensions-transport-sockets-tls-v3-sslconfig) for more details.",
           "properties": {
+            "connectionKeepalive": {
+              "description": "ConnectionKeepalive enables HTTP/2 keepalive PINGs on upstream connections,\nactively detecting half-dead connections: if a PING is not acknowledged\nwithin the timeout, the connection is closed.\nSee [Envoy documentation](https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/protocol.proto#envoy-v3-api-msg-config-core-v3-keepalivesettings) for more details.",
+              "properties": {
+                "connectionIdleInterval": {
+                  "description": "If set, a PING is sent before dispatching new streams on a connection that\nhas been idle for at least this duration, verifying the connection is\nstill alive before reusing it.",
+                  "type": "string",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "invalid duration value",
+                      "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                    },
+                    {
+                      "message": "connectionIdleInterval must be at least 1ms",
+                      "rule": "duration(self) >= duration('1ms')"
+                    }
+                  ]
+                },
+                "interval": {
+                  "description": "Interval between keepalive PINGs. If unset, PINGs are only sent when\ntriggered by ConnectionIdleInterval.",
+                  "type": "string",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "invalid duration value",
+                      "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                    },
+                    {
+                      "message": "interval must be at least 1ms",
+                      "rule": "duration(self) >= duration('1ms')"
+                    }
+                  ]
+                },
+                "timeout": {
+                  "description": "Timeout after which the connection is closed if no response to a keepalive\nPING is received. A PING response is considered received if any frame\narrives on the connection while the PING is outstanding.",
+                  "type": "string",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "invalid duration value",
+                      "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                    },
+                    {
+                      "message": "timeout must be at least 1ms",
+                      "rule": "duration(self) >= duration('1ms')"
+                    }
+                  ]
+                }
+              },
+              "required": [
+                "timeout"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
             "initialConnectionWindowSize": {
               "anyOf": [
                 {
@@ -648,10 +700,67 @@
                   "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
                 }
               ]
+            },
+            "zoneAware": {
+              "description": "ZoneAware configures zone-aware routing behavior for the load balancer.\nWhen enabled, traffic is preferentially routed to endpoints in the same\navailability zone as the Envoy proxy.\nThis is mutually exclusive with localityType.\n\nNote: This feature is experimental and subject to breaking changes in future releases.",
+              "properties": {
+                "preferLocal": {
+                  "description": "PreferLocal enables Envoy's zone-aware routing which prefers sending traffic\nto local zone endpoints while maintaining overall traffic balance across zones.\nOn Kubernetes 1.35+, the zone is automatically derived from node label.\nThe KGATEWAY_NODE_* environment variables on the proxy pod can be set as an explicit override.\nSee https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/upstream/load_balancing/zone_aware",
+                  "properties": {
+                    "force": {
+                      "description": "Force enables Envoy forced zone-local routing. Envoy routes to same-zone\nendpoints while the local endpoint threshold is met. If there are not enough\nlocal endpoints, traffic falls back to standard zone-aware routing behavior.",
+                      "properties": {
+                        "minEndpointsInZoneThreshold": {
+                          "default": 1,
+                          "description": "MinEndpointsInZoneThreshold is the minimum number of endpoints that must\nexist in the local zone for forced zone-local routing to be active.\nIf the local zone has fewer endpoints than this threshold, the system\nfalls back to standard zone-aware routing behavior.\nDefaults to 1.",
+                          "format": "int32",
+                          "minimum": 1,
+                          "type": "integer"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "minEndpointsThreshold": {
+                      "default": 6,
+                      "description": "MinEndpointsThreshold is the minimum number of total endpoints in the cluster\nthat must exist for zone-aware routing to be enabled. If the total number\nof endpoints is below this threshold, zone-aware routing is disabled.\nThis maps to Envoy's min_cluster_size setting.\nDefaults to 6.",
+                      "format": "int64",
+                      "minimum": 1,
+                      "type": "integer"
+                    },
+                    "routingEnabled": {
+                      "default": 100,
+                      "description": "RoutingEnabled is the percentage of requests for which Envoy applies\nzone-aware routing once the minEndpointsThreshold is met.\nDefaults to 100.",
+                      "format": "int32",
+                      "maximum": 100,
+                      "minimum": 0,
+                      "type": "integer"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "x-kubernetes-validations": [
+                {
+                  "message": "at least one of the fields in [preferLocal] must be set",
+                  "rule": "[has(self.preferLocal)].filter(x,x==true).size() >= 1"
+                }
+              ],
+              "additionalProperties": false
             }
           },
           "type": "object",
           "x-kubernetes-validations": [
+            {
+              "message": "localityType and zoneAware are mutually exclusive",
+              "rule": "!(has(self.localityType) && has(self.zoneAware))"
+            },
+            {
+              "message": "zoneAware is not supported with ringHash or maglev load balancers",
+              "rule": "!((has(self.ringHash) || has(self.maglev)) && has(self.zoneAware))"
+            },
             {
               "message": "exactly one of the fields in [leastRequest roundRobin ringHash maglev random] must be set",
               "rule": "[has(self.leastRequest),has(self.roundRobin),has(self.ringHash),has(self.maglev),has(self.random)].filter(x,x==true).size() == 1"
@@ -922,6 +1031,12 @@
                     "1.3"
                   ],
                   "type": "string"
+                },
+                "signatureAlgorithms": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
                 }
               },
               "type": "object",

--- a/gateway.kgateway.dev/gatewayextension_v1alpha1.json
+++ b/gateway.kgateway.dev/gatewayextension_v1alpha1.json
@@ -201,6 +201,20 @@
                         "type": "string"
                       },
                       "type": "array"
+                    },
+                    "headersToClient": {
+                      "description": "HeadersToClient specifies which headers from the authorization response\nshould be forwarded back to the downstream client when the request is denied.\nMaps to Envoy's allowed_client_headers. Required for redirect-based flows\n(e.g. oauth2-proxy returning 302 + Location) so that the redirect Location\nheader reaches the browser on denial.\nCommon examples: [\"location\", \"set-cookie\", \"www-authenticate\"]",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "headersToClientOnSuccess": {
+                      "description": "HeadersToClientOnSuccess specifies which headers from the authorization response\nshould be forwarded back to the downstream client when the request is allowed.\nMaps to Envoy's allowed_client_headers_on_success.\nCommon examples: [\"set-cookie\", \"x-auth-token\"]",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
                     }
                   },
                   "type": "object",
@@ -481,6 +495,43 @@
               "description": "FailOpen determines if requests are allowed when the ext proc service is unavailable.\nDefaults to true, meaning requests are allowed upstream even if the ext proc service is unavailable.",
               "type": "boolean"
             },
+            "filterStage": {
+              "description": "FilterStage specifies where in the HTTP filter chain the ExtProc filter\nshould be placed. If not specified, the ExtProc filter defaults to running\nafter the AuthZ stage.",
+              "properties": {
+                "predicate": {
+                  "default": "During",
+                  "description": "Predicate specifies placement relative to the stage: Before, During,\nor After.",
+                  "enum": [
+                    "Before",
+                    "During",
+                    "After"
+                  ],
+                  "type": "string"
+                },
+                "stage": {
+                  "description": "Stage selects the well-known position in the filter chain.",
+                  "enum": [
+                    "Fault",
+                    "AuthN",
+                    "AuthZ",
+                    "RateLimit",
+                    "Route"
+                  ],
+                  "type": "string"
+                },
+                "weight": {
+                  "default": 0,
+                  "description": "Weight controls ordering among multiple filters at the same\nstage and predicate. Higher weight places the filter earlier in the\nchain. Defaults to 0. Filters with the same stage, predicate, and\nweight are sorted alphabetically by filter name for consistency.",
+                  "format": "int32",
+                  "type": "integer"
+                }
+              },
+              "required": [
+                "stage"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
             "grpcService": {
               "description": "GrpcService is the GRPC service that will handle the processing.",
               "properties": {
@@ -749,6 +800,13 @@
               "type": "object",
               "additionalProperties": false
             },
+            "requestAttributes": {
+              "description": "RequestAttributes specifies a list of Envoy attribute expressions whose values will be\nincluded in the ProcessingRequest.attributes map sent to the external processing server\non every HTTP request.\nSee: https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/http/ext_proc/v3/ext_proc.proto",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
             "routeCacheAction": {
               "default": "FromResponse",
               "description": "RouteCacheAction describes the route cache action to be taken when an\nexternal processor response is received in response to request headers.\nThe default behavior is \"FromResponse\" which will only clear the route cache when\nan external processing response has the clear_route_cache field set.",
@@ -864,6 +922,31 @@
                       "remote": {
                         "description": "RemoteJWKS configures getting the public keys to validate the JWT from a remote JWKS server.",
                         "properties": {
+                          "asyncFetch": {
+                            "description": "AsyncFetch configures fetching the JWKS asynchronously and caching it on a timer,\ninstead of fetching it on demand during request handling.",
+                            "properties": {
+                              "failedRefetchDuration": {
+                                "description": "FailedRefetchDuration is how long to wait before retrying the fetch after a failure.\nIf unspecified, Envoy default of 1 second is used.",
+                                "type": "string",
+                                "x-kubernetes-validations": [
+                                  {
+                                    "message": "invalid duration value",
+                                    "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                  },
+                                  {
+                                    "message": "failedRefetchDuration must be at least 1ms.",
+                                    "rule": "duration(self) >= duration('1ms')"
+                                  }
+                                ]
+                              },
+                              "fastListener": {
+                                "description": "FastListener controls when the listener is considered ready relative to the\ninitial JWKS fetch.\nIf false or unset, the listener waits for the first JWKS fetch to complete before\nit starts serving traffic, so requests are never validated against an empty key set.\nIf true, the listener starts immediately and the first fetch happens in the background.",
+                                "type": "boolean"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
                           "backendRef": {
                             "description": "BackendRef is reference to the backend of the JWKS server.",
                             "properties": {
@@ -928,6 +1011,63 @@
                                 "rule": "duration(self) >= duration('1ms')"
                               }
                             ]
+                          },
+                          "retryPolicy": {
+                            "description": "RetryPolicy configures how the JWKS fetch is retried (with exponential backoff)\nwhen the remote JWKS server is unavailable.",
+                            "properties": {
+                              "backOff": {
+                                "description": "BackOff configures the exponential backoff strategy between retries.\nIf unset, the default base interval is 1000ms and the default maximum interval is\n10 times the base interval.",
+                                "properties": {
+                                  "baseInterval": {
+                                    "description": "BaseInterval is the base interval for the exponential backoff computation.\nIt must be greater than zero and less than or equal to MaxInterval.",
+                                    "type": "string",
+                                    "x-kubernetes-validations": [
+                                      {
+                                        "message": "invalid duration value",
+                                        "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                      },
+                                      {
+                                        "message": "baseInterval must be at least 1ms.",
+                                        "rule": "duration(self) >= duration('1ms')"
+                                      }
+                                    ]
+                                  },
+                                  "maxInterval": {
+                                    "description": "MaxInterval is the maximum interval between retries. If set, it must be greater than\nor equal to BaseInterval. Defaults to 10 times the BaseInterval.",
+                                    "type": "string",
+                                    "x-kubernetes-validations": [
+                                      {
+                                        "message": "invalid duration value",
+                                        "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                      },
+                                      {
+                                        "message": "maxInterval must be at least 1ms.",
+                                        "rule": "duration(self) >= duration('1ms')"
+                                      }
+                                    ]
+                                  }
+                                },
+                                "required": [
+                                  "baseInterval"
+                                ],
+                                "type": "object",
+                                "x-kubernetes-validations": [
+                                  {
+                                    "message": "maxInterval must be greater than or equal to baseInterval",
+                                    "rule": "!has(self.maxInterval) || duration(self.maxInterval) >= duration(self.baseInterval)"
+                                  }
+                                ],
+                                "additionalProperties": false
+                              },
+                              "numRetries": {
+                                "description": "NumRetries is the allowed number of retries when fetching the JWKS fails.\nDefaults to 1 if unset.",
+                                "format": "int32",
+                                "minimum": 1,
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
                           },
                           "url": {
                             "description": "URL is the URL of the remote JWKS server, it must be a full FQDN with protocol, host and path.\nFor example, https://example.com/keys",
@@ -1324,6 +1464,57 @@
                     }
                   },
                   "type": "object",
+                  "additionalProperties": false
+                },
+                "jwksBackendRef": {
+                  "description": "JWKSBackendRef specifies the backend to use for fetching the JWKS.\nIf not set, the parent OAuth2Provider's BackendRef is used.",
+                  "properties": {
+                    "group": {
+                      "default": "",
+                      "description": "Group is the group of the referent. For example, \"gateway.networking.k8s.io\".\nWhen unspecified or empty string, core API group is inferred.",
+                      "maxLength": 253,
+                      "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                      "type": "string"
+                    },
+                    "kind": {
+                      "default": "Service",
+                      "description": "Kind is the Kubernetes resource kind of the referent. For example\n\"Service\".\n\nDefaults to \"Service\" when not specified.\n\nExternalName services can refer to CNAME DNS records that may live\noutside of the cluster and as such are difficult to reason about in\nterms of conformance. They also may not be safe to forward to (see\nCVE-2021-25740 for more information). Implementations SHOULD NOT\nsupport ExternalName Services.\n\nSupport: Core (Services with a type other than ExternalName)\n\nSupport: Implementation-specific (Services with type ExternalName)",
+                      "maxLength": 63,
+                      "minLength": 1,
+                      "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
+                      "type": "string"
+                    },
+                    "name": {
+                      "description": "Name is the name of the referent.",
+                      "maxLength": 253,
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "namespace": {
+                      "description": "Namespace is the namespace of the backend. When unspecified, the local\nnamespace is inferred.\n\nNote that when a namespace different than the local namespace is specified,\na ReferenceGrant object is required in the referent namespace to allow that\nnamespace's owner to accept the reference. See the ReferenceGrant\ndocumentation for details.\n\nSupport: Core",
+                      "maxLength": 63,
+                      "minLength": 1,
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                      "type": "string"
+                    },
+                    "port": {
+                      "description": "Port specifies the destination port number to use for this resource.\nPort is required when the referent is a Kubernetes Service. In this\ncase, the port number is the service port number, not the target port.\nFor other resources, destination port might be derived from the referent\nresource or this field.",
+                      "format": "int32",
+                      "maximum": 65535,
+                      "minimum": 1,
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "name"
+                  ],
+                  "type": "object",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "Must have port for Service reference",
+                      "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
+                    }
+                  ],
                   "additionalProperties": false
                 },
                 "jwksURI": {

--- a/gateway.kgateway.dev/gatewayparameters_v1alpha1.json
+++ b/gateway.kgateway.dev/gatewayparameters_v1alpha1.json
@@ -132,6 +132,10 @@
                       "type": "object",
                       "additionalProperties": false
                     },
+                    "enableReadinessProbeProxyProtocol": {
+                      "description": "EnableReadinessProbeProxyProtocol enables the PROXY protocol listener filter\non the kgateway readiness listener (port 8082).\nSet this to true if and only if the load balancer in front of the gateway\nprepends PROXY protocol headers to incoming TCP connections targeting the\nreadiness port. For example, when using an AWS NLB with proxy protocol v2\nenabled at the target group level\n(`service.beta.kubernetes.io/aws-load-balancer-proxy-protocol: \"*\"`).\nDefaults to false.",
+                      "type": "boolean"
+                    },
                     "logFormat": {
                       "description": "Envoy application log format. Does *not* affect access logs. Can be JSON or custom text format.\nDefaults to text with default format string as defined in Envoy documentation.\nSee https://www.envoyproxy.io/docs/envoy/latest/operations/cli#cmdoption-log-format for format flag options.",
                       "properties": {
@@ -378,7 +382,7 @@
                   "description": "The envoy container image. See\nhttps://kubernetes.io/docs/concepts/containers/images\nfor details.\n\nDefault values, which may be overridden individually:\n\n\tregistry: quay.io/solo-io\n\trepository: envoy-wrapper\n\ttag: <kgateway version>\n\tpullPolicy: IfNotPresent",
                   "properties": {
                     "digest": {
-                      "description": "The hash digest of the image, e.g. `sha256:12345...`",
+                      "description": "The hash digest of the image, e.g. `sha256:12345...`\n\nTag and Digest are coupled at merge time: specifying a non-empty Digest\nwithout also specifying a Tag clears any inherited Tag, so the rendered\nimage reference is `repo@digest`. To keep both an inherited (or\noverridden) tag and digest, specify non-empty values for both fields.\nTo clear an inherited Digest while keeping an inherited Tag, set Digest\nto the empty string.",
                       "type": "string"
                     },
                     "pullPolicy": {
@@ -394,7 +398,7 @@
                       "type": "string"
                     },
                     "tag": {
-                      "description": "The image tag.",
+                      "description": "The image tag.\n\nTag and Digest are coupled at merge time: specifying a non-empty Tag\nwithout also specifying a Digest clears any inherited Digest, so the\nrendered image reference is `repo:tag`. To keep both an inherited (or\noverridden) tag and digest, specify non-empty values for both fields.\nTo clear an inherited Tag while keeping an inherited Digest, set Tag to\nthe empty string.",
                       "type": "string"
                     }
                   },
@@ -521,7 +525,7 @@
                       "type": "boolean"
                     },
                     "procMount": {
-                      "description": "procMount denotes the type of proc mount to use for the containers.\nThe default value is Default which uses the container runtime defaults for\nreadonly paths and masked paths.\nThis requires the ProcMountType feature flag to be enabled.\nNote that this field cannot be set when spec.os.name is windows.",
+                      "description": "procMount denotes the type of proc mount to use for the containers.\nThe default value is Default which uses the container runtime defaults for\nreadonly paths and masked paths.\nNote that this field cannot be set when spec.os.name is windows.",
                       "type": "string"
                     },
                     "readOnlyRootFilesystem": {
@@ -1692,7 +1696,7 @@
                             "type": "boolean"
                           },
                           "procMount": {
-                            "description": "procMount denotes the type of proc mount to use for the containers.\nThe default value is Default which uses the container runtime defaults for\nreadonly paths and masked paths.\nThis requires the ProcMountType feature flag to be enabled.\nNote that this field cannot be set when spec.os.name is windows.",
+                            "description": "procMount denotes the type of proc mount to use for the containers.\nThe default value is Default which uses the container runtime defaults for\nreadonly paths and masked paths.\nNote that this field cannot be set when spec.os.name is windows.",
                             "type": "string"
                           },
                           "readOnlyRootFilesystem": {
@@ -2051,7 +2055,7 @@
                       "description": "The container image. See\nhttps://kubernetes.io/docs/concepts/containers/images\nfor details.",
                       "properties": {
                         "digest": {
-                          "description": "The hash digest of the image, e.g. `sha256:12345...`",
+                          "description": "The hash digest of the image, e.g. `sha256:12345...`\n\nTag and Digest are coupled at merge time: specifying a non-empty Digest\nwithout also specifying a Tag clears any inherited Tag, so the rendered\nimage reference is `repo@digest`. To keep both an inherited (or\noverridden) tag and digest, specify non-empty values for both fields.\nTo clear an inherited Digest while keeping an inherited Tag, set Digest\nto the empty string.",
                           "type": "string"
                         },
                         "pullPolicy": {
@@ -2067,7 +2071,7 @@
                           "type": "string"
                         },
                         "tag": {
-                          "description": "The image tag.",
+                          "description": "The image tag.\n\nTag and Digest are coupled at merge time: specifying a non-empty Tag\nwithout also specifying a Digest clears any inherited Digest, so the\nrendered image reference is `repo:tag`. To keep both an inherited (or\noverridden) tag and digest, specify non-empty values for both fields.\nTo clear an inherited Tag while keeping an inherited Digest, set Tag to\nthe empty string.",
                           "type": "string"
                         }
                       },
@@ -2210,7 +2214,7 @@
                           "type": "boolean"
                         },
                         "procMount": {
-                          "description": "procMount denotes the type of proc mount to use for the containers.\nThe default value is Default which uses the container runtime defaults for\nreadonly paths and masked paths.\nThis requires the ProcMountType feature flag to be enabled.\nNote that this field cannot be set when spec.os.name is windows.",
+                          "description": "procMount denotes the type of proc mount to use for the containers.\nThe default value is Default which uses the container runtime defaults for\nreadonly paths and masked paths.\nNote that this field cannot be set when spec.os.name is windows.",
                           "type": "string"
                         },
                         "readOnlyRootFilesystem": {
@@ -3901,7 +3905,7 @@
                         "additionalProperties": false
                       },
                       "image": {
-                        "description": "image represents an OCI object (a container image or artifact) pulled and mounted on the kubelet's host machine.\nThe volume is resolved at pod startup depending on which PullPolicy value is provided:\n\n- Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.\n- Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.\n- IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.\n\nThe volume gets re-resolved if the pod gets deleted and recreated, which means that new remote content will become available on pod recreation.\nA failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.\nThe types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.\nThe OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.\nThe volume will be mounted read-only (ro) and non-executable files (noexec).\nSub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath) before 1.33.\nThe field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.",
+                        "description": "image represents an OCI object (a container image or artifact) pulled and mounted on the kubelet's host machine.\nThe volume is resolved at pod startup depending on which PullPolicy value is provided:\n\n- Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.\n- Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.\n- IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.\n\nThe volume gets re-resolved if the pod gets deleted and recreated, which means that new remote content will become available on pod recreation.\nA failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.\nThe types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.\nThe OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.\nThe volume will be mounted read-only (ro).\nSub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath) before 1.33.\nThe field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.",
                         "properties": {
                           "pullPolicy": {
                             "description": "Policy for pulling OCI objects. Possible values are:\nAlways: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.\nNever: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.\nIfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.\nDefaults to Always if :latest tag is specified, or IfNotPresent otherwise.",
@@ -4050,7 +4054,7 @@
                         "additionalProperties": false
                       },
                       "portworxVolume": {
-                        "description": "portworxVolume represents a portworx volume attached and mounted on kubelets host machine.\nDeprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type\nare redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate\nis on.",
+                        "description": "portworxVolume represents a portworx volume attached and mounted on kubelets host machine.\nDeprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type\nare redirected to the pxd.portworx.com CSI driver.",
                         "properties": {
                           "fsType": {
                             "description": "fSType represents the filesystem type to mount\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\". Implicitly inferred to be \"ext4\" if unspecified.",
@@ -4880,7 +4884,7 @@
                   "additionalProperties": {
                     "type": "string"
                   },
-                  "description": "A selector which must be true for the pod to fit on a node. See\nhttps://kubernetes.io/docs/concepts/configuration/assign-pod-node/ for\ndetails.",
+                  "description": "A selector which must be true for the pod to fit on a node. See\nhttps://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/ for\ndetails.",
                   "type": "object"
                 },
                 "priorityClassName": {
@@ -5360,7 +5364,7 @@
                   "type": "integer"
                 },
                 "tolerations": {
-                  "description": "do not use slice of pointers: https://github.com/kubernetes/code-generator/issues/166\nIf specified, the pod's tolerations. See\nhttps://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#toleration-v1-core\nfor details.",
+                  "description": "If specified, the pod's tolerations. See\nhttps://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#toleration-v1-core\nfor details.",
                   "items": {
                     "description": "The pod this Toleration is attached to tolerates any taint that matches\nthe triple <key,value,effect> using the matching operator <operator>.",
                     "properties": {
@@ -5510,7 +5514,7 @@
                   "description": "The SDS container image. See\nhttps://kubernetes.io/docs/concepts/containers/images\nfor details.",
                   "properties": {
                     "digest": {
-                      "description": "The hash digest of the image, e.g. `sha256:12345...`",
+                      "description": "The hash digest of the image, e.g. `sha256:12345...`\n\nTag and Digest are coupled at merge time: specifying a non-empty Digest\nwithout also specifying a Tag clears any inherited Tag, so the rendered\nimage reference is `repo@digest`. To keep both an inherited (or\noverridden) tag and digest, specify non-empty values for both fields.\nTo clear an inherited Digest while keeping an inherited Tag, set Digest\nto the empty string.",
                       "type": "string"
                     },
                     "pullPolicy": {
@@ -5526,7 +5530,7 @@
                       "type": "string"
                     },
                     "tag": {
-                      "description": "The image tag.",
+                      "description": "The image tag.\n\nTag and Digest are coupled at merge time: specifying a non-empty Tag\nwithout also specifying a Digest clears any inherited Digest, so the\nrendered image reference is `repo:tag`. To keep both an inherited (or\noverridden) tag and digest, specify non-empty values for both fields.\nTo clear an inherited Tag while keeping an inherited Digest, set Tag to\nthe empty string.",
                       "type": "string"
                     }
                   },
@@ -5653,7 +5657,7 @@
                       "type": "boolean"
                     },
                     "procMount": {
-                      "description": "procMount denotes the type of proc mount to use for the containers.\nThe default value is Default which uses the container runtime defaults for\nreadonly paths and masked paths.\nThis requires the ProcMountType feature flag to be enabled.\nNote that this field cannot be set when spec.os.name is windows.",
+                      "description": "procMount denotes the type of proc mount to use for the containers.\nThe default value is Default which uses the container runtime defaults for\nreadonly paths and masked paths.\nNote that this field cannot be set when spec.os.name is windows.",
                       "type": "string"
                     },
                     "readOnlyRootFilesystem": {

--- a/gateway.kgateway.dev/httplistenerpolicy_v1alpha1.json
+++ b/gateway.kgateway.dev/httplistenerpolicy_v1alpha1.json
@@ -101,7 +101,7 @@
                             },
                             "value": {
                               "description": "Value to compare against.",
-                              "format": "int32",
+                              "format": "uint32",
                               "maximum": 4294967295,
                               "minimum": 0,
                               "type": "integer"
@@ -273,7 +273,7 @@
                             },
                             "value": {
                               "description": "Value to compare against.",
-                              "format": "int32",
+                              "format": "uint32",
                               "maximum": 4294967295,
                               "minimum": 0,
                               "type": "integer"
@@ -325,7 +325,7 @@
                       },
                       "value": {
                         "description": "Value to compare against.",
-                        "format": "int32",
+                        "format": "uint32",
                         "maximum": 4294967295,
                         "minimum": 0,
                         "type": "integer"
@@ -457,7 +457,7 @@
                             },
                             "value": {
                               "description": "Value to compare against.",
-                              "format": "int32",
+                              "format": "uint32",
                               "maximum": 4294967295,
                               "minimum": 0,
                               "type": "integer"
@@ -629,7 +629,7 @@
                             },
                             "value": {
                               "description": "Value to compare against.",
-                              "format": "int32",
+                              "format": "uint32",
                               "maximum": 4294967295,
                               "minimum": 0,
                               "type": "integer"
@@ -728,7 +728,7 @@
                       },
                       "value": {
                         "description": "Value to compare against.",
-                        "format": "int32",
+                        "format": "uint32",
                         "maximum": 4294967295,
                         "minimum": 0,
                         "type": "integer"
@@ -1306,6 +1306,51 @@
           "type": "object",
           "additionalProperties": false
         },
+        "forwardClientCertDetails": {
+          "description": "ForwardClientCertDetails configures how Envoy handles the x-forwarded-client-cert (XFCC)\nheader and which parts of the downstream client certificate are forwarded to upstream\nbackends. Most modes only have effect on listeners where mTLS is configured. The exceptions\nare Sanitize, which strips XFCC unconditionally, and AlwaysForwardOnly, which forwards XFCC\nunconditionally; on a non-mTLS listener under any other mode the setting is a no-op.\nSee: https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto#envoy-v3-api-field-extensions-filters-network-http-connection-manager-v3-httpconnectionmanager-forward-client-cert-details",
+          "properties": {
+            "details": {
+              "description": "Details selects which fields from the downstream client certificate are written into\nthe XFCC header that is sent upstream. These fields are only honored by Envoy when\nMode is AppendForward or SanitizeSet.",
+              "properties": {
+                "cert": {
+                  "description": "Cert forwards the entire client certificate in URL-encoded PEM format in the XFCC header.",
+                  "type": "boolean"
+                },
+                "chain": {
+                  "description": "Chain forwards the entire client certificate chain (including the leaf certificate) in\nURL-encoded PEM format in the XFCC header.",
+                  "type": "boolean"
+                },
+                "dns": {
+                  "description": "DNS forwards DNS-type Subject Alternative Names from the client certificate in the XFCC header.",
+                  "type": "boolean"
+                },
+                "subject": {
+                  "description": "Subject forwards the certificate Subject in the XFCC header.",
+                  "type": "boolean"
+                },
+                "uri": {
+                  "description": "URI forwards the URI-type Subject Alternative Name from the client certificate in the XFCC header.",
+                  "type": "boolean"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "mode": {
+              "description": "Mode controls how Envoy handles the XFCC header on the request forwarded upstream.\nIf unset and Details is provided, Mode defaults to SanitizeSet.\nIf both Mode and Details are unset, this field has no effect.\n\n- Sanitize: do not send the XFCC header upstream.\n- ForwardOnly: forward the XFCC header in the request unchanged.\n- AppendForward: append the current client's details to the XFCC header.\n- SanitizeSet: reset the XFCC header with the current client's details, ignoring any client-supplied value.\n- AlwaysForwardOnly: always forward the XFCC header, even for non-mTLS connections.",
+              "enum": [
+                "Sanitize",
+                "ForwardOnly",
+                "AppendForward",
+                "SanitizeSet",
+                "AlwaysForwardOnly"
+              ],
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
         "generateRequestId": {
           "description": "GenerateRequestId:  Whether the connection manager will generate the x-request-id header if it does not exist.\nThis defaults to true. Generating a random UUID4 is expensive so in high throughput scenarios where this feature is not desired it can be disabled.\nSee here for more information https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto#envoy-v3-api-field-extensions-filters-network-http-connection-manager-v3-httpconnectionmanager-generate-request-id",
           "type": "boolean"
@@ -1329,6 +1374,10 @@
         "http2ProtocolOptions": {
           "description": "Http2ProtocolOptions configures downstream HTTP/2 behavior on the listener's\nHttpConnectionManager.\nSee here for more information: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/protocol.proto#config-core-v3-http2protocoloptions",
           "properties": {
+            "allowConnect": {
+              "description": "AllowConnect allows proxying of WebSocket and other upgrades over HTTP/2 by\nenabling Envoy to handle Extended CONNECT requests (RFC 8441) on the downstream\nconnection. This is required for WebSocket-over-HTTP/2 when the listener advertises\nh2 in its ALPN; otherwise user agents that use Extended CONNECT (e.g. Firefox) fail\nto establish WebSocket connections.\nDefaults to false.",
+              "type": "boolean"
+            },
             "initialConnectionWindowSize": {
               "anyOf": [
                 {
@@ -1367,7 +1416,7 @@
           "additionalProperties": false
         },
         "idleTimeout": {
-          "description": "IdleTimeout is the idle timeout for connnections.\nSee here for more information: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/protocol.proto#envoy-v3-api-msg-config-core-v3-httpprotocoloptions",
+          "description": "IdleTimeout is the idle timeout for connections.\nSee here for more information: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/protocol.proto#envoy-v3-api-msg-config-core-v3-httpprotocoloptions",
           "type": "string",
           "x-kubernetes-validations": [
             {
@@ -1375,6 +1424,964 @@
               "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
             }
           ]
+        },
+        "localReplies": {
+          "description": "LocalReplies configures how Envoy's local replies are formatted etc.",
+          "properties": {
+            "defaultBodyFormat": {
+              "description": "DefaultBodyFormat is the format to use for local reply bodies if it's not overridden by any mapper.\nYou can use the `%LOCAL_REPLY_BODY%` substitution to insert the original reply such as an error message.",
+              "properties": {
+                "contentType": {
+                  "description": "ContentType defines the HTTP Content-Type header to be sent with the response.\nBy default, `text/plain` is used for the Text format and `application/json` for the JSON format.\nNote: This setting does not currently take effect due to a bug in Envoy, a fix for which is pending release.\nThe option is included for completeness and will become effective with a future version of Envoy.",
+                  "type": "string"
+                },
+                "json": {
+                  "description": "JSON is a format object by which Envoy will produce a JSON response body.\nMutually exclusive with Text.\nSee https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/substitution_format_string.proto#envoy-v3-api-field-config-core-v3-substitutionformatstring-json-format for details.\n\nSetting a field to `null` in the JSON object requires the use of\n`kubectl apply --server-side` or equivalent. With the default client-side\n`kubectl apply`, null values are stripped by kubectl before reaching\nthe API server.",
+                  "type": "object",
+                  "x-kubernetes-preserve-unknown-fields": true
+                },
+                "text": {
+                  "description": "Text is a format string by which Envoy will format the response body.\nMutually exclusive with JSON.\nSee https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/substitution_format_string.proto#envoy-v3-api-field-config-core-v3-substitutionformatstring-text-format for details.",
+                  "maxLength": 4096,
+                  "minLength": 1,
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "x-kubernetes-validations": [
+                {
+                  "message": "exactly one of the fields in [json text] must be set",
+                  "rule": "[has(self.json),has(self.text)].filter(x,x==true).size() == 1"
+                }
+              ],
+              "additionalProperties": false
+            },
+            "mappers": {
+              "description": "A list of custom options to apply based on filters. This may override the DefaultBodyFormat.",
+              "items": {
+                "description": "LocalReplyMapper may customize the local reply based on stream, request, and response properties such as status code.",
+                "properties": {
+                  "body": {
+                    "description": "New body text for the reply if specified.\nAvailable as `%LOCAL_REPLY_BODY%` in substitution strings.",
+                    "type": "string"
+                  },
+                  "bodyFormatOverride": {
+                    "description": "Alternative body format for the reply if specified. Takes precedence over default body format.",
+                    "properties": {
+                      "contentType": {
+                        "description": "ContentType defines the HTTP Content-Type header to be sent with the response.\nBy default, `text/plain` is used for the Text format and `application/json` for the JSON format.\nNote: This setting does not currently take effect due to a bug in Envoy, a fix for which is pending release.\nThe option is included for completeness and will become effective with a future version of Envoy.",
+                        "type": "string"
+                      },
+                      "json": {
+                        "description": "JSON is a format object by which Envoy will produce a JSON response body.\nMutually exclusive with Text.\nSee https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/substitution_format_string.proto#envoy-v3-api-field-config-core-v3-substitutionformatstring-json-format for details.\n\nSetting a field to `null` in the JSON object requires the use of\n`kubectl apply --server-side` or equivalent. With the default client-side\n`kubectl apply`, null values are stripped by kubectl before reaching\nthe API server.",
+                        "type": "object",
+                        "x-kubernetes-preserve-unknown-fields": true
+                      },
+                      "text": {
+                        "description": "Text is a format string by which Envoy will format the response body.\nMutually exclusive with JSON.\nSee https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/substitution_format_string.proto#envoy-v3-api-field-config-core-v3-substitutionformatstring-text-format for details.",
+                        "maxLength": 4096,
+                        "minLength": 1,
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "x-kubernetes-validations": [
+                      {
+                        "message": "exactly one of the fields in [json text] must be set",
+                        "rule": "[has(self.json),has(self.text)].filter(x,x==true).size() == 1"
+                      }
+                    ],
+                    "additionalProperties": false
+                  },
+                  "filter": {
+                    "allOf": [
+                      {
+                        "maxProperties": 1,
+                        "minProperties": 1
+                      },
+                      {
+                        "maxProperties": 1,
+                        "minProperties": 1
+                      }
+                    ],
+                    "description": "A filter that determines if this mapper should apply.",
+                    "properties": {
+                      "andFilter": {
+                        "description": "Performs a logical \"and\" operation on the result of each individual filter.\nBased on: https://www.envoyproxy.io/docs/envoy/v1.33.0/api-v3/config/accesslog/v3/accesslog.proto#config-accesslog-v3-andfilter",
+                        "items": {
+                          "description": "FilterType represents the type of filter to apply (only one of these should be set).\nBased on: https://www.envoyproxy.io/docs/envoy/v1.33.0/api-v3/config/accesslog/v3/accesslog.proto#envoy-v3-api-msg-config-accesslog-v3-accesslogfilter",
+                          "maxProperties": 1,
+                          "minProperties": 1,
+                          "properties": {
+                            "celFilter": {
+                              "description": "CELFilter filters requests based on Common Expression Language (CEL).",
+                              "properties": {
+                                "match": {
+                                  "description": "The CEL expressions to evaluate. AccessLogs are only emitted when the CEL expressions evaluates to true.\nsee: https://www.envoyproxy.io/docs/envoy/v1.33.0/xds/type/v3/cel.proto.html#common-expression-language-cel-proto",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "match"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "durationFilter": {
+                              "description": "DurationFilter filters based on request duration.\nBased on: https://www.envoyproxy.io/docs/envoy/v1.33.0/api-v3/config/accesslog/v3/accesslog.proto#config-accesslog-v3-durationfilter",
+                              "properties": {
+                                "op": {
+                                  "description": "Op represents comparison operators.",
+                                  "enum": [
+                                    "EQ",
+                                    "GE",
+                                    "LE"
+                                  ],
+                                  "type": "string"
+                                },
+                                "value": {
+                                  "description": "Value to compare against.",
+                                  "format": "uint32",
+                                  "maximum": 4294967295,
+                                  "minimum": 0,
+                                  "type": "integer"
+                                }
+                              },
+                              "required": [
+                                "op",
+                                "value"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "grpcStatusFilter": {
+                              "description": "GrpcStatusFilter filters gRPC requests based on their response status.\nBased on: https://www.envoyproxy.io/docs/envoy/v1.33.0/api-v3/config/accesslog/v3/accesslog.proto#enum-config-accesslog-v3-grpcstatusfilter-status",
+                              "properties": {
+                                "exclude": {
+                                  "type": "boolean"
+                                },
+                                "statuses": {
+                                  "items": {
+                                    "description": "GrpcStatus represents possible gRPC statuses.",
+                                    "enum": [
+                                      "OK",
+                                      "CANCELED",
+                                      "UNKNOWN",
+                                      "INVALID_ARGUMENT",
+                                      "DEADLINE_EXCEEDED",
+                                      "NOT_FOUND",
+                                      "ALREADY_EXISTS",
+                                      "PERMISSION_DENIED",
+                                      "RESOURCE_EXHAUSTED",
+                                      "FAILED_PRECONDITION",
+                                      "ABORTED",
+                                      "OUT_OF_RANGE",
+                                      "UNIMPLEMENTED",
+                                      "INTERNAL",
+                                      "UNAVAILABLE",
+                                      "DATA_LOSS",
+                                      "UNAUTHENTICATED"
+                                    ],
+                                    "type": "string"
+                                  },
+                                  "minItems": 1,
+                                  "type": "array"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "headerFilter": {
+                              "description": "HeaderFilter filters requests based on headers.\nBased on: https://www.envoyproxy.io/docs/envoy/v1.33.0/api-v3/config/accesslog/v3/accesslog.proto#config-accesslog-v3-headerfilter",
+                              "properties": {
+                                "header": {
+                                  "description": "HTTPHeaderMatch describes how to select a HTTP route by matching HTTP request\nheaders.",
+                                  "properties": {
+                                    "name": {
+                                      "description": "Name is the name of the HTTP Header to be matched. Name matching MUST be\ncase-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).\n\nIf multiple entries specify equivalent header names, only the first\nentry with an equivalent name MUST be considered for a match. Subsequent\nentries with an equivalent header name MUST be ignored. Due to the\ncase-insensitivity of header names, \"foo\" and \"Foo\" are considered\nequivalent.\n\nWhen a header is repeated in an HTTP request, it is\nimplementation-specific behavior as to how this is represented.\nGenerally, proxies should follow the guidance from the RFC:\nhttps://www.rfc-editor.org/rfc/rfc7230.html#section-3.2.2 regarding\nprocessing a repeated header, with special handling for \"Set-Cookie\".",
+                                      "maxLength": 256,
+                                      "minLength": 1,
+                                      "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                                      "type": "string"
+                                    },
+                                    "type": {
+                                      "default": "Exact",
+                                      "description": "Type specifies how to match against the value of the header.\n\nSupport: Core (Exact)\n\nSupport: Implementation-specific (RegularExpression)\n\nSince RegularExpression HeaderMatchType has implementation-specific\nconformance, implementations can support POSIX, PCRE or any other dialects\nof regular expressions. Please read the implementation's documentation to\ndetermine the supported dialect.",
+                                      "enum": [
+                                        "Exact",
+                                        "RegularExpression"
+                                      ],
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "description": "Value is the value of HTTP Header to be matched.\n<gateway:experimental:description>\nMust consist of printable US-ASCII characters, optionally separated\nby single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2\n</gateway:experimental:description>\n\n<gateway:experimental:validation:Pattern=`^[!-~]+([\\t ]?[!-~]+)*$`>",
+                                      "maxLength": 4096,
+                                      "minLength": 1,
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "name",
+                                    "value"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "required": [
+                                "header"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "notHealthCheckFilter": {
+                              "description": "Filters for requests that are not health check requests.\nBased on: https://www.envoyproxy.io/docs/envoy/v1.33.0/api-v3/config/accesslog/v3/accesslog.proto#config-accesslog-v3-nothealthcheckfilter",
+                              "type": "boolean"
+                            },
+                            "responseFlagFilter": {
+                              "description": "ResponseFlagFilter filters based on response flags.\nBased on: https://www.envoyproxy.io/docs/envoy/v1.33.0/api-v3/config/accesslog/v3/accesslog.proto#config-accesslog-v3-responseflagfilter",
+                              "properties": {
+                                "flags": {
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "minItems": 1,
+                                  "type": "array"
+                                }
+                              },
+                              "required": [
+                                "flags"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "runtimeFilter": {
+                              "description": "Filters for random sampling of access logs.\nBased on: https://www.envoyproxy.io/docs/envoy/v1.33.0/api-v3/config/accesslog/v3/accesslog.proto#config-accesslog-v3-runtimefilter",
+                              "properties": {
+                                "percentSampled": {
+                                  "description": "By default, the runtime filter will log on every request when the runtime key is set.\nIf this field is set, it additionally applies a fractional percent check so that only a\nfraction of requests are logged.",
+                                  "properties": {
+                                    "denominator": {
+                                      "description": "Specifies the denominator. If the denominator specified is less than the numerator,\nthe final fractional percentage is capped at 1 (100%).\nDefaults to HUNDRED.",
+                                      "enum": [
+                                        "HUNDRED",
+                                        "TEN_THOUSAND",
+                                        "MILLION"
+                                      ],
+                                      "type": "string"
+                                    },
+                                    "numerator": {
+                                      "description": "Specifies the numerator. Defaults to 0.",
+                                      "format": "int32",
+                                      "minimum": 0,
+                                      "type": "integer"
+                                    }
+                                  },
+                                  "required": [
+                                    "numerator"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "runtimeKey": {
+                                  "description": "The runtime key to look up in the runtime implementation. This key determines whether\nthe access log is enabled. When the runtime key value is set, the filter checks this key\nat runtime to decide whether to log each request.",
+                                  "minLength": 1,
+                                  "type": "string"
+                                },
+                                "useIndependentRandomness": {
+                                  "description": "If set to true, the filter uses Envoy's independent randomness source.\nWhen false (the default), the filter uses the runtime key lookup.",
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "runtimeKey"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "statusCodeFilter": {
+                              "description": "StatusCodeFilter filters based on HTTP status code.\nBased on: https://www.envoyproxy.io/docs/envoy/v1.33.0/api-v3/config/accesslog/v3/accesslog.proto#envoy-v3-api-msg-config-accesslog-v3-statuscodefilter",
+                              "properties": {
+                                "op": {
+                                  "description": "Op represents comparison operators.",
+                                  "enum": [
+                                    "EQ",
+                                    "GE",
+                                    "LE"
+                                  ],
+                                  "type": "string"
+                                },
+                                "value": {
+                                  "description": "Value to compare against.",
+                                  "format": "uint32",
+                                  "maximum": 4294967295,
+                                  "minimum": 0,
+                                  "type": "integer"
+                                }
+                              },
+                              "required": [
+                                "op",
+                                "value"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "traceableFilter": {
+                              "description": "Filters for requests that are traceable.\nBased on: https://www.envoyproxy.io/docs/envoy/v1.33.0/api-v3/config/accesslog/v3/accesslog.proto#config-accesslog-v3-traceablefilter",
+                              "type": "boolean"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "minItems": 2,
+                        "type": "array"
+                      },
+                      "celFilter": {
+                        "description": "CELFilter filters requests based on Common Expression Language (CEL).",
+                        "properties": {
+                          "match": {
+                            "description": "The CEL expressions to evaluate. AccessLogs are only emitted when the CEL expressions evaluates to true.\nsee: https://www.envoyproxy.io/docs/envoy/v1.33.0/xds/type/v3/cel.proto.html#common-expression-language-cel-proto",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "match"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "durationFilter": {
+                        "description": "DurationFilter filters based on request duration.\nBased on: https://www.envoyproxy.io/docs/envoy/v1.33.0/api-v3/config/accesslog/v3/accesslog.proto#config-accesslog-v3-durationfilter",
+                        "properties": {
+                          "op": {
+                            "description": "Op represents comparison operators.",
+                            "enum": [
+                              "EQ",
+                              "GE",
+                              "LE"
+                            ],
+                            "type": "string"
+                          },
+                          "value": {
+                            "description": "Value to compare against.",
+                            "format": "uint32",
+                            "maximum": 4294967295,
+                            "minimum": 0,
+                            "type": "integer"
+                          }
+                        },
+                        "required": [
+                          "op",
+                          "value"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "grpcStatusFilter": {
+                        "description": "GrpcStatusFilter filters gRPC requests based on their response status.\nBased on: https://www.envoyproxy.io/docs/envoy/v1.33.0/api-v3/config/accesslog/v3/accesslog.proto#enum-config-accesslog-v3-grpcstatusfilter-status",
+                        "properties": {
+                          "exclude": {
+                            "type": "boolean"
+                          },
+                          "statuses": {
+                            "items": {
+                              "description": "GrpcStatus represents possible gRPC statuses.",
+                              "enum": [
+                                "OK",
+                                "CANCELED",
+                                "UNKNOWN",
+                                "INVALID_ARGUMENT",
+                                "DEADLINE_EXCEEDED",
+                                "NOT_FOUND",
+                                "ALREADY_EXISTS",
+                                "PERMISSION_DENIED",
+                                "RESOURCE_EXHAUSTED",
+                                "FAILED_PRECONDITION",
+                                "ABORTED",
+                                "OUT_OF_RANGE",
+                                "UNIMPLEMENTED",
+                                "INTERNAL",
+                                "UNAVAILABLE",
+                                "DATA_LOSS",
+                                "UNAUTHENTICATED"
+                              ],
+                              "type": "string"
+                            },
+                            "minItems": 1,
+                            "type": "array"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "headerFilter": {
+                        "description": "HeaderFilter filters requests based on headers.\nBased on: https://www.envoyproxy.io/docs/envoy/v1.33.0/api-v3/config/accesslog/v3/accesslog.proto#config-accesslog-v3-headerfilter",
+                        "properties": {
+                          "header": {
+                            "description": "HTTPHeaderMatch describes how to select a HTTP route by matching HTTP request\nheaders.",
+                            "properties": {
+                              "name": {
+                                "description": "Name is the name of the HTTP Header to be matched. Name matching MUST be\ncase-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).\n\nIf multiple entries specify equivalent header names, only the first\nentry with an equivalent name MUST be considered for a match. Subsequent\nentries with an equivalent header name MUST be ignored. Due to the\ncase-insensitivity of header names, \"foo\" and \"Foo\" are considered\nequivalent.\n\nWhen a header is repeated in an HTTP request, it is\nimplementation-specific behavior as to how this is represented.\nGenerally, proxies should follow the guidance from the RFC:\nhttps://www.rfc-editor.org/rfc/rfc7230.html#section-3.2.2 regarding\nprocessing a repeated header, with special handling for \"Set-Cookie\".",
+                                "maxLength": 256,
+                                "minLength": 1,
+                                "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                                "type": "string"
+                              },
+                              "type": {
+                                "default": "Exact",
+                                "description": "Type specifies how to match against the value of the header.\n\nSupport: Core (Exact)\n\nSupport: Implementation-specific (RegularExpression)\n\nSince RegularExpression HeaderMatchType has implementation-specific\nconformance, implementations can support POSIX, PCRE or any other dialects\nof regular expressions. Please read the implementation's documentation to\ndetermine the supported dialect.",
+                                "enum": [
+                                  "Exact",
+                                  "RegularExpression"
+                                ],
+                                "type": "string"
+                              },
+                              "value": {
+                                "description": "Value is the value of HTTP Header to be matched.\n<gateway:experimental:description>\nMust consist of printable US-ASCII characters, optionally separated\nby single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2\n</gateway:experimental:description>\n\n<gateway:experimental:validation:Pattern=`^[!-~]+([\\t ]?[!-~]+)*$`>",
+                                "maxLength": 4096,
+                                "minLength": 1,
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "name",
+                              "value"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "required": [
+                          "header"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "notHealthCheckFilter": {
+                        "description": "Filters for requests that are not health check requests.\nBased on: https://www.envoyproxy.io/docs/envoy/v1.33.0/api-v3/config/accesslog/v3/accesslog.proto#config-accesslog-v3-nothealthcheckfilter",
+                        "type": "boolean"
+                      },
+                      "orFilter": {
+                        "description": "Performs a logical \"or\" operation on the result of each individual filter.\nBased on: https://www.envoyproxy.io/docs/envoy/v1.33.0/api-v3/config/accesslog/v3/accesslog.proto#config-accesslog-v3-orfilter",
+                        "items": {
+                          "description": "FilterType represents the type of filter to apply (only one of these should be set).\nBased on: https://www.envoyproxy.io/docs/envoy/v1.33.0/api-v3/config/accesslog/v3/accesslog.proto#envoy-v3-api-msg-config-accesslog-v3-accesslogfilter",
+                          "maxProperties": 1,
+                          "minProperties": 1,
+                          "properties": {
+                            "celFilter": {
+                              "description": "CELFilter filters requests based on Common Expression Language (CEL).",
+                              "properties": {
+                                "match": {
+                                  "description": "The CEL expressions to evaluate. AccessLogs are only emitted when the CEL expressions evaluates to true.\nsee: https://www.envoyproxy.io/docs/envoy/v1.33.0/xds/type/v3/cel.proto.html#common-expression-language-cel-proto",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "match"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "durationFilter": {
+                              "description": "DurationFilter filters based on request duration.\nBased on: https://www.envoyproxy.io/docs/envoy/v1.33.0/api-v3/config/accesslog/v3/accesslog.proto#config-accesslog-v3-durationfilter",
+                              "properties": {
+                                "op": {
+                                  "description": "Op represents comparison operators.",
+                                  "enum": [
+                                    "EQ",
+                                    "GE",
+                                    "LE"
+                                  ],
+                                  "type": "string"
+                                },
+                                "value": {
+                                  "description": "Value to compare against.",
+                                  "format": "uint32",
+                                  "maximum": 4294967295,
+                                  "minimum": 0,
+                                  "type": "integer"
+                                }
+                              },
+                              "required": [
+                                "op",
+                                "value"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "grpcStatusFilter": {
+                              "description": "GrpcStatusFilter filters gRPC requests based on their response status.\nBased on: https://www.envoyproxy.io/docs/envoy/v1.33.0/api-v3/config/accesslog/v3/accesslog.proto#enum-config-accesslog-v3-grpcstatusfilter-status",
+                              "properties": {
+                                "exclude": {
+                                  "type": "boolean"
+                                },
+                                "statuses": {
+                                  "items": {
+                                    "description": "GrpcStatus represents possible gRPC statuses.",
+                                    "enum": [
+                                      "OK",
+                                      "CANCELED",
+                                      "UNKNOWN",
+                                      "INVALID_ARGUMENT",
+                                      "DEADLINE_EXCEEDED",
+                                      "NOT_FOUND",
+                                      "ALREADY_EXISTS",
+                                      "PERMISSION_DENIED",
+                                      "RESOURCE_EXHAUSTED",
+                                      "FAILED_PRECONDITION",
+                                      "ABORTED",
+                                      "OUT_OF_RANGE",
+                                      "UNIMPLEMENTED",
+                                      "INTERNAL",
+                                      "UNAVAILABLE",
+                                      "DATA_LOSS",
+                                      "UNAUTHENTICATED"
+                                    ],
+                                    "type": "string"
+                                  },
+                                  "minItems": 1,
+                                  "type": "array"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "headerFilter": {
+                              "description": "HeaderFilter filters requests based on headers.\nBased on: https://www.envoyproxy.io/docs/envoy/v1.33.0/api-v3/config/accesslog/v3/accesslog.proto#config-accesslog-v3-headerfilter",
+                              "properties": {
+                                "header": {
+                                  "description": "HTTPHeaderMatch describes how to select a HTTP route by matching HTTP request\nheaders.",
+                                  "properties": {
+                                    "name": {
+                                      "description": "Name is the name of the HTTP Header to be matched. Name matching MUST be\ncase-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).\n\nIf multiple entries specify equivalent header names, only the first\nentry with an equivalent name MUST be considered for a match. Subsequent\nentries with an equivalent header name MUST be ignored. Due to the\ncase-insensitivity of header names, \"foo\" and \"Foo\" are considered\nequivalent.\n\nWhen a header is repeated in an HTTP request, it is\nimplementation-specific behavior as to how this is represented.\nGenerally, proxies should follow the guidance from the RFC:\nhttps://www.rfc-editor.org/rfc/rfc7230.html#section-3.2.2 regarding\nprocessing a repeated header, with special handling for \"Set-Cookie\".",
+                                      "maxLength": 256,
+                                      "minLength": 1,
+                                      "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                                      "type": "string"
+                                    },
+                                    "type": {
+                                      "default": "Exact",
+                                      "description": "Type specifies how to match against the value of the header.\n\nSupport: Core (Exact)\n\nSupport: Implementation-specific (RegularExpression)\n\nSince RegularExpression HeaderMatchType has implementation-specific\nconformance, implementations can support POSIX, PCRE or any other dialects\nof regular expressions. Please read the implementation's documentation to\ndetermine the supported dialect.",
+                                      "enum": [
+                                        "Exact",
+                                        "RegularExpression"
+                                      ],
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "description": "Value is the value of HTTP Header to be matched.\n<gateway:experimental:description>\nMust consist of printable US-ASCII characters, optionally separated\nby single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2\n</gateway:experimental:description>\n\n<gateway:experimental:validation:Pattern=`^[!-~]+([\\t ]?[!-~]+)*$`>",
+                                      "maxLength": 4096,
+                                      "minLength": 1,
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "name",
+                                    "value"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "required": [
+                                "header"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "notHealthCheckFilter": {
+                              "description": "Filters for requests that are not health check requests.\nBased on: https://www.envoyproxy.io/docs/envoy/v1.33.0/api-v3/config/accesslog/v3/accesslog.proto#config-accesslog-v3-nothealthcheckfilter",
+                              "type": "boolean"
+                            },
+                            "responseFlagFilter": {
+                              "description": "ResponseFlagFilter filters based on response flags.\nBased on: https://www.envoyproxy.io/docs/envoy/v1.33.0/api-v3/config/accesslog/v3/accesslog.proto#config-accesslog-v3-responseflagfilter",
+                              "properties": {
+                                "flags": {
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "minItems": 1,
+                                  "type": "array"
+                                }
+                              },
+                              "required": [
+                                "flags"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "runtimeFilter": {
+                              "description": "Filters for random sampling of access logs.\nBased on: https://www.envoyproxy.io/docs/envoy/v1.33.0/api-v3/config/accesslog/v3/accesslog.proto#config-accesslog-v3-runtimefilter",
+                              "properties": {
+                                "percentSampled": {
+                                  "description": "By default, the runtime filter will log on every request when the runtime key is set.\nIf this field is set, it additionally applies a fractional percent check so that only a\nfraction of requests are logged.",
+                                  "properties": {
+                                    "denominator": {
+                                      "description": "Specifies the denominator. If the denominator specified is less than the numerator,\nthe final fractional percentage is capped at 1 (100%).\nDefaults to HUNDRED.",
+                                      "enum": [
+                                        "HUNDRED",
+                                        "TEN_THOUSAND",
+                                        "MILLION"
+                                      ],
+                                      "type": "string"
+                                    },
+                                    "numerator": {
+                                      "description": "Specifies the numerator. Defaults to 0.",
+                                      "format": "int32",
+                                      "minimum": 0,
+                                      "type": "integer"
+                                    }
+                                  },
+                                  "required": [
+                                    "numerator"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "runtimeKey": {
+                                  "description": "The runtime key to look up in the runtime implementation. This key determines whether\nthe access log is enabled. When the runtime key value is set, the filter checks this key\nat runtime to decide whether to log each request.",
+                                  "minLength": 1,
+                                  "type": "string"
+                                },
+                                "useIndependentRandomness": {
+                                  "description": "If set to true, the filter uses Envoy's independent randomness source.\nWhen false (the default), the filter uses the runtime key lookup.",
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "runtimeKey"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "statusCodeFilter": {
+                              "description": "StatusCodeFilter filters based on HTTP status code.\nBased on: https://www.envoyproxy.io/docs/envoy/v1.33.0/api-v3/config/accesslog/v3/accesslog.proto#envoy-v3-api-msg-config-accesslog-v3-statuscodefilter",
+                              "properties": {
+                                "op": {
+                                  "description": "Op represents comparison operators.",
+                                  "enum": [
+                                    "EQ",
+                                    "GE",
+                                    "LE"
+                                  ],
+                                  "type": "string"
+                                },
+                                "value": {
+                                  "description": "Value to compare against.",
+                                  "format": "uint32",
+                                  "maximum": 4294967295,
+                                  "minimum": 0,
+                                  "type": "integer"
+                                }
+                              },
+                              "required": [
+                                "op",
+                                "value"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "traceableFilter": {
+                              "description": "Filters for requests that are traceable.\nBased on: https://www.envoyproxy.io/docs/envoy/v1.33.0/api-v3/config/accesslog/v3/accesslog.proto#config-accesslog-v3-traceablefilter",
+                              "type": "boolean"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "minItems": 2,
+                        "type": "array"
+                      },
+                      "responseFlagFilter": {
+                        "description": "ResponseFlagFilter filters based on response flags.\nBased on: https://www.envoyproxy.io/docs/envoy/v1.33.0/api-v3/config/accesslog/v3/accesslog.proto#config-accesslog-v3-responseflagfilter",
+                        "properties": {
+                          "flags": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "minItems": 1,
+                            "type": "array"
+                          }
+                        },
+                        "required": [
+                          "flags"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "runtimeFilter": {
+                        "description": "Filters for random sampling of access logs.\nBased on: https://www.envoyproxy.io/docs/envoy/v1.33.0/api-v3/config/accesslog/v3/accesslog.proto#config-accesslog-v3-runtimefilter",
+                        "properties": {
+                          "percentSampled": {
+                            "description": "By default, the runtime filter will log on every request when the runtime key is set.\nIf this field is set, it additionally applies a fractional percent check so that only a\nfraction of requests are logged.",
+                            "properties": {
+                              "denominator": {
+                                "description": "Specifies the denominator. If the denominator specified is less than the numerator,\nthe final fractional percentage is capped at 1 (100%).\nDefaults to HUNDRED.",
+                                "enum": [
+                                  "HUNDRED",
+                                  "TEN_THOUSAND",
+                                  "MILLION"
+                                ],
+                                "type": "string"
+                              },
+                              "numerator": {
+                                "description": "Specifies the numerator. Defaults to 0.",
+                                "format": "int32",
+                                "minimum": 0,
+                                "type": "integer"
+                              }
+                            },
+                            "required": [
+                              "numerator"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "runtimeKey": {
+                            "description": "The runtime key to look up in the runtime implementation. This key determines whether\nthe access log is enabled. When the runtime key value is set, the filter checks this key\nat runtime to decide whether to log each request.",
+                            "minLength": 1,
+                            "type": "string"
+                          },
+                          "useIndependentRandomness": {
+                            "description": "If set to true, the filter uses Envoy's independent randomness source.\nWhen false (the default), the filter uses the runtime key lookup.",
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "runtimeKey"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "statusCodeFilter": {
+                        "description": "StatusCodeFilter filters based on HTTP status code.\nBased on: https://www.envoyproxy.io/docs/envoy/v1.33.0/api-v3/config/accesslog/v3/accesslog.proto#envoy-v3-api-msg-config-accesslog-v3-statuscodefilter",
+                        "properties": {
+                          "op": {
+                            "description": "Op represents comparison operators.",
+                            "enum": [
+                              "EQ",
+                              "GE",
+                              "LE"
+                            ],
+                            "type": "string"
+                          },
+                          "value": {
+                            "description": "Value to compare against.",
+                            "format": "uint32",
+                            "maximum": 4294967295,
+                            "minimum": 0,
+                            "type": "integer"
+                          }
+                        },
+                        "required": [
+                          "op",
+                          "value"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "traceableFilter": {
+                        "description": "Filters for requests that are traceable.\nBased on: https://www.envoyproxy.io/docs/envoy/v1.33.0/api-v3/config/accesslog/v3/accesslog.proto#config-accesslog-v3-traceablefilter",
+                        "type": "boolean"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "headers": {
+                    "description": "Headers to add or set for the reply if specified.",
+                    "properties": {
+                      "add": {
+                        "description": "Add adds the given header(s) (name, value) to the request before the action.\nIt appends to any existing values associated with the header name.\n\nInput:\n  GET /foo HTTP/1.1\n  my-header: foo\n\nConfig:\n  add:\n  - name: \"my-header\"\n    value: \"bar,baz\"\n\nOutput:\n  GET /foo HTTP/1.1\n  my-header: foo,bar,baz",
+                        "items": {
+                          "description": "HTTPHeader represents a single header name/value pair. Exactly one of value or secretRef must\nbe set. When using secretRef, name and key interact as follows:\n  - Both present: name is the header name, key is the Secret data key.\n  - name absent, key present: the key is also used as the header name.\n  - name present, key absent: the name is also used as the Secret data key.\n  - Both absent: every entry in the Secret is injected as a header (data key -> header name).",
+                          "properties": {
+                            "name": {
+                              "description": "Name is the HTTP header field name. Name matching is case-insensitive.\n(See https://tools.ietf.org/html/rfc7230#section-3.2.)\nRequired when value is set. When secretRef is used, if omitted the Secret data key is\nused as the header name; if both name and key are omitted every Secret entry is injected\nas a header.",
+                              "maxLength": 256,
+                              "minLength": 1,
+                              "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                              "type": "string"
+                            },
+                            "secretRef": {
+                              "description": "SecretRef sources the header value from a key in a Kubernetes Secret.\nMutually exclusive with value.",
+                              "properties": {
+                                "key": {
+                                  "description": "Key is the key within the Secret's data map to use as the header value. When omitted and\nthe parent HTTPHeader.name is set, that name is used as the key. When both key and name are\nomitted, all entries in the Secret are injected as headers.",
+                                  "maxLength": 253,
+                                  "minLength": 1,
+                                  "pattern": "^[-._a-zA-Z0-9]+$",
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "description": "Name is the name of the Kubernetes Secret.",
+                                  "maxLength": 253,
+                                  "minLength": 1,
+                                  "type": "string"
+                                },
+                                "namespace": {
+                                  "description": "Namespace is the namespace of the Secret. If omitted, defaults to the namespace of the\nreferencing policy. Cross-namespace references require a ReferenceGrant in the target\nnamespace permitting access from the policy's namespace.",
+                                  "maxLength": 63,
+                                  "minLength": 1,
+                                  "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "name"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "value": {
+                              "description": "Value is an inline string value for the header. Mutually exclusive with secretRef.\nMust consist of printable US-ASCII characters. (See https://tools.ietf.org/html/rfc7230#section-3.2.)",
+                              "maxLength": 4096,
+                              "minLength": 1,
+                              "pattern": "^[!-~]+([\\t ]?[!-~]+)*$",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "x-kubernetes-validations": [
+                            {
+                              "message": "name is required when using an inline value",
+                              "rule": "has(self.value) ? has(self.name) : true"
+                            },
+                            {
+                              "message": "exactly one of the fields in [value secretRef] must be set",
+                              "rule": "[has(self.value),has(self.secretRef)].filter(x,x==true).size() == 1"
+                            }
+                          ],
+                          "additionalProperties": false
+                        },
+                        "maxItems": 16,
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
+                      },
+                      "remove": {
+                        "description": "Remove the given header(s) from the HTTP request before the action. The\nvalue of Remove is a list of HTTP header names. Note that header names are\ncase-insensitive (see [RFC 2616, Section 4.2](https://datatracker.ietf.org/doc/html/rfc2616#section-4.2)).\n\nInput:\n  GET /foo HTTP/1.1\n  my-header1: foo\n  my-header2: bar\n  my-header3: baz\n\nConfig:\n  remove: [\"my-header1\", \"my-header3\"]\n\nOutput:\n  GET /foo HTTP/1.1\n  my-header2: bar",
+                        "items": {
+                          "type": "string"
+                        },
+                        "maxItems": 16,
+                        "type": "array",
+                        "x-kubernetes-list-type": "set"
+                      },
+                      "set": {
+                        "description": "Set overwrites the request with the given header (name, value) before the action.\n\nInput:\n  GET /foo HTTP/1.1\n  my-header: foo\n\nConfig:\n  set:\n  - name: \"my-header\"\n    value: \"bar\"\n\nOutput:\n  GET /foo HTTP/1.1\n  my-header: bar",
+                        "items": {
+                          "description": "HTTPHeader represents a single header name/value pair. Exactly one of value or secretRef must\nbe set. When using secretRef, name and key interact as follows:\n  - Both present: name is the header name, key is the Secret data key.\n  - name absent, key present: the key is also used as the header name.\n  - name present, key absent: the name is also used as the Secret data key.\n  - Both absent: every entry in the Secret is injected as a header (data key -> header name).",
+                          "properties": {
+                            "name": {
+                              "description": "Name is the HTTP header field name. Name matching is case-insensitive.\n(See https://tools.ietf.org/html/rfc7230#section-3.2.)\nRequired when value is set. When secretRef is used, if omitted the Secret data key is\nused as the header name; if both name and key are omitted every Secret entry is injected\nas a header.",
+                              "maxLength": 256,
+                              "minLength": 1,
+                              "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                              "type": "string"
+                            },
+                            "secretRef": {
+                              "description": "SecretRef sources the header value from a key in a Kubernetes Secret.\nMutually exclusive with value.",
+                              "properties": {
+                                "key": {
+                                  "description": "Key is the key within the Secret's data map to use as the header value. When omitted and\nthe parent HTTPHeader.name is set, that name is used as the key. When both key and name are\nomitted, all entries in the Secret are injected as headers.",
+                                  "maxLength": 253,
+                                  "minLength": 1,
+                                  "pattern": "^[-._a-zA-Z0-9]+$",
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "description": "Name is the name of the Kubernetes Secret.",
+                                  "maxLength": 253,
+                                  "minLength": 1,
+                                  "type": "string"
+                                },
+                                "namespace": {
+                                  "description": "Namespace is the namespace of the Secret. If omitted, defaults to the namespace of the\nreferencing policy. Cross-namespace references require a ReferenceGrant in the target\nnamespace permitting access from the policy's namespace.",
+                                  "maxLength": 63,
+                                  "minLength": 1,
+                                  "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "name"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "value": {
+                              "description": "Value is an inline string value for the header. Mutually exclusive with secretRef.\nMust consist of printable US-ASCII characters. (See https://tools.ietf.org/html/rfc7230#section-3.2.)",
+                              "maxLength": 4096,
+                              "minLength": 1,
+                              "pattern": "^[!-~]+([\\t ]?[!-~]+)*$",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "x-kubernetes-validations": [
+                            {
+                              "message": "name is required when using an inline value",
+                              "rule": "has(self.value) ? has(self.name) : true"
+                            },
+                            {
+                              "message": "exactly one of the fields in [value secretRef] must be set",
+                              "rule": "[has(self.value),has(self.secretRef)].filter(x,x==true).size() == 1"
+                            }
+                          ],
+                          "additionalProperties": false
+                        },
+                        "maxItems": 16,
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
+                      }
+                    },
+                    "type": "object",
+                    "x-kubernetes-validations": [
+                      {
+                        "message": "Local reply mappers may only add or modify headers, not remove them",
+                        "rule": "!has(self.remove)"
+                      },
+                      {
+                        "message": "at least one of the fields in [set add remove] must be set",
+                        "rule": "[has(self.set),has(self.add),has(self.remove)].filter(x,x==true).size() >= 1"
+                      }
+                    ],
+                    "additionalProperties": false
+                  },
+                  "statusCode": {
+                    "description": "New response status code for the reply if specified.",
+                    "format": "int32",
+                    "maximum": 599,
+                    "minimum": 100,
+                    "type": "integer"
+                  }
+                },
+                "required": [
+                  "filter"
+                ],
+                "type": "object",
+                "x-kubernetes-validations": [
+                  {
+                    "message": "at least one of the fields in [statusCode body bodyFormatOverride headers] must be set",
+                    "rule": "[has(self.statusCode),has(self.body),has(self.bodyFormatOverride),has(self.headers)].filter(x,x==true).size() >= 1"
+                  }
+                ],
+                "additionalProperties": false
+              },
+              "maxItems": 16,
+              "minItems": 1,
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "x-kubernetes-validations": [
+            {
+              "message": "at least one of the fields in [mappers defaultBodyFormat] must be set",
+              "rule": "[has(self.mappers),has(self.defaultBodyFormat)].filter(x,x==true).size() >= 1"
+            }
+          ],
+          "additionalProperties": false
         },
         "maxHeadersCount": {
           "description": "MaxHeadersCount sets the maximum number of headers allowed in a request.\nDownstream requests that exceed this limit will receive a 431 response for HTTP/1.x and a\nstream reset for HTTP/2. If unset, defaults to Envoy's built-in default of 100.\nSee here for more information: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/protocol.proto#envoy-v3-api-field-config-core-v3-httpprotocoloptions-max-headers-count",
@@ -1387,6 +2394,12 @@
           "format": "int32",
           "maximum": 8192,
           "minimum": 1,
+          "type": "integer"
+        },
+        "maxRequestsPerConnection": {
+          "description": "MaxRequestsPerConnection sets the maximum number of requests served over a single downstream\nkeepalive connection. When the limit is reached, Envoy closes the connection, which forces\nclients to reconnect. This allows L4 load balancers like AWS NLB to rebalance long-lived\nHTTP/2 and gRPC connections across gateway pods.\nIf set to 0 or unspecified, defaults to unlimited.\nSee here for more information: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/protocol.proto#envoy-v3-api-field-config-core-v3-httpprotocoloptions-max-requests-per-connection",
+          "format": "int32",
+          "minimum": 0,
           "type": "integer"
         },
         "preserveExternalRequestId": {
@@ -1404,6 +2417,11 @@
             "AppendIfAbsent",
             "PassThrough"
           ],
+          "type": "string"
+        },
+        "serverName": {
+          "description": "ServerName determines the value of the server header.\nSee here for more information: https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto#envoy-v3-api-field-extensions-filters-network-http-connection-manager-v3-httpconnectionmanager-server-name",
+          "minLength": 1,
           "type": "string"
         },
         "skipXFFAppend": {
@@ -1966,6 +2984,10 @@
         {
           "message": "only one of xffNumTrustedHops and xffTrustedCIDRs may be set",
           "rule": "!has(self.xffNumTrustedHops) || !has(self.xffTrustedCIDRs)"
+        },
+        {
+          "message": "forwardClientCertDetails.details requires mode to be AppendForward or SanitizeSet (or unset)",
+          "rule": "!has(self.forwardClientCertDetails) || !has(self.forwardClientCertDetails.details) || !has(self.forwardClientCertDetails.mode) || self.forwardClientCertDetails.mode == 'AppendForward' || self.forwardClientCertDetails.mode == 'SanitizeSet'"
         }
       ],
       "additionalProperties": false

--- a/gateway.kgateway.dev/listenerpolicy_v1alpha1.json
+++ b/gateway.kgateway.dev/listenerpolicy_v1alpha1.json
@@ -170,7 +170,7 @@
                                     },
                                     "value": {
                                       "description": "Value to compare against.",
-                                      "format": "int32",
+                                      "format": "uint32",
                                       "maximum": 4294967295,
                                       "minimum": 0,
                                       "type": "integer"
@@ -342,7 +342,7 @@
                                     },
                                     "value": {
                                       "description": "Value to compare against.",
-                                      "format": "int32",
+                                      "format": "uint32",
                                       "maximum": 4294967295,
                                       "minimum": 0,
                                       "type": "integer"
@@ -394,7 +394,7 @@
                               },
                               "value": {
                                 "description": "Value to compare against.",
-                                "format": "int32",
+                                "format": "uint32",
                                 "maximum": 4294967295,
                                 "minimum": 0,
                                 "type": "integer"
@@ -526,7 +526,7 @@
                                     },
                                     "value": {
                                       "description": "Value to compare against.",
-                                      "format": "int32",
+                                      "format": "uint32",
                                       "maximum": 4294967295,
                                       "minimum": 0,
                                       "type": "integer"
@@ -698,7 +698,7 @@
                                     },
                                     "value": {
                                       "description": "Value to compare against.",
-                                      "format": "int32",
+                                      "format": "uint32",
                                       "maximum": 4294967295,
                                       "minimum": 0,
                                       "type": "integer"
@@ -797,7 +797,7 @@
                               },
                               "value": {
                                 "description": "Value to compare against.",
-                                "format": "int32",
+                                "format": "uint32",
                                 "maximum": 4294967295,
                                 "minimum": 0,
                                 "type": "integer"
@@ -1375,6 +1375,51 @@
                   "type": "object",
                   "additionalProperties": false
                 },
+                "forwardClientCertDetails": {
+                  "description": "ForwardClientCertDetails configures how Envoy handles the x-forwarded-client-cert (XFCC)\nheader and which parts of the downstream client certificate are forwarded to upstream\nbackends. Most modes only have effect on listeners where mTLS is configured. The exceptions\nare Sanitize, which strips XFCC unconditionally, and AlwaysForwardOnly, which forwards XFCC\nunconditionally; on a non-mTLS listener under any other mode the setting is a no-op.\nSee: https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto#envoy-v3-api-field-extensions-filters-network-http-connection-manager-v3-httpconnectionmanager-forward-client-cert-details",
+                  "properties": {
+                    "details": {
+                      "description": "Details selects which fields from the downstream client certificate are written into\nthe XFCC header that is sent upstream. These fields are only honored by Envoy when\nMode is AppendForward or SanitizeSet.",
+                      "properties": {
+                        "cert": {
+                          "description": "Cert forwards the entire client certificate in URL-encoded PEM format in the XFCC header.",
+                          "type": "boolean"
+                        },
+                        "chain": {
+                          "description": "Chain forwards the entire client certificate chain (including the leaf certificate) in\nURL-encoded PEM format in the XFCC header.",
+                          "type": "boolean"
+                        },
+                        "dns": {
+                          "description": "DNS forwards DNS-type Subject Alternative Names from the client certificate in the XFCC header.",
+                          "type": "boolean"
+                        },
+                        "subject": {
+                          "description": "Subject forwards the certificate Subject in the XFCC header.",
+                          "type": "boolean"
+                        },
+                        "uri": {
+                          "description": "URI forwards the URI-type Subject Alternative Name from the client certificate in the XFCC header.",
+                          "type": "boolean"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "mode": {
+                      "description": "Mode controls how Envoy handles the XFCC header on the request forwarded upstream.\nIf unset and Details is provided, Mode defaults to SanitizeSet.\nIf both Mode and Details are unset, this field has no effect.\n\n- Sanitize: do not send the XFCC header upstream.\n- ForwardOnly: forward the XFCC header in the request unchanged.\n- AppendForward: append the current client's details to the XFCC header.\n- SanitizeSet: reset the XFCC header with the current client's details, ignoring any client-supplied value.\n- AlwaysForwardOnly: always forward the XFCC header, even for non-mTLS connections.",
+                      "enum": [
+                        "Sanitize",
+                        "ForwardOnly",
+                        "AppendForward",
+                        "SanitizeSet",
+                        "AlwaysForwardOnly"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
                 "generateRequestId": {
                   "description": "GenerateRequestId:  Whether the connection manager will generate the x-request-id header if it does not exist.\nThis defaults to true. Generating a random UUID4 is expensive so in high throughput scenarios where this feature is not desired it can be disabled.\nSee here for more information https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto#envoy-v3-api-field-extensions-filters-network-http-connection-manager-v3-httpconnectionmanager-generate-request-id",
                   "type": "boolean"
@@ -1398,6 +1443,10 @@
                 "http2ProtocolOptions": {
                   "description": "Http2ProtocolOptions configures downstream HTTP/2 behavior on the listener's\nHttpConnectionManager.\nSee here for more information: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/protocol.proto#config-core-v3-http2protocoloptions",
                   "properties": {
+                    "allowConnect": {
+                      "description": "AllowConnect allows proxying of WebSocket and other upgrades over HTTP/2 by\nenabling Envoy to handle Extended CONNECT requests (RFC 8441) on the downstream\nconnection. This is required for WebSocket-over-HTTP/2 when the listener advertises\nh2 in its ALPN; otherwise user agents that use Extended CONNECT (e.g. Firefox) fail\nto establish WebSocket connections.\nDefaults to false.",
+                      "type": "boolean"
+                    },
                     "initialConnectionWindowSize": {
                       "anyOf": [
                         {
@@ -1436,7 +1485,7 @@
                   "additionalProperties": false
                 },
                 "idleTimeout": {
-                  "description": "IdleTimeout is the idle timeout for connnections.\nSee here for more information: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/protocol.proto#envoy-v3-api-msg-config-core-v3-httpprotocoloptions",
+                  "description": "IdleTimeout is the idle timeout for connections.\nSee here for more information: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/protocol.proto#envoy-v3-api-msg-config-core-v3-httpprotocoloptions",
                   "type": "string",
                   "x-kubernetes-validations": [
                     {
@@ -1444,6 +1493,964 @@
                       "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
                     }
                   ]
+                },
+                "localReplies": {
+                  "description": "LocalReplies configures how Envoy's local replies are formatted etc.",
+                  "properties": {
+                    "defaultBodyFormat": {
+                      "description": "DefaultBodyFormat is the format to use for local reply bodies if it's not overridden by any mapper.\nYou can use the `%LOCAL_REPLY_BODY%` substitution to insert the original reply such as an error message.",
+                      "properties": {
+                        "contentType": {
+                          "description": "ContentType defines the HTTP Content-Type header to be sent with the response.\nBy default, `text/plain` is used for the Text format and `application/json` for the JSON format.\nNote: This setting does not currently take effect due to a bug in Envoy, a fix for which is pending release.\nThe option is included for completeness and will become effective with a future version of Envoy.",
+                          "type": "string"
+                        },
+                        "json": {
+                          "description": "JSON is a format object by which Envoy will produce a JSON response body.\nMutually exclusive with Text.\nSee https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/substitution_format_string.proto#envoy-v3-api-field-config-core-v3-substitutionformatstring-json-format for details.\n\nSetting a field to `null` in the JSON object requires the use of\n`kubectl apply --server-side` or equivalent. With the default client-side\n`kubectl apply`, null values are stripped by kubectl before reaching\nthe API server.",
+                          "type": "object",
+                          "x-kubernetes-preserve-unknown-fields": true
+                        },
+                        "text": {
+                          "description": "Text is a format string by which Envoy will format the response body.\nMutually exclusive with JSON.\nSee https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/substitution_format_string.proto#envoy-v3-api-field-config-core-v3-substitutionformatstring-text-format for details.",
+                          "maxLength": 4096,
+                          "minLength": 1,
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "x-kubernetes-validations": [
+                        {
+                          "message": "exactly one of the fields in [json text] must be set",
+                          "rule": "[has(self.json),has(self.text)].filter(x,x==true).size() == 1"
+                        }
+                      ],
+                      "additionalProperties": false
+                    },
+                    "mappers": {
+                      "description": "A list of custom options to apply based on filters. This may override the DefaultBodyFormat.",
+                      "items": {
+                        "description": "LocalReplyMapper may customize the local reply based on stream, request, and response properties such as status code.",
+                        "properties": {
+                          "body": {
+                            "description": "New body text for the reply if specified.\nAvailable as `%LOCAL_REPLY_BODY%` in substitution strings.",
+                            "type": "string"
+                          },
+                          "bodyFormatOverride": {
+                            "description": "Alternative body format for the reply if specified. Takes precedence over default body format.",
+                            "properties": {
+                              "contentType": {
+                                "description": "ContentType defines the HTTP Content-Type header to be sent with the response.\nBy default, `text/plain` is used for the Text format and `application/json` for the JSON format.\nNote: This setting does not currently take effect due to a bug in Envoy, a fix for which is pending release.\nThe option is included for completeness and will become effective with a future version of Envoy.",
+                                "type": "string"
+                              },
+                              "json": {
+                                "description": "JSON is a format object by which Envoy will produce a JSON response body.\nMutually exclusive with Text.\nSee https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/substitution_format_string.proto#envoy-v3-api-field-config-core-v3-substitutionformatstring-json-format for details.\n\nSetting a field to `null` in the JSON object requires the use of\n`kubectl apply --server-side` or equivalent. With the default client-side\n`kubectl apply`, null values are stripped by kubectl before reaching\nthe API server.",
+                                "type": "object",
+                                "x-kubernetes-preserve-unknown-fields": true
+                              },
+                              "text": {
+                                "description": "Text is a format string by which Envoy will format the response body.\nMutually exclusive with JSON.\nSee https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/substitution_format_string.proto#envoy-v3-api-field-config-core-v3-substitutionformatstring-text-format for details.",
+                                "maxLength": 4096,
+                                "minLength": 1,
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-validations": [
+                              {
+                                "message": "exactly one of the fields in [json text] must be set",
+                                "rule": "[has(self.json),has(self.text)].filter(x,x==true).size() == 1"
+                              }
+                            ],
+                            "additionalProperties": false
+                          },
+                          "filter": {
+                            "allOf": [
+                              {
+                                "maxProperties": 1,
+                                "minProperties": 1
+                              },
+                              {
+                                "maxProperties": 1,
+                                "minProperties": 1
+                              }
+                            ],
+                            "description": "A filter that determines if this mapper should apply.",
+                            "properties": {
+                              "andFilter": {
+                                "description": "Performs a logical \"and\" operation on the result of each individual filter.\nBased on: https://www.envoyproxy.io/docs/envoy/v1.33.0/api-v3/config/accesslog/v3/accesslog.proto#config-accesslog-v3-andfilter",
+                                "items": {
+                                  "description": "FilterType represents the type of filter to apply (only one of these should be set).\nBased on: https://www.envoyproxy.io/docs/envoy/v1.33.0/api-v3/config/accesslog/v3/accesslog.proto#envoy-v3-api-msg-config-accesslog-v3-accesslogfilter",
+                                  "maxProperties": 1,
+                                  "minProperties": 1,
+                                  "properties": {
+                                    "celFilter": {
+                                      "description": "CELFilter filters requests based on Common Expression Language (CEL).",
+                                      "properties": {
+                                        "match": {
+                                          "description": "The CEL expressions to evaluate. AccessLogs are only emitted when the CEL expressions evaluates to true.\nsee: https://www.envoyproxy.io/docs/envoy/v1.33.0/xds/type/v3/cel.proto.html#common-expression-language-cel-proto",
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "match"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "durationFilter": {
+                                      "description": "DurationFilter filters based on request duration.\nBased on: https://www.envoyproxy.io/docs/envoy/v1.33.0/api-v3/config/accesslog/v3/accesslog.proto#config-accesslog-v3-durationfilter",
+                                      "properties": {
+                                        "op": {
+                                          "description": "Op represents comparison operators.",
+                                          "enum": [
+                                            "EQ",
+                                            "GE",
+                                            "LE"
+                                          ],
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "description": "Value to compare against.",
+                                          "format": "uint32",
+                                          "maximum": 4294967295,
+                                          "minimum": 0,
+                                          "type": "integer"
+                                        }
+                                      },
+                                      "required": [
+                                        "op",
+                                        "value"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "grpcStatusFilter": {
+                                      "description": "GrpcStatusFilter filters gRPC requests based on their response status.\nBased on: https://www.envoyproxy.io/docs/envoy/v1.33.0/api-v3/config/accesslog/v3/accesslog.proto#enum-config-accesslog-v3-grpcstatusfilter-status",
+                                      "properties": {
+                                        "exclude": {
+                                          "type": "boolean"
+                                        },
+                                        "statuses": {
+                                          "items": {
+                                            "description": "GrpcStatus represents possible gRPC statuses.",
+                                            "enum": [
+                                              "OK",
+                                              "CANCELED",
+                                              "UNKNOWN",
+                                              "INVALID_ARGUMENT",
+                                              "DEADLINE_EXCEEDED",
+                                              "NOT_FOUND",
+                                              "ALREADY_EXISTS",
+                                              "PERMISSION_DENIED",
+                                              "RESOURCE_EXHAUSTED",
+                                              "FAILED_PRECONDITION",
+                                              "ABORTED",
+                                              "OUT_OF_RANGE",
+                                              "UNIMPLEMENTED",
+                                              "INTERNAL",
+                                              "UNAVAILABLE",
+                                              "DATA_LOSS",
+                                              "UNAUTHENTICATED"
+                                            ],
+                                            "type": "string"
+                                          },
+                                          "minItems": 1,
+                                          "type": "array"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "headerFilter": {
+                                      "description": "HeaderFilter filters requests based on headers.\nBased on: https://www.envoyproxy.io/docs/envoy/v1.33.0/api-v3/config/accesslog/v3/accesslog.proto#config-accesslog-v3-headerfilter",
+                                      "properties": {
+                                        "header": {
+                                          "description": "HTTPHeaderMatch describes how to select a HTTP route by matching HTTP request\nheaders.",
+                                          "properties": {
+                                            "name": {
+                                              "description": "Name is the name of the HTTP Header to be matched. Name matching MUST be\ncase-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).\n\nIf multiple entries specify equivalent header names, only the first\nentry with an equivalent name MUST be considered for a match. Subsequent\nentries with an equivalent header name MUST be ignored. Due to the\ncase-insensitivity of header names, \"foo\" and \"Foo\" are considered\nequivalent.\n\nWhen a header is repeated in an HTTP request, it is\nimplementation-specific behavior as to how this is represented.\nGenerally, proxies should follow the guidance from the RFC:\nhttps://www.rfc-editor.org/rfc/rfc7230.html#section-3.2.2 regarding\nprocessing a repeated header, with special handling for \"Set-Cookie\".",
+                                              "maxLength": 256,
+                                              "minLength": 1,
+                                              "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                                              "type": "string"
+                                            },
+                                            "type": {
+                                              "default": "Exact",
+                                              "description": "Type specifies how to match against the value of the header.\n\nSupport: Core (Exact)\n\nSupport: Implementation-specific (RegularExpression)\n\nSince RegularExpression HeaderMatchType has implementation-specific\nconformance, implementations can support POSIX, PCRE or any other dialects\nof regular expressions. Please read the implementation's documentation to\ndetermine the supported dialect.",
+                                              "enum": [
+                                                "Exact",
+                                                "RegularExpression"
+                                              ],
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "description": "Value is the value of HTTP Header to be matched.\n<gateway:experimental:description>\nMust consist of printable US-ASCII characters, optionally separated\nby single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2\n</gateway:experimental:description>\n\n<gateway:experimental:validation:Pattern=`^[!-~]+([\\t ]?[!-~]+)*$`>",
+                                              "maxLength": 4096,
+                                              "minLength": 1,
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "name",
+                                            "value"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "required": [
+                                        "header"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "notHealthCheckFilter": {
+                                      "description": "Filters for requests that are not health check requests.\nBased on: https://www.envoyproxy.io/docs/envoy/v1.33.0/api-v3/config/accesslog/v3/accesslog.proto#config-accesslog-v3-nothealthcheckfilter",
+                                      "type": "boolean"
+                                    },
+                                    "responseFlagFilter": {
+                                      "description": "ResponseFlagFilter filters based on response flags.\nBased on: https://www.envoyproxy.io/docs/envoy/v1.33.0/api-v3/config/accesslog/v3/accesslog.proto#config-accesslog-v3-responseflagfilter",
+                                      "properties": {
+                                        "flags": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "minItems": 1,
+                                          "type": "array"
+                                        }
+                                      },
+                                      "required": [
+                                        "flags"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "runtimeFilter": {
+                                      "description": "Filters for random sampling of access logs.\nBased on: https://www.envoyproxy.io/docs/envoy/v1.33.0/api-v3/config/accesslog/v3/accesslog.proto#config-accesslog-v3-runtimefilter",
+                                      "properties": {
+                                        "percentSampled": {
+                                          "description": "By default, the runtime filter will log on every request when the runtime key is set.\nIf this field is set, it additionally applies a fractional percent check so that only a\nfraction of requests are logged.",
+                                          "properties": {
+                                            "denominator": {
+                                              "description": "Specifies the denominator. If the denominator specified is less than the numerator,\nthe final fractional percentage is capped at 1 (100%).\nDefaults to HUNDRED.",
+                                              "enum": [
+                                                "HUNDRED",
+                                                "TEN_THOUSAND",
+                                                "MILLION"
+                                              ],
+                                              "type": "string"
+                                            },
+                                            "numerator": {
+                                              "description": "Specifies the numerator. Defaults to 0.",
+                                              "format": "int32",
+                                              "minimum": 0,
+                                              "type": "integer"
+                                            }
+                                          },
+                                          "required": [
+                                            "numerator"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "runtimeKey": {
+                                          "description": "The runtime key to look up in the runtime implementation. This key determines whether\nthe access log is enabled. When the runtime key value is set, the filter checks this key\nat runtime to decide whether to log each request.",
+                                          "minLength": 1,
+                                          "type": "string"
+                                        },
+                                        "useIndependentRandomness": {
+                                          "description": "If set to true, the filter uses Envoy's independent randomness source.\nWhen false (the default), the filter uses the runtime key lookup.",
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "runtimeKey"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "statusCodeFilter": {
+                                      "description": "StatusCodeFilter filters based on HTTP status code.\nBased on: https://www.envoyproxy.io/docs/envoy/v1.33.0/api-v3/config/accesslog/v3/accesslog.proto#envoy-v3-api-msg-config-accesslog-v3-statuscodefilter",
+                                      "properties": {
+                                        "op": {
+                                          "description": "Op represents comparison operators.",
+                                          "enum": [
+                                            "EQ",
+                                            "GE",
+                                            "LE"
+                                          ],
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "description": "Value to compare against.",
+                                          "format": "uint32",
+                                          "maximum": 4294967295,
+                                          "minimum": 0,
+                                          "type": "integer"
+                                        }
+                                      },
+                                      "required": [
+                                        "op",
+                                        "value"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "traceableFilter": {
+                                      "description": "Filters for requests that are traceable.\nBased on: https://www.envoyproxy.io/docs/envoy/v1.33.0/api-v3/config/accesslog/v3/accesslog.proto#config-accesslog-v3-traceablefilter",
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "minItems": 2,
+                                "type": "array"
+                              },
+                              "celFilter": {
+                                "description": "CELFilter filters requests based on Common Expression Language (CEL).",
+                                "properties": {
+                                  "match": {
+                                    "description": "The CEL expressions to evaluate. AccessLogs are only emitted when the CEL expressions evaluates to true.\nsee: https://www.envoyproxy.io/docs/envoy/v1.33.0/xds/type/v3/cel.proto.html#common-expression-language-cel-proto",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "match"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "durationFilter": {
+                                "description": "DurationFilter filters based on request duration.\nBased on: https://www.envoyproxy.io/docs/envoy/v1.33.0/api-v3/config/accesslog/v3/accesslog.proto#config-accesslog-v3-durationfilter",
+                                "properties": {
+                                  "op": {
+                                    "description": "Op represents comparison operators.",
+                                    "enum": [
+                                      "EQ",
+                                      "GE",
+                                      "LE"
+                                    ],
+                                    "type": "string"
+                                  },
+                                  "value": {
+                                    "description": "Value to compare against.",
+                                    "format": "uint32",
+                                    "maximum": 4294967295,
+                                    "minimum": 0,
+                                    "type": "integer"
+                                  }
+                                },
+                                "required": [
+                                  "op",
+                                  "value"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "grpcStatusFilter": {
+                                "description": "GrpcStatusFilter filters gRPC requests based on their response status.\nBased on: https://www.envoyproxy.io/docs/envoy/v1.33.0/api-v3/config/accesslog/v3/accesslog.proto#enum-config-accesslog-v3-grpcstatusfilter-status",
+                                "properties": {
+                                  "exclude": {
+                                    "type": "boolean"
+                                  },
+                                  "statuses": {
+                                    "items": {
+                                      "description": "GrpcStatus represents possible gRPC statuses.",
+                                      "enum": [
+                                        "OK",
+                                        "CANCELED",
+                                        "UNKNOWN",
+                                        "INVALID_ARGUMENT",
+                                        "DEADLINE_EXCEEDED",
+                                        "NOT_FOUND",
+                                        "ALREADY_EXISTS",
+                                        "PERMISSION_DENIED",
+                                        "RESOURCE_EXHAUSTED",
+                                        "FAILED_PRECONDITION",
+                                        "ABORTED",
+                                        "OUT_OF_RANGE",
+                                        "UNIMPLEMENTED",
+                                        "INTERNAL",
+                                        "UNAVAILABLE",
+                                        "DATA_LOSS",
+                                        "UNAUTHENTICATED"
+                                      ],
+                                      "type": "string"
+                                    },
+                                    "minItems": 1,
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "headerFilter": {
+                                "description": "HeaderFilter filters requests based on headers.\nBased on: https://www.envoyproxy.io/docs/envoy/v1.33.0/api-v3/config/accesslog/v3/accesslog.proto#config-accesslog-v3-headerfilter",
+                                "properties": {
+                                  "header": {
+                                    "description": "HTTPHeaderMatch describes how to select a HTTP route by matching HTTP request\nheaders.",
+                                    "properties": {
+                                      "name": {
+                                        "description": "Name is the name of the HTTP Header to be matched. Name matching MUST be\ncase-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).\n\nIf multiple entries specify equivalent header names, only the first\nentry with an equivalent name MUST be considered for a match. Subsequent\nentries with an equivalent header name MUST be ignored. Due to the\ncase-insensitivity of header names, \"foo\" and \"Foo\" are considered\nequivalent.\n\nWhen a header is repeated in an HTTP request, it is\nimplementation-specific behavior as to how this is represented.\nGenerally, proxies should follow the guidance from the RFC:\nhttps://www.rfc-editor.org/rfc/rfc7230.html#section-3.2.2 regarding\nprocessing a repeated header, with special handling for \"Set-Cookie\".",
+                                        "maxLength": 256,
+                                        "minLength": 1,
+                                        "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                                        "type": "string"
+                                      },
+                                      "type": {
+                                        "default": "Exact",
+                                        "description": "Type specifies how to match against the value of the header.\n\nSupport: Core (Exact)\n\nSupport: Implementation-specific (RegularExpression)\n\nSince RegularExpression HeaderMatchType has implementation-specific\nconformance, implementations can support POSIX, PCRE or any other dialects\nof regular expressions. Please read the implementation's documentation to\ndetermine the supported dialect.",
+                                        "enum": [
+                                          "Exact",
+                                          "RegularExpression"
+                                        ],
+                                        "type": "string"
+                                      },
+                                      "value": {
+                                        "description": "Value is the value of HTTP Header to be matched.\n<gateway:experimental:description>\nMust consist of printable US-ASCII characters, optionally separated\nby single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2\n</gateway:experimental:description>\n\n<gateway:experimental:validation:Pattern=`^[!-~]+([\\t ]?[!-~]+)*$`>",
+                                        "maxLength": 4096,
+                                        "minLength": 1,
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "name",
+                                      "value"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "required": [
+                                  "header"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "notHealthCheckFilter": {
+                                "description": "Filters for requests that are not health check requests.\nBased on: https://www.envoyproxy.io/docs/envoy/v1.33.0/api-v3/config/accesslog/v3/accesslog.proto#config-accesslog-v3-nothealthcheckfilter",
+                                "type": "boolean"
+                              },
+                              "orFilter": {
+                                "description": "Performs a logical \"or\" operation on the result of each individual filter.\nBased on: https://www.envoyproxy.io/docs/envoy/v1.33.0/api-v3/config/accesslog/v3/accesslog.proto#config-accesslog-v3-orfilter",
+                                "items": {
+                                  "description": "FilterType represents the type of filter to apply (only one of these should be set).\nBased on: https://www.envoyproxy.io/docs/envoy/v1.33.0/api-v3/config/accesslog/v3/accesslog.proto#envoy-v3-api-msg-config-accesslog-v3-accesslogfilter",
+                                  "maxProperties": 1,
+                                  "minProperties": 1,
+                                  "properties": {
+                                    "celFilter": {
+                                      "description": "CELFilter filters requests based on Common Expression Language (CEL).",
+                                      "properties": {
+                                        "match": {
+                                          "description": "The CEL expressions to evaluate. AccessLogs are only emitted when the CEL expressions evaluates to true.\nsee: https://www.envoyproxy.io/docs/envoy/v1.33.0/xds/type/v3/cel.proto.html#common-expression-language-cel-proto",
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "match"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "durationFilter": {
+                                      "description": "DurationFilter filters based on request duration.\nBased on: https://www.envoyproxy.io/docs/envoy/v1.33.0/api-v3/config/accesslog/v3/accesslog.proto#config-accesslog-v3-durationfilter",
+                                      "properties": {
+                                        "op": {
+                                          "description": "Op represents comparison operators.",
+                                          "enum": [
+                                            "EQ",
+                                            "GE",
+                                            "LE"
+                                          ],
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "description": "Value to compare against.",
+                                          "format": "uint32",
+                                          "maximum": 4294967295,
+                                          "minimum": 0,
+                                          "type": "integer"
+                                        }
+                                      },
+                                      "required": [
+                                        "op",
+                                        "value"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "grpcStatusFilter": {
+                                      "description": "GrpcStatusFilter filters gRPC requests based on their response status.\nBased on: https://www.envoyproxy.io/docs/envoy/v1.33.0/api-v3/config/accesslog/v3/accesslog.proto#enum-config-accesslog-v3-grpcstatusfilter-status",
+                                      "properties": {
+                                        "exclude": {
+                                          "type": "boolean"
+                                        },
+                                        "statuses": {
+                                          "items": {
+                                            "description": "GrpcStatus represents possible gRPC statuses.",
+                                            "enum": [
+                                              "OK",
+                                              "CANCELED",
+                                              "UNKNOWN",
+                                              "INVALID_ARGUMENT",
+                                              "DEADLINE_EXCEEDED",
+                                              "NOT_FOUND",
+                                              "ALREADY_EXISTS",
+                                              "PERMISSION_DENIED",
+                                              "RESOURCE_EXHAUSTED",
+                                              "FAILED_PRECONDITION",
+                                              "ABORTED",
+                                              "OUT_OF_RANGE",
+                                              "UNIMPLEMENTED",
+                                              "INTERNAL",
+                                              "UNAVAILABLE",
+                                              "DATA_LOSS",
+                                              "UNAUTHENTICATED"
+                                            ],
+                                            "type": "string"
+                                          },
+                                          "minItems": 1,
+                                          "type": "array"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "headerFilter": {
+                                      "description": "HeaderFilter filters requests based on headers.\nBased on: https://www.envoyproxy.io/docs/envoy/v1.33.0/api-v3/config/accesslog/v3/accesslog.proto#config-accesslog-v3-headerfilter",
+                                      "properties": {
+                                        "header": {
+                                          "description": "HTTPHeaderMatch describes how to select a HTTP route by matching HTTP request\nheaders.",
+                                          "properties": {
+                                            "name": {
+                                              "description": "Name is the name of the HTTP Header to be matched. Name matching MUST be\ncase-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).\n\nIf multiple entries specify equivalent header names, only the first\nentry with an equivalent name MUST be considered for a match. Subsequent\nentries with an equivalent header name MUST be ignored. Due to the\ncase-insensitivity of header names, \"foo\" and \"Foo\" are considered\nequivalent.\n\nWhen a header is repeated in an HTTP request, it is\nimplementation-specific behavior as to how this is represented.\nGenerally, proxies should follow the guidance from the RFC:\nhttps://www.rfc-editor.org/rfc/rfc7230.html#section-3.2.2 regarding\nprocessing a repeated header, with special handling for \"Set-Cookie\".",
+                                              "maxLength": 256,
+                                              "minLength": 1,
+                                              "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                                              "type": "string"
+                                            },
+                                            "type": {
+                                              "default": "Exact",
+                                              "description": "Type specifies how to match against the value of the header.\n\nSupport: Core (Exact)\n\nSupport: Implementation-specific (RegularExpression)\n\nSince RegularExpression HeaderMatchType has implementation-specific\nconformance, implementations can support POSIX, PCRE or any other dialects\nof regular expressions. Please read the implementation's documentation to\ndetermine the supported dialect.",
+                                              "enum": [
+                                                "Exact",
+                                                "RegularExpression"
+                                              ],
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "description": "Value is the value of HTTP Header to be matched.\n<gateway:experimental:description>\nMust consist of printable US-ASCII characters, optionally separated\nby single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2\n</gateway:experimental:description>\n\n<gateway:experimental:validation:Pattern=`^[!-~]+([\\t ]?[!-~]+)*$`>",
+                                              "maxLength": 4096,
+                                              "minLength": 1,
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "name",
+                                            "value"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "required": [
+                                        "header"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "notHealthCheckFilter": {
+                                      "description": "Filters for requests that are not health check requests.\nBased on: https://www.envoyproxy.io/docs/envoy/v1.33.0/api-v3/config/accesslog/v3/accesslog.proto#config-accesslog-v3-nothealthcheckfilter",
+                                      "type": "boolean"
+                                    },
+                                    "responseFlagFilter": {
+                                      "description": "ResponseFlagFilter filters based on response flags.\nBased on: https://www.envoyproxy.io/docs/envoy/v1.33.0/api-v3/config/accesslog/v3/accesslog.proto#config-accesslog-v3-responseflagfilter",
+                                      "properties": {
+                                        "flags": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "minItems": 1,
+                                          "type": "array"
+                                        }
+                                      },
+                                      "required": [
+                                        "flags"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "runtimeFilter": {
+                                      "description": "Filters for random sampling of access logs.\nBased on: https://www.envoyproxy.io/docs/envoy/v1.33.0/api-v3/config/accesslog/v3/accesslog.proto#config-accesslog-v3-runtimefilter",
+                                      "properties": {
+                                        "percentSampled": {
+                                          "description": "By default, the runtime filter will log on every request when the runtime key is set.\nIf this field is set, it additionally applies a fractional percent check so that only a\nfraction of requests are logged.",
+                                          "properties": {
+                                            "denominator": {
+                                              "description": "Specifies the denominator. If the denominator specified is less than the numerator,\nthe final fractional percentage is capped at 1 (100%).\nDefaults to HUNDRED.",
+                                              "enum": [
+                                                "HUNDRED",
+                                                "TEN_THOUSAND",
+                                                "MILLION"
+                                              ],
+                                              "type": "string"
+                                            },
+                                            "numerator": {
+                                              "description": "Specifies the numerator. Defaults to 0.",
+                                              "format": "int32",
+                                              "minimum": 0,
+                                              "type": "integer"
+                                            }
+                                          },
+                                          "required": [
+                                            "numerator"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "runtimeKey": {
+                                          "description": "The runtime key to look up in the runtime implementation. This key determines whether\nthe access log is enabled. When the runtime key value is set, the filter checks this key\nat runtime to decide whether to log each request.",
+                                          "minLength": 1,
+                                          "type": "string"
+                                        },
+                                        "useIndependentRandomness": {
+                                          "description": "If set to true, the filter uses Envoy's independent randomness source.\nWhen false (the default), the filter uses the runtime key lookup.",
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "runtimeKey"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "statusCodeFilter": {
+                                      "description": "StatusCodeFilter filters based on HTTP status code.\nBased on: https://www.envoyproxy.io/docs/envoy/v1.33.0/api-v3/config/accesslog/v3/accesslog.proto#envoy-v3-api-msg-config-accesslog-v3-statuscodefilter",
+                                      "properties": {
+                                        "op": {
+                                          "description": "Op represents comparison operators.",
+                                          "enum": [
+                                            "EQ",
+                                            "GE",
+                                            "LE"
+                                          ],
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "description": "Value to compare against.",
+                                          "format": "uint32",
+                                          "maximum": 4294967295,
+                                          "minimum": 0,
+                                          "type": "integer"
+                                        }
+                                      },
+                                      "required": [
+                                        "op",
+                                        "value"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "traceableFilter": {
+                                      "description": "Filters for requests that are traceable.\nBased on: https://www.envoyproxy.io/docs/envoy/v1.33.0/api-v3/config/accesslog/v3/accesslog.proto#config-accesslog-v3-traceablefilter",
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "minItems": 2,
+                                "type": "array"
+                              },
+                              "responseFlagFilter": {
+                                "description": "ResponseFlagFilter filters based on response flags.\nBased on: https://www.envoyproxy.io/docs/envoy/v1.33.0/api-v3/config/accesslog/v3/accesslog.proto#config-accesslog-v3-responseflagfilter",
+                                "properties": {
+                                  "flags": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "minItems": 1,
+                                    "type": "array"
+                                  }
+                                },
+                                "required": [
+                                  "flags"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "runtimeFilter": {
+                                "description": "Filters for random sampling of access logs.\nBased on: https://www.envoyproxy.io/docs/envoy/v1.33.0/api-v3/config/accesslog/v3/accesslog.proto#config-accesslog-v3-runtimefilter",
+                                "properties": {
+                                  "percentSampled": {
+                                    "description": "By default, the runtime filter will log on every request when the runtime key is set.\nIf this field is set, it additionally applies a fractional percent check so that only a\nfraction of requests are logged.",
+                                    "properties": {
+                                      "denominator": {
+                                        "description": "Specifies the denominator. If the denominator specified is less than the numerator,\nthe final fractional percentage is capped at 1 (100%).\nDefaults to HUNDRED.",
+                                        "enum": [
+                                          "HUNDRED",
+                                          "TEN_THOUSAND",
+                                          "MILLION"
+                                        ],
+                                        "type": "string"
+                                      },
+                                      "numerator": {
+                                        "description": "Specifies the numerator. Defaults to 0.",
+                                        "format": "int32",
+                                        "minimum": 0,
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "required": [
+                                      "numerator"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "runtimeKey": {
+                                    "description": "The runtime key to look up in the runtime implementation. This key determines whether\nthe access log is enabled. When the runtime key value is set, the filter checks this key\nat runtime to decide whether to log each request.",
+                                    "minLength": 1,
+                                    "type": "string"
+                                  },
+                                  "useIndependentRandomness": {
+                                    "description": "If set to true, the filter uses Envoy's independent randomness source.\nWhen false (the default), the filter uses the runtime key lookup.",
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "runtimeKey"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "statusCodeFilter": {
+                                "description": "StatusCodeFilter filters based on HTTP status code.\nBased on: https://www.envoyproxy.io/docs/envoy/v1.33.0/api-v3/config/accesslog/v3/accesslog.proto#envoy-v3-api-msg-config-accesslog-v3-statuscodefilter",
+                                "properties": {
+                                  "op": {
+                                    "description": "Op represents comparison operators.",
+                                    "enum": [
+                                      "EQ",
+                                      "GE",
+                                      "LE"
+                                    ],
+                                    "type": "string"
+                                  },
+                                  "value": {
+                                    "description": "Value to compare against.",
+                                    "format": "uint32",
+                                    "maximum": 4294967295,
+                                    "minimum": 0,
+                                    "type": "integer"
+                                  }
+                                },
+                                "required": [
+                                  "op",
+                                  "value"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "traceableFilter": {
+                                "description": "Filters for requests that are traceable.\nBased on: https://www.envoyproxy.io/docs/envoy/v1.33.0/api-v3/config/accesslog/v3/accesslog.proto#config-accesslog-v3-traceablefilter",
+                                "type": "boolean"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "headers": {
+                            "description": "Headers to add or set for the reply if specified.",
+                            "properties": {
+                              "add": {
+                                "description": "Add adds the given header(s) (name, value) to the request before the action.\nIt appends to any existing values associated with the header name.\n\nInput:\n  GET /foo HTTP/1.1\n  my-header: foo\n\nConfig:\n  add:\n  - name: \"my-header\"\n    value: \"bar,baz\"\n\nOutput:\n  GET /foo HTTP/1.1\n  my-header: foo,bar,baz",
+                                "items": {
+                                  "description": "HTTPHeader represents a single header name/value pair. Exactly one of value or secretRef must\nbe set. When using secretRef, name and key interact as follows:\n  - Both present: name is the header name, key is the Secret data key.\n  - name absent, key present: the key is also used as the header name.\n  - name present, key absent: the name is also used as the Secret data key.\n  - Both absent: every entry in the Secret is injected as a header (data key -> header name).",
+                                  "properties": {
+                                    "name": {
+                                      "description": "Name is the HTTP header field name. Name matching is case-insensitive.\n(See https://tools.ietf.org/html/rfc7230#section-3.2.)\nRequired when value is set. When secretRef is used, if omitted the Secret data key is\nused as the header name; if both name and key are omitted every Secret entry is injected\nas a header.",
+                                      "maxLength": 256,
+                                      "minLength": 1,
+                                      "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                                      "type": "string"
+                                    },
+                                    "secretRef": {
+                                      "description": "SecretRef sources the header value from a key in a Kubernetes Secret.\nMutually exclusive with value.",
+                                      "properties": {
+                                        "key": {
+                                          "description": "Key is the key within the Secret's data map to use as the header value. When omitted and\nthe parent HTTPHeader.name is set, that name is used as the key. When both key and name are\nomitted, all entries in the Secret are injected as headers.",
+                                          "maxLength": 253,
+                                          "minLength": 1,
+                                          "pattern": "^[-._a-zA-Z0-9]+$",
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "description": "Name is the name of the Kubernetes Secret.",
+                                          "maxLength": 253,
+                                          "minLength": 1,
+                                          "type": "string"
+                                        },
+                                        "namespace": {
+                                          "description": "Namespace is the namespace of the Secret. If omitted, defaults to the namespace of the\nreferencing policy. Cross-namespace references require a ReferenceGrant in the target\nnamespace permitting access from the policy's namespace.",
+                                          "maxLength": 63,
+                                          "minLength": 1,
+                                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "name"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "value": {
+                                      "description": "Value is an inline string value for the header. Mutually exclusive with secretRef.\nMust consist of printable US-ASCII characters. (See https://tools.ietf.org/html/rfc7230#section-3.2.)",
+                                      "maxLength": 4096,
+                                      "minLength": 1,
+                                      "pattern": "^[!-~]+([\\t ]?[!-~]+)*$",
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "x-kubernetes-validations": [
+                                    {
+                                      "message": "name is required when using an inline value",
+                                      "rule": "has(self.value) ? has(self.name) : true"
+                                    },
+                                    {
+                                      "message": "exactly one of the fields in [value secretRef] must be set",
+                                      "rule": "[has(self.value),has(self.secretRef)].filter(x,x==true).size() == 1"
+                                    }
+                                  ],
+                                  "additionalProperties": false
+                                },
+                                "maxItems": 16,
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
+                              },
+                              "remove": {
+                                "description": "Remove the given header(s) from the HTTP request before the action. The\nvalue of Remove is a list of HTTP header names. Note that header names are\ncase-insensitive (see [RFC 2616, Section 4.2](https://datatracker.ietf.org/doc/html/rfc2616#section-4.2)).\n\nInput:\n  GET /foo HTTP/1.1\n  my-header1: foo\n  my-header2: bar\n  my-header3: baz\n\nConfig:\n  remove: [\"my-header1\", \"my-header3\"]\n\nOutput:\n  GET /foo HTTP/1.1\n  my-header2: bar",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "maxItems": 16,
+                                "type": "array",
+                                "x-kubernetes-list-type": "set"
+                              },
+                              "set": {
+                                "description": "Set overwrites the request with the given header (name, value) before the action.\n\nInput:\n  GET /foo HTTP/1.1\n  my-header: foo\n\nConfig:\n  set:\n  - name: \"my-header\"\n    value: \"bar\"\n\nOutput:\n  GET /foo HTTP/1.1\n  my-header: bar",
+                                "items": {
+                                  "description": "HTTPHeader represents a single header name/value pair. Exactly one of value or secretRef must\nbe set. When using secretRef, name and key interact as follows:\n  - Both present: name is the header name, key is the Secret data key.\n  - name absent, key present: the key is also used as the header name.\n  - name present, key absent: the name is also used as the Secret data key.\n  - Both absent: every entry in the Secret is injected as a header (data key -> header name).",
+                                  "properties": {
+                                    "name": {
+                                      "description": "Name is the HTTP header field name. Name matching is case-insensitive.\n(See https://tools.ietf.org/html/rfc7230#section-3.2.)\nRequired when value is set. When secretRef is used, if omitted the Secret data key is\nused as the header name; if both name and key are omitted every Secret entry is injected\nas a header.",
+                                      "maxLength": 256,
+                                      "minLength": 1,
+                                      "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                                      "type": "string"
+                                    },
+                                    "secretRef": {
+                                      "description": "SecretRef sources the header value from a key in a Kubernetes Secret.\nMutually exclusive with value.",
+                                      "properties": {
+                                        "key": {
+                                          "description": "Key is the key within the Secret's data map to use as the header value. When omitted and\nthe parent HTTPHeader.name is set, that name is used as the key. When both key and name are\nomitted, all entries in the Secret are injected as headers.",
+                                          "maxLength": 253,
+                                          "minLength": 1,
+                                          "pattern": "^[-._a-zA-Z0-9]+$",
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "description": "Name is the name of the Kubernetes Secret.",
+                                          "maxLength": 253,
+                                          "minLength": 1,
+                                          "type": "string"
+                                        },
+                                        "namespace": {
+                                          "description": "Namespace is the namespace of the Secret. If omitted, defaults to the namespace of the\nreferencing policy. Cross-namespace references require a ReferenceGrant in the target\nnamespace permitting access from the policy's namespace.",
+                                          "maxLength": 63,
+                                          "minLength": 1,
+                                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "name"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "value": {
+                                      "description": "Value is an inline string value for the header. Mutually exclusive with secretRef.\nMust consist of printable US-ASCII characters. (See https://tools.ietf.org/html/rfc7230#section-3.2.)",
+                                      "maxLength": 4096,
+                                      "minLength": 1,
+                                      "pattern": "^[!-~]+([\\t ]?[!-~]+)*$",
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "x-kubernetes-validations": [
+                                    {
+                                      "message": "name is required when using an inline value",
+                                      "rule": "has(self.value) ? has(self.name) : true"
+                                    },
+                                    {
+                                      "message": "exactly one of the fields in [value secretRef] must be set",
+                                      "rule": "[has(self.value),has(self.secretRef)].filter(x,x==true).size() == 1"
+                                    }
+                                  ],
+                                  "additionalProperties": false
+                                },
+                                "maxItems": 16,
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-validations": [
+                              {
+                                "message": "Local reply mappers may only add or modify headers, not remove them",
+                                "rule": "!has(self.remove)"
+                              },
+                              {
+                                "message": "at least one of the fields in [set add remove] must be set",
+                                "rule": "[has(self.set),has(self.add),has(self.remove)].filter(x,x==true).size() >= 1"
+                              }
+                            ],
+                            "additionalProperties": false
+                          },
+                          "statusCode": {
+                            "description": "New response status code for the reply if specified.",
+                            "format": "int32",
+                            "maximum": 599,
+                            "minimum": 100,
+                            "type": "integer"
+                          }
+                        },
+                        "required": [
+                          "filter"
+                        ],
+                        "type": "object",
+                        "x-kubernetes-validations": [
+                          {
+                            "message": "at least one of the fields in [statusCode body bodyFormatOverride headers] must be set",
+                            "rule": "[has(self.statusCode),has(self.body),has(self.bodyFormatOverride),has(self.headers)].filter(x,x==true).size() >= 1"
+                          }
+                        ],
+                        "additionalProperties": false
+                      },
+                      "maxItems": 16,
+                      "minItems": 1,
+                      "type": "array"
+                    }
+                  },
+                  "type": "object",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "at least one of the fields in [mappers defaultBodyFormat] must be set",
+                      "rule": "[has(self.mappers),has(self.defaultBodyFormat)].filter(x,x==true).size() >= 1"
+                    }
+                  ],
+                  "additionalProperties": false
                 },
                 "maxHeadersCount": {
                   "description": "MaxHeadersCount sets the maximum number of headers allowed in a request.\nDownstream requests that exceed this limit will receive a 431 response for HTTP/1.x and a\nstream reset for HTTP/2. If unset, defaults to Envoy's built-in default of 100.\nSee here for more information: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/protocol.proto#envoy-v3-api-field-config-core-v3-httpprotocoloptions-max-headers-count",
@@ -1456,6 +2463,12 @@
                   "format": "int32",
                   "maximum": 8192,
                   "minimum": 1,
+                  "type": "integer"
+                },
+                "maxRequestsPerConnection": {
+                  "description": "MaxRequestsPerConnection sets the maximum number of requests served over a single downstream\nkeepalive connection. When the limit is reached, Envoy closes the connection, which forces\nclients to reconnect. This allows L4 load balancers like AWS NLB to rebalance long-lived\nHTTP/2 and gRPC connections across gateway pods.\nIf set to 0 or unspecified, defaults to unlimited.\nSee here for more information: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/protocol.proto#envoy-v3-api-field-config-core-v3-httpprotocoloptions-max-requests-per-connection",
+                  "format": "int32",
+                  "minimum": 0,
                   "type": "integer"
                 },
                 "preserveExternalRequestId": {
@@ -1473,6 +2486,11 @@
                     "AppendIfAbsent",
                     "PassThrough"
                   ],
+                  "type": "string"
+                },
+                "serverName": {
+                  "description": "ServerName determines the value of the server header.\nSee here for more information: https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto#envoy-v3-api-field-extensions-filters-network-http-connection-manager-v3-httpconnectionmanager-server-name",
+                  "minLength": 1,
                   "type": "string"
                 },
                 "skipXFFAppend": {
@@ -1950,6 +2968,10 @@
                 {
                   "message": "only one of xffNumTrustedHops and xffTrustedCIDRs may be set",
                   "rule": "!has(self.xffNumTrustedHops) || !has(self.xffTrustedCIDRs)"
+                },
+                {
+                  "message": "forwardClientCertDetails.details requires mode to be AppendForward or SanitizeSet (or unset)",
+                  "rule": "!has(self.forwardClientCertDetails) || !has(self.forwardClientCertDetails.details) || !has(self.forwardClientCertDetails.mode) || self.forwardClientCertDetails.mode == 'AppendForward' || self.forwardClientCertDetails.mode == 'SanitizeSet'"
                 }
               ],
               "additionalProperties": false
@@ -2011,6 +3033,16 @@
               },
               "type": "object",
               "additionalProperties": false
+            },
+            "transportSocketConnectTimeout": {
+              "description": "TransportSocketConnectTimeout is the timeout for the transport socket to complete after a new connection is accepted.\nIf the timeout fires, the connection is closed. Setting this protects Envoy from clients that open connections and\nthen never complete the TLS handshake. Applied to every filter chain on the listener.\nSee here for more information: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/listener/v3/listener_components.proto#envoy-v3-api-field-config-listener-v3-filterchain-transport-socket-connect-timeout",
+              "type": "string",
+              "x-kubernetes-validations": [
+                {
+                  "message": "invalid duration value",
+                  "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                }
+              ]
             }
           },
           "type": "object",
@@ -2112,7 +3144,7 @@
                                           },
                                           "value": {
                                             "description": "Value to compare against.",
-                                            "format": "int32",
+                                            "format": "uint32",
                                             "maximum": 4294967295,
                                             "minimum": 0,
                                             "type": "integer"
@@ -2284,7 +3316,7 @@
                                           },
                                           "value": {
                                             "description": "Value to compare against.",
-                                            "format": "int32",
+                                            "format": "uint32",
                                             "maximum": 4294967295,
                                             "minimum": 0,
                                             "type": "integer"
@@ -2336,7 +3368,7 @@
                                     },
                                     "value": {
                                       "description": "Value to compare against.",
-                                      "format": "int32",
+                                      "format": "uint32",
                                       "maximum": 4294967295,
                                       "minimum": 0,
                                       "type": "integer"
@@ -2468,7 +3500,7 @@
                                           },
                                           "value": {
                                             "description": "Value to compare against.",
-                                            "format": "int32",
+                                            "format": "uint32",
                                             "maximum": 4294967295,
                                             "minimum": 0,
                                             "type": "integer"
@@ -2640,7 +3672,7 @@
                                           },
                                           "value": {
                                             "description": "Value to compare against.",
-                                            "format": "int32",
+                                            "format": "uint32",
                                             "maximum": 4294967295,
                                             "minimum": 0,
                                             "type": "integer"
@@ -2739,7 +3771,7 @@
                                     },
                                     "value": {
                                       "description": "Value to compare against.",
-                                      "format": "int32",
+                                      "format": "uint32",
                                       "maximum": 4294967295,
                                       "minimum": 0,
                                       "type": "integer"
@@ -3317,6 +4349,51 @@
                         "type": "object",
                         "additionalProperties": false
                       },
+                      "forwardClientCertDetails": {
+                        "description": "ForwardClientCertDetails configures how Envoy handles the x-forwarded-client-cert (XFCC)\nheader and which parts of the downstream client certificate are forwarded to upstream\nbackends. Most modes only have effect on listeners where mTLS is configured. The exceptions\nare Sanitize, which strips XFCC unconditionally, and AlwaysForwardOnly, which forwards XFCC\nunconditionally; on a non-mTLS listener under any other mode the setting is a no-op.\nSee: https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto#envoy-v3-api-field-extensions-filters-network-http-connection-manager-v3-httpconnectionmanager-forward-client-cert-details",
+                        "properties": {
+                          "details": {
+                            "description": "Details selects which fields from the downstream client certificate are written into\nthe XFCC header that is sent upstream. These fields are only honored by Envoy when\nMode is AppendForward or SanitizeSet.",
+                            "properties": {
+                              "cert": {
+                                "description": "Cert forwards the entire client certificate in URL-encoded PEM format in the XFCC header.",
+                                "type": "boolean"
+                              },
+                              "chain": {
+                                "description": "Chain forwards the entire client certificate chain (including the leaf certificate) in\nURL-encoded PEM format in the XFCC header.",
+                                "type": "boolean"
+                              },
+                              "dns": {
+                                "description": "DNS forwards DNS-type Subject Alternative Names from the client certificate in the XFCC header.",
+                                "type": "boolean"
+                              },
+                              "subject": {
+                                "description": "Subject forwards the certificate Subject in the XFCC header.",
+                                "type": "boolean"
+                              },
+                              "uri": {
+                                "description": "URI forwards the URI-type Subject Alternative Name from the client certificate in the XFCC header.",
+                                "type": "boolean"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "mode": {
+                            "description": "Mode controls how Envoy handles the XFCC header on the request forwarded upstream.\nIf unset and Details is provided, Mode defaults to SanitizeSet.\nIf both Mode and Details are unset, this field has no effect.\n\n- Sanitize: do not send the XFCC header upstream.\n- ForwardOnly: forward the XFCC header in the request unchanged.\n- AppendForward: append the current client's details to the XFCC header.\n- SanitizeSet: reset the XFCC header with the current client's details, ignoring any client-supplied value.\n- AlwaysForwardOnly: always forward the XFCC header, even for non-mTLS connections.",
+                            "enum": [
+                              "Sanitize",
+                              "ForwardOnly",
+                              "AppendForward",
+                              "SanitizeSet",
+                              "AlwaysForwardOnly"
+                            ],
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
                       "generateRequestId": {
                         "description": "GenerateRequestId:  Whether the connection manager will generate the x-request-id header if it does not exist.\nThis defaults to true. Generating a random UUID4 is expensive so in high throughput scenarios where this feature is not desired it can be disabled.\nSee here for more information https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto#envoy-v3-api-field-extensions-filters-network-http-connection-manager-v3-httpconnectionmanager-generate-request-id",
                         "type": "boolean"
@@ -3340,6 +4417,10 @@
                       "http2ProtocolOptions": {
                         "description": "Http2ProtocolOptions configures downstream HTTP/2 behavior on the listener's\nHttpConnectionManager.\nSee here for more information: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/protocol.proto#config-core-v3-http2protocoloptions",
                         "properties": {
+                          "allowConnect": {
+                            "description": "AllowConnect allows proxying of WebSocket and other upgrades over HTTP/2 by\nenabling Envoy to handle Extended CONNECT requests (RFC 8441) on the downstream\nconnection. This is required for WebSocket-over-HTTP/2 when the listener advertises\nh2 in its ALPN; otherwise user agents that use Extended CONNECT (e.g. Firefox) fail\nto establish WebSocket connections.\nDefaults to false.",
+                            "type": "boolean"
+                          },
                           "initialConnectionWindowSize": {
                             "anyOf": [
                               {
@@ -3378,7 +4459,7 @@
                         "additionalProperties": false
                       },
                       "idleTimeout": {
-                        "description": "IdleTimeout is the idle timeout for connnections.\nSee here for more information: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/protocol.proto#envoy-v3-api-msg-config-core-v3-httpprotocoloptions",
+                        "description": "IdleTimeout is the idle timeout for connections.\nSee here for more information: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/protocol.proto#envoy-v3-api-msg-config-core-v3-httpprotocoloptions",
                         "type": "string",
                         "x-kubernetes-validations": [
                           {
@@ -3386,6 +4467,964 @@
                             "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
                           }
                         ]
+                      },
+                      "localReplies": {
+                        "description": "LocalReplies configures how Envoy's local replies are formatted etc.",
+                        "properties": {
+                          "defaultBodyFormat": {
+                            "description": "DefaultBodyFormat is the format to use for local reply bodies if it's not overridden by any mapper.\nYou can use the `%LOCAL_REPLY_BODY%` substitution to insert the original reply such as an error message.",
+                            "properties": {
+                              "contentType": {
+                                "description": "ContentType defines the HTTP Content-Type header to be sent with the response.\nBy default, `text/plain` is used for the Text format and `application/json` for the JSON format.\nNote: This setting does not currently take effect due to a bug in Envoy, a fix for which is pending release.\nThe option is included for completeness and will become effective with a future version of Envoy.",
+                                "type": "string"
+                              },
+                              "json": {
+                                "description": "JSON is a format object by which Envoy will produce a JSON response body.\nMutually exclusive with Text.\nSee https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/substitution_format_string.proto#envoy-v3-api-field-config-core-v3-substitutionformatstring-json-format for details.\n\nSetting a field to `null` in the JSON object requires the use of\n`kubectl apply --server-side` or equivalent. With the default client-side\n`kubectl apply`, null values are stripped by kubectl before reaching\nthe API server.",
+                                "type": "object",
+                                "x-kubernetes-preserve-unknown-fields": true
+                              },
+                              "text": {
+                                "description": "Text is a format string by which Envoy will format the response body.\nMutually exclusive with JSON.\nSee https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/substitution_format_string.proto#envoy-v3-api-field-config-core-v3-substitutionformatstring-text-format for details.",
+                                "maxLength": 4096,
+                                "minLength": 1,
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-validations": [
+                              {
+                                "message": "exactly one of the fields in [json text] must be set",
+                                "rule": "[has(self.json),has(self.text)].filter(x,x==true).size() == 1"
+                              }
+                            ],
+                            "additionalProperties": false
+                          },
+                          "mappers": {
+                            "description": "A list of custom options to apply based on filters. This may override the DefaultBodyFormat.",
+                            "items": {
+                              "description": "LocalReplyMapper may customize the local reply based on stream, request, and response properties such as status code.",
+                              "properties": {
+                                "body": {
+                                  "description": "New body text for the reply if specified.\nAvailable as `%LOCAL_REPLY_BODY%` in substitution strings.",
+                                  "type": "string"
+                                },
+                                "bodyFormatOverride": {
+                                  "description": "Alternative body format for the reply if specified. Takes precedence over default body format.",
+                                  "properties": {
+                                    "contentType": {
+                                      "description": "ContentType defines the HTTP Content-Type header to be sent with the response.\nBy default, `text/plain` is used for the Text format and `application/json` for the JSON format.\nNote: This setting does not currently take effect due to a bug in Envoy, a fix for which is pending release.\nThe option is included for completeness and will become effective with a future version of Envoy.",
+                                      "type": "string"
+                                    },
+                                    "json": {
+                                      "description": "JSON is a format object by which Envoy will produce a JSON response body.\nMutually exclusive with Text.\nSee https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/substitution_format_string.proto#envoy-v3-api-field-config-core-v3-substitutionformatstring-json-format for details.\n\nSetting a field to `null` in the JSON object requires the use of\n`kubectl apply --server-side` or equivalent. With the default client-side\n`kubectl apply`, null values are stripped by kubectl before reaching\nthe API server.",
+                                      "type": "object",
+                                      "x-kubernetes-preserve-unknown-fields": true
+                                    },
+                                    "text": {
+                                      "description": "Text is a format string by which Envoy will format the response body.\nMutually exclusive with JSON.\nSee https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/substitution_format_string.proto#envoy-v3-api-field-config-core-v3-substitutionformatstring-text-format for details.",
+                                      "maxLength": 4096,
+                                      "minLength": 1,
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "x-kubernetes-validations": [
+                                    {
+                                      "message": "exactly one of the fields in [json text] must be set",
+                                      "rule": "[has(self.json),has(self.text)].filter(x,x==true).size() == 1"
+                                    }
+                                  ],
+                                  "additionalProperties": false
+                                },
+                                "filter": {
+                                  "allOf": [
+                                    {
+                                      "maxProperties": 1,
+                                      "minProperties": 1
+                                    },
+                                    {
+                                      "maxProperties": 1,
+                                      "minProperties": 1
+                                    }
+                                  ],
+                                  "description": "A filter that determines if this mapper should apply.",
+                                  "properties": {
+                                    "andFilter": {
+                                      "description": "Performs a logical \"and\" operation on the result of each individual filter.\nBased on: https://www.envoyproxy.io/docs/envoy/v1.33.0/api-v3/config/accesslog/v3/accesslog.proto#config-accesslog-v3-andfilter",
+                                      "items": {
+                                        "description": "FilterType represents the type of filter to apply (only one of these should be set).\nBased on: https://www.envoyproxy.io/docs/envoy/v1.33.0/api-v3/config/accesslog/v3/accesslog.proto#envoy-v3-api-msg-config-accesslog-v3-accesslogfilter",
+                                        "maxProperties": 1,
+                                        "minProperties": 1,
+                                        "properties": {
+                                          "celFilter": {
+                                            "description": "CELFilter filters requests based on Common Expression Language (CEL).",
+                                            "properties": {
+                                              "match": {
+                                                "description": "The CEL expressions to evaluate. AccessLogs are only emitted when the CEL expressions evaluates to true.\nsee: https://www.envoyproxy.io/docs/envoy/v1.33.0/xds/type/v3/cel.proto.html#common-expression-language-cel-proto",
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "match"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "durationFilter": {
+                                            "description": "DurationFilter filters based on request duration.\nBased on: https://www.envoyproxy.io/docs/envoy/v1.33.0/api-v3/config/accesslog/v3/accesslog.proto#config-accesslog-v3-durationfilter",
+                                            "properties": {
+                                              "op": {
+                                                "description": "Op represents comparison operators.",
+                                                "enum": [
+                                                  "EQ",
+                                                  "GE",
+                                                  "LE"
+                                                ],
+                                                "type": "string"
+                                              },
+                                              "value": {
+                                                "description": "Value to compare against.",
+                                                "format": "uint32",
+                                                "maximum": 4294967295,
+                                                "minimum": 0,
+                                                "type": "integer"
+                                              }
+                                            },
+                                            "required": [
+                                              "op",
+                                              "value"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "grpcStatusFilter": {
+                                            "description": "GrpcStatusFilter filters gRPC requests based on their response status.\nBased on: https://www.envoyproxy.io/docs/envoy/v1.33.0/api-v3/config/accesslog/v3/accesslog.proto#enum-config-accesslog-v3-grpcstatusfilter-status",
+                                            "properties": {
+                                              "exclude": {
+                                                "type": "boolean"
+                                              },
+                                              "statuses": {
+                                                "items": {
+                                                  "description": "GrpcStatus represents possible gRPC statuses.",
+                                                  "enum": [
+                                                    "OK",
+                                                    "CANCELED",
+                                                    "UNKNOWN",
+                                                    "INVALID_ARGUMENT",
+                                                    "DEADLINE_EXCEEDED",
+                                                    "NOT_FOUND",
+                                                    "ALREADY_EXISTS",
+                                                    "PERMISSION_DENIED",
+                                                    "RESOURCE_EXHAUSTED",
+                                                    "FAILED_PRECONDITION",
+                                                    "ABORTED",
+                                                    "OUT_OF_RANGE",
+                                                    "UNIMPLEMENTED",
+                                                    "INTERNAL",
+                                                    "UNAVAILABLE",
+                                                    "DATA_LOSS",
+                                                    "UNAUTHENTICATED"
+                                                  ],
+                                                  "type": "string"
+                                                },
+                                                "minItems": 1,
+                                                "type": "array"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "headerFilter": {
+                                            "description": "HeaderFilter filters requests based on headers.\nBased on: https://www.envoyproxy.io/docs/envoy/v1.33.0/api-v3/config/accesslog/v3/accesslog.proto#config-accesslog-v3-headerfilter",
+                                            "properties": {
+                                              "header": {
+                                                "description": "HTTPHeaderMatch describes how to select a HTTP route by matching HTTP request\nheaders.",
+                                                "properties": {
+                                                  "name": {
+                                                    "description": "Name is the name of the HTTP Header to be matched. Name matching MUST be\ncase-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).\n\nIf multiple entries specify equivalent header names, only the first\nentry with an equivalent name MUST be considered for a match. Subsequent\nentries with an equivalent header name MUST be ignored. Due to the\ncase-insensitivity of header names, \"foo\" and \"Foo\" are considered\nequivalent.\n\nWhen a header is repeated in an HTTP request, it is\nimplementation-specific behavior as to how this is represented.\nGenerally, proxies should follow the guidance from the RFC:\nhttps://www.rfc-editor.org/rfc/rfc7230.html#section-3.2.2 regarding\nprocessing a repeated header, with special handling for \"Set-Cookie\".",
+                                                    "maxLength": 256,
+                                                    "minLength": 1,
+                                                    "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                                                    "type": "string"
+                                                  },
+                                                  "type": {
+                                                    "default": "Exact",
+                                                    "description": "Type specifies how to match against the value of the header.\n\nSupport: Core (Exact)\n\nSupport: Implementation-specific (RegularExpression)\n\nSince RegularExpression HeaderMatchType has implementation-specific\nconformance, implementations can support POSIX, PCRE or any other dialects\nof regular expressions. Please read the implementation's documentation to\ndetermine the supported dialect.",
+                                                    "enum": [
+                                                      "Exact",
+                                                      "RegularExpression"
+                                                    ],
+                                                    "type": "string"
+                                                  },
+                                                  "value": {
+                                                    "description": "Value is the value of HTTP Header to be matched.\n<gateway:experimental:description>\nMust consist of printable US-ASCII characters, optionally separated\nby single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2\n</gateway:experimental:description>\n\n<gateway:experimental:validation:Pattern=`^[!-~]+([\\t ]?[!-~]+)*$`>",
+                                                    "maxLength": 4096,
+                                                    "minLength": 1,
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "name",
+                                                  "value"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              }
+                                            },
+                                            "required": [
+                                              "header"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "notHealthCheckFilter": {
+                                            "description": "Filters for requests that are not health check requests.\nBased on: https://www.envoyproxy.io/docs/envoy/v1.33.0/api-v3/config/accesslog/v3/accesslog.proto#config-accesslog-v3-nothealthcheckfilter",
+                                            "type": "boolean"
+                                          },
+                                          "responseFlagFilter": {
+                                            "description": "ResponseFlagFilter filters based on response flags.\nBased on: https://www.envoyproxy.io/docs/envoy/v1.33.0/api-v3/config/accesslog/v3/accesslog.proto#config-accesslog-v3-responseflagfilter",
+                                            "properties": {
+                                              "flags": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "minItems": 1,
+                                                "type": "array"
+                                              }
+                                            },
+                                            "required": [
+                                              "flags"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "runtimeFilter": {
+                                            "description": "Filters for random sampling of access logs.\nBased on: https://www.envoyproxy.io/docs/envoy/v1.33.0/api-v3/config/accesslog/v3/accesslog.proto#config-accesslog-v3-runtimefilter",
+                                            "properties": {
+                                              "percentSampled": {
+                                                "description": "By default, the runtime filter will log on every request when the runtime key is set.\nIf this field is set, it additionally applies a fractional percent check so that only a\nfraction of requests are logged.",
+                                                "properties": {
+                                                  "denominator": {
+                                                    "description": "Specifies the denominator. If the denominator specified is less than the numerator,\nthe final fractional percentage is capped at 1 (100%).\nDefaults to HUNDRED.",
+                                                    "enum": [
+                                                      "HUNDRED",
+                                                      "TEN_THOUSAND",
+                                                      "MILLION"
+                                                    ],
+                                                    "type": "string"
+                                                  },
+                                                  "numerator": {
+                                                    "description": "Specifies the numerator. Defaults to 0.",
+                                                    "format": "int32",
+                                                    "minimum": 0,
+                                                    "type": "integer"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "numerator"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "runtimeKey": {
+                                                "description": "The runtime key to look up in the runtime implementation. This key determines whether\nthe access log is enabled. When the runtime key value is set, the filter checks this key\nat runtime to decide whether to log each request.",
+                                                "minLength": 1,
+                                                "type": "string"
+                                              },
+                                              "useIndependentRandomness": {
+                                                "description": "If set to true, the filter uses Envoy's independent randomness source.\nWhen false (the default), the filter uses the runtime key lookup.",
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "required": [
+                                              "runtimeKey"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "statusCodeFilter": {
+                                            "description": "StatusCodeFilter filters based on HTTP status code.\nBased on: https://www.envoyproxy.io/docs/envoy/v1.33.0/api-v3/config/accesslog/v3/accesslog.proto#envoy-v3-api-msg-config-accesslog-v3-statuscodefilter",
+                                            "properties": {
+                                              "op": {
+                                                "description": "Op represents comparison operators.",
+                                                "enum": [
+                                                  "EQ",
+                                                  "GE",
+                                                  "LE"
+                                                ],
+                                                "type": "string"
+                                              },
+                                              "value": {
+                                                "description": "Value to compare against.",
+                                                "format": "uint32",
+                                                "maximum": 4294967295,
+                                                "minimum": 0,
+                                                "type": "integer"
+                                              }
+                                            },
+                                            "required": [
+                                              "op",
+                                              "value"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "traceableFilter": {
+                                            "description": "Filters for requests that are traceable.\nBased on: https://www.envoyproxy.io/docs/envoy/v1.33.0/api-v3/config/accesslog/v3/accesslog.proto#config-accesslog-v3-traceablefilter",
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "minItems": 2,
+                                      "type": "array"
+                                    },
+                                    "celFilter": {
+                                      "description": "CELFilter filters requests based on Common Expression Language (CEL).",
+                                      "properties": {
+                                        "match": {
+                                          "description": "The CEL expressions to evaluate. AccessLogs are only emitted when the CEL expressions evaluates to true.\nsee: https://www.envoyproxy.io/docs/envoy/v1.33.0/xds/type/v3/cel.proto.html#common-expression-language-cel-proto",
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "match"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "durationFilter": {
+                                      "description": "DurationFilter filters based on request duration.\nBased on: https://www.envoyproxy.io/docs/envoy/v1.33.0/api-v3/config/accesslog/v3/accesslog.proto#config-accesslog-v3-durationfilter",
+                                      "properties": {
+                                        "op": {
+                                          "description": "Op represents comparison operators.",
+                                          "enum": [
+                                            "EQ",
+                                            "GE",
+                                            "LE"
+                                          ],
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "description": "Value to compare against.",
+                                          "format": "uint32",
+                                          "maximum": 4294967295,
+                                          "minimum": 0,
+                                          "type": "integer"
+                                        }
+                                      },
+                                      "required": [
+                                        "op",
+                                        "value"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "grpcStatusFilter": {
+                                      "description": "GrpcStatusFilter filters gRPC requests based on their response status.\nBased on: https://www.envoyproxy.io/docs/envoy/v1.33.0/api-v3/config/accesslog/v3/accesslog.proto#enum-config-accesslog-v3-grpcstatusfilter-status",
+                                      "properties": {
+                                        "exclude": {
+                                          "type": "boolean"
+                                        },
+                                        "statuses": {
+                                          "items": {
+                                            "description": "GrpcStatus represents possible gRPC statuses.",
+                                            "enum": [
+                                              "OK",
+                                              "CANCELED",
+                                              "UNKNOWN",
+                                              "INVALID_ARGUMENT",
+                                              "DEADLINE_EXCEEDED",
+                                              "NOT_FOUND",
+                                              "ALREADY_EXISTS",
+                                              "PERMISSION_DENIED",
+                                              "RESOURCE_EXHAUSTED",
+                                              "FAILED_PRECONDITION",
+                                              "ABORTED",
+                                              "OUT_OF_RANGE",
+                                              "UNIMPLEMENTED",
+                                              "INTERNAL",
+                                              "UNAVAILABLE",
+                                              "DATA_LOSS",
+                                              "UNAUTHENTICATED"
+                                            ],
+                                            "type": "string"
+                                          },
+                                          "minItems": 1,
+                                          "type": "array"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "headerFilter": {
+                                      "description": "HeaderFilter filters requests based on headers.\nBased on: https://www.envoyproxy.io/docs/envoy/v1.33.0/api-v3/config/accesslog/v3/accesslog.proto#config-accesslog-v3-headerfilter",
+                                      "properties": {
+                                        "header": {
+                                          "description": "HTTPHeaderMatch describes how to select a HTTP route by matching HTTP request\nheaders.",
+                                          "properties": {
+                                            "name": {
+                                              "description": "Name is the name of the HTTP Header to be matched. Name matching MUST be\ncase-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).\n\nIf multiple entries specify equivalent header names, only the first\nentry with an equivalent name MUST be considered for a match. Subsequent\nentries with an equivalent header name MUST be ignored. Due to the\ncase-insensitivity of header names, \"foo\" and \"Foo\" are considered\nequivalent.\n\nWhen a header is repeated in an HTTP request, it is\nimplementation-specific behavior as to how this is represented.\nGenerally, proxies should follow the guidance from the RFC:\nhttps://www.rfc-editor.org/rfc/rfc7230.html#section-3.2.2 regarding\nprocessing a repeated header, with special handling for \"Set-Cookie\".",
+                                              "maxLength": 256,
+                                              "minLength": 1,
+                                              "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                                              "type": "string"
+                                            },
+                                            "type": {
+                                              "default": "Exact",
+                                              "description": "Type specifies how to match against the value of the header.\n\nSupport: Core (Exact)\n\nSupport: Implementation-specific (RegularExpression)\n\nSince RegularExpression HeaderMatchType has implementation-specific\nconformance, implementations can support POSIX, PCRE or any other dialects\nof regular expressions. Please read the implementation's documentation to\ndetermine the supported dialect.",
+                                              "enum": [
+                                                "Exact",
+                                                "RegularExpression"
+                                              ],
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "description": "Value is the value of HTTP Header to be matched.\n<gateway:experimental:description>\nMust consist of printable US-ASCII characters, optionally separated\nby single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2\n</gateway:experimental:description>\n\n<gateway:experimental:validation:Pattern=`^[!-~]+([\\t ]?[!-~]+)*$`>",
+                                              "maxLength": 4096,
+                                              "minLength": 1,
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "name",
+                                            "value"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "required": [
+                                        "header"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "notHealthCheckFilter": {
+                                      "description": "Filters for requests that are not health check requests.\nBased on: https://www.envoyproxy.io/docs/envoy/v1.33.0/api-v3/config/accesslog/v3/accesslog.proto#config-accesslog-v3-nothealthcheckfilter",
+                                      "type": "boolean"
+                                    },
+                                    "orFilter": {
+                                      "description": "Performs a logical \"or\" operation on the result of each individual filter.\nBased on: https://www.envoyproxy.io/docs/envoy/v1.33.0/api-v3/config/accesslog/v3/accesslog.proto#config-accesslog-v3-orfilter",
+                                      "items": {
+                                        "description": "FilterType represents the type of filter to apply (only one of these should be set).\nBased on: https://www.envoyproxy.io/docs/envoy/v1.33.0/api-v3/config/accesslog/v3/accesslog.proto#envoy-v3-api-msg-config-accesslog-v3-accesslogfilter",
+                                        "maxProperties": 1,
+                                        "minProperties": 1,
+                                        "properties": {
+                                          "celFilter": {
+                                            "description": "CELFilter filters requests based on Common Expression Language (CEL).",
+                                            "properties": {
+                                              "match": {
+                                                "description": "The CEL expressions to evaluate. AccessLogs are only emitted when the CEL expressions evaluates to true.\nsee: https://www.envoyproxy.io/docs/envoy/v1.33.0/xds/type/v3/cel.proto.html#common-expression-language-cel-proto",
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "match"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "durationFilter": {
+                                            "description": "DurationFilter filters based on request duration.\nBased on: https://www.envoyproxy.io/docs/envoy/v1.33.0/api-v3/config/accesslog/v3/accesslog.proto#config-accesslog-v3-durationfilter",
+                                            "properties": {
+                                              "op": {
+                                                "description": "Op represents comparison operators.",
+                                                "enum": [
+                                                  "EQ",
+                                                  "GE",
+                                                  "LE"
+                                                ],
+                                                "type": "string"
+                                              },
+                                              "value": {
+                                                "description": "Value to compare against.",
+                                                "format": "uint32",
+                                                "maximum": 4294967295,
+                                                "minimum": 0,
+                                                "type": "integer"
+                                              }
+                                            },
+                                            "required": [
+                                              "op",
+                                              "value"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "grpcStatusFilter": {
+                                            "description": "GrpcStatusFilter filters gRPC requests based on their response status.\nBased on: https://www.envoyproxy.io/docs/envoy/v1.33.0/api-v3/config/accesslog/v3/accesslog.proto#enum-config-accesslog-v3-grpcstatusfilter-status",
+                                            "properties": {
+                                              "exclude": {
+                                                "type": "boolean"
+                                              },
+                                              "statuses": {
+                                                "items": {
+                                                  "description": "GrpcStatus represents possible gRPC statuses.",
+                                                  "enum": [
+                                                    "OK",
+                                                    "CANCELED",
+                                                    "UNKNOWN",
+                                                    "INVALID_ARGUMENT",
+                                                    "DEADLINE_EXCEEDED",
+                                                    "NOT_FOUND",
+                                                    "ALREADY_EXISTS",
+                                                    "PERMISSION_DENIED",
+                                                    "RESOURCE_EXHAUSTED",
+                                                    "FAILED_PRECONDITION",
+                                                    "ABORTED",
+                                                    "OUT_OF_RANGE",
+                                                    "UNIMPLEMENTED",
+                                                    "INTERNAL",
+                                                    "UNAVAILABLE",
+                                                    "DATA_LOSS",
+                                                    "UNAUTHENTICATED"
+                                                  ],
+                                                  "type": "string"
+                                                },
+                                                "minItems": 1,
+                                                "type": "array"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "headerFilter": {
+                                            "description": "HeaderFilter filters requests based on headers.\nBased on: https://www.envoyproxy.io/docs/envoy/v1.33.0/api-v3/config/accesslog/v3/accesslog.proto#config-accesslog-v3-headerfilter",
+                                            "properties": {
+                                              "header": {
+                                                "description": "HTTPHeaderMatch describes how to select a HTTP route by matching HTTP request\nheaders.",
+                                                "properties": {
+                                                  "name": {
+                                                    "description": "Name is the name of the HTTP Header to be matched. Name matching MUST be\ncase-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).\n\nIf multiple entries specify equivalent header names, only the first\nentry with an equivalent name MUST be considered for a match. Subsequent\nentries with an equivalent header name MUST be ignored. Due to the\ncase-insensitivity of header names, \"foo\" and \"Foo\" are considered\nequivalent.\n\nWhen a header is repeated in an HTTP request, it is\nimplementation-specific behavior as to how this is represented.\nGenerally, proxies should follow the guidance from the RFC:\nhttps://www.rfc-editor.org/rfc/rfc7230.html#section-3.2.2 regarding\nprocessing a repeated header, with special handling for \"Set-Cookie\".",
+                                                    "maxLength": 256,
+                                                    "minLength": 1,
+                                                    "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                                                    "type": "string"
+                                                  },
+                                                  "type": {
+                                                    "default": "Exact",
+                                                    "description": "Type specifies how to match against the value of the header.\n\nSupport: Core (Exact)\n\nSupport: Implementation-specific (RegularExpression)\n\nSince RegularExpression HeaderMatchType has implementation-specific\nconformance, implementations can support POSIX, PCRE or any other dialects\nof regular expressions. Please read the implementation's documentation to\ndetermine the supported dialect.",
+                                                    "enum": [
+                                                      "Exact",
+                                                      "RegularExpression"
+                                                    ],
+                                                    "type": "string"
+                                                  },
+                                                  "value": {
+                                                    "description": "Value is the value of HTTP Header to be matched.\n<gateway:experimental:description>\nMust consist of printable US-ASCII characters, optionally separated\nby single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2\n</gateway:experimental:description>\n\n<gateway:experimental:validation:Pattern=`^[!-~]+([\\t ]?[!-~]+)*$`>",
+                                                    "maxLength": 4096,
+                                                    "minLength": 1,
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "name",
+                                                  "value"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              }
+                                            },
+                                            "required": [
+                                              "header"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "notHealthCheckFilter": {
+                                            "description": "Filters for requests that are not health check requests.\nBased on: https://www.envoyproxy.io/docs/envoy/v1.33.0/api-v3/config/accesslog/v3/accesslog.proto#config-accesslog-v3-nothealthcheckfilter",
+                                            "type": "boolean"
+                                          },
+                                          "responseFlagFilter": {
+                                            "description": "ResponseFlagFilter filters based on response flags.\nBased on: https://www.envoyproxy.io/docs/envoy/v1.33.0/api-v3/config/accesslog/v3/accesslog.proto#config-accesslog-v3-responseflagfilter",
+                                            "properties": {
+                                              "flags": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "minItems": 1,
+                                                "type": "array"
+                                              }
+                                            },
+                                            "required": [
+                                              "flags"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "runtimeFilter": {
+                                            "description": "Filters for random sampling of access logs.\nBased on: https://www.envoyproxy.io/docs/envoy/v1.33.0/api-v3/config/accesslog/v3/accesslog.proto#config-accesslog-v3-runtimefilter",
+                                            "properties": {
+                                              "percentSampled": {
+                                                "description": "By default, the runtime filter will log on every request when the runtime key is set.\nIf this field is set, it additionally applies a fractional percent check so that only a\nfraction of requests are logged.",
+                                                "properties": {
+                                                  "denominator": {
+                                                    "description": "Specifies the denominator. If the denominator specified is less than the numerator,\nthe final fractional percentage is capped at 1 (100%).\nDefaults to HUNDRED.",
+                                                    "enum": [
+                                                      "HUNDRED",
+                                                      "TEN_THOUSAND",
+                                                      "MILLION"
+                                                    ],
+                                                    "type": "string"
+                                                  },
+                                                  "numerator": {
+                                                    "description": "Specifies the numerator. Defaults to 0.",
+                                                    "format": "int32",
+                                                    "minimum": 0,
+                                                    "type": "integer"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "numerator"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "runtimeKey": {
+                                                "description": "The runtime key to look up in the runtime implementation. This key determines whether\nthe access log is enabled. When the runtime key value is set, the filter checks this key\nat runtime to decide whether to log each request.",
+                                                "minLength": 1,
+                                                "type": "string"
+                                              },
+                                              "useIndependentRandomness": {
+                                                "description": "If set to true, the filter uses Envoy's independent randomness source.\nWhen false (the default), the filter uses the runtime key lookup.",
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "required": [
+                                              "runtimeKey"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "statusCodeFilter": {
+                                            "description": "StatusCodeFilter filters based on HTTP status code.\nBased on: https://www.envoyproxy.io/docs/envoy/v1.33.0/api-v3/config/accesslog/v3/accesslog.proto#envoy-v3-api-msg-config-accesslog-v3-statuscodefilter",
+                                            "properties": {
+                                              "op": {
+                                                "description": "Op represents comparison operators.",
+                                                "enum": [
+                                                  "EQ",
+                                                  "GE",
+                                                  "LE"
+                                                ],
+                                                "type": "string"
+                                              },
+                                              "value": {
+                                                "description": "Value to compare against.",
+                                                "format": "uint32",
+                                                "maximum": 4294967295,
+                                                "minimum": 0,
+                                                "type": "integer"
+                                              }
+                                            },
+                                            "required": [
+                                              "op",
+                                              "value"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "traceableFilter": {
+                                            "description": "Filters for requests that are traceable.\nBased on: https://www.envoyproxy.io/docs/envoy/v1.33.0/api-v3/config/accesslog/v3/accesslog.proto#config-accesslog-v3-traceablefilter",
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "minItems": 2,
+                                      "type": "array"
+                                    },
+                                    "responseFlagFilter": {
+                                      "description": "ResponseFlagFilter filters based on response flags.\nBased on: https://www.envoyproxy.io/docs/envoy/v1.33.0/api-v3/config/accesslog/v3/accesslog.proto#config-accesslog-v3-responseflagfilter",
+                                      "properties": {
+                                        "flags": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "minItems": 1,
+                                          "type": "array"
+                                        }
+                                      },
+                                      "required": [
+                                        "flags"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "runtimeFilter": {
+                                      "description": "Filters for random sampling of access logs.\nBased on: https://www.envoyproxy.io/docs/envoy/v1.33.0/api-v3/config/accesslog/v3/accesslog.proto#config-accesslog-v3-runtimefilter",
+                                      "properties": {
+                                        "percentSampled": {
+                                          "description": "By default, the runtime filter will log on every request when the runtime key is set.\nIf this field is set, it additionally applies a fractional percent check so that only a\nfraction of requests are logged.",
+                                          "properties": {
+                                            "denominator": {
+                                              "description": "Specifies the denominator. If the denominator specified is less than the numerator,\nthe final fractional percentage is capped at 1 (100%).\nDefaults to HUNDRED.",
+                                              "enum": [
+                                                "HUNDRED",
+                                                "TEN_THOUSAND",
+                                                "MILLION"
+                                              ],
+                                              "type": "string"
+                                            },
+                                            "numerator": {
+                                              "description": "Specifies the numerator. Defaults to 0.",
+                                              "format": "int32",
+                                              "minimum": 0,
+                                              "type": "integer"
+                                            }
+                                          },
+                                          "required": [
+                                            "numerator"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "runtimeKey": {
+                                          "description": "The runtime key to look up in the runtime implementation. This key determines whether\nthe access log is enabled. When the runtime key value is set, the filter checks this key\nat runtime to decide whether to log each request.",
+                                          "minLength": 1,
+                                          "type": "string"
+                                        },
+                                        "useIndependentRandomness": {
+                                          "description": "If set to true, the filter uses Envoy's independent randomness source.\nWhen false (the default), the filter uses the runtime key lookup.",
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "runtimeKey"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "statusCodeFilter": {
+                                      "description": "StatusCodeFilter filters based on HTTP status code.\nBased on: https://www.envoyproxy.io/docs/envoy/v1.33.0/api-v3/config/accesslog/v3/accesslog.proto#envoy-v3-api-msg-config-accesslog-v3-statuscodefilter",
+                                      "properties": {
+                                        "op": {
+                                          "description": "Op represents comparison operators.",
+                                          "enum": [
+                                            "EQ",
+                                            "GE",
+                                            "LE"
+                                          ],
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "description": "Value to compare against.",
+                                          "format": "uint32",
+                                          "maximum": 4294967295,
+                                          "minimum": 0,
+                                          "type": "integer"
+                                        }
+                                      },
+                                      "required": [
+                                        "op",
+                                        "value"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "traceableFilter": {
+                                      "description": "Filters for requests that are traceable.\nBased on: https://www.envoyproxy.io/docs/envoy/v1.33.0/api-v3/config/accesslog/v3/accesslog.proto#config-accesslog-v3-traceablefilter",
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "headers": {
+                                  "description": "Headers to add or set for the reply if specified.",
+                                  "properties": {
+                                    "add": {
+                                      "description": "Add adds the given header(s) (name, value) to the request before the action.\nIt appends to any existing values associated with the header name.\n\nInput:\n  GET /foo HTTP/1.1\n  my-header: foo\n\nConfig:\n  add:\n  - name: \"my-header\"\n    value: \"bar,baz\"\n\nOutput:\n  GET /foo HTTP/1.1\n  my-header: foo,bar,baz",
+                                      "items": {
+                                        "description": "HTTPHeader represents a single header name/value pair. Exactly one of value or secretRef must\nbe set. When using secretRef, name and key interact as follows:\n  - Both present: name is the header name, key is the Secret data key.\n  - name absent, key present: the key is also used as the header name.\n  - name present, key absent: the name is also used as the Secret data key.\n  - Both absent: every entry in the Secret is injected as a header (data key -> header name).",
+                                        "properties": {
+                                          "name": {
+                                            "description": "Name is the HTTP header field name. Name matching is case-insensitive.\n(See https://tools.ietf.org/html/rfc7230#section-3.2.)\nRequired when value is set. When secretRef is used, if omitted the Secret data key is\nused as the header name; if both name and key are omitted every Secret entry is injected\nas a header.",
+                                            "maxLength": 256,
+                                            "minLength": 1,
+                                            "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                                            "type": "string"
+                                          },
+                                          "secretRef": {
+                                            "description": "SecretRef sources the header value from a key in a Kubernetes Secret.\nMutually exclusive with value.",
+                                            "properties": {
+                                              "key": {
+                                                "description": "Key is the key within the Secret's data map to use as the header value. When omitted and\nthe parent HTTPHeader.name is set, that name is used as the key. When both key and name are\nomitted, all entries in the Secret are injected as headers.",
+                                                "maxLength": 253,
+                                                "minLength": 1,
+                                                "pattern": "^[-._a-zA-Z0-9]+$",
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "description": "Name is the name of the Kubernetes Secret.",
+                                                "maxLength": 253,
+                                                "minLength": 1,
+                                                "type": "string"
+                                              },
+                                              "namespace": {
+                                                "description": "Namespace is the namespace of the Secret. If omitted, defaults to the namespace of the\nreferencing policy. Cross-namespace references require a ReferenceGrant in the target\nnamespace permitting access from the policy's namespace.",
+                                                "maxLength": 63,
+                                                "minLength": 1,
+                                                "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "value": {
+                                            "description": "Value is an inline string value for the header. Mutually exclusive with secretRef.\nMust consist of printable US-ASCII characters. (See https://tools.ietf.org/html/rfc7230#section-3.2.)",
+                                            "maxLength": 4096,
+                                            "minLength": 1,
+                                            "pattern": "^[!-~]+([\\t ]?[!-~]+)*$",
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "name is required when using an inline value",
+                                            "rule": "has(self.value) ? has(self.name) : true"
+                                          },
+                                          {
+                                            "message": "exactly one of the fields in [value secretRef] must be set",
+                                            "rule": "[has(self.value),has(self.secretRef)].filter(x,x==true).size() == 1"
+                                          }
+                                        ],
+                                        "additionalProperties": false
+                                      },
+                                      "maxItems": 16,
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
+                                    },
+                                    "remove": {
+                                      "description": "Remove the given header(s) from the HTTP request before the action. The\nvalue of Remove is a list of HTTP header names. Note that header names are\ncase-insensitive (see [RFC 2616, Section 4.2](https://datatracker.ietf.org/doc/html/rfc2616#section-4.2)).\n\nInput:\n  GET /foo HTTP/1.1\n  my-header1: foo\n  my-header2: bar\n  my-header3: baz\n\nConfig:\n  remove: [\"my-header1\", \"my-header3\"]\n\nOutput:\n  GET /foo HTTP/1.1\n  my-header2: bar",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "maxItems": 16,
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "set"
+                                    },
+                                    "set": {
+                                      "description": "Set overwrites the request with the given header (name, value) before the action.\n\nInput:\n  GET /foo HTTP/1.1\n  my-header: foo\n\nConfig:\n  set:\n  - name: \"my-header\"\n    value: \"bar\"\n\nOutput:\n  GET /foo HTTP/1.1\n  my-header: bar",
+                                      "items": {
+                                        "description": "HTTPHeader represents a single header name/value pair. Exactly one of value or secretRef must\nbe set. When using secretRef, name and key interact as follows:\n  - Both present: name is the header name, key is the Secret data key.\n  - name absent, key present: the key is also used as the header name.\n  - name present, key absent: the name is also used as the Secret data key.\n  - Both absent: every entry in the Secret is injected as a header (data key -> header name).",
+                                        "properties": {
+                                          "name": {
+                                            "description": "Name is the HTTP header field name. Name matching is case-insensitive.\n(See https://tools.ietf.org/html/rfc7230#section-3.2.)\nRequired when value is set. When secretRef is used, if omitted the Secret data key is\nused as the header name; if both name and key are omitted every Secret entry is injected\nas a header.",
+                                            "maxLength": 256,
+                                            "minLength": 1,
+                                            "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                                            "type": "string"
+                                          },
+                                          "secretRef": {
+                                            "description": "SecretRef sources the header value from a key in a Kubernetes Secret.\nMutually exclusive with value.",
+                                            "properties": {
+                                              "key": {
+                                                "description": "Key is the key within the Secret's data map to use as the header value. When omitted and\nthe parent HTTPHeader.name is set, that name is used as the key. When both key and name are\nomitted, all entries in the Secret are injected as headers.",
+                                                "maxLength": 253,
+                                                "minLength": 1,
+                                                "pattern": "^[-._a-zA-Z0-9]+$",
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "description": "Name is the name of the Kubernetes Secret.",
+                                                "maxLength": 253,
+                                                "minLength": 1,
+                                                "type": "string"
+                                              },
+                                              "namespace": {
+                                                "description": "Namespace is the namespace of the Secret. If omitted, defaults to the namespace of the\nreferencing policy. Cross-namespace references require a ReferenceGrant in the target\nnamespace permitting access from the policy's namespace.",
+                                                "maxLength": 63,
+                                                "minLength": 1,
+                                                "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "value": {
+                                            "description": "Value is an inline string value for the header. Mutually exclusive with secretRef.\nMust consist of printable US-ASCII characters. (See https://tools.ietf.org/html/rfc7230#section-3.2.)",
+                                            "maxLength": 4096,
+                                            "minLength": 1,
+                                            "pattern": "^[!-~]+([\\t ]?[!-~]+)*$",
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "name is required when using an inline value",
+                                            "rule": "has(self.value) ? has(self.name) : true"
+                                          },
+                                          {
+                                            "message": "exactly one of the fields in [value secretRef] must be set",
+                                            "rule": "[has(self.value),has(self.secretRef)].filter(x,x==true).size() == 1"
+                                          }
+                                        ],
+                                        "additionalProperties": false
+                                      },
+                                      "maxItems": 16,
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "x-kubernetes-validations": [
+                                    {
+                                      "message": "Local reply mappers may only add or modify headers, not remove them",
+                                      "rule": "!has(self.remove)"
+                                    },
+                                    {
+                                      "message": "at least one of the fields in [set add remove] must be set",
+                                      "rule": "[has(self.set),has(self.add),has(self.remove)].filter(x,x==true).size() >= 1"
+                                    }
+                                  ],
+                                  "additionalProperties": false
+                                },
+                                "statusCode": {
+                                  "description": "New response status code for the reply if specified.",
+                                  "format": "int32",
+                                  "maximum": 599,
+                                  "minimum": 100,
+                                  "type": "integer"
+                                }
+                              },
+                              "required": [
+                                "filter"
+                              ],
+                              "type": "object",
+                              "x-kubernetes-validations": [
+                                {
+                                  "message": "at least one of the fields in [statusCode body bodyFormatOverride headers] must be set",
+                                  "rule": "[has(self.statusCode),has(self.body),has(self.bodyFormatOverride),has(self.headers)].filter(x,x==true).size() >= 1"
+                                }
+                              ],
+                              "additionalProperties": false
+                            },
+                            "maxItems": 16,
+                            "minItems": 1,
+                            "type": "array"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-validations": [
+                          {
+                            "message": "at least one of the fields in [mappers defaultBodyFormat] must be set",
+                            "rule": "[has(self.mappers),has(self.defaultBodyFormat)].filter(x,x==true).size() >= 1"
+                          }
+                        ],
+                        "additionalProperties": false
                       },
                       "maxHeadersCount": {
                         "description": "MaxHeadersCount sets the maximum number of headers allowed in a request.\nDownstream requests that exceed this limit will receive a 431 response for HTTP/1.x and a\nstream reset for HTTP/2. If unset, defaults to Envoy's built-in default of 100.\nSee here for more information: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/protocol.proto#envoy-v3-api-field-config-core-v3-httpprotocoloptions-max-headers-count",
@@ -3398,6 +5437,12 @@
                         "format": "int32",
                         "maximum": 8192,
                         "minimum": 1,
+                        "type": "integer"
+                      },
+                      "maxRequestsPerConnection": {
+                        "description": "MaxRequestsPerConnection sets the maximum number of requests served over a single downstream\nkeepalive connection. When the limit is reached, Envoy closes the connection, which forces\nclients to reconnect. This allows L4 load balancers like AWS NLB to rebalance long-lived\nHTTP/2 and gRPC connections across gateway pods.\nIf set to 0 or unspecified, defaults to unlimited.\nSee here for more information: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/protocol.proto#envoy-v3-api-field-config-core-v3-httpprotocoloptions-max-requests-per-connection",
+                        "format": "int32",
+                        "minimum": 0,
                         "type": "integer"
                       },
                       "preserveExternalRequestId": {
@@ -3415,6 +5460,11 @@
                           "AppendIfAbsent",
                           "PassThrough"
                         ],
+                        "type": "string"
+                      },
+                      "serverName": {
+                        "description": "ServerName determines the value of the server header.\nSee here for more information: https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto#envoy-v3-api-field-extensions-filters-network-http-connection-manager-v3-httpconnectionmanager-server-name",
+                        "minLength": 1,
                         "type": "string"
                       },
                       "skipXFFAppend": {
@@ -3892,6 +5942,10 @@
                       {
                         "message": "only one of xffNumTrustedHops and xffTrustedCIDRs may be set",
                         "rule": "!has(self.xffNumTrustedHops) || !has(self.xffTrustedCIDRs)"
+                      },
+                      {
+                        "message": "forwardClientCertDetails.details requires mode to be AppendForward or SanitizeSet (or unset)",
+                        "rule": "!has(self.forwardClientCertDetails) || !has(self.forwardClientCertDetails.details) || !has(self.forwardClientCertDetails.mode) || self.forwardClientCertDetails.mode == 'AppendForward' || self.forwardClientCertDetails.mode == 'SanitizeSet'"
                       }
                     ],
                     "additionalProperties": false
@@ -3953,6 +6007,16 @@
                     },
                     "type": "object",
                     "additionalProperties": false
+                  },
+                  "transportSocketConnectTimeout": {
+                    "description": "TransportSocketConnectTimeout is the timeout for the transport socket to complete after a new connection is accepted.\nIf the timeout fires, the connection is closed. Setting this protects Envoy from clients that open connections and\nthen never complete the TLS handshake. Applied to every filter chain on the listener.\nSee here for more information: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/listener/v3/listener_components.proto#envoy-v3-api-field-config-listener-v3-filterchain-transport-socket-connect-timeout",
+                    "type": "string",
+                    "x-kubernetes-validations": [
+                      {
+                        "message": "invalid duration value",
+                        "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                      }
+                    ]
                   }
                 },
                 "type": "object",

--- a/gateway.kgateway.dev/trafficpolicy_v1alpha1.json
+++ b/gateway.kgateway.dev/trafficpolicy_v1alpha1.json
@@ -15,7 +15,7 @@
       "description": "TrafficPolicySpec defines the desired state of a traffic policy.",
       "properties": {
         "acl": {
-          "description": "ACL configures IP-based access control for HTTP requests.\nRules are evaluated using longest-prefix matching on the effictive client IP\nfrom envoy base on settings. See the UseRemoteAddress, XffTrustedCIDRs,\nXffNumTrustedHops settings under ListenerPolicy -> HttpSettings for details.",
+          "description": "ACL configures IP-based access control for HTTP requests.\nRules are evaluated using longest-prefix matching on the effictive client IP\nfrom envoy base on settings. See the UseRemoteAddress, XffTrustedCIDRs,\nXffNumTrustedHops settings under ListenerPolicy -> HttpSettings for details.\n\nWhen multiple TrafficPolicy objects target the same route, their ACL fields are\ndeep-merged by default: rules are unioned (higher-priority policy's rules first),\nand singleton fields (defaultAction, denyResponse) are taken from the higher-priority\npolicy. If singleton fields conflict between policies, the merge falls back to\nshallow (higher-priority policy wins entirely). Gateway-level and route-level ACL\npolicies are kept in separate merge groups and are never combined with each other;\na route-level ACL completely replaces the gateway-level ACL for that route.",
           "properties": {
             "defaultAction": {
               "description": "DefaultAction is the action to take when no rule matches the client IP.",
@@ -243,7 +243,7 @@
           "additionalProperties": false
         },
         "autoHostRewrite": {
-          "description": "AutoHostRewrite rewrites the Host header to the DNS name of the selected upstream.\nNOTE: This field is only honored for HTTPRoute targets.\nNOTE: If `autoHostRewrite` is set on a route that also has a [URLRewrite filter](https://gateway-api.sigs.k8s.io/reference/spec/#httpurlrewritefilter)\nconfigured to override the `hostname`, the `hostname` value will be used and `autoHostRewrite` will be ignored.",
+          "description": "AutoHostRewrite rewrites the Host header to the DNS name of the selected upstream.\nNOTE: This field is only honored for HTTPRoute targets.\nNOTE: If `autoHostRewrite` is set on a route that also has a [URLRewrite filter](https://gateway-api.sigs.k8s.io/reference/api-spec/main/spec/#httpurlrewritefilter)\nconfigured to override the `hostname`, the `hostname` value will be used and `autoHostRewrite` will be ignored.",
           "type": "boolean"
         },
         "basicAuth": {
@@ -341,22 +341,72 @@
           "description": "Compression configures response compression (per-route) and request/response\ndecompression (listener-level insertion triggered by route enable).\nThe response compression configuration is only honored for HTTPRoute targets.",
           "properties": {
             "requestDecompression": {
-              "description": "RequestDecompression controls request decompression.\nIf set, gzip requests will be decompressed.",
+              "description": "RequestDecompression controls request decompression.\nIf set, request bodies in the configured codecs are decompressed before forwarding.",
               "properties": {
                 "disable": {
                   "description": "Disables decompression.",
                   "type": "object"
+                },
+                "libraries": {
+                  "default": [
+                    "Gzip"
+                  ],
+                  "description": "Libraries lists the codecs to decompress on request bodies. Envoy selects the decompressor\nby the request's `Content-Encoding` header, so the list order is not significant. Request\nbodies encoded with a codec not in this list are passed through to the backend unchanged.\nDefaults to [Gzip].",
+                  "items": {
+                    "description": "CompressionLibrary identifies a compression codec used to compress responses or decompress requests.",
+                    "enum": [
+                      "Gzip",
+                      "Brotli",
+                      "Zstd"
+                    ],
+                    "type": "string"
+                  },
+                  "maxItems": 3,
+                  "minItems": 1,
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "libraries must not contain duplicates",
+                      "rule": "self.all(x, self.exists_one(y, y == x))"
+                    }
+                  ]
                 }
               },
               "type": "object",
               "additionalProperties": false
             },
             "responseCompression": {
-              "description": "ResponseCompression controls response compression to the downstream.\nIf set, responses with the appropriate `Accept-Encoding` header with certain textual content types will be compressed using gzip.\nThe content-types that will be compressed are:\n- `application/javascript`\n- `application/json`\n- `application/xhtml+xml`\n- `image/svg+xml`\n- `text/css`\n- `text/html`\n- `text/plain`\n- `text/xml`",
+              "description": "ResponseCompression controls response compression to the downstream.\nIf set, responses with a matching `Accept-Encoding` header and certain textual content types will be compressed.\nThe compression codecs default to gzip and can be selected via `responseCompression.libraries`,\nwhich Envoy negotiates against the request's `Accept-Encoding` header.\nThe content-types that will be compressed are:\n- `application/javascript`\n- `application/json`\n- `application/xhtml+xml`\n- `image/svg+xml`\n- `text/css`\n- `text/html`\n- `text/plain`\n- `text/xml`",
               "properties": {
                 "disable": {
                   "description": "Disables compression.",
                   "type": "object"
+                },
+                "libraries": {
+                  "default": [
+                    "Gzip"
+                  ],
+                  "description": "Libraries lists the compression codecs to offer for responses.\nEnvoy negotiates the codec based on the downstream request's `Accept-Encoding` header,\npicking the highest-quality codec the client accepts. On equal quality the client's\nordering decides. If the client accepts none of the offered codecs, the response is\nsent uncompressed.\nDefaults to [Gzip].",
+                  "items": {
+                    "description": "CompressionLibrary identifies a compression codec used to compress responses or decompress requests.",
+                    "enum": [
+                      "Gzip",
+                      "Brotli",
+                      "Zstd"
+                    ],
+                    "type": "string"
+                  },
+                  "maxItems": 3,
+                  "minItems": 1,
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "libraries must not contain duplicates",
+                      "rule": "self.all(x, self.exists_one(y, y == x))"
+                    }
+                  ]
                 }
               },
               "type": "object",
@@ -380,7 +430,7 @@
               "type": "boolean"
             },
             "allowHeaders": {
-              "description": "AllowHeaders indicates which HTTP request headers are supported for\naccessing the requested resource.\n\nHeader names are not case-sensitive.\n\nMultiple header names in the value of the `Access-Control-Allow-Headers`\nresponse header are separated by a comma (\",\").\n\nWhen the `AllowHeaders` field is configured with one or more headers, the\ngateway must return the `Access-Control-Allow-Headers` response header\nwhich value is present in the `AllowHeaders` field.\n\nIf any header name in the `Access-Control-Request-Headers` request header\nis not included in the list of header names specified by the response\nheader `Access-Control-Allow-Headers`, it will present an error on the\nclient side.\n\nIf any header name in the `Access-Control-Allow-Headers` response header\ndoes not recognize by the client, it will also occur an error on the\nclient side.\n\nA wildcard indicates that the requests with all HTTP headers are allowed.\nIf config contains the wildcard \"*\" in allowHeaders and the request is\nnot credentialed, the `Access-Control-Allow-Headers` response header\ncan either use the `*` wildcard or the value of\nAccess-Control-Request-Headers from the request.\n\nWhen the request is credentialed, the gateway must not specify the `*`\nwildcard in the `Access-Control-Allow-Headers` response header. When\nalso the `AllowCredentials` field is true and `AllowHeaders` field\nis specified with the `*` wildcard, the gateway must specify one or more\nHTTP headers in the value of the `Access-Control-Allow-Headers` response\nheader. The value of the header `Access-Control-Allow-Headers` is same as\nthe `Access-Control-Request-Headers` header provided by the client. If\nthe header `Access-Control-Request-Headers` is not included in the\nrequest, the gateway will omit the `Access-Control-Allow-Headers`\nresponse header, instead of specifying the `*` wildcard.\n\nSupport: Extended",
+              "description": "AllowHeaders indicates which HTTP request headers are supported for\naccessing the requested resource.\n\nHeader names are not case-sensitive.\n\nMultiple header names in the value of the `Access-Control-Allow-Headers`\nresponse header are separated by a comma (\",\").\n\nWhen the `allowHeaders` field is configured with one or more headers, the\ngateway must return the `Access-Control-Allow-Headers` response header\nwhich value is present in the `allowHeaders` field.\n\nIf any header name in the `Access-Control-Request-Headers` request header\nis not included in the list of header names specified by the response\nheader `Access-Control-Allow-Headers`, it will present an error on the\nclient side.\n\nIf any header name in the `Access-Control-Allow-Headers` response header\ndoes not recognize by the client, it will also occur an error on the\nclient side.\n\nA wildcard indicates that the requests with all HTTP headers are allowed.\n\nIf the configuration contains the wildcard `*` in `allowHeaders` and\n`allowCredentials` is set to `false`, the `Access-Control-Allow-Headers`\nresponse header may either contain the wildcard `*` or echo the value\nof the `Access-Control-Request-Headers` request header.\n\nIf the configuration contains the wildcard `*` in `allowHeaders` and\n`allowCredentials` is set to `true`, the gateway must not return `*`\nin the `Access-Control-Allow-Headers` response header. Instead, it must\nreturn one or more header names matching the value of the\n`Access-Control-Request-Headers` request header.\nIf the `Access-Control-Request-Headers` header is not present in the\nrequest, the gateway must omit the `Access-Control-Allow-Headers`\nresponse header.\n\nSupport: Extended",
               "items": {
                 "description": "HTTPHeaderName is the name of an HTTP header.\n\nValid values include:\n\n* \"Authorization\"\n* \"Set-Cookie\"\n\nInvalid values include:\n\n  - \":method\" - \":\" is an invalid character. This means that HTTP/2 pseudo\n    headers are not currently supported by this type.\n  - \"/invalid\" - \"/ \" is an invalid character",
                 "maxLength": 256,
@@ -399,7 +449,7 @@
               ]
             },
             "allowMethods": {
-              "description": "AllowMethods indicates which HTTP methods are supported for accessing the\nrequested resource.\n\nValid values are any method defined by RFC9110, along with the special\nvalue `*`, which represents all HTTP methods are allowed.\n\nMethod names are case-sensitive, so these values are also case-sensitive.\n(See https://www.rfc-editor.org/rfc/rfc2616#section-5.1.1)\n\nMultiple method names in the value of the `Access-Control-Allow-Methods`\nresponse header are separated by a comma (\",\").\n\nA CORS-safelisted method is a method that is `GET`, `HEAD`, or `POST`.\n(See https://fetch.spec.whatwg.org/#cors-safelisted-method) The\nCORS-safelisted methods are always allowed, regardless of whether they\nare specified in the `AllowMethods` field.\n\nWhen the `AllowMethods` field is configured with one or more methods, the\ngateway must return the `Access-Control-Allow-Methods` response header\nwhich value is present in the `AllowMethods` field.\n\nIf the HTTP method of the `Access-Control-Request-Method` request header\nis not included in the list of methods specified by the response header\n`Access-Control-Allow-Methods`, it will present an error on the client\nside.\n\nIf config contains the wildcard \"*\" in allowMethods and the request is\nnot credentialed, the `Access-Control-Allow-Methods` response header\ncan either use the `*` wildcard or the value of\nAccess-Control-Request-Method from the request.\n\nWhen the request is credentialed, the gateway must not specify the `*`\nwildcard in the `Access-Control-Allow-Methods` response header. When\nalso the `AllowCredentials` field is true and `AllowMethods` field\nspecified with the `*` wildcard, the gateway must specify one HTTP method\nin the value of the Access-Control-Allow-Methods response header. The\nvalue of the header `Access-Control-Allow-Methods` is same as the\n`Access-Control-Request-Method` header provided by the client. If the\nheader `Access-Control-Request-Method` is not included in the request,\nthe gateway will omit the `Access-Control-Allow-Methods` response header,\ninstead of specifying the `*` wildcard.\n\nSupport: Extended",
+              "description": "AllowMethods indicates which HTTP methods are supported for accessing the\nrequested resource.\n\nValid values are any method defined by RFC9110, along with the special\nvalue `*`, which represents all HTTP methods are allowed.\n\nMethod names are case-sensitive, so these values are also case-sensitive.\n(See https://www.rfc-editor.org/rfc/rfc2616#section-5.1.1)\n\nMultiple method names in the value of the `Access-Control-Allow-Methods`\nresponse header are separated by a comma (\",\").\n\nA CORS-safelisted method is a method that is `GET`, `HEAD`, or `POST`.\n(See https://fetch.spec.whatwg.org/#cors-safelisted-method) The\nCORS-safelisted methods are always allowed, regardless of whether they\nare specified in the `allowMethods` field.\n\nWhen the `allowMethods` field is configured with one or more methods, the\ngateway must return the `Access-Control-Allow-Methods` response header\nwhich value is present in the `allowMethods` field.\n\nIf the HTTP method of the `Access-Control-Request-Method` request header\nis not included in the list of methods specified by the response header\n`Access-Control-Allow-Methods`, it will present an error on the client\nside.\n\nIf the configuration contains the wildcard `*` in `allowMethods` and\n`allowCredentials` is set to `false`, the `Access-Control-Allow-Methods`\nresponse header may either contain the wildcard `*` or echo the value\nof the `Access-Control-Request-Method` request header.\n\nIf the configuration contains the wildcard `*` in `allowMethods` and\n`allowCredentials` is set to `true`, the gateway must not return `*`\nin the `Access-Control-Allow-Methods` response header. Instead, it must\nreturn a single HTTP method matching the value of the\n`Access-Control-Request-Method` request header.\nIf the `Access-Control-Request-Method` header is not present in the request,\nthe gateway must omit the `Access-Control-Allow-Methods` response header.\n\nSupport: Extended",
               "items": {
                 "enum": [
                   "GET",
@@ -426,7 +476,7 @@
               ]
             },
             "allowOrigins": {
-              "description": "AllowOrigins indicates whether the response can be shared with requested\nresource from the given `Origin`.\n\nThe `Origin` consists of a scheme and a host, with an optional port, and\ntakes the form `<scheme>://<host>(:<port>)`.\n\nValid values for scheme are: `http` and `https`.\n\nValid values for port are any integer between 1 and 65535 (the list of\navailable TCP/UDP ports). Note that, if not included, port `80` is\nassumed for `http` scheme origins, and port `443` is assumed for `https`\norigins. This may affect origin matching.\n\nThe host part of the origin may contain the wildcard character `*`. These\nwildcard characters behave as follows:\n\n* `*` is a greedy match to the _left_, including any number of\n  DNS labels to the left of its position. This also means that\n  `*` will include any number of period `.` characters to the\n  left of its position.\n* A wildcard by itself matches all hosts.\n\nAn origin value that includes _only_ the `*` character indicates requests\nfrom all `Origin`s are allowed.\n\nWhen the `AllowOrigins` field is configured with multiple origins, it\nmeans the server supports clients from multiple origins. If the request\n`Origin` matches the configured allowed origins, the gateway must return\nthe given `Origin` and sets value of the header\n`Access-Control-Allow-Origin` same as the `Origin` header provided by the\nclient.\n\nThe status code of a successful response to a \"preflight\" request is\nalways an OK status (i.e., 204 or 200).\n\nIf the request `Origin` does not match the configured allowed origins,\nthe gateway returns 204/200 response but doesn't set the relevant\ncross-origin response headers. Alternatively, the gateway responds with\n403 status to the \"preflight\" request is denied, coupled with omitting\nthe CORS headers. The cross-origin request fails on the client side.\nTherefore, the client doesn't attempt the actual cross-origin request.\n\nConversely, if the request `Origin` matches one of the configured\nallowed origins, the gateway sets the response header\n`Access-Control-Allow-Origin` to the same value as the `Origin`\nheader provided by the client.\n\nWhen config has the wildcard (\"*\") in allowOrigins, and the request\nis not credentialed (e.g., it is a preflight request), the\n`Access-Control-Allow-Origin` response header either contains the\nwildcard as well or the Origin from the request.\n\nWhen the request is credentialed, the gateway must not specify the `*`\nwildcard in the `Access-Control-Allow-Origin` response header. When\nalso the `AllowCredentials` field is true and `AllowOrigins` field\nspecified with the `*` wildcard, the gateway must return a single origin\nin the value of the `Access-Control-Allow-Origin` response header,\ninstead of specifying the `*` wildcard. The value of the header\n`Access-Control-Allow-Origin` is same as the `Origin` header provided by\nthe client.\n\nSupport: Extended",
+              "description": "AllowOrigins indicates whether the response can be shared with requested\nresource from the given `Origin`.\n\nThe `Origin` consists of a scheme and a host, with an optional port, and\ntakes the form `<scheme>://<host>(:<port>)`.\n\nValid values for scheme are: `http` and `https`.\n\nValid values for port are any integer between 1 and 65535 (the list of\navailable TCP/UDP ports). Note that, if not included, port `80` is\nassumed for `http` scheme origins, and port `443` is assumed for `https`\norigins. This may affect origin matching.\n\nThe host part of the origin may contain the wildcard character `*`. These\nwildcard characters behave as follows:\n\n* `*` is a greedy match to the _left_, including any number of\n  DNS labels to the left of its position. This also means that\n  `*` will include any number of period `.` characters to the\n  left of its position.\n* A wildcard by itself matches all hosts.\n\nAn origin value that includes _only_ the `*` character indicates requests\nfrom all `Origin`s are allowed.\n\nWhen the `allowOrigins` field is configured with multiple origins, it\nmeans the server supports clients from multiple origins. If the request\n`Origin` matches the configured allowed origins, the gateway must return\nthe given `Origin` and sets value of the header\n`Access-Control-Allow-Origin` same as the `Origin` header provided by the\nclient.\n\nThe status code of a successful response to a \"preflight\" request is\nalways an OK status (i.e., 204 or 200).\n\nIf the request `Origin` does not match the configured allowed origins,\nthe gateway returns 204/200 response but doesn't set the relevant\ncross-origin response headers. Alternatively, the gateway responds with\n403 status to the \"preflight\" request is denied, coupled with omitting\nthe CORS headers. The cross-origin request fails on the client side.\nTherefore, the client doesn't attempt the actual cross-origin request.\n\nConversely, if the request `Origin` matches one of the configured\nallowed origins, the gateway sets the response header\n`Access-Control-Allow-Origin` to the same value as the `Origin`\nheader provided by the client.\n\nIf the configuration contains the wildcard `*` in `allowOrigins` and\n`allowCredentials` is set to `false`, the `Access-Control-Allow-Origin`\nresponse header may either contain the wildcard `*` or echo the value\nof the `Origin` request header.\n\nIf the configuration contains the wildcard `*` in `allowOrigins` and\n`allowCredentials` is set to `true`, the gateway must not return `*`\nin the `Access-Control-Allow-Origin` response header. Instead, it must\nreturn a single origin matching the value of the `Origin` request header.\n\nSupport: Extended",
               "items": {
                 "description": "The CORSOrigin MUST NOT be a relative URI, and it MUST follow the URI syntax and\nencoding rules specified in RFC3986.  The CORSOrigin MUST include both a\nscheme (\"http\" or \"https\") and a scheme-specific-part, or it should be a single '*' character.\nURIs that include an authority MUST include a fully qualified domain name or\nIP address as the host.",
                 "maxLength": 253,
@@ -449,7 +499,7 @@
               "type": "object"
             },
             "exposeHeaders": {
-              "description": "ExposeHeaders indicates which HTTP response headers can be exposed\nto client-side scripts in response to a cross-origin request.\n\nA CORS-safelisted response header is an HTTP header in a CORS response\nthat it is considered safe to expose to the client scripts.\nThe CORS-safelisted response headers include the following headers:\n`Cache-Control`\n`Content-Language`\n`Content-Length`\n`Content-Type`\n`Expires`\n`Last-Modified`\n`Pragma`\n(See https://fetch.spec.whatwg.org/#cors-safelisted-response-header-name)\nThe CORS-safelisted response headers are exposed to client by default.\n\nWhen an HTTP header name is specified using the `ExposeHeaders` field,\nthis additional header will be exposed as part of the response to the\nclient.\n\nHeader names are not case-sensitive.\n\nMultiple header names in the value of the `Access-Control-Expose-Headers`\nresponse header are separated by a comma (\",\").\n\nA wildcard indicates that the responses with all HTTP headers are exposed\nto clients. The `Access-Control-Expose-Headers` response header can only\nuse `*` wildcard as value when the request is not credentialed.\n\nWhen the `exposeHeaders` config field contains the \"*\" wildcard and\nthe request is credentialed, the gateway cannot use the `*` wildcard in\nthe `Access-Control-Expose-Headers` response header.\n\nSupport: Extended",
+              "description": "ExposeHeaders indicates which HTTP response headers can be exposed\nto client-side scripts in response to a cross-origin request.\n\nA CORS-safelisted response header is an HTTP header in a CORS response\nthat it is considered safe to expose to the client scripts.\nThe CORS-safelisted response headers include the following headers:\n`Cache-Control`\n`Content-Language`\n`Content-Length`\n`Content-Type`\n`Expires`\n`Last-Modified`\n`Pragma`\n(See https://fetch.spec.whatwg.org/#cors-safelisted-response-header-name)\nThe CORS-safelisted response headers are exposed to client by default.\n\nWhen an HTTP header name is specified using the `exposeHeaders` field,\nthis additional header will be exposed as part of the response to the\nclient.\n\nHeader names are not case-sensitive.\n\nMultiple header names in the value of the `Access-Control-Expose-Headers`\nresponse header are separated by a comma (\",\").\n\nA wildcard indicates that the responses with all HTTP headers are exposed\nto clients.\n\nIf the configuration contains the wildcard `*` in `exposeHeaders` and\n`allowCredentials` is set to `false`, the `Access-Control-Expose-Headers`\nresponse header can contain the wildcard `*`.\n\nIf the configuration contains the wildcard `*` in `exposeHeaders` and\n`allowCredentials` is set to `true`, the gateway cannot use the `*`\nin the `Access-Control-Expose-Headers` response header.\n\nSupport: Extended",
               "items": {
                 "description": "HTTPHeaderName is the name of an HTTP header.\n\nValid values include:\n\n* \"Authorization\"\n* \"Set-Cookie\"\n\nInvalid values include:\n\n  - \":method\" - \":\" is an invalid character. This means that HTTP/2 pseudo\n    headers are not currently supported by this type.\n  - \"/invalid\" - \"/ \" is an invalid character",
                 "maxLength": 256,
@@ -851,40 +901,74 @@
               "description": "Request modifies request headers.",
               "properties": {
                 "add": {
-                  "description": "Add adds the given header(s) (name, value) to the request\nbefore the action. It appends to any existing values associated\nwith the header name.\n\nInput:\n  GET /foo HTTP/1.1\n  my-header: foo\n\nConfig:\n  add:\n  - name: \"my-header\"\n    value: \"bar,baz\"\n\nOutput:\n  GET /foo HTTP/1.1\n  my-header: foo,bar,baz",
+                  "description": "Add adds the given header(s) (name, value) to the request before the action.\nIt appends to any existing values associated with the header name.\n\nInput:\n  GET /foo HTTP/1.1\n  my-header: foo\n\nConfig:\n  add:\n  - name: \"my-header\"\n    value: \"bar,baz\"\n\nOutput:\n  GET /foo HTTP/1.1\n  my-header: foo,bar,baz",
                   "items": {
-                    "description": "HTTPHeader represents an HTTP Header name and value as defined by RFC 7230.",
+                    "description": "HTTPHeader represents a single header name/value pair. Exactly one of value or secretRef must\nbe set. When using secretRef, name and key interact as follows:\n  - Both present: name is the header name, key is the Secret data key.\n  - name absent, key present: the key is also used as the header name.\n  - name present, key absent: the name is also used as the Secret data key.\n  - Both absent: every entry in the Secret is injected as a header (data key -> header name).",
                     "properties": {
                       "name": {
-                        "description": "Name is the name of the HTTP Header to be matched. Name matching MUST be\ncase-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).\n\nIf multiple entries specify equivalent header names, the first entry with\nan equivalent name MUST be considered for a match. Subsequent entries\nwith an equivalent header name MUST be ignored. Due to the\ncase-insensitivity of header names, \"foo\" and \"Foo\" are considered\nequivalent.",
+                        "description": "Name is the HTTP header field name. Name matching is case-insensitive.\n(See https://tools.ietf.org/html/rfc7230#section-3.2.)\nRequired when value is set. When secretRef is used, if omitted the Secret data key is\nused as the header name; if both name and key are omitted every Secret entry is injected\nas a header.",
                         "maxLength": 256,
                         "minLength": 1,
                         "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
                         "type": "string"
                       },
+                      "secretRef": {
+                        "description": "SecretRef sources the header value from a key in a Kubernetes Secret.\nMutually exclusive with value.",
+                        "properties": {
+                          "key": {
+                            "description": "Key is the key within the Secret's data map to use as the header value. When omitted and\nthe parent HTTPHeader.name is set, that name is used as the key. When both key and name are\nomitted, all entries in the Secret are injected as headers.",
+                            "maxLength": 253,
+                            "minLength": 1,
+                            "pattern": "^[-._a-zA-Z0-9]+$",
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "Name is the name of the Kubernetes Secret.",
+                            "maxLength": 253,
+                            "minLength": 1,
+                            "type": "string"
+                          },
+                          "namespace": {
+                            "description": "Namespace is the namespace of the Secret. If omitted, defaults to the namespace of the\nreferencing policy. Cross-namespace references require a ReferenceGrant in the target\nnamespace permitting access from the policy's namespace.",
+                            "maxLength": 63,
+                            "minLength": 1,
+                            "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "name"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
                       "value": {
-                        "description": "Value is the value of HTTP Header to be matched.\n<gateway:experimental:description>\nMust consist of printable US-ASCII characters, optionally separated\nby single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2\n</gateway:experimental:description>\n\n<gateway:experimental:validation:Pattern=`^[!-~]+([\\t ]?[!-~]+)*$`>",
+                        "description": "Value is an inline string value for the header. Mutually exclusive with secretRef.\nMust consist of printable US-ASCII characters. (See https://tools.ietf.org/html/rfc7230#section-3.2.)",
                         "maxLength": 4096,
                         "minLength": 1,
+                        "pattern": "^[!-~]+([\\t ]?[!-~]+)*$",
                         "type": "string"
                       }
                     },
-                    "required": [
-                      "name",
-                      "value"
-                    ],
                     "type": "object",
+                    "x-kubernetes-validations": [
+                      {
+                        "message": "name is required when using an inline value",
+                        "rule": "has(self.value) ? has(self.name) : true"
+                      },
+                      {
+                        "message": "exactly one of the fields in [value secretRef] must be set",
+                        "rule": "[has(self.value),has(self.secretRef)].filter(x,x==true).size() == 1"
+                      }
+                    ],
                     "additionalProperties": false
                   },
                   "maxItems": 16,
                   "type": "array",
-                  "x-kubernetes-list-map-keys": [
-                    "name"
-                  ],
-                  "x-kubernetes-list-type": "map"
+                  "x-kubernetes-list-type": "atomic"
                 },
                 "remove": {
-                  "description": "Remove the given header(s) from the HTTP request before the action. The\nvalue of Remove is a list of HTTP header names. Note that the header\nnames are case-insensitive (see\nhttps://datatracker.ietf.org/doc/html/rfc2616#section-4.2).\n\nInput:\n  GET /foo HTTP/1.1\n  my-header1: foo\n  my-header2: bar\n  my-header3: baz\n\nConfig:\n  remove: [\"my-header1\", \"my-header3\"]\n\nOutput:\n  GET /foo HTTP/1.1\n  my-header2: bar",
+                  "description": "Remove the given header(s) from the HTTP request before the action. The\nvalue of Remove is a list of HTTP header names. Note that header names are\ncase-insensitive (see [RFC 2616, Section 4.2](https://datatracker.ietf.org/doc/html/rfc2616#section-4.2)).\n\nInput:\n  GET /foo HTTP/1.1\n  my-header1: foo\n  my-header2: bar\n  my-header3: baz\n\nConfig:\n  remove: [\"my-header1\", \"my-header3\"]\n\nOutput:\n  GET /foo HTTP/1.1\n  my-header2: bar",
                   "items": {
                     "type": "string"
                   },
@@ -893,80 +977,154 @@
                   "x-kubernetes-list-type": "set"
                 },
                 "set": {
-                  "description": "Set overwrites the request with the given header (name, value)\nbefore the action.\n\nInput:\n  GET /foo HTTP/1.1\n  my-header: foo\n\nConfig:\n  set:\n  - name: \"my-header\"\n    value: \"bar\"\n\nOutput:\n  GET /foo HTTP/1.1\n  my-header: bar",
+                  "description": "Set overwrites the request with the given header (name, value) before the action.\n\nInput:\n  GET /foo HTTP/1.1\n  my-header: foo\n\nConfig:\n  set:\n  - name: \"my-header\"\n    value: \"bar\"\n\nOutput:\n  GET /foo HTTP/1.1\n  my-header: bar",
                   "items": {
-                    "description": "HTTPHeader represents an HTTP Header name and value as defined by RFC 7230.",
+                    "description": "HTTPHeader represents a single header name/value pair. Exactly one of value or secretRef must\nbe set. When using secretRef, name and key interact as follows:\n  - Both present: name is the header name, key is the Secret data key.\n  - name absent, key present: the key is also used as the header name.\n  - name present, key absent: the name is also used as the Secret data key.\n  - Both absent: every entry in the Secret is injected as a header (data key -> header name).",
                     "properties": {
                       "name": {
-                        "description": "Name is the name of the HTTP Header to be matched. Name matching MUST be\ncase-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).\n\nIf multiple entries specify equivalent header names, the first entry with\nan equivalent name MUST be considered for a match. Subsequent entries\nwith an equivalent header name MUST be ignored. Due to the\ncase-insensitivity of header names, \"foo\" and \"Foo\" are considered\nequivalent.",
+                        "description": "Name is the HTTP header field name. Name matching is case-insensitive.\n(See https://tools.ietf.org/html/rfc7230#section-3.2.)\nRequired when value is set. When secretRef is used, if omitted the Secret data key is\nused as the header name; if both name and key are omitted every Secret entry is injected\nas a header.",
                         "maxLength": 256,
                         "minLength": 1,
                         "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
                         "type": "string"
                       },
+                      "secretRef": {
+                        "description": "SecretRef sources the header value from a key in a Kubernetes Secret.\nMutually exclusive with value.",
+                        "properties": {
+                          "key": {
+                            "description": "Key is the key within the Secret's data map to use as the header value. When omitted and\nthe parent HTTPHeader.name is set, that name is used as the key. When both key and name are\nomitted, all entries in the Secret are injected as headers.",
+                            "maxLength": 253,
+                            "minLength": 1,
+                            "pattern": "^[-._a-zA-Z0-9]+$",
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "Name is the name of the Kubernetes Secret.",
+                            "maxLength": 253,
+                            "minLength": 1,
+                            "type": "string"
+                          },
+                          "namespace": {
+                            "description": "Namespace is the namespace of the Secret. If omitted, defaults to the namespace of the\nreferencing policy. Cross-namespace references require a ReferenceGrant in the target\nnamespace permitting access from the policy's namespace.",
+                            "maxLength": 63,
+                            "minLength": 1,
+                            "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "name"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
                       "value": {
-                        "description": "Value is the value of HTTP Header to be matched.\n<gateway:experimental:description>\nMust consist of printable US-ASCII characters, optionally separated\nby single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2\n</gateway:experimental:description>\n\n<gateway:experimental:validation:Pattern=`^[!-~]+([\\t ]?[!-~]+)*$`>",
+                        "description": "Value is an inline string value for the header. Mutually exclusive with secretRef.\nMust consist of printable US-ASCII characters. (See https://tools.ietf.org/html/rfc7230#section-3.2.)",
                         "maxLength": 4096,
                         "minLength": 1,
+                        "pattern": "^[!-~]+([\\t ]?[!-~]+)*$",
                         "type": "string"
                       }
                     },
-                    "required": [
-                      "name",
-                      "value"
-                    ],
                     "type": "object",
+                    "x-kubernetes-validations": [
+                      {
+                        "message": "name is required when using an inline value",
+                        "rule": "has(self.value) ? has(self.name) : true"
+                      },
+                      {
+                        "message": "exactly one of the fields in [value secretRef] must be set",
+                        "rule": "[has(self.value),has(self.secretRef)].filter(x,x==true).size() == 1"
+                      }
+                    ],
                     "additionalProperties": false
                   },
                   "maxItems": 16,
                   "type": "array",
-                  "x-kubernetes-list-map-keys": [
-                    "name"
-                  ],
-                  "x-kubernetes-list-type": "map"
+                  "x-kubernetes-list-type": "atomic"
                 }
               },
               "type": "object",
+              "x-kubernetes-validations": [
+                {
+                  "message": "at least one of the fields in [set add remove] must be set",
+                  "rule": "[has(self.set),has(self.add),has(self.remove)].filter(x,x==true).size() >= 1"
+                }
+              ],
               "additionalProperties": false
             },
             "response": {
               "description": "Response modifies response headers.",
               "properties": {
                 "add": {
-                  "description": "Add adds the given header(s) (name, value) to the request\nbefore the action. It appends to any existing values associated\nwith the header name.\n\nInput:\n  GET /foo HTTP/1.1\n  my-header: foo\n\nConfig:\n  add:\n  - name: \"my-header\"\n    value: \"bar,baz\"\n\nOutput:\n  GET /foo HTTP/1.1\n  my-header: foo,bar,baz",
+                  "description": "Add adds the given header(s) (name, value) to the request before the action.\nIt appends to any existing values associated with the header name.\n\nInput:\n  GET /foo HTTP/1.1\n  my-header: foo\n\nConfig:\n  add:\n  - name: \"my-header\"\n    value: \"bar,baz\"\n\nOutput:\n  GET /foo HTTP/1.1\n  my-header: foo,bar,baz",
                   "items": {
-                    "description": "HTTPHeader represents an HTTP Header name and value as defined by RFC 7230.",
+                    "description": "HTTPHeader represents a single header name/value pair. Exactly one of value or secretRef must\nbe set. When using secretRef, name and key interact as follows:\n  - Both present: name is the header name, key is the Secret data key.\n  - name absent, key present: the key is also used as the header name.\n  - name present, key absent: the name is also used as the Secret data key.\n  - Both absent: every entry in the Secret is injected as a header (data key -> header name).",
                     "properties": {
                       "name": {
-                        "description": "Name is the name of the HTTP Header to be matched. Name matching MUST be\ncase-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).\n\nIf multiple entries specify equivalent header names, the first entry with\nan equivalent name MUST be considered for a match. Subsequent entries\nwith an equivalent header name MUST be ignored. Due to the\ncase-insensitivity of header names, \"foo\" and \"Foo\" are considered\nequivalent.",
+                        "description": "Name is the HTTP header field name. Name matching is case-insensitive.\n(See https://tools.ietf.org/html/rfc7230#section-3.2.)\nRequired when value is set. When secretRef is used, if omitted the Secret data key is\nused as the header name; if both name and key are omitted every Secret entry is injected\nas a header.",
                         "maxLength": 256,
                         "minLength": 1,
                         "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
                         "type": "string"
                       },
+                      "secretRef": {
+                        "description": "SecretRef sources the header value from a key in a Kubernetes Secret.\nMutually exclusive with value.",
+                        "properties": {
+                          "key": {
+                            "description": "Key is the key within the Secret's data map to use as the header value. When omitted and\nthe parent HTTPHeader.name is set, that name is used as the key. When both key and name are\nomitted, all entries in the Secret are injected as headers.",
+                            "maxLength": 253,
+                            "minLength": 1,
+                            "pattern": "^[-._a-zA-Z0-9]+$",
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "Name is the name of the Kubernetes Secret.",
+                            "maxLength": 253,
+                            "minLength": 1,
+                            "type": "string"
+                          },
+                          "namespace": {
+                            "description": "Namespace is the namespace of the Secret. If omitted, defaults to the namespace of the\nreferencing policy. Cross-namespace references require a ReferenceGrant in the target\nnamespace permitting access from the policy's namespace.",
+                            "maxLength": 63,
+                            "minLength": 1,
+                            "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "name"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
                       "value": {
-                        "description": "Value is the value of HTTP Header to be matched.\n<gateway:experimental:description>\nMust consist of printable US-ASCII characters, optionally separated\nby single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2\n</gateway:experimental:description>\n\n<gateway:experimental:validation:Pattern=`^[!-~]+([\\t ]?[!-~]+)*$`>",
+                        "description": "Value is an inline string value for the header. Mutually exclusive with secretRef.\nMust consist of printable US-ASCII characters. (See https://tools.ietf.org/html/rfc7230#section-3.2.)",
                         "maxLength": 4096,
                         "minLength": 1,
+                        "pattern": "^[!-~]+([\\t ]?[!-~]+)*$",
                         "type": "string"
                       }
                     },
-                    "required": [
-                      "name",
-                      "value"
-                    ],
                     "type": "object",
+                    "x-kubernetes-validations": [
+                      {
+                        "message": "name is required when using an inline value",
+                        "rule": "has(self.value) ? has(self.name) : true"
+                      },
+                      {
+                        "message": "exactly one of the fields in [value secretRef] must be set",
+                        "rule": "[has(self.value),has(self.secretRef)].filter(x,x==true).size() == 1"
+                      }
+                    ],
                     "additionalProperties": false
                   },
                   "maxItems": 16,
                   "type": "array",
-                  "x-kubernetes-list-map-keys": [
-                    "name"
-                  ],
-                  "x-kubernetes-list-type": "map"
+                  "x-kubernetes-list-type": "atomic"
                 },
                 "remove": {
-                  "description": "Remove the given header(s) from the HTTP request before the action. The\nvalue of Remove is a list of HTTP header names. Note that the header\nnames are case-insensitive (see\nhttps://datatracker.ietf.org/doc/html/rfc2616#section-4.2).\n\nInput:\n  GET /foo HTTP/1.1\n  my-header1: foo\n  my-header2: bar\n  my-header3: baz\n\nConfig:\n  remove: [\"my-header1\", \"my-header3\"]\n\nOutput:\n  GET /foo HTTP/1.1\n  my-header2: bar",
+                  "description": "Remove the given header(s) from the HTTP request before the action. The\nvalue of Remove is a list of HTTP header names. Note that header names are\ncase-insensitive (see [RFC 2616, Section 4.2](https://datatracker.ietf.org/doc/html/rfc2616#section-4.2)).\n\nInput:\n  GET /foo HTTP/1.1\n  my-header1: foo\n  my-header2: bar\n  my-header3: baz\n\nConfig:\n  remove: [\"my-header1\", \"my-header3\"]\n\nOutput:\n  GET /foo HTTP/1.1\n  my-header2: bar",
                   "items": {
                     "type": "string"
                   },
@@ -975,40 +1133,80 @@
                   "x-kubernetes-list-type": "set"
                 },
                 "set": {
-                  "description": "Set overwrites the request with the given header (name, value)\nbefore the action.\n\nInput:\n  GET /foo HTTP/1.1\n  my-header: foo\n\nConfig:\n  set:\n  - name: \"my-header\"\n    value: \"bar\"\n\nOutput:\n  GET /foo HTTP/1.1\n  my-header: bar",
+                  "description": "Set overwrites the request with the given header (name, value) before the action.\n\nInput:\n  GET /foo HTTP/1.1\n  my-header: foo\n\nConfig:\n  set:\n  - name: \"my-header\"\n    value: \"bar\"\n\nOutput:\n  GET /foo HTTP/1.1\n  my-header: bar",
                   "items": {
-                    "description": "HTTPHeader represents an HTTP Header name and value as defined by RFC 7230.",
+                    "description": "HTTPHeader represents a single header name/value pair. Exactly one of value or secretRef must\nbe set. When using secretRef, name and key interact as follows:\n  - Both present: name is the header name, key is the Secret data key.\n  - name absent, key present: the key is also used as the header name.\n  - name present, key absent: the name is also used as the Secret data key.\n  - Both absent: every entry in the Secret is injected as a header (data key -> header name).",
                     "properties": {
                       "name": {
-                        "description": "Name is the name of the HTTP Header to be matched. Name matching MUST be\ncase-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).\n\nIf multiple entries specify equivalent header names, the first entry with\nan equivalent name MUST be considered for a match. Subsequent entries\nwith an equivalent header name MUST be ignored. Due to the\ncase-insensitivity of header names, \"foo\" and \"Foo\" are considered\nequivalent.",
+                        "description": "Name is the HTTP header field name. Name matching is case-insensitive.\n(See https://tools.ietf.org/html/rfc7230#section-3.2.)\nRequired when value is set. When secretRef is used, if omitted the Secret data key is\nused as the header name; if both name and key are omitted every Secret entry is injected\nas a header.",
                         "maxLength": 256,
                         "minLength": 1,
                         "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
                         "type": "string"
                       },
+                      "secretRef": {
+                        "description": "SecretRef sources the header value from a key in a Kubernetes Secret.\nMutually exclusive with value.",
+                        "properties": {
+                          "key": {
+                            "description": "Key is the key within the Secret's data map to use as the header value. When omitted and\nthe parent HTTPHeader.name is set, that name is used as the key. When both key and name are\nomitted, all entries in the Secret are injected as headers.",
+                            "maxLength": 253,
+                            "minLength": 1,
+                            "pattern": "^[-._a-zA-Z0-9]+$",
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "Name is the name of the Kubernetes Secret.",
+                            "maxLength": 253,
+                            "minLength": 1,
+                            "type": "string"
+                          },
+                          "namespace": {
+                            "description": "Namespace is the namespace of the Secret. If omitted, defaults to the namespace of the\nreferencing policy. Cross-namespace references require a ReferenceGrant in the target\nnamespace permitting access from the policy's namespace.",
+                            "maxLength": 63,
+                            "minLength": 1,
+                            "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "name"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
                       "value": {
-                        "description": "Value is the value of HTTP Header to be matched.\n<gateway:experimental:description>\nMust consist of printable US-ASCII characters, optionally separated\nby single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2\n</gateway:experimental:description>\n\n<gateway:experimental:validation:Pattern=`^[!-~]+([\\t ]?[!-~]+)*$`>",
+                        "description": "Value is an inline string value for the header. Mutually exclusive with secretRef.\nMust consist of printable US-ASCII characters. (See https://tools.ietf.org/html/rfc7230#section-3.2.)",
                         "maxLength": 4096,
                         "minLength": 1,
+                        "pattern": "^[!-~]+([\\t ]?[!-~]+)*$",
                         "type": "string"
                       }
                     },
-                    "required": [
-                      "name",
-                      "value"
-                    ],
                     "type": "object",
+                    "x-kubernetes-validations": [
+                      {
+                        "message": "name is required when using an inline value",
+                        "rule": "has(self.value) ? has(self.name) : true"
+                      },
+                      {
+                        "message": "exactly one of the fields in [value secretRef] must be set",
+                        "rule": "[has(self.value),has(self.secretRef)].filter(x,x==true).size() == 1"
+                      }
+                    ],
                     "additionalProperties": false
                   },
                   "maxItems": 16,
                   "type": "array",
-                  "x-kubernetes-list-map-keys": [
-                    "name"
-                  ],
-                  "x-kubernetes-list-type": "map"
+                  "x-kubernetes-list-type": "atomic"
                 }
               },
               "type": "object",
+              "x-kubernetes-validations": [
+                {
+                  "message": "at least one of the fields in [set add remove] must be set",
+                  "rule": "[has(self.set),has(self.add),has(self.remove)].filter(x,x==true).size() >= 1"
+                }
+              ],
               "additionalProperties": false
             }
           },
@@ -1019,6 +1217,66 @@
               "rule": "[has(self.request),has(self.response)].filter(x,x==true).size() >= 1"
             }
           ],
+          "additionalProperties": false
+        },
+        "internalRedirect": {
+          "description": "InternalRedirect handles upstream 3xx redirects inside the gateway.\nApplies only to routes that forward traffic to a backend.",
+          "properties": {
+            "allowCrossSchemeRedirect": {
+              "description": "AllowCrossSchemeRedirect permits redirects across http/https schemes.\nDefaults to false.",
+              "type": "boolean"
+            },
+            "maxRedirects": {
+              "description": "MaxRedirects caps followed redirects for a single downstream request.\nDefaults to 1.",
+              "format": "int32",
+              "minimum": 1,
+              "type": "integer"
+            },
+            "redirectResponseCodes": {
+              "description": "RedirectResponseCodes are upstream status codes that trigger internal redirects.\nIf unset, only 302 redirects are followed.",
+              "items": {
+                "description": "InternalRedirectResponseCode is a 3xx response code supported for internal redirects.",
+                "enum": [
+                  301,
+                  302,
+                  303,
+                  307,
+                  308
+                ],
+                "format": "int32",
+                "type": "integer"
+              },
+              "maxItems": 5,
+              "minItems": 1,
+              "type": "array",
+              "x-kubernetes-validations": [
+                {
+                  "message": "redirectResponseCodes must not contain duplicates",
+                  "rule": "self.all(c, self.exists_one(c2, c2 == c))"
+                }
+              ]
+            },
+            "responseHeadersToCopy": {
+              "description": "ResponseHeadersToCopy are copied from the redirect response to the\ninternally redirected request.",
+              "items": {
+                "description": "HTTPHeaderName is the name of an HTTP header.\n\nValid values include:\n\n* \"Authorization\"\n* \"Set-Cookie\"\n\nInvalid values include:\n\n  - \":method\" - \":\" is an invalid character. This means that HTTP/2 pseudo\n    headers are not currently supported by this type.\n  - \"/invalid\" - \"/ \" is an invalid character",
+                "maxLength": 256,
+                "minLength": 1,
+                "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                "type": "string"
+              },
+              "maxItems": 16,
+              "minItems": 1,
+              "type": "array",
+              "x-kubernetes-validations": [
+                {
+                  "message": "responseHeadersToCopy must not contain duplicates",
+                  "rule": "self.all(h, self.exists_one(h2, h2 == h))"
+                }
+              ]
+            }
+          },
+          "type": "object",
           "additionalProperties": false
         },
         "jwtAuth": {
@@ -1308,7 +1566,7 @@
           "additionalProperties": false
         },
         "retry": {
-          "description": "Retry defines the policy for retrying requests.\nIt is applicable to HTTPRoutes, Gateway listeners and ListenerSets, and ignored for other targeted kinds.",
+          "description": "Retry defines the policy for retrying requests.\nIt is applicable to HTTPRoutes, GRPCRoutes, Gateways, Gateway listeners, and\nListenerSets, and ignored for other targeted kinds.\nWhen attached above the route level, the retry policy applies to all routes it\ncovers; a route-level retry policy (from a more specific TrafficPolicy or the\nbuilt-in HTTPRoute retry) takes precedence.",
           "properties": {
             "attempts": {
               "default": 1,
@@ -1333,7 +1591,7 @@
               ]
             },
             "perTryTimeout": {
-              "description": "PerTryTimeout specifies the timeout per retry attempt (incliding the initial attempt).\nIf a global timeout is configured on a route, this timeout must be less than the global\nroute timeout.\nIt is specified as a sequence of decimal numbers, each with optional fraction and a unit suffix, such as \"1s\" or \"500ms\".",
+              "description": "PerTryTimeout specifies the timeout per retry attempt (including the initial attempt).\nIf a global timeout is configured on a route, this timeout must be less than the global\nroute timeout.\nIt is specified as a sequence of decimal numbers, each with optional fraction and a unit suffix, such as \"1s\" or \"500ms\".",
               "type": "string",
               "x-kubernetes-validations": [
                 {
@@ -1392,6 +1650,13 @@
             }
           ],
           "additionalProperties": false
+        },
+        "statPrefix": {
+          "description": "StatPrefix sets a custom prefix on the Envoy route so that per-route\nstatistics are emitted for the targeted routes. When set, Envoy emits stats under\n`vhost.<vhost>.route.<statPrefix>.*`.\n\nThe value is composed of stat-safe literal characters (letters, digits,\nand `_ % . -`) and/or `{{ \"{{ ... }}\" }}` template tokens that are substituted at\ntranslation time with metadata from the route the policy is applied to.\nThe supported template variables are:\n  - `{{ \"{{route_name}}\" }}`: the name of the route resource (e.g. HTTPRoute).\n  - `{{ \"{{route_namespace}}\" }}`: the namespace of the route resource.\n  - `{{ \"{{rule_name}}\" }}`: the name of the matched route rule, or empty if the\n    rule is unnamed.\n\nFor example, `{{ \"{{route_namespace}}\" }}.{{ \"{{route_name}}\" }}` renders to\n`my-ns.my-route`. Whitespace is permitted only inside the braces of a\ntemplate token; unmatched braces, unsupported variable names, and any\nother characters are rejected.\n\nRecommended value: `{{ \"{{route_namespace}}\" }}.{{ \"{{route_name}}\" }}.{{ \"{{rule_name}}\" }}`,\nwhich uniquely identifies each route rule.\n\nNOTE: This field is only honored for HTTPRoute and GRPCRoute targets.",
+          "maxLength": 256,
+          "minLength": 1,
+          "pattern": "^([a-zA-Z0-9_%.-]|\\{\\{\\s*(route_name|route_namespace|rule_name)\\s*\\}\\})+$",
+          "type": "string"
         },
         "targetRefs": {
           "description": "TargetRefs specifies the target resources by reference to attach the policy to.",
@@ -1493,7 +1758,7 @@
           ]
         },
         "timeouts": {
-          "description": "Timeouts defines the timeouts for requests\nIt is applicable to HTTPRoutes and ignored for other targeted kinds.",
+          "description": "Timeouts defines the timeouts for requests.\nIt is applicable to HTTPRoutes, GRPCRoutes, and Gateways (including individual\nGateway listeners via sectionName), and ignored for other targeted kinds.\nWhen attached above the route level, the timeouts apply to all routes it\ncovers; a route-level timeout (from a more specific TrafficPolicy or the\nbuilt-in HTTPRoute timeouts) takes precedence.",
           "properties": {
             "request": {
               "description": "Request specifies a timeout for an individual request from the gateway to a backend.\nThis spans between the point at which the entire downstream request (i.e. end-of-stream) has been\nprocessed and when the backend response has been completely processed.\nA value of 0 effectively disables the timeout.\nIt is specified as a sequence of decimal numbers, each with optional fraction and a unit suffix, such as \"1s\" or \"500ms\".",
@@ -2008,23 +2273,23 @@
       "x-kubernetes-validations": [
         {
           "message": "autoHostRewrite can only be used when targeting HTTPRoute resources",
-          "rule": "!has(self.autoHostRewrite) || ((has(self.targetRefs) && self.targetRefs.all(r, r.kind == 'HTTPRoute')) || (has(self.targetSelectors) && self.targetSelectors.all(r, r.kind == 'HTTPRoute')))"
+          "rule": "!has(self.autoHostRewrite) || ((!has(self.targetRefs) || self.targetRefs.all(r, r.kind == 'HTTPRoute')) && (!has(self.targetSelectors) || self.targetSelectors.all(r, r.kind == 'HTTPRoute')))"
+        },
+        {
+          "message": "urlRewrite can only be used when targeting HTTPRoute resources",
+          "rule": "!has(self.urlRewrite) || ((!has(self.targetRefs) || self.targetRefs.all(r, r.kind == 'HTTPRoute')) && (!has(self.targetSelectors) || self.targetSelectors.all(r, r.kind == 'HTTPRoute')))"
         },
         {
           "message": "tracing can only be used when targeting HTTPRoute or GRPCRoute resources",
-          "rule": "!has(self.tracing) || ((has(self.targetRefs) && self.targetRefs.all(r, r.kind == 'HTTPRoute' || r.kind == 'GRPCRoute')) || (has(self.targetSelectors) && self.targetSelectors.all(r, r.kind == 'HTTPRoute' || r.kind == 'GRPCRoute')))"
+          "rule": "!has(self.tracing) || ((!has(self.targetRefs) || self.targetRefs.all(r, r.kind == 'HTTPRoute' || r.kind == 'GRPCRoute')) && (!has(self.targetSelectors) || self.targetSelectors.all(r, r.kind == 'HTTPRoute' || r.kind == 'GRPCRoute')))"
+        },
+        {
+          "message": "statPrefix can only be used when targeting HTTPRoute or GRPCRoute resources",
+          "rule": "!has(self.statPrefix) || ((!has(self.targetRefs) || self.targetRefs.all(r, r.kind == 'HTTPRoute' || r.kind == 'GRPCRoute')) && (!has(self.targetSelectors) || self.targetSelectors.all(r, r.kind == 'HTTPRoute' || r.kind == 'GRPCRoute')))"
         },
         {
           "message": "retry.perTryTimeout must be less than timeouts.request",
           "rule": "has(self.retry) && has(self.timeouts) ? (has(self.retry.perTryTimeout) && has(self.timeouts.request) ? duration(self.retry.perTryTimeout) < duration(self.timeouts.request) : true) : true"
-        },
-        {
-          "message": "targetRefs[].sectionName must be set when targeting Gateway resources with retry policy",
-          "rule": "has(self.retry) && has(self.targetRefs) ? self.targetRefs.all(r, (r.kind == 'Gateway' ? has(r.sectionName) : true )) : true"
-        },
-        {
-          "message": "targetSelectors[].sectionName must be set when targeting Gateway resources with retry policy",
-          "rule": "has(self.retry) && has(self.targetSelectors) ? self.targetSelectors.all(r, (r.kind == 'Gateway' ? has(r.sectionName) : true )) : true"
         }
       ],
       "additionalProperties": false


### PR DESCRIPTION
Regenerates the `gateway.kgateway.dev` schemas from **kgateway-crds v2.4.2** (released 2026-08-03).

### Why

The schemas currently in the catalog were generated from **v2.3.5**. kgateway v2.4.0 added fields that the v2.3.5 schema does not know about, and since the generated schemas set `additionalProperties: false`, the stale schema *rejects* those fields rather than ignoring them — so `kubeconform` fails on manifests the live API server accepts.

Concrete example, `TrafficPolicy`:

```
at '/spec/compression/responseCompression': additional properties 'libraries' not allowed
```

`spec.compression.responseCompression.libraries`, `spec.internalRedirect` and `spec.statPrefix` all landed in v2.4.0.

### How it was generated

Using the tool the README specifies, against the CRD chart published for the release:

```bash
helm pull oci://cr.kgateway.dev/kgateway-dev/charts/kgateway-crds --version v2.4.2 --untar
python3 openapi2jsonschema.py kgateway-crds/templates/gateway.kgateway.dev_*.yaml
```

### Verification

- Running the same pipeline against **v2.3.5** reproduces the eight schemas currently on `main` **byte-for-byte**, which confirms the generation path and conventions match how these files were originally produced.
- The diff is **purely additive**: 433 property paths added, **0 removed**, across the 7 changed files. No manifest that validates against the current schemas can regress.
- `directresponse_v1alpha1.json` is unchanged between v2.3.5 and v2.4.2 and is therefore not included.

### Changed

| Schema | |
|---|---|
| `backend_v1alpha1.json` | +14 paths |
| `backendconfigpolicy_v1alpha1.json` | +11 |
| `gatewayextension_v1alpha1.json` | +21 |
| `gatewayparameters_v1alpha1.json` | +1 |
| `httplistenerpolicy_v1alpha1.json` | +120 |
| `listenerpolicy_v1alpha1.json` | +242 |
| `trafficpolicy_v1alpha1.json` | +24 |