### PR TITLE
feat(alb.networking.azure.io): add Application Gateway for Containers CRDs

### DIFF
--- a/alb.networking.azure.io/applicationloadbalancer_v1.json
+++ b/alb.networking.azure.io/applicationloadbalancer_v1.json
@@ -1,0 +1,119 @@
+{
+  "description": "ApplicationLoadBalancer is the schema for the Application Gateway for Containers resource.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "Spec is the specifications for Application Gateway for Containers resource.",
+      "properties": {
+        "associations": {
+          "description": "Associations are subnet resource IDs the Application Gateway for Containers resource are associated with.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "default": {
+        "conditions": [
+          {
+            "lastTransitionTime": "1970-01-01T00:00:00Z",
+            "message": "Waiting for controller",
+            "reason": "Pending",
+            "status": "Unknown",
+            "type": "Accepted"
+          }
+        ]
+      },
+      "description": "Status defines the current state of Application Gateway for Containers resource.",
+      "properties": {
+        "conditions": {
+          "default": [
+            {
+              "lastTransitionTime": "1970-01-01T00:00:00Z",
+              "message": "Waiting for controller",
+              "reason": "Pending",
+              "status": "Unknown",
+              "type": "Accepted"
+            }
+          ],
+          "description": "Known condition types are:\n\n* \"Accepted\"\n* \"Ready\"",
+          "items": {
+            "description": "Condition contains details for one aspect of the current state of this API Resource.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "lastTransitionTime is the last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "message is a human readable message indicating details about the transition.\nThis may be an empty string.",
+                "maxLength": 32768,
+                "type": "string"
+              },
+              "observedGeneration": {
+                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon.\nFor instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date\nwith respect to the current state of the instance.",
+                "format": "int64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "reason": {
+                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition.\nProducers of specific condition types may define expected values and meanings for this field,\nand whether the values are considered a guaranteed API.\nThe value should be a CamelCase string.\nThis field may not be empty.",
+                "maxLength": 1024,
+                "minLength": 1,
+                "pattern": "^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$",
+                "type": "string"
+              },
+              "status": {
+                "description": "status of the condition, one of True, False, Unknown.",
+                "enum": [
+                  "True",
+                  "False",
+                  "Unknown"
+                ],
+                "type": "string"
+              },
+              "type": {
+                "description": "type of condition in CamelCase or in foo.example.com/CamelCase.",
+                "maxLength": 316,
+                "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$",
+                "type": "string"
+              }
+            },
+            "required": [
+              "lastTransitionTime",
+              "message",
+              "reason",
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "maxItems": 8,
+          "type": "array",
+          "x-kubernetes-list-map-keys": [
+            "type"
+          ],
+          "x-kubernetes-list-type": "map"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/alb.networking.azure.io/backendloadbalancingpolicy_v1.json
+++ b/alb.networking.azure.io/backendloadbalancingpolicy_v1.json
@@ -1,0 +1,319 @@
+{
+  "description": "BackendLoadBalancingPolicy represents the configuration for backend load balancing.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "Spec is the BackendLoadBalancingPolicy specification.",
+      "properties": {
+        "circuitBreaker": {
+          "description": "CircuitBreaker defines the schema for configuring Circuit Breaking",
+          "properties": {
+            "maxConnections": {
+              "default": 1000000000,
+              "description": "The maximum number of connections that will be made to the backend service.\nDefault is 1000000000 (disabled).",
+              "format": "int32",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "maxPendingRequests": {
+              "default": 1000000000,
+              "description": "Maximum number of pending requests that will be made to the backend service.\nDefault is 1000000000 (disabled).",
+              "format": "int32",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "maxRequests": {
+              "default": 1000000000,
+              "description": "Maximum number of parallel requests that will be made to the backend service.\nDefault is 1000000000 (disabled).",
+              "format": "int32",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "maxRetries": {
+              "default": 1000000000,
+              "description": "The maximum number of parallel retries allowed to the backend service.\nDefault is 1000000000 (disabled).",
+              "format": "int32",
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "loadBalancing": {
+          "description": "LoadBalancing defines the schema for configuring Load Balancing options",
+          "properties": {
+            "slowStart": {
+              "description": "SlowStart defines the schema for Slow Start specification",
+              "properties": {
+                "aggression": {
+                  "default": "1.0",
+                  "description": "The speed of traffic increase over the slow start window, must be greater than 0.0.\nDefaults to 1.0 if unspecified.",
+                  "pattern": "^([0-9]+([.][0-9]+)?|[.][0-9]+)$",
+                  "type": "string"
+                },
+                "startWeightPercent": {
+                  "default": 10,
+                  "description": "The minimum or starting percentage of traffic to send to new endpoints.\nDefaults to 10% if unspecified.",
+                  "format": "int32",
+                  "maximum": 100,
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "window": {
+                  "description": "The duration of the slow start window.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "window"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "strategy": {
+              "description": "Strategy defines the policy to use when load balancing traffic to the backend service.\nDefault is round-robin.",
+              "enum": [
+                "round-robin",
+                "least-request"
+              ],
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "targetRefs": {
+          "description": "TargetRefs identifies a list of API objects to apply policy to.",
+          "items": {
+            "description": "TargetRefSpec defines the target reference and ports for the backend load balancing policy.",
+            "properties": {
+              "ports": {
+                "description": "Ports specifies the list of ports on the target where the policy is applied.",
+                "items": {
+                  "description": "BackendLoadBalancingPolicyPort defines the port configuration for the backend load balancing policy.",
+                  "properties": {
+                    "port": {
+                      "description": "Port is the port to use for connection to the backend",
+                      "format": "int32",
+                      "minimum": 1,
+                      "type": "integer"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "array"
+              },
+              "targetRef": {
+                "description": "TargetRef identifies an API object to apply policy to.",
+                "properties": {
+                  "group": {
+                    "description": "Group is the group of the target resource.",
+                    "maxLength": 253,
+                    "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                    "type": "string"
+                  },
+                  "kind": {
+                    "description": "Kind is kind of the target resource.",
+                    "maxLength": 63,
+                    "minLength": 1,
+                    "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
+                    "type": "string"
+                  },
+                  "name": {
+                    "description": "Name is the name of the target resource.",
+                    "maxLength": 253,
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "namespace": {
+                    "description": "Namespace is the namespace of the referent. When unspecified, the local\nnamespace is inferred. Even when policy targets a resource in a different\nnamespace, it MUST only apply to traffic originating from the same\nnamespace as the policy.",
+                    "maxLength": 63,
+                    "minLength": 1,
+                    "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                    "type": "string"
+                  },
+                  "sectionNames": {
+                    "description": "SectionNames is the name of the section within the target resource. When\nunspecified, this targetRef targets the entire resource. In the following\nresources, SectionNames is interpreted as the following:\n\n* Gateway: Listener Name\n* Service: Port Name\n\nIf a SectionNames is specified, but doesn't exist on the targeted object,\nthe Policy fails to attach, and the policy implementation will record\na `ResolvedRefs` or similar Condition in the Policy's status.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "group",
+                  "kind",
+                  "name"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              }
+            },
+            "required": [
+              "targetRef"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "targetRefs"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "Status defines the current state of BackendLoadBalancingPolicy.",
+      "properties": {
+        "targets": {
+          "items": {
+            "description": "BackendLoadBalancingPolicyTargetStatus defines the observed status for a target ref",
+            "properties": {
+              "conditions": {
+                "default": [
+                  {
+                    "lastTransitionTime": "1970-01-01T00:00:00Z",
+                    "message": "Waiting for controller",
+                    "reason": "Pending",
+                    "status": "Unknown",
+                    "type": "Accepted"
+                  }
+                ],
+                "items": {
+                  "description": "Condition contains details for one aspect of the current state of this API Resource.",
+                  "properties": {
+                    "lastTransitionTime": {
+                      "description": "lastTransitionTime is the last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
+                      "format": "date-time",
+                      "type": "string"
+                    },
+                    "message": {
+                      "description": "message is a human readable message indicating details about the transition.\nThis may be an empty string.",
+                      "maxLength": 32768,
+                      "type": "string"
+                    },
+                    "observedGeneration": {
+                      "description": "observedGeneration represents the .metadata.generation that the condition was set based upon.\nFor instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date\nwith respect to the current state of the instance.",
+                      "format": "int64",
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "reason": {
+                      "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition.\nProducers of specific condition types may define expected values and meanings for this field,\nand whether the values are considered a guaranteed API.\nThe value should be a CamelCase string.\nThis field may not be empty.",
+                      "maxLength": 1024,
+                      "minLength": 1,
+                      "pattern": "^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$",
+                      "type": "string"
+                    },
+                    "status": {
+                      "description": "status of the condition, one of True, False, Unknown.",
+                      "enum": [
+                        "True",
+                        "False",
+                        "Unknown"
+                      ],
+                      "type": "string"
+                    },
+                    "type": {
+                      "description": "type of condition in CamelCase or in foo.example.com/CamelCase.",
+                      "maxLength": 316,
+                      "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "lastTransitionTime",
+                    "message",
+                    "reason",
+                    "status",
+                    "type"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "maxItems": 8,
+                "minItems": 1,
+                "type": "array",
+                "x-kubernetes-list-map-keys": [
+                  "type"
+                ],
+                "x-kubernetes-list-type": "map"
+              },
+              "targetRef": {
+                "description": "CustomTargetRef is a reference to a custom resource that isn't part of the\nKubernetes core API.",
+                "properties": {
+                  "group": {
+                    "description": "Group is the group of the target resource.",
+                    "maxLength": 253,
+                    "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                    "type": "string"
+                  },
+                  "kind": {
+                    "description": "Kind is kind of the target resource.",
+                    "maxLength": 63,
+                    "minLength": 1,
+                    "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
+                    "type": "string"
+                  },
+                  "name": {
+                    "description": "Name is the name of the target resource.",
+                    "maxLength": 253,
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "namespace": {
+                    "description": "Namespace is the namespace of the referent. When unspecified, the local\nnamespace is inferred. Even when policy targets a resource in a different\nnamespace, it MUST only apply to traffic originating from the same\nnamespace as the policy.",
+                    "maxLength": 63,
+                    "minLength": 1,
+                    "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                    "type": "string"
+                  },
+                  "sectionNames": {
+                    "description": "SectionNames is the name of the section within the target resource. When\nunspecified, this targetRef targets the entire resource. In the following\nresources, SectionNames is interpreted as the following:\n\n* Gateway: Listener Name\n* Service: Port Name\n\nIf a SectionNames is specified, but doesn't exist on the targeted object,\nthe Policy fails to attach, and the policy implementation will record\na `ResolvedRefs` or similar Condition in the Policy's status.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "group",
+                  "kind",
+                  "name"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              }
+            },
+            "required": [
+              "targetRef"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "targets"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/alb.networking.azure.io/backendtlspolicy_v1.json
+++ b/alb.networking.azure.io/backendtlspolicy_v1.json
@@ -1,0 +1,394 @@
+{
+  "description": "BackendTLSPolicy is the schema for the BackendTLSPolicys API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "Spec is the BackendTLSPolicy specification.",
+      "properties": {
+        "default": {
+          "description": "Default defines default policy configuration for the targeted resource.",
+          "properties": {
+            "clientCertificateRef": {
+              "description": "ClientCertificateRef is the reference to the client certificate to\nuse for the TLS connection to the backend.",
+              "properties": {
+                "group": {
+                  "default": "",
+                  "description": "Group is the group of the referent. For example, \"gateway.networking.k8s.io\".\nWhen unspecified or empty string, core API group is inferred.",
+                  "maxLength": 253,
+                  "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                  "type": "string"
+                },
+                "kind": {
+                  "default": "Secret",
+                  "description": "Kind is kind of the referent. For example \"Secret\".",
+                  "maxLength": 63,
+                  "minLength": 1,
+                  "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
+                  "type": "string"
+                },
+                "name": {
+                  "description": "Name is the name of the referent.",
+                  "maxLength": 253,
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "namespace": {
+                  "description": "Namespace is the namespace of the referenced object. When unspecified, the local\nnamespace is inferred.\n\nNote that when a namespace different than the local namespace is specified,\na ReferenceGrant object is required in the referent namespace to allow that\nnamespace's owner to accept the reference. See the ReferenceGrant\ndocumentation for details.\n\nSupport: Core",
+                  "maxLength": 63,
+                  "minLength": 1,
+                  "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "name"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "ports": {
+              "description": "Ports specifies the list of ports where the policy is applied.",
+              "items": {
+                "description": "BackendTLSPolicyPort defines the port to use for the TLS connection to the backend",
+                "properties": {
+                  "port": {
+                    "description": "Port is the port to use for the TLS connection to the backend",
+                    "minimum": 1,
+                    "type": "integer"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "sni": {
+              "description": "Sni is the server name to use for the TLS connection to the backend.",
+              "type": "string"
+            },
+            "verify": {
+              "description": "Verify provides the options to verify the peer certificate.",
+              "properties": {
+                "caCertificateRef": {
+                  "description": "CaCertificateRef is the CA certificate used to verify peer certificate.",
+                  "properties": {
+                    "group": {
+                      "default": "",
+                      "description": "Group is the group of the referent. For example, \"gateway.networking.k8s.io\".\nWhen unspecified or empty string, core API group is inferred.",
+                      "maxLength": 253,
+                      "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                      "type": "string"
+                    },
+                    "kind": {
+                      "default": "Secret",
+                      "description": "Kind is kind of the referent. For example \"Secret\".",
+                      "maxLength": 63,
+                      "minLength": 1,
+                      "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
+                      "type": "string"
+                    },
+                    "name": {
+                      "description": "Name is the name of the referent.",
+                      "maxLength": 253,
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "namespace": {
+                      "description": "Namespace is the namespace of the referenced object. When unspecified, the local\nnamespace is inferred.\n\nNote that when a namespace different than the local namespace is specified,\na ReferenceGrant object is required in the referent namespace to allow that\nnamespace's owner to accept the reference. See the ReferenceGrant\ndocumentation for details.\n\nSupport: Core",
+                      "maxLength": 63,
+                      "minLength": 1,
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "name"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "subjectAltName": {
+                  "description": "SubjectAltName is the subject alternative name used to verify peer\ncertificate.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "caCertificateRef"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "override": {
+          "description": "Override defines policy configuration that should override policy\nconfiguration attached below the targeted resource in the hierarchy.\n\nNote: Override is currently not supported and result in a validation error.\nSupport for Override will be added in a future release.",
+          "properties": {
+            "clientCertificateRef": {
+              "description": "ClientCertificateRef is the reference to the client certificate to\nuse for the TLS connection to the backend.",
+              "properties": {
+                "group": {
+                  "default": "",
+                  "description": "Group is the group of the referent. For example, \"gateway.networking.k8s.io\".\nWhen unspecified or empty string, core API group is inferred.",
+                  "maxLength": 253,
+                  "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                  "type": "string"
+                },
+                "kind": {
+                  "default": "Secret",
+                  "description": "Kind is kind of the referent. For example \"Secret\".",
+                  "maxLength": 63,
+                  "minLength": 1,
+                  "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
+                  "type": "string"
+                },
+                "name": {
+                  "description": "Name is the name of the referent.",
+                  "maxLength": 253,
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "namespace": {
+                  "description": "Namespace is the namespace of the referenced object. When unspecified, the local\nnamespace is inferred.\n\nNote that when a namespace different than the local namespace is specified,\na ReferenceGrant object is required in the referent namespace to allow that\nnamespace's owner to accept the reference. See the ReferenceGrant\ndocumentation for details.\n\nSupport: Core",
+                  "maxLength": 63,
+                  "minLength": 1,
+                  "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "name"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "ports": {
+              "description": "Ports specifies the list of ports where the policy is applied.",
+              "items": {
+                "description": "BackendTLSPolicyPort defines the port to use for the TLS connection to the backend",
+                "properties": {
+                  "port": {
+                    "description": "Port is the port to use for the TLS connection to the backend",
+                    "minimum": 1,
+                    "type": "integer"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "sni": {
+              "description": "Sni is the server name to use for the TLS connection to the backend.",
+              "type": "string"
+            },
+            "verify": {
+              "description": "Verify provides the options to verify the peer certificate.",
+              "properties": {
+                "caCertificateRef": {
+                  "description": "CaCertificateRef is the CA certificate used to verify peer certificate.",
+                  "properties": {
+                    "group": {
+                      "default": "",
+                      "description": "Group is the group of the referent. For example, \"gateway.networking.k8s.io\".\nWhen unspecified or empty string, core API group is inferred.",
+                      "maxLength": 253,
+                      "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                      "type": "string"
+                    },
+                    "kind": {
+                      "default": "Secret",
+                      "description": "Kind is kind of the referent. For example \"Secret\".",
+                      "maxLength": 63,
+                      "minLength": 1,
+                      "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
+                      "type": "string"
+                    },
+                    "name": {
+                      "description": "Name is the name of the referent.",
+                      "maxLength": 253,
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "namespace": {
+                      "description": "Namespace is the namespace of the referenced object. When unspecified, the local\nnamespace is inferred.\n\nNote that when a namespace different than the local namespace is specified,\na ReferenceGrant object is required in the referent namespace to allow that\nnamespace's owner to accept the reference. See the ReferenceGrant\ndocumentation for details.\n\nSupport: Core",
+                      "maxLength": 63,
+                      "minLength": 1,
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "name"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "subjectAltName": {
+                  "description": "SubjectAltName is the subject alternative name used to verify peer\ncertificate.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "caCertificateRef"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "targetRef": {
+          "description": "TargetRef identifies an API object to apply policy to.",
+          "properties": {
+            "group": {
+              "description": "Group is the group of the target resource.",
+              "maxLength": 253,
+              "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+              "type": "string"
+            },
+            "kind": {
+              "description": "Kind is kind of the target resource.",
+              "maxLength": 63,
+              "minLength": 1,
+              "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
+              "type": "string"
+            },
+            "name": {
+              "description": "Name is the name of the target resource.",
+              "maxLength": 253,
+              "minLength": 1,
+              "type": "string"
+            },
+            "namespace": {
+              "description": "Namespace is the namespace of the referent. When unspecified, the local\nnamespace is inferred. Even when policy targets a resource in a different\nnamespace, it MUST only apply to traffic originating from the same\nnamespace as the policy.",
+              "maxLength": 63,
+              "minLength": 1,
+              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "type": "string"
+            },
+            "sectionNames": {
+              "description": "SectionNames is the name of the section within the target resource. When\nunspecified, this targetRef targets the entire resource. In the following\nresources, SectionNames is interpreted as the following:\n\n* Gateway: Listener Name\n* Service: Port Name\n\nIf a SectionNames is specified, but doesn't exist on the targeted object,\nthe Policy fails to attach, and the policy implementation will record\na `ResolvedRefs` or similar Condition in the Policy's status.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "group",
+            "kind",
+            "name"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "targetRef"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "default": {
+        "conditions": [
+          {
+            "lastTransitionTime": "1970-01-01T00:00:00Z",
+            "message": "Waiting for controller",
+            "reason": "Pending",
+            "status": "Unknown",
+            "type": "Accepted"
+          }
+        ]
+      },
+      "description": "Status defines the current state of BackendTLSPolicy.",
+      "properties": {
+        "conditions": {
+          "default": [
+            {
+              "lastTransitionTime": "1970-01-01T00:00:00Z",
+              "message": "Waiting for controller",
+              "reason": "Pending",
+              "status": "Unknown",
+              "type": "Accepted"
+            }
+          ],
+          "description": "Conditions describe the current conditions of the BackendTLSPolicy.\n\nImplementations should prefer to express BackendTLSPolicy conditions\nusing the `BackendTLSPolicyConditionType` and `BackendTLSPolicyConditionReason`\nconstants so that operators and tools can converge on a common\nvocabulary to describe BackendTLSPolicy state.\n\nKnown condition types are:\n\n* \"Accepted\"\n* \"ResolvedRefs\"",
+          "items": {
+            "description": "Condition contains details for one aspect of the current state of this API Resource.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "lastTransitionTime is the last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "message is a human readable message indicating details about the transition.\nThis may be an empty string.",
+                "maxLength": 32768,
+                "type": "string"
+              },
+              "observedGeneration": {
+                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon.\nFor instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date\nwith respect to the current state of the instance.",
+                "format": "int64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "reason": {
+                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition.\nProducers of specific condition types may define expected values and meanings for this field,\nand whether the values are considered a guaranteed API.\nThe value should be a CamelCase string.\nThis field may not be empty.",
+                "maxLength": 1024,
+                "minLength": 1,
+                "pattern": "^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$",
+                "type": "string"
+              },
+              "status": {
+                "description": "status of the condition, one of True, False, Unknown.",
+                "enum": [
+                  "True",
+                  "False",
+                  "Unknown"
+                ],
+                "type": "string"
+              },
+              "type": {
+                "description": "type of condition in CamelCase or in foo.example.com/CamelCase.",
+                "maxLength": 316,
+                "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$",
+                "type": "string"
+              }
+            },
+            "required": [
+              "lastTransitionTime",
+              "message",
+              "reason",
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "maxItems": 8,
+          "type": "array",
+          "x-kubernetes-list-map-keys": [
+            "type"
+          ],
+          "x-kubernetes-list-type": "map"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/alb.networking.azure.io/frontendtlspolicy_v1.json
+++ b/alb.networking.azure.io/frontendtlspolicy_v1.json
@@ -1,0 +1,330 @@
+{
+  "description": "FrontendTLSPolicy is the schema for the FrontendTLSPolicy API",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "Spec is the FrontendTLSPolicy specification.",
+      "properties": {
+        "default": {
+          "description": "Default defines default policy configuration for the targeted resource.",
+          "properties": {
+            "policyType": {
+              "default": {
+                "name": "2023-06",
+                "type": "predefined"
+              },
+              "description": "Type is the type of the policy.",
+              "properties": {
+                "name": {
+                  "description": "Name is the name of the policy.",
+                  "type": "string"
+                },
+                "type": {
+                  "description": "PredefinedFrontendTLSPolicyType is the type of the predefined Frontend TLS Policy.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "name",
+                "type"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "verify": {
+              "description": "Verify provides the options to verify the peer certificate.",
+              "properties": {
+                "caCertificateRef": {
+                  "description": "CaCertificateRef is the CA certificate used to verify peer certificate.",
+                  "properties": {
+                    "group": {
+                      "default": "",
+                      "description": "Group is the group of the referent. For example, \"gateway.networking.k8s.io\".\nWhen unspecified or empty string, core API group is inferred.",
+                      "maxLength": 253,
+                      "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                      "type": "string"
+                    },
+                    "kind": {
+                      "default": "Secret",
+                      "description": "Kind is kind of the referent. For example \"Secret\".",
+                      "maxLength": 63,
+                      "minLength": 1,
+                      "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
+                      "type": "string"
+                    },
+                    "name": {
+                      "description": "Name is the name of the referent.",
+                      "maxLength": 253,
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "namespace": {
+                      "description": "Namespace is the namespace of the referenced object. When unspecified, the local\nnamespace is inferred.\n\nNote that when a namespace different than the local namespace is specified,\na ReferenceGrant object is required in the referent namespace to allow that\nnamespace's owner to accept the reference. See the ReferenceGrant\ndocumentation for details.\n\nSupport: Core",
+                      "maxLength": 63,
+                      "minLength": 1,
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "name"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "subjectAltNames": {
+                  "description": "SubjectAltNames is the list of subject alternative names used to verify peer\ncertificate.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                }
+              },
+              "required": [
+                "caCertificateRef"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "override": {
+          "description": "Override defines policy configuration that should override policy\nconfiguration attached below the targeted resource in the hierarchy.\n\nNote: Override is currently not supported and result in a validation error.\nSupport for Override will be added in a future release.",
+          "properties": {
+            "policyType": {
+              "default": {
+                "name": "2023-06",
+                "type": "predefined"
+              },
+              "description": "Type is the type of the policy.",
+              "properties": {
+                "name": {
+                  "description": "Name is the name of the policy.",
+                  "type": "string"
+                },
+                "type": {
+                  "description": "PredefinedFrontendTLSPolicyType is the type of the predefined Frontend TLS Policy.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "name",
+                "type"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "verify": {
+              "description": "Verify provides the options to verify the peer certificate.",
+              "properties": {
+                "caCertificateRef": {
+                  "description": "CaCertificateRef is the CA certificate used to verify peer certificate.",
+                  "properties": {
+                    "group": {
+                      "default": "",
+                      "description": "Group is the group of the referent. For example, \"gateway.networking.k8s.io\".\nWhen unspecified or empty string, core API group is inferred.",
+                      "maxLength": 253,
+                      "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                      "type": "string"
+                    },
+                    "kind": {
+                      "default": "Secret",
+                      "description": "Kind is kind of the referent. For example \"Secret\".",
+                      "maxLength": 63,
+                      "minLength": 1,
+                      "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
+                      "type": "string"
+                    },
+                    "name": {
+                      "description": "Name is the name of the referent.",
+                      "maxLength": 253,
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "namespace": {
+                      "description": "Namespace is the namespace of the referenced object. When unspecified, the local\nnamespace is inferred.\n\nNote that when a namespace different than the local namespace is specified,\na ReferenceGrant object is required in the referent namespace to allow that\nnamespace's owner to accept the reference. See the ReferenceGrant\ndocumentation for details.\n\nSupport: Core",
+                      "maxLength": 63,
+                      "minLength": 1,
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "name"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "subjectAltNames": {
+                  "description": "SubjectAltNames is the list of subject alternative names used to verify peer\ncertificate.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                }
+              },
+              "required": [
+                "caCertificateRef"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "targetRef": {
+          "description": "TargetRef identifies an API object to apply policy to.",
+          "properties": {
+            "group": {
+              "description": "Group is the group of the target resource.",
+              "maxLength": 253,
+              "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+              "type": "string"
+            },
+            "kind": {
+              "description": "Kind is kind of the target resource.",
+              "maxLength": 63,
+              "minLength": 1,
+              "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
+              "type": "string"
+            },
+            "name": {
+              "description": "Name is the name of the target resource.",
+              "maxLength": 253,
+              "minLength": 1,
+              "type": "string"
+            },
+            "namespace": {
+              "description": "Namespace is the namespace of the referent. When unspecified, the local\nnamespace is inferred. Even when policy targets a resource in a different\nnamespace, it MUST only apply to traffic originating from the same\nnamespace as the policy.",
+              "maxLength": 63,
+              "minLength": 1,
+              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "type": "string"
+            },
+            "sectionNames": {
+              "description": "SectionNames is the name of the section within the target resource. When\nunspecified, this targetRef targets the entire resource. In the following\nresources, SectionNames is interpreted as the following:\n\n* Gateway: Listener Name\n* Service: Port Name\n\nIf a SectionNames is specified, but doesn't exist on the targeted object,\nthe Policy fails to attach, and the policy implementation will record\na `ResolvedRefs` or similar Condition in the Policy's status.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "group",
+            "kind",
+            "name"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "targetRef"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "default": {
+        "conditions": [
+          {
+            "lastTransitionTime": "1970-01-01T00:00:00Z",
+            "message": "Waiting for controller",
+            "reason": "Pending",
+            "status": "Unknown",
+            "type": "Accepted"
+          }
+        ]
+      },
+      "description": "Status defines the current state of FrontendTLSPolicy.",
+      "properties": {
+        "conditions": {
+          "default": [
+            {
+              "lastTransitionTime": "1970-01-01T00:00:00Z",
+              "message": "Waiting for controller",
+              "reason": "Pending",
+              "status": "Unknown",
+              "type": "Accepted"
+            }
+          ],
+          "description": "Conditions describe the current conditions of the FrontendTLSPolicy.\n\nImplementations should prefer to express FrontendTLSPolicy conditions\nusing the `FrontendTLSPolicyConditionType` and `FrontendTLSPolicyConditionReason`\nconstants so that operators and tools can converge on a common\nvocabulary to describe FrontendTLSPolicy state.\n\nKnown condition types are:\n\n* \"Accepted\"",
+          "items": {
+            "description": "Condition contains details for one aspect of the current state of this API Resource.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "lastTransitionTime is the last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "message is a human readable message indicating details about the transition.\nThis may be an empty string.",
+                "maxLength": 32768,
+                "type": "string"
+              },
+              "observedGeneration": {
+                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon.\nFor instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date\nwith respect to the current state of the instance.",
+                "format": "int64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "reason": {
+                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition.\nProducers of specific condition types may define expected values and meanings for this field,\nand whether the values are considered a guaranteed API.\nThe value should be a CamelCase string.\nThis field may not be empty.",
+                "maxLength": 1024,
+                "minLength": 1,
+                "pattern": "^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$",
+                "type": "string"
+              },
+              "status": {
+                "description": "status of the condition, one of True, False, Unknown.",
+                "enum": [
+                  "True",
+                  "False",
+                  "Unknown"
+                ],
+                "type": "string"
+              },
+              "type": {
+                "description": "type of condition in CamelCase or in foo.example.com/CamelCase.",
+                "maxLength": 316,
+                "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$",
+                "type": "string"
+              }
+            },
+            "required": [
+              "lastTransitionTime",
+              "message",
+              "reason",
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "maxItems": 8,
+          "type": "array",
+          "x-kubernetes-list-map-keys": [
+            "type"
+          ],
+          "x-kubernetes-list-type": "map"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/alb.networking.azure.io/healthcheckpolicy_v1.json
+++ b/alb.networking.azure.io/healthcheckpolicy_v1.json
@@ -1,0 +1,352 @@
+{
+  "description": "HealthCheckPolicy is the schema for the HealthCheckPolicy API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "Spec is the HealthCheckPolicy specification.",
+      "properties": {
+        "default": {
+          "description": "Default defines default policy configuration for the targeted resource.",
+          "properties": {
+            "grpc": {
+              "description": "GRPC configures a gRPC v1 HealthCheck (https://github.com/grpc/grpc-proto/blob/master/grpc/health/v1/health.proto)\nagainst the target resource.",
+              "properties": {
+                "authority": {
+                  "description": "Authority if present is used as the value of the Authority header in the health check.",
+                  "type": "string"
+                },
+                "service": {
+                  "description": "Service allows the configuration of a Health check registered under a different service name.",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "healthyThreshold": {
+              "description": "HealthyThreshold is the number of consecutive successful HealthCheck checks.",
+              "format": "int32",
+              "type": "integer"
+            },
+            "http": {
+              "description": "HTTP defines the HTTP constraint specification for the HealthCheck of a\ntarget resource.",
+              "properties": {
+                "host": {
+                  "description": "Host is the host header value to use for HealthCheck checks.",
+                  "type": "string"
+                },
+                "match": {
+                  "description": "Match defines the HTTP matchers to use for HealthCheck checks.",
+                  "properties": {
+                    "body": {
+                      "description": "Body defines the HTTP body matchers to use for HealthCheck checks.",
+                      "type": "string"
+                    },
+                    "statusCodes": {
+                      "description": "StatusCodes defines the HTTP status code matchers to use for HealthCheck checks.",
+                      "items": {
+                        "description": "StatusCodes defines the HTTP status code matchers to use for HealthCheck checks.",
+                        "properties": {
+                          "end": {
+                            "description": "End defines the end of the range of status codes to use for HealthCheck checks.\nThis is inclusive.",
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "start": {
+                            "description": "Start defines the start of the range of status codes to use for HealthCheck checks.\nThis is inclusive.",
+                            "format": "int32",
+                            "type": "integer"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "path": {
+                  "description": "Path is the path to use for HealthCheck checks.",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "interval": {
+              "description": "Interval is the number of seconds between HealthCheck checks.",
+              "type": "string"
+            },
+            "port": {
+              "description": "Port is the port to use for HealthCheck checks.",
+              "format": "int32",
+              "type": "integer"
+            },
+            "timeout": {
+              "description": "Timeout is the number of seconds after which the HealthCheck check is\nconsidered failed.",
+              "type": "string"
+            },
+            "unhealthyThreshold": {
+              "description": "UnhealthyThreshold is the number of consecutive failed HealthCheck checks.",
+              "format": "int32",
+              "type": "integer"
+            },
+            "useTLS": {
+              "description": "UseTLS indicates whether health check should enforce TLS.\nBy default, health check will use the same protocol as the\nservice if the same port is used for health check. If the port\nis different, health check will be plaintext.",
+              "type": "boolean"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "override": {
+          "description": "Override defines policy configuration that should override policy\nconfiguration attached below the targeted resource in the hierarchy.\n\nNote: Override is currently not supported and will result in a validation error.\nSupport for Override will be added in a future release.",
+          "properties": {
+            "grpc": {
+              "description": "GRPC configures a gRPC v1 HealthCheck (https://github.com/grpc/grpc-proto/blob/master/grpc/health/v1/health.proto)\nagainst the target resource.",
+              "properties": {
+                "authority": {
+                  "description": "Authority if present is used as the value of the Authority header in the health check.",
+                  "type": "string"
+                },
+                "service": {
+                  "description": "Service allows the configuration of a Health check registered under a different service name.",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "healthyThreshold": {
+              "description": "HealthyThreshold is the number of consecutive successful HealthCheck checks.",
+              "format": "int32",
+              "type": "integer"
+            },
+            "http": {
+              "description": "HTTP defines the HTTP constraint specification for the HealthCheck of a\ntarget resource.",
+              "properties": {
+                "host": {
+                  "description": "Host is the host header value to use for HealthCheck checks.",
+                  "type": "string"
+                },
+                "match": {
+                  "description": "Match defines the HTTP matchers to use for HealthCheck checks.",
+                  "properties": {
+                    "body": {
+                      "description": "Body defines the HTTP body matchers to use for HealthCheck checks.",
+                      "type": "string"
+                    },
+                    "statusCodes": {
+                      "description": "StatusCodes defines the HTTP status code matchers to use for HealthCheck checks.",
+                      "items": {
+                        "description": "StatusCodes defines the HTTP status code matchers to use for HealthCheck checks.",
+                        "properties": {
+                          "end": {
+                            "description": "End defines the end of the range of status codes to use for HealthCheck checks.\nThis is inclusive.",
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "start": {
+                            "description": "Start defines the start of the range of status codes to use for HealthCheck checks.\nThis is inclusive.",
+                            "format": "int32",
+                            "type": "integer"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "path": {
+                  "description": "Path is the path to use for HealthCheck checks.",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "interval": {
+              "description": "Interval is the number of seconds between HealthCheck checks.",
+              "type": "string"
+            },
+            "port": {
+              "description": "Port is the port to use for HealthCheck checks.",
+              "format": "int32",
+              "type": "integer"
+            },
+            "timeout": {
+              "description": "Timeout is the number of seconds after which the HealthCheck check is\nconsidered failed.",
+              "type": "string"
+            },
+            "unhealthyThreshold": {
+              "description": "UnhealthyThreshold is the number of consecutive failed HealthCheck checks.",
+              "format": "int32",
+              "type": "integer"
+            },
+            "useTLS": {
+              "description": "UseTLS indicates whether health check should enforce TLS.\nBy default, health check will use the same protocol as the\nservice if the same port is used for health check. If the port\nis different, health check will be plaintext.",
+              "type": "boolean"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "targetRef": {
+          "description": "TargetRef identifies an API object to apply policy to.",
+          "properties": {
+            "group": {
+              "description": "Group is the group of the target resource.",
+              "maxLength": 253,
+              "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+              "type": "string"
+            },
+            "kind": {
+              "description": "Kind is kind of the target resource.",
+              "maxLength": 63,
+              "minLength": 1,
+              "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
+              "type": "string"
+            },
+            "name": {
+              "description": "Name is the name of the target resource.",
+              "maxLength": 253,
+              "minLength": 1,
+              "type": "string"
+            },
+            "namespace": {
+              "description": "Namespace is the namespace of the referent. When unspecified, the local\nnamespace is inferred. Even when policy targets a resource in a different\nnamespace, it MUST only apply to traffic originating from the same\nnamespace as the policy.",
+              "maxLength": 63,
+              "minLength": 1,
+              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "type": "string"
+            },
+            "sectionNames": {
+              "description": "SectionNames is the name of the section within the target resource. When\nunspecified, this targetRef targets the entire resource. In the following\nresources, SectionNames is interpreted as the following:\n\n* Gateway: Listener Name\n* Service: Port Name\n\nIf a SectionNames is specified, but doesn't exist on the targeted object,\nthe Policy fails to attach, and the policy implementation will record\na `ResolvedRefs` or similar Condition in the Policy's status.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "group",
+            "kind",
+            "name"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "targetRef"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "default": {
+        "conditions": [
+          {
+            "lastTransitionTime": "1970-01-01T00:00:00Z",
+            "message": "Waiting for controller",
+            "reason": "Pending",
+            "status": "Unknown",
+            "type": "Accepted"
+          }
+        ]
+      },
+      "description": "Status defines the current state of HealthCheckPolicy.",
+      "properties": {
+        "conditions": {
+          "default": [
+            {
+              "lastTransitionTime": "1970-01-01T00:00:00Z",
+              "message": "Waiting for controller",
+              "reason": "Pending",
+              "status": "Unknown",
+              "type": "Accepted"
+            }
+          ],
+          "description": "Conditions describe the current conditions of the HealthCheckPolicy.\n\nImplementations should prefer to express HealthCheckPolicy conditions\nusing the `HealthCheckPolicyConditionType` and `HealthCheckPolicyConditionReason`\nconstants so that operators and tools can converge on a common\nvocabulary to describe HealthCheckPolicy state.\n\nKnown condition types are:\n\n* \"Accepted\"",
+          "items": {
+            "description": "Condition contains details for one aspect of the current state of this API Resource.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "lastTransitionTime is the last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "message is a human readable message indicating details about the transition.\nThis may be an empty string.",
+                "maxLength": 32768,
+                "type": "string"
+              },
+              "observedGeneration": {
+                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon.\nFor instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date\nwith respect to the current state of the instance.",
+                "format": "int64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "reason": {
+                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition.\nProducers of specific condition types may define expected values and meanings for this field,\nand whether the values are considered a guaranteed API.\nThe value should be a CamelCase string.\nThis field may not be empty.",
+                "maxLength": 1024,
+                "minLength": 1,
+                "pattern": "^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$",
+                "type": "string"
+              },
+              "status": {
+                "description": "status of the condition, one of True, False, Unknown.",
+                "enum": [
+                  "True",
+                  "False",
+                  "Unknown"
+                ],
+                "type": "string"
+              },
+              "type": {
+                "description": "type of condition in CamelCase or in foo.example.com/CamelCase.",
+                "maxLength": 316,
+                "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$",
+                "type": "string"
+              }
+            },
+            "required": [
+              "lastTransitionTime",
+              "message",
+              "reason",
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "maxItems": 8,
+          "type": "array",
+          "x-kubernetes-list-map-keys": [
+            "type"
+          ],
+          "x-kubernetes-list-type": "map"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/alb.networking.azure.io/ingressextension_v1.json
+++ b/alb.networking.azure.io/ingressextension_v1.json
@@ -1,0 +1,750 @@
+{
+  "description": "IngressExtension is the schema for the IngressExtension API",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "Spec is the IngressExtension specification.",
+      "properties": {
+        "backendSettings": {
+          "description": "BackendSettings defines a set of configuration options for Ingress service backends",
+          "items": {
+            "description": "IngressBackendSettings provides extended configuration options for a backend service",
+            "properties": {
+              "loadBalancingPolicySpec": {
+                "description": "LoadBalancing defines the load balancing policy for the backend service",
+                "properties": {
+                  "circuitBreaker": {
+                    "description": "CircuitBreaker defines the schema for configuring Circuit Breaking",
+                    "properties": {
+                      "maxConnections": {
+                        "default": 1000000000,
+                        "description": "The maximum number of connections that will be made to the backend service.\nDefault is 1000000000 (disabled).",
+                        "format": "int32",
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "maxPendingRequests": {
+                        "default": 1000000000,
+                        "description": "Maximum number of pending requests that will be made to the backend service.\nDefault is 1000000000 (disabled).",
+                        "format": "int32",
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "maxRequests": {
+                        "default": 1000000000,
+                        "description": "Maximum number of parallel requests that will be made to the backend service.\nDefault is 1000000000 (disabled).",
+                        "format": "int32",
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "maxRetries": {
+                        "default": 1000000000,
+                        "description": "The maximum number of parallel retries allowed to the backend service.\nDefault is 1000000000 (disabled).",
+                        "format": "int32",
+                        "minimum": 0,
+                        "type": "integer"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "loadBalancing": {
+                    "description": "LoadBalancing defines the schema for configuring Load Balancing options",
+                    "properties": {
+                      "slowStart": {
+                        "description": "SlowStart defines the schema for Slow Start specification",
+                        "properties": {
+                          "aggression": {
+                            "default": "1.0",
+                            "description": "The speed of traffic increase over the slow start window, must be greater than 0.0.\nDefaults to 1.0 if unspecified.",
+                            "pattern": "^([0-9]+([.][0-9]+)?|[.][0-9]+)$",
+                            "type": "string"
+                          },
+                          "startWeightPercent": {
+                            "default": 10,
+                            "description": "The minimum or starting percentage of traffic to send to new endpoints.\nDefaults to 10% if unspecified.",
+                            "format": "int32",
+                            "maximum": 100,
+                            "minimum": 0,
+                            "type": "integer"
+                          },
+                          "window": {
+                            "description": "The duration of the slow start window.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "window"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "strategy": {
+                        "description": "Strategy defines the policy to use when load balancing traffic to the backend service.\nDefault is round-robin.",
+                        "enum": [
+                          "round-robin",
+                          "least-request"
+                        ],
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "targetRefs": {
+                    "description": "TargetRefs identifies a list of API objects to apply policy to.",
+                    "items": {
+                      "description": "TargetRefSpec defines the target reference and ports for the backend load balancing policy.",
+                      "properties": {
+                        "ports": {
+                          "description": "Ports specifies the list of ports on the target where the policy is applied.",
+                          "items": {
+                            "description": "BackendLoadBalancingPolicyPort defines the port configuration for the backend load balancing policy.",
+                            "properties": {
+                              "port": {
+                                "description": "Port is the port to use for connection to the backend",
+                                "format": "int32",
+                                "minimum": 1,
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "targetRef": {
+                          "description": "TargetRef identifies an API object to apply policy to.",
+                          "properties": {
+                            "group": {
+                              "description": "Group is the group of the target resource.",
+                              "maxLength": 253,
+                              "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                              "type": "string"
+                            },
+                            "kind": {
+                              "description": "Kind is kind of the target resource.",
+                              "maxLength": 63,
+                              "minLength": 1,
+                              "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
+                              "type": "string"
+                            },
+                            "name": {
+                              "description": "Name is the name of the target resource.",
+                              "maxLength": 253,
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "namespace": {
+                              "description": "Namespace is the namespace of the referent. When unspecified, the local\nnamespace is inferred. Even when policy targets a resource in a different\nnamespace, it MUST only apply to traffic originating from the same\nnamespace as the policy.",
+                              "maxLength": 63,
+                              "minLength": 1,
+                              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                              "type": "string"
+                            },
+                            "sectionNames": {
+                              "description": "SectionNames is the name of the section within the target resource. When\nunspecified, this targetRef targets the entire resource. In the following\nresources, SectionNames is interpreted as the following:\n\n* Gateway: Listener Name\n* Service: Port Name\n\nIf a SectionNames is specified, but doesn't exist on the targeted object,\nthe Policy fails to attach, and the policy implementation will record\na `ResolvedRefs` or similar Condition in the Policy's status.",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "required": [
+                            "group",
+                            "kind",
+                            "name"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "targetRef"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "targetRefs"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "ports": {
+                "description": "Ports can be used to indicate if the backend service is listening on HTTP or HTTPS",
+                "items": {
+                  "description": "IngressBackendPort describes a port on a backend.\nOnly one of Name/Number should be defined.",
+                  "properties": {
+                    "name": {
+                      "description": "Name must refer to a name on a port on the backend service",
+                      "type": "string"
+                    },
+                    "port": {
+                      "description": "Port indicates the port  on the backend service",
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "protocol": {
+                      "description": "Protocol should be one of \"HTTP\", \"HTTPS\"",
+                      "enum": [
+                        "HTTP",
+                        "HTTPS"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "protocol"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "array"
+              },
+              "service": {
+                "description": "Service is the name of a backend service that this configuration applies to",
+                "type": "string"
+              },
+              "sessionAffinity": {
+                "description": "SessionAffinity allows client requests to be consistently given to the same backend",
+                "properties": {
+                  "affinityType": {
+                    "description": "AffinityType defines the affinity type for the Service",
+                    "enum": [
+                      "application-cookie",
+                      "managed-cookie"
+                    ],
+                    "type": "string"
+                  },
+                  "cookieDuration": {
+                    "type": "string"
+                  },
+                  "cookieName": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "affinityType"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "timeouts": {
+                "description": "Timeouts define a set of timeout parameters to be applied to an Ingress",
+                "properties": {
+                  "requestTimeout": {
+                    "description": "RequestTimeout defines the timeout used by the load balancer when forwarding requests to a backend service",
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "trustedRootCertificate": {
+                "description": "TrustedRootCertificate can be used to supply a certificate for the gateway to trust when communicating to the\nbackend on a port specified as https",
+                "type": "string"
+              }
+            },
+            "required": [
+              "service"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "rules": {
+          "description": "Rules define the rules per host",
+          "items": {
+            "description": "IngressRuleSetting provides configuration options for rules",
+            "properties": {
+              "additionalHostnames": {
+                "description": "AdditionalHostnames specifies more hostnames to listen on",
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "host": {
+                "description": "Host is used to match against Ingress rules with the same hostname in order to identify which rules affect these settings",
+                "type": "string"
+              },
+              "requestRedirect": {
+                "description": "RequestRedirect defines the redirect behavior for the rule",
+                "properties": {
+                  "hostname": {
+                    "description": "Hostname is the hostname to be used in the value of the `Location`\nheader in the response.\nWhen empty, the hostname in the `Host` header of the request is used.",
+                    "maxLength": 253,
+                    "minLength": 1,
+                    "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                    "type": "string"
+                  },
+                  "path": {
+                    "description": "Path defines parameters used to modify the path of the incoming request.\nThe modified path is then used to construct the `Location` header. When\nempty, the request path is used as-is.",
+                    "properties": {
+                      "replaceFullPath": {
+                        "description": "ReplaceFullPath specifies the value with which to replace the full path\nof a request during a rewrite or redirect.",
+                        "maxLength": 1024,
+                        "type": "string"
+                      },
+                      "replacePrefixMatch": {
+                        "description": "ReplacePrefixMatch specifies the value with which to replace the prefix\nmatch of a request during a rewrite or redirect. For example, a request\nto \"/foo/bar\" with a prefix match of \"/foo\" and a ReplacePrefixMatch\nof \"/xyz\" would be modified to \"/xyz/bar\".\n\nThis matches the behavior of the PathPrefix match type. This\nmatches full path elements. A path element refers to the list of labels\nin the path split by the `/` separator. When specified, a trailing `/` is\nignored. For example, the paths `/abc`, `/abc/`, and `/abc/def` would all\nmatch the prefix `/abc`, but the path `/abcd` wouldn't.\n\nReplacePrefixMatch is only compatible with a `PathPrefix` HTTPRouteMatch.\nUsing any other HTTPRouteMatch type on the same HTTPRouteRule results in\nthe implementation setting the Accepted Condition for the Route to `status: False`.\n\nRequest Path | Prefix Match | Replace Prefix | Modified Path\n|------------|--------------|----------------|----------\n/foo/bar     | /foo         | /xyz           | /xyz/bar\n/foo/bar     | /foo         | /xyz/          | /xyz/bar\n/foo/bar     | /foo/        | /xyz           | /xyz/bar\n/foo/bar     | /foo/        | /xyz/          | /xyz/bar\n/foo         | /foo         | /xyz           | /xyz\n/foo/        | /foo         | /xyz           | /xyz/\n/foo/bar     | /foo         | <empty string> | /bar\n/foo/        | /foo         | <empty string> | /\n/foo         | /foo         | <empty string> | /\n/foo/        | /foo         | /              | /\n/foo         | /foo         | /              | /",
+                        "maxLength": 1024,
+                        "type": "string"
+                      },
+                      "type": {
+                        "description": "Type defines the type of path modifier. More types may be\nadded in a future release of the API.\n\nValues may be added to this enum, implementations\nmust ensure unknown values won't cause a crash.\n\nUnknown values here must result in the implementation setting the\nAccepted Condition for the rule to be false",
+                        "enum": [
+                          "ReplaceFullPath",
+                          "ReplacePrefixMatch"
+                        ],
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "type"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "port": {
+                    "description": "Port is the port to be used in the value of the `Location`\nheader in the response.\n\nIf no port is specified, the redirect port MUST be derived using the\nfollowing rules:\n\n* If redirect scheme is not-empty, the redirect port MUST be the well-known\n  port associated with the redirect scheme. Specifically \"http\" to port 80\n  and \"https\" to port 443. If the redirect scheme doesn't have a\n  well-known port, the listener port of the Gateway SHOULD be used.\n* If redirect scheme is empty, the redirect port MUST be the Gateway\n  Listener port.\n\nImplementations SHOULD NOT add the port number in the 'Location'\nheader in the following cases:\n\n* A Location header that uses HTTP (whether that is determined via\n  the Listener protocol or the Scheme field) _and_ use port 80.\n* A Location header that uses HTTPS (whether that is determined via\n  the Listener protocol or the Scheme field) _and_ use port 443.",
+                    "format": "int32",
+                    "maximum": 65535,
+                    "minimum": 1,
+                    "type": "integer"
+                  },
+                  "scheme": {
+                    "description": "Scheme is the scheme to be used in the value of the `Location` header in\nthe response. When empty, the scheme of the request is used.",
+                    "enum": [
+                      "http",
+                      "https"
+                    ],
+                    "type": "string"
+                  },
+                  "statusCode": {
+                    "default": 302,
+                    "description": "StatusCode is the HTTP status code to be used in response.\n\nValues may be added to this enum, implementations\nmust ensure that unknown values won't cause a crash.",
+                    "enum": [
+                      301,
+                      302,
+                      303,
+                      307
+                    ],
+                    "type": "integer"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "rewrites": {
+                "description": "Rewrites defines the rewrites for the rule",
+                "items": {
+                  "description": "IngressRewrites provides the various rewrites supported on a rule",
+                  "properties": {
+                    "requestHeaderModifier": {
+                      "description": "RequestHeaderModifier defines a schema that modifies request headers.",
+                      "properties": {
+                        "add": {
+                          "description": "Add adds the given header(s) (name, value) to the request\nbefore the action. It appends to any existing values associated\nwith the header name.\n\nInput:\n  GET /foo HTTP/1.1\n  my-header: foo\n\nConfig:\n  add:\n  - name: \"my-header\"\n    value: \"bar,baz\"\n\nOutput:\n  GET /foo HTTP/1.1\n  my-header: foo,bar,baz",
+                          "items": {
+                            "description": "HTTPHeader represents an HTTP Header name and value as defined by RFC 7230.",
+                            "properties": {
+                              "name": {
+                                "description": "Name is the name of the HTTP Header to be matched. Name matching MUST be\ncase insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).\n\nIf multiple entries specify equivalent header names, the first entry with\nan equivalent name MUST be considered for a match. Subsequent entries\nwith an equivalent header name MUST be ignored. Due to the\ncase-insensitivity of header names, \"foo\" and \"Foo\" are considered\nequivalent.",
+                                "maxLength": 256,
+                                "minLength": 1,
+                                "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                                "type": "string"
+                              },
+                              "value": {
+                                "description": "Value is the value of HTTP Header to be matched.",
+                                "maxLength": 4096,
+                                "minLength": 1,
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "name",
+                              "value"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "maxItems": 16,
+                          "type": "array",
+                          "x-kubernetes-list-map-keys": [
+                            "name"
+                          ],
+                          "x-kubernetes-list-type": "map"
+                        },
+                        "remove": {
+                          "description": "Remove the given header(s) from the HTTP request before the action. The\nvalue of Remove is a list of HTTP header names. Header names\nare case-insensitive (see\nhttps://datatracker.ietf.org/doc/html/rfc2616#section-4.2).\n\nInput:\n  GET /foo HTTP/1.1\n  my-header1: foo\n  my-header2: bar\n  my-header3: baz\n\nConfig:\n  remove: [\"my-header1\", \"my-header3\"]\n\nOutput:\n  GET /foo HTTP/1.1\n  my-header2: bar",
+                          "items": {
+                            "type": "string"
+                          },
+                          "maxItems": 16,
+                          "type": "array"
+                        },
+                        "set": {
+                          "description": "Set overwrites the request with the given header (name, value)\nbefore the action.\n\nInput:\n  GET /foo HTTP/1.1\n  my-header: foo\n\nConfig:\n  set:\n  - name: \"my-header\"\n    value: \"bar\"\n\nOutput:\n  GET /foo HTTP/1.1\n  my-header: bar",
+                          "items": {
+                            "description": "HTTPHeader represents an HTTP Header name and value as defined by RFC 7230.",
+                            "properties": {
+                              "name": {
+                                "description": "Name is the name of the HTTP Header to be matched. Name matching MUST be\ncase insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).\n\nIf multiple entries specify equivalent header names, the first entry with\nan equivalent name MUST be considered for a match. Subsequent entries\nwith an equivalent header name MUST be ignored. Due to the\ncase-insensitivity of header names, \"foo\" and \"Foo\" are considered\nequivalent.",
+                                "maxLength": 256,
+                                "minLength": 1,
+                                "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                                "type": "string"
+                              },
+                              "value": {
+                                "description": "Value is the value of HTTP Header to be matched.",
+                                "maxLength": 4096,
+                                "minLength": 1,
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "name",
+                              "value"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "maxItems": 16,
+                          "type": "array",
+                          "x-kubernetes-list-map-keys": [
+                            "name"
+                          ],
+                          "x-kubernetes-list-type": "map"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "responseHeaderModifier": {
+                      "description": "RequestHeaderModifier defines a schema that modifies response headers.",
+                      "properties": {
+                        "add": {
+                          "description": "Add adds the given header(s) (name, value) to the request\nbefore the action. It appends to any existing values associated\nwith the header name.\n\nInput:\n  GET /foo HTTP/1.1\n  my-header: foo\n\nConfig:\n  add:\n  - name: \"my-header\"\n    value: \"bar,baz\"\n\nOutput:\n  GET /foo HTTP/1.1\n  my-header: foo,bar,baz",
+                          "items": {
+                            "description": "HTTPHeader represents an HTTP Header name and value as defined by RFC 7230.",
+                            "properties": {
+                              "name": {
+                                "description": "Name is the name of the HTTP Header to be matched. Name matching MUST be\ncase insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).\n\nIf multiple entries specify equivalent header names, the first entry with\nan equivalent name MUST be considered for a match. Subsequent entries\nwith an equivalent header name MUST be ignored. Due to the\ncase-insensitivity of header names, \"foo\" and \"Foo\" are considered\nequivalent.",
+                                "maxLength": 256,
+                                "minLength": 1,
+                                "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                                "type": "string"
+                              },
+                              "value": {
+                                "description": "Value is the value of HTTP Header to be matched.",
+                                "maxLength": 4096,
+                                "minLength": 1,
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "name",
+                              "value"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "maxItems": 16,
+                          "type": "array",
+                          "x-kubernetes-list-map-keys": [
+                            "name"
+                          ],
+                          "x-kubernetes-list-type": "map"
+                        },
+                        "remove": {
+                          "description": "Remove the given header(s) from the HTTP request before the action. The\nvalue of Remove is a list of HTTP header names. Header names\nare case-insensitive (see\nhttps://datatracker.ietf.org/doc/html/rfc2616#section-4.2).\n\nInput:\n  GET /foo HTTP/1.1\n  my-header1: foo\n  my-header2: bar\n  my-header3: baz\n\nConfig:\n  remove: [\"my-header1\", \"my-header3\"]\n\nOutput:\n  GET /foo HTTP/1.1\n  my-header2: bar",
+                          "items": {
+                            "type": "string"
+                          },
+                          "maxItems": 16,
+                          "type": "array"
+                        },
+                        "set": {
+                          "description": "Set overwrites the request with the given header (name, value)\nbefore the action.\n\nInput:\n  GET /foo HTTP/1.1\n  my-header: foo\n\nConfig:\n  set:\n  - name: \"my-header\"\n    value: \"bar\"\n\nOutput:\n  GET /foo HTTP/1.1\n  my-header: bar",
+                          "items": {
+                            "description": "HTTPHeader represents an HTTP Header name and value as defined by RFC 7230.",
+                            "properties": {
+                              "name": {
+                                "description": "Name is the name of the HTTP Header to be matched. Name matching MUST be\ncase insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).\n\nIf multiple entries specify equivalent header names, the first entry with\nan equivalent name MUST be considered for a match. Subsequent entries\nwith an equivalent header name MUST be ignored. Due to the\ncase-insensitivity of header names, \"foo\" and \"Foo\" are considered\nequivalent.",
+                                "maxLength": 256,
+                                "minLength": 1,
+                                "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                                "type": "string"
+                              },
+                              "value": {
+                                "description": "Value is the value of HTTP Header to be matched.",
+                                "maxLength": 4096,
+                                "minLength": 1,
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "name",
+                              "value"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "maxItems": 16,
+                          "type": "array",
+                          "x-kubernetes-list-map-keys": [
+                            "name"
+                          ],
+                          "x-kubernetes-list-type": "map"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": {
+                      "description": "Type identifies the type of rewrite",
+                      "enum": [
+                        "RequestHeaderModifier",
+                        "ResponseHeaderModifier",
+                        "URLRewrite"
+                      ],
+                      "type": "string"
+                    },
+                    "urlRewrite": {
+                      "description": "URLRewrite defines a schema that modifies a request during forwarding.",
+                      "properties": {
+                        "hostname": {
+                          "description": "Hostname is the value to be used to replace the Host header value during\nforwarding.",
+                          "maxLength": 253,
+                          "minLength": 1,
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                          "type": "string"
+                        },
+                        "path": {
+                          "description": "Path defines a path rewrite.",
+                          "properties": {
+                            "replaceFullPath": {
+                              "description": "ReplaceFullPath specifies the value with which to replace the full path\nof a request during a rewrite or redirect.",
+                              "maxLength": 1024,
+                              "type": "string"
+                            },
+                            "replacePrefixMatch": {
+                              "description": "ReplacePrefixMatch specifies the value with which to replace the prefix\nmatch of a request during a rewrite or redirect. For example, a request\nto \"/foo/bar\" with a prefix match of \"/foo\" and a ReplacePrefixMatch\nof \"/xyz\" would be modified to \"/xyz/bar\".\n\nThis matches the behavior of the PathPrefix match type. This\nmatches full path elements. A path element refers to the list of labels\nin the path split by the `/` separator. When specified, a trailing `/` is\nignored. For example, the paths `/abc`, `/abc/`, and `/abc/def` would all\nmatch the prefix `/abc`, but the path `/abcd` wouldn't.\n\nReplacePrefixMatch is only compatible with a `PathPrefix` HTTPRouteMatch.\nUsing any other HTTPRouteMatch type on the same HTTPRouteRule results in\nthe implementation setting the Accepted Condition for the Route to `status: False`.\n\nRequest Path | Prefix Match | Replace Prefix | Modified Path\n|------------|--------------|----------------|----------\n/foo/bar     | /foo         | /xyz           | /xyz/bar\n/foo/bar     | /foo         | /xyz/          | /xyz/bar\n/foo/bar     | /foo/        | /xyz           | /xyz/bar\n/foo/bar     | /foo/        | /xyz/          | /xyz/bar\n/foo         | /foo         | /xyz           | /xyz\n/foo/        | /foo         | /xyz           | /xyz/\n/foo/bar     | /foo         | <empty string> | /bar\n/foo/        | /foo         | <empty string> | /\n/foo         | /foo         | <empty string> | /\n/foo/        | /foo         | /              | /\n/foo         | /foo         | /              | /",
+                              "maxLength": 1024,
+                              "type": "string"
+                            },
+                            "type": {
+                              "description": "Type defines the type of path modifier. More types may be\nadded in a future release of the API.\n\nValues may be added to this enum, implementations\nmust ensure unknown values won't cause a crash.\n\nUnknown values here must result in the implementation setting the\nAccepted Condition for the rule to be false",
+                              "enum": [
+                                "ReplaceFullPath",
+                                "ReplacePrefixMatch"
+                              ],
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "type"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": [
+                    "type"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "array"
+              }
+            },
+            "required": [
+              "host"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "default": {
+        "conditions": [
+          {
+            "lastTransitionTime": "1970-01-01T00:00:00Z",
+            "message": "Waiting for controller",
+            "reason": "Pending",
+            "status": "Unknown",
+            "type": "Accepted"
+          }
+        ]
+      },
+      "description": "IngressExtensionStatus describes the current state of the IngressExtension",
+      "properties": {
+        "backendSettings": {
+          "description": "BackendSettings has detailed status information regarding each BackendSettings",
+          "items": {
+            "description": "IngressBackendSettingStatus describes the state of a BackendSetting",
+            "properties": {
+              "service": {
+                "description": "Service identifies the BackendSetting this status describes",
+                "type": "string"
+              },
+              "valid": {
+                "description": "Valid indicates that there are no validation errors present on this BackendSetting",
+                "type": "boolean"
+              },
+              "validationErrors": {
+                "description": "Errors are a list of errors relating to this setting",
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              }
+            },
+            "required": [
+              "service",
+              "valid"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "conditions": {
+          "default": [
+            {
+              "lastTransitionTime": "1970-01-01T00:00:00Z",
+              "message": "Waiting for controller",
+              "reason": "Pending",
+              "status": "Unknown",
+              "type": "Accepted"
+            },
+            {
+              "lastTransitionTime": "1970-01-01T00:00:00Z",
+              "message": "Waiting for controller",
+              "reason": "Pending",
+              "status": "Unknown",
+              "type": "ValidationErrors"
+            }
+          ],
+          "description": "Conditions describe the current conditions of the IngressExtension.\nKnown condition types are:\n\n* \"Accepted\"\n* \"Errors\"",
+          "items": {
+            "description": "Condition contains details for one aspect of the current state of this API Resource.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "lastTransitionTime is the last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "message is a human readable message indicating details about the transition.\nThis may be an empty string.",
+                "maxLength": 32768,
+                "type": "string"
+              },
+              "observedGeneration": {
+                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon.\nFor instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date\nwith respect to the current state of the instance.",
+                "format": "int64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "reason": {
+                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition.\nProducers of specific condition types may define expected values and meanings for this field,\nand whether the values are considered a guaranteed API.\nThe value should be a CamelCase string.\nThis field may not be empty.",
+                "maxLength": 1024,
+                "minLength": 1,
+                "pattern": "^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$",
+                "type": "string"
+              },
+              "status": {
+                "description": "status of the condition, one of True, False, Unknown.",
+                "enum": [
+                  "True",
+                  "False",
+                  "Unknown"
+                ],
+                "type": "string"
+              },
+              "type": {
+                "description": "type of condition in CamelCase or in foo.example.com/CamelCase.",
+                "maxLength": 316,
+                "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$",
+                "type": "string"
+              }
+            },
+            "required": [
+              "lastTransitionTime",
+              "message",
+              "reason",
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "maxItems": 8,
+          "type": "array",
+          "x-kubernetes-list-map-keys": [
+            "type"
+          ],
+          "x-kubernetes-list-type": "map"
+        },
+        "rules": {
+          "description": "Rules have detailed status information regarding each Rule",
+          "items": {
+            "description": "IngressRuleStatus describes the state of a rule",
+            "properties": {
+              "host": {
+                "description": "Host identifies the rule this status describes",
+                "type": "string"
+              },
+              "valid": {
+                "description": "Valid indicates that there are no validation errors present on this rule",
+                "type": "boolean"
+              },
+              "validationErrors": {
+                "description": "Errors are a list of errors relating to this setting",
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              }
+            },
+            "required": [
+              "host"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/alb.networking.azure.io/routepolicy_v1.json
+++ b/alb.networking.azure.io/routepolicy_v1.json
@@ -1,0 +1,244 @@
+{
+  "description": "RoutePolicy is the schema for the RoutePolicy API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "Spec is the RoutePolicy specification.",
+      "properties": {
+        "default": {
+          "description": "Default defines default policy configuration for the targeted resource.",
+          "properties": {
+            "sessionAffinity": {
+              "description": "SessionAffinity defines the schema for Session Affinity specification",
+              "properties": {
+                "affinityType": {
+                  "description": "AffinityType defines the affinity type for the Service",
+                  "enum": [
+                    "application-cookie",
+                    "managed-cookie"
+                  ],
+                  "type": "string"
+                },
+                "cookieDuration": {
+                  "type": "string"
+                },
+                "cookieName": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "affinityType"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "timeouts": {
+              "description": "Custom Timeouts\nTimeout for the target resource.",
+              "properties": {
+                "routeTimeout": {
+                  "description": "RouteTimeout is the timeout for the route.",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "override": {
+          "description": "Override defines policy configuration that should override policy\nconfiguration attached below the targeted resource in the hierarchy.\n\nNote: Override is currently not supported and result in a validation error.\nSupport for Override will be added in a future release.",
+          "properties": {
+            "sessionAffinity": {
+              "description": "SessionAffinity defines the schema for Session Affinity specification",
+              "properties": {
+                "affinityType": {
+                  "description": "AffinityType defines the affinity type for the Service",
+                  "enum": [
+                    "application-cookie",
+                    "managed-cookie"
+                  ],
+                  "type": "string"
+                },
+                "cookieDuration": {
+                  "type": "string"
+                },
+                "cookieName": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "affinityType"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "timeouts": {
+              "description": "Custom Timeouts\nTimeout for the target resource.",
+              "properties": {
+                "routeTimeout": {
+                  "description": "RouteTimeout is the timeout for the route.",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "targetRef": {
+          "description": "TargetRef identifies an API object to apply policy to.",
+          "properties": {
+            "group": {
+              "description": "Group is the group of the target resource.",
+              "maxLength": 253,
+              "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+              "type": "string"
+            },
+            "kind": {
+              "description": "Kind is kind of the target resource.",
+              "maxLength": 63,
+              "minLength": 1,
+              "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
+              "type": "string"
+            },
+            "name": {
+              "description": "Name is the name of the target resource.",
+              "maxLength": 253,
+              "minLength": 1,
+              "type": "string"
+            },
+            "namespace": {
+              "description": "Namespace is the namespace of the referent. When unspecified, the local\nnamespace is inferred. Even when policy targets a resource in a different\nnamespace, it MUST only apply to traffic originating from the same\nnamespace as the policy.",
+              "maxLength": 63,
+              "minLength": 1,
+              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "type": "string"
+            },
+            "sectionNames": {
+              "description": "SectionNames is the name of the section within the target resource. When\nunspecified, this targetRef targets the entire resource. In the following\nresources, SectionNames is interpreted as the following:\n\n* Gateway: Listener Name\n* Service: Port Name\n\nIf a SectionNames is specified, but doesn't exist on the targeted object,\nthe Policy fails to attach, and the policy implementation will record\na `ResolvedRefs` or similar Condition in the Policy's status.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "group",
+            "kind",
+            "name"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "targetRef"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "default": {
+        "conditions": [
+          {
+            "lastTransitionTime": "1970-01-01T00:00:00Z",
+            "message": "Waiting for controller",
+            "reason": "Pending",
+            "status": "Unknown",
+            "type": "Accepted"
+          }
+        ]
+      },
+      "description": "Status defines the current state of RoutePolicy.",
+      "properties": {
+        "conditions": {
+          "default": [
+            {
+              "lastTransitionTime": "1970-01-01T00:00:00Z",
+              "message": "Waiting for controller",
+              "reason": "Pending",
+              "status": "Unknown",
+              "type": "Accepted"
+            }
+          ],
+          "description": "Conditions describe the current conditions of the RoutePolicy.\n\nImplementations should prefer to express RoutePolicy conditions\nusing the `RoutePolicyConditionType` and `RoutePolicyConditionReason`\nconstants so that operators and tools can converge on a common\nvocabulary to describe RoutePolicy state.\n\nKnown condition types are:\n\n* \"Accepted\"",
+          "items": {
+            "description": "Condition contains details for one aspect of the current state of this API Resource.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "lastTransitionTime is the last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "message is a human readable message indicating details about the transition.\nThis may be an empty string.",
+                "maxLength": 32768,
+                "type": "string"
+              },
+              "observedGeneration": {
+                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon.\nFor instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date\nwith respect to the current state of the instance.",
+                "format": "int64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "reason": {
+                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition.\nProducers of specific condition types may define expected values and meanings for this field,\nand whether the values are considered a guaranteed API.\nThe value should be a CamelCase string.\nThis field may not be empty.",
+                "maxLength": 1024,
+                "minLength": 1,
+                "pattern": "^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$",
+                "type": "string"
+              },
+              "status": {
+                "description": "status of the condition, one of True, False, Unknown.",
+                "enum": [
+                  "True",
+                  "False",
+                  "Unknown"
+                ],
+                "type": "string"
+              },
+              "type": {
+                "description": "type of condition in CamelCase or in foo.example.com/CamelCase.",
+                "maxLength": 316,
+                "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$",
+                "type": "string"
+              }
+            },
+            "required": [
+              "lastTransitionTime",
+              "message",
+              "reason",
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "maxItems": 8,
+          "type": "array",
+          "x-kubernetes-list-map-keys": [
+            "type"
+          ],
+          "x-kubernetes-list-type": "map"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/alb.networking.azure.io/webapplicationfirewallpolicy_v1.json
+++ b/alb.networking.azure.io/webapplicationfirewallpolicy_v1.json
@@ -1,0 +1,173 @@
+{
+  "description": "WebApplicationFirewallPolicy is the schema for the Application Gateway for Containers Security Policy child resource.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "Spec is the specifications for Application Gateway for Containers Security Policy child resource.",
+      "properties": {
+        "targetRef": {
+          "description": "TargetRef identifies an API object to apply policy to.",
+          "properties": {
+            "group": {
+              "description": "Group is the group of the target resource.",
+              "maxLength": 253,
+              "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+              "type": "string"
+            },
+            "kind": {
+              "description": "Kind is kind of the target resource.",
+              "maxLength": 63,
+              "minLength": 1,
+              "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
+              "type": "string"
+            },
+            "name": {
+              "description": "Name is the name of the target resource.",
+              "maxLength": 253,
+              "minLength": 1,
+              "type": "string"
+            },
+            "namespace": {
+              "description": "Namespace is the namespace of the referent. When unspecified, the local\nnamespace is inferred. Even when policy targets a resource in a different\nnamespace, it MUST only apply to traffic originating from the same\nnamespace as the policy.",
+              "maxLength": 63,
+              "minLength": 1,
+              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "type": "string"
+            },
+            "sectionNames": {
+              "description": "SectionNames is the name of the section within the target resource. When\nunspecified, this targetRef targets the entire resource. In the following\nresources, SectionNames is interpreted as the following:\n\n* Gateway: Listener Name\n* Service: Port Name\n\nIf a SectionNames is specified, but doesn't exist on the targeted object,\nthe Policy fails to attach, and the policy implementation will record\na `ResolvedRefs` or similar Condition in the Policy's status.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "group",
+            "kind",
+            "name"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "webApplicationFirewall": {
+          "description": "WebApplicationFirewallPolicy is used to specify a WebApplicationPolicy resource",
+          "properties": {
+            "id": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "id"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "targetRef"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "default": {
+        "conditions": [
+          {
+            "lastTransitionTime": "1970-01-01T00:00:00Z",
+            "message": "Waiting for controller",
+            "reason": "Pending",
+            "status": "Unknown",
+            "type": "Accepted"
+          }
+        ]
+      },
+      "description": "Status defines the current state of Application Gateway for Containers Security Policy child resource.",
+      "properties": {
+        "conditions": {
+          "default": [
+            {
+              "lastTransitionTime": "1970-01-01T00:00:00Z",
+              "message": "Waiting for controller",
+              "reason": "Pending",
+              "status": "Unknown",
+              "type": "Accepted"
+            }
+          ],
+          "description": "Known condition types are:\n\n* \"Accepted\"\n* \"Deployment\"\n* \"ResolvedRefs\"\n* \"Programmed\"",
+          "items": {
+            "description": "Condition contains details for one aspect of the current state of this API Resource.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "lastTransitionTime is the last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "message is a human readable message indicating details about the transition.\nThis may be an empty string.",
+                "maxLength": 32768,
+                "type": "string"
+              },
+              "observedGeneration": {
+                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon.\nFor instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date\nwith respect to the current state of the instance.",
+                "format": "int64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "reason": {
+                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition.\nProducers of specific condition types may define expected values and meanings for this field,\nand whether the values are considered a guaranteed API.\nThe value should be a CamelCase string.\nThis field may not be empty.",
+                "maxLength": 1024,
+                "minLength": 1,
+                "pattern": "^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$",
+                "type": "string"
+              },
+              "status": {
+                "description": "status of the condition, one of True, False, Unknown.",
+                "enum": [
+                  "True",
+                  "False",
+                  "Unknown"
+                ],
+                "type": "string"
+              },
+              "type": {
+                "description": "type of condition in CamelCase or in foo.example.com/CamelCase.",
+                "maxLength": 316,
+                "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$",
+                "type": "string"
+              }
+            },
+            "required": [
+              "lastTransitionTime",
+              "message",
+              "reason",
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "maxItems": 8,
+          "type": "array",
+          "x-kubernetes-list-map-keys": [
+            "type"
+          ],
+          "x-kubernetes-list-type": "map"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/index.yaml
+++ b/index.yaml
@@ -359,6 +359,39 @@ akri.sh:
     filename: akri.sh/instance_v0.json
     kind: Instance
     name: instance_v0
+alb.networking.azure.io:
+  - apiVersion: alb.networking.azure.io/v1
+    filename: alb.networking.azure.io/applicationloadbalancer_v1.json
+    kind: ApplicationLoadBalancer
+    name: applicationloadbalancer_v1
+  - apiVersion: alb.networking.azure.io/v1
+    filename: alb.networking.azure.io/backendloadbalancingpolicy_v1.json
+    kind: BackendLoadBalancingPolicy
+    name: backendloadbalancingpolicy_v1
+  - apiVersion: alb.networking.azure.io/v1
+    filename: alb.networking.azure.io/backendtlspolicy_v1.json
+    kind: BackendTLSPolicy
+    name: backendtlspolicy_v1
+  - apiVersion: alb.networking.azure.io/v1
+    filename: alb.networking.azure.io/frontendtlspolicy_v1.json
+    kind: FrontendTLSPolicy
+    name: frontendtlspolicy_v1
+  - apiVersion: alb.networking.azure.io/v1
+    filename: alb.networking.azure.io/healthcheckpolicy_v1.json
+    kind: HealthCheckPolicy
+    name: healthcheckpolicy_v1
+  - apiVersion: alb.networking.azure.io/v1
+    filename: alb.networking.azure.io/ingressextension_v1.json
+    kind: IngressExtension
+    name: ingressextension_v1
+  - apiVersion: alb.networking.azure.io/v1
+    filename: alb.networking.azure.io/routepolicy_v1.json
+    kind: RoutePolicy
+    name: routepolicy_v1
+  - apiVersion: alb.networking.azure.io/v1
+    filename: alb.networking.azure.io/webapplicationfirewallpolicy_v1.json
+    kind: WebApplicationFirewallPolicy
+    name: webapplicationfirewallpolicy_v1
 alerting.grafana.crossplane.io:
   - apiVersion: alerting.grafana.crossplane.io/v1alpha1
     filename: alerting.grafana.crossplane.io/messagetemplate_v1alpha1.json


### PR DESCRIPTION
## What

Adds JSON schemas for the **`alb.networking.azure.io`** API group — the CRDs used by the [Azure Application Gateway for Containers](https://learn.microsoft.com/azure/application-gateway/for-containers/overview) ALB Controller on AKS.

New group `alb.networking.azure.io/v1` (8 CRDs):

| Kind | Version |
|------|---------|
| ApplicationLoadBalancer | v1 |
| BackendLoadBalancingPolicy | v1 |
| BackendTLSPolicy | v1 |
| FrontendTLSPolicy | v1 |
| HealthCheckPolicy | v1 |
| IngressExtension | v1 |
| RoutePolicy | v1 |
| WebApplicationFirewallPolicy | v1 |

`index.yaml` updated with the new group (surgical insertion in alphabetical order, no unrelated entries touched).

## How

Extracted from live AKS clusters and converted using this repo's own tooling — `Utilities/openapi2jsonschema.py` with `FILENAME_FORMAT={fullgroup}_{kind}_{version}`, exactly as `Utilities/crd-extractor.sh` does — then organized into `<group>/<kind>_<version>.json`.

The related `appgw.ingress.azure.io` CRD was also present in the clusters but is already in the catalog and regenerated byte-identical, so it is not included here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)